### PR TITLE
Auto-generate tag feeds and make tags clickable

### DIFF
--- a/pkg/plugins/auto_feeds.go
+++ b/pkg/plugins/auto_feeds.go
@@ -321,7 +321,7 @@ func (p *AutoFeedsPlugin) generateArchiveFeeds(posts []*models.Post, config Auto
 func getAutoFeedsConfig(config *lifecycle.Config) AutoFeedsConfig {
 	defaultConfig := AutoFeedsConfig{
 		Tags: AutoFeedTypeConfig{
-			Enabled:    false,
+			Enabled:    true, // Tag feeds enabled by default
 			SlugPrefix: "tags",
 			Formats: models.FeedFormats{
 				HTML: true,

--- a/pkg/plugins/auto_feeds_test.go
+++ b/pkg/plugins/auto_feeds_test.go
@@ -389,7 +389,7 @@ func TestAutoFeedsPlugin_NoAutoFeedsConfigured(t *testing.T) {
 		{Path: "post1.md", Slug: "post1", Title: strPtr("Post"), Tags: []string{"test"}, Date: &date},
 	})
 
-	// No auto_feeds config (all disabled by default)
+	// No auto_feeds config (tag feeds enabled by default)
 	config := lifecycle.NewConfig()
 	config.Extra = map[string]interface{}{}
 	m.SetConfig(config)
@@ -401,8 +401,9 @@ func TestAutoFeedsPlugin_NoAutoFeedsConfigured(t *testing.T) {
 	}
 
 	feeds := m.Feeds()
-	if len(feeds) != 0 {
-		t.Errorf("expected 0 feeds when auto_feeds disabled, got %d", len(feeds))
+	// With tag feeds enabled by default, we should get 1 feed for the "test" tag
+	if len(feeds) != 1 {
+		t.Errorf("expected 1 feed (tag feed) with default config, got %d", len(feeds))
 	}
 }
 

--- a/templates/partials/card.html
+++ b/templates/partials/card.html
@@ -9,7 +9,7 @@
     {% if post.tags %}
     <div class="tags">
         {% for tag in post.tags %}
-        <span class="tag">{{ tag }}</span>
+        <a href="/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
         {% endfor %}
     </div>
     {% endif %}


### PR DESCRIPTION
## Summary

- Enable tag feeds by default (change `Tags.Enabled` from `false` to `true`)
- Make tags clickable links in card templates (use `<a href="/tags/{{ tag | slugify }}/">` instead of `<span>`)

## Changes

- `pkg/plugins/auto_feeds.go`: Change default for Tags.Enabled to true
- `templates/partials/card.html`: Convert tag spans to anchor links
- `pkg/plugins/auto_feeds_test.go`: Update test expectation (1 feed instead of 0)

## Testing

- All existing tests pass
- Site builds successfully with 31 feeds (including tag feeds)
- Tag pages generated at `/tags/{slug}/index.html`

Fixes #9