### PR TITLE
Add configurable nav/footer with centered layout

### DIFF
--- a/cmd/markata-go/cmd/core.go
+++ b/cmd/markata-go/cmd/core.go
@@ -58,6 +58,8 @@ func createManager(cfgPath string) (*lifecycle.Manager, error) {
 	lcConfig.Extra["feeds"] = cfg.Feeds
 	lcConfig.Extra["feed_defaults"] = cfg.FeedDefaults
 	lcConfig.Extra["use_gitignore"] = cfg.GlobConfig.UseGitignore
+	lcConfig.Extra["nav"] = cfg.Nav
+	lcConfig.Extra["footer"] = cfg.Footer
 
 	// Pass theme configuration to plugins
 	lcConfig.Extra["theme"] = map[string]interface{}{

--- a/markata-go.toml
+++ b/markata-go.toml
@@ -3,10 +3,10 @@
 
 [markata-go]
 # Site settings
-title = "My Site"
-description = "A site built with markata-go"
+title = "markata-go"
+description = "A fast, plugin-driven static site generator written in Go"
 url = "https://example.com"
-author = "Your Name"
+author = "Waylon Walker"
 
 # Build settings
 output_dir = "public"
@@ -19,6 +19,20 @@ concurrency = 0
 # Plugin configuration
 hooks = ["default"]
 disabled_hooks = []
+
+# Navigation links
+[[markata-go.nav]]
+label = "Docs"
+url = "/docs/"
+
+[[markata-go.nav]]
+label = "Blog"
+url = "/blog/"
+
+[[markata-go.nav]]
+label = "GitHub"
+url = "https://github.com/WaylonWalker/markata-go"
+external = true
 
 
 # NAME                      VARIANT  SOURCE     DESCRIPTION

--- a/pkg/config/merge.go
+++ b/pkg/config/merge.go
@@ -49,6 +49,9 @@ func MergeConfigs(base, override *models.Config) *models.Config {
 	if len(override.DisabledHooks) > 0 {
 		result.DisabledHooks = override.DisabledHooks
 	}
+	if len(override.Nav) > 0 {
+		result.Nav = override.Nav
+	}
 
 	// Integer fields - override if non-zero
 	if override.Concurrency != 0 {
@@ -59,6 +62,7 @@ func MergeConfigs(base, override *models.Config) *models.Config {
 	result.GlobConfig = mergeGlobConfig(base.GlobConfig, override.GlobConfig)
 	result.MarkdownConfig = mergeMarkdownConfig(base.MarkdownConfig, override.MarkdownConfig)
 	result.FeedDefaults = mergeFeedDefaults(base.FeedDefaults, override.FeedDefaults)
+	result.Footer = mergeFooterConfig(base.Footer, override.Footer)
 
 	// Feeds array - replace if non-empty
 	if len(override.Feeds) > 0 {
@@ -92,6 +96,20 @@ func mergeThemeConfig(base, override models.ThemeConfig) models.ThemeConfig {
 		for k, v := range override.Variables {
 			result.Variables[k] = v
 		}
+	}
+
+	return result
+}
+
+// mergeFooterConfig merges FooterConfig values.
+func mergeFooterConfig(base, override models.FooterConfig) models.FooterConfig {
+	result := base
+
+	if override.Text != "" {
+		result.Text = override.Text
+	}
+	if override.ShowCopyright != nil {
+		result.ShowCopyright = override.ShowCopyright
 	}
 
 	return result

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -63,6 +63,8 @@ type tomlConfig struct {
 	Author        string             `toml:"author"`
 	AssetsDir     string             `toml:"assets_dir"`
 	TemplatesDir  string             `toml:"templates_dir"`
+	Nav           []tomlNavItem      `toml:"nav"`
+	Footer        tomlFooterConfig   `toml:"footer"`
 	Hooks         []string           `toml:"hooks"`
 	DisabledHooks []string           `toml:"disabled_hooks"`
 	Glob          tomlGlobConfig     `toml:"glob"`
@@ -72,6 +74,17 @@ type tomlConfig struct {
 	Concurrency   int                `toml:"concurrency"`
 	Theme         tomlThemeConfig    `toml:"theme"`
 	UnknownFields map[string]any     `toml:"-"`
+}
+
+type tomlNavItem struct {
+	Label    string `toml:"label"`
+	URL      string `toml:"url"`
+	External bool   `toml:"external"`
+}
+
+type tomlFooterConfig struct {
+	Text          string `toml:"text"`
+	ShowCopyright *bool  `toml:"show_copyright"`
 }
 
 type tomlThemeConfig struct {
@@ -152,10 +165,20 @@ func (c *tomlConfig) toConfig() *models.Config {
 		},
 		Concurrency: c.Concurrency,
 		Theme:       c.Theme.toThemeConfig(),
+		Footer:      c.Footer.toFooterConfig(),
 	}
 
 	if c.Glob.UseGitignore != nil {
 		config.GlobConfig.UseGitignore = *c.Glob.UseGitignore
+	}
+
+	// Convert nav items
+	for _, nav := range c.Nav {
+		config.Nav = append(config.Nav, models.NavItem{
+			Label:    nav.Label,
+			URL:      nav.URL,
+			External: nav.External,
+		})
 	}
 
 	// Convert feeds
@@ -167,6 +190,13 @@ func (c *tomlConfig) toConfig() *models.Config {
 	config.FeedDefaults = c.FeedDefaults.toFeedDefaults()
 
 	return config
+}
+
+func (f *tomlFooterConfig) toFooterConfig() models.FooterConfig {
+	return models.FooterConfig{
+		Text:          f.Text,
+		ShowCopyright: f.ShowCopyright,
+	}
 }
 
 func (t *tomlThemeConfig) toThemeConfig() models.ThemeConfig {
@@ -252,6 +282,8 @@ type yamlConfig struct {
 	Author        string             `yaml:"author"`
 	AssetsDir     string             `yaml:"assets_dir"`
 	TemplatesDir  string             `yaml:"templates_dir"`
+	Nav           []yamlNavItem      `yaml:"nav"`
+	Footer        yamlFooterConfig   `yaml:"footer"`
 	Hooks         []string           `yaml:"hooks"`
 	DisabledHooks []string           `yaml:"disabled_hooks"`
 	Glob          yamlGlobConfig     `yaml:"glob"`
@@ -259,6 +291,17 @@ type yamlConfig struct {
 	Feeds         []yamlFeedConfig   `yaml:"feeds"`
 	FeedDefaults  yamlFeedDefaults   `yaml:"feed_defaults"`
 	Concurrency   int                `yaml:"concurrency"`
+}
+
+type yamlNavItem struct {
+	Label    string `yaml:"label"`
+	URL      string `yaml:"url"`
+	External bool   `yaml:"external"`
+}
+
+type yamlFooterConfig struct {
+	Text          string `yaml:"text"`
+	ShowCopyright *bool  `yaml:"show_copyright"`
 }
 
 type yamlGlobConfig struct {
@@ -332,10 +375,20 @@ func (c *yamlConfig) toConfig() *models.Config {
 			Extensions: c.Markdown.Extensions,
 		},
 		Concurrency: c.Concurrency,
+		Footer:      c.Footer.toFooterConfig(),
 	}
 
 	if c.Glob.UseGitignore != nil {
 		config.GlobConfig.UseGitignore = *c.Glob.UseGitignore
+	}
+
+	// Convert nav items
+	for _, nav := range c.Nav {
+		config.Nav = append(config.Nav, models.NavItem{
+			Label:    nav.Label,
+			URL:      nav.URL,
+			External: nav.External,
+		})
 	}
 
 	// Convert feeds
@@ -347,6 +400,13 @@ func (c *yamlConfig) toConfig() *models.Config {
 	config.FeedDefaults = c.FeedDefaults.toFeedDefaults()
 
 	return config
+}
+
+func (f *yamlFooterConfig) toFooterConfig() models.FooterConfig {
+	return models.FooterConfig{
+		Text:          f.Text,
+		ShowCopyright: f.ShowCopyright,
+	}
 }
 
 func (f *yamlFeedConfig) toFeedConfig() models.FeedConfig {
@@ -419,6 +479,8 @@ type jsonConfig struct {
 	Author        string             `json:"author"`
 	AssetsDir     string             `json:"assets_dir"`
 	TemplatesDir  string             `json:"templates_dir"`
+	Nav           []jsonNavItem      `json:"nav"`
+	Footer        jsonFooterConfig   `json:"footer"`
 	Hooks         []string           `json:"hooks"`
 	DisabledHooks []string           `json:"disabled_hooks"`
 	Glob          jsonGlobConfig     `json:"glob"`
@@ -426,6 +488,17 @@ type jsonConfig struct {
 	Feeds         []jsonFeedConfig   `json:"feeds"`
 	FeedDefaults  jsonFeedDefaults   `json:"feed_defaults"`
 	Concurrency   int                `json:"concurrency"`
+}
+
+type jsonNavItem struct {
+	Label    string `json:"label"`
+	URL      string `json:"url"`
+	External bool   `json:"external"`
+}
+
+type jsonFooterConfig struct {
+	Text          string `json:"text"`
+	ShowCopyright *bool  `json:"show_copyright"`
 }
 
 type jsonGlobConfig struct {
@@ -499,10 +572,20 @@ func (c *jsonConfig) toConfig() *models.Config {
 			Extensions: c.Markdown.Extensions,
 		},
 		Concurrency: c.Concurrency,
+		Footer:      c.Footer.toFooterConfig(),
 	}
 
 	if c.Glob.UseGitignore != nil {
 		config.GlobConfig.UseGitignore = *c.Glob.UseGitignore
+	}
+
+	// Convert nav items
+	for _, nav := range c.Nav {
+		config.Nav = append(config.Nav, models.NavItem{
+			Label:    nav.Label,
+			URL:      nav.URL,
+			External: nav.External,
+		})
 	}
 
 	// Convert feeds
@@ -514,6 +597,13 @@ func (c *jsonConfig) toConfig() *models.Config {
 	config.FeedDefaults = c.FeedDefaults.toFeedDefaults()
 
 	return config
+}
+
+func (f *jsonFooterConfig) toFooterConfig() models.FooterConfig {
+	return models.FooterConfig{
+		Text:          f.Text,
+		ShowCopyright: f.ShowCopyright,
+	}
 }
 
 func (f *jsonFeedConfig) toFeedConfig() models.FeedConfig {

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -1,5 +1,26 @@
 package models
 
+// NavItem represents a navigation link.
+type NavItem struct {
+	// Label is the display text for the nav link
+	Label string `json:"label" yaml:"label" toml:"label"`
+
+	// URL is the link destination (can be relative or absolute)
+	URL string `json:"url" yaml:"url" toml:"url"`
+
+	// External indicates if the link opens in a new tab (default: false)
+	External bool `json:"external,omitempty" yaml:"external,omitempty" toml:"external,omitempty"`
+}
+
+// FooterConfig configures the site footer.
+type FooterConfig struct {
+	// Text is the footer text (supports template variables like {{ year }})
+	Text string `json:"text,omitempty" yaml:"text,omitempty" toml:"text,omitempty"`
+
+	// ShowCopyright shows the copyright line (default: true)
+	ShowCopyright *bool `json:"show_copyright,omitempty" yaml:"show_copyright,omitempty" toml:"show_copyright,omitempty"`
+}
+
 // Config represents the site configuration for markata-go.
 type Config struct {
 	// OutputDir is the directory where generated files are written (default: "output")
@@ -22,6 +43,12 @@ type Config struct {
 
 	// TemplatesDir is the directory containing templates (default: "templates")
 	TemplatesDir string `json:"templates_dir" yaml:"templates_dir" toml:"templates_dir"`
+
+	// Nav is the list of navigation links
+	Nav []NavItem `json:"nav" yaml:"nav" toml:"nav"`
+
+	// Footer configures the site footer
+	Footer FooterConfig `json:"footer" yaml:"footer" toml:"footer"`
 
 	// Hooks is the list of hooks to run (default: ["default"])
 	Hooks []string `json:"hooks" yaml:"hooks" toml:"hooks"`

--- a/pkg/plugins/publish_feeds.go
+++ b/pkg/plugins/publish_feeds.go
@@ -175,6 +175,16 @@ func (p *PublishFeedsPlugin) generateFeedPageHTML(fc *models.FeedConfig, page *m
 			Author:      getStringFromExtra(config.Extra, "author"),
 		}
 
+		// Copy nav items if available
+		if navItems, ok := config.Extra["nav"].([]models.NavItem); ok {
+			modelsConfig.Nav = navItems
+		}
+
+		// Copy footer config if available
+		if footer, ok := config.Extra["footer"].(models.FooterConfig); ok {
+			modelsConfig.Footer = footer
+		}
+
 		// Create feed context
 		ctx := templates.NewFeedContext(fc, page, modelsConfig)
 

--- a/pkg/plugins/templates.go
+++ b/pkg/plugins/templates.go
@@ -134,7 +134,7 @@ func toModelsConfig(config *lifecycle.Config) *models.Config {
 		return nil
 	}
 	// Convert lifecycle.Config to models.Config
-	return &models.Config{
+	modelsConfig := &models.Config{
 		OutputDir:    config.OutputDir,
 		Title:        getStringFromExtra(config.Extra, "title"),
 		URL:          getStringFromExtra(config.Extra, "url"),
@@ -142,6 +142,18 @@ func toModelsConfig(config *lifecycle.Config) *models.Config {
 		Author:       getStringFromExtra(config.Extra, "author"),
 		TemplatesDir: getStringFromExtra(config.Extra, "templates_dir"),
 	}
+
+	// Copy nav items if available
+	if navItems, ok := config.Extra["nav"].([]models.NavItem); ok {
+		modelsConfig.Nav = navItems
+	}
+
+	// Copy footer config if available
+	if footer, ok := config.Extra["footer"].(models.FooterConfig); ok {
+		modelsConfig.Footer = footer
+	}
+
+	return modelsConfig
 }
 
 // getStringFromExtra safely gets a string value from the Extra map.

--- a/pkg/templates/context.go
+++ b/pkg/templates/context.go
@@ -142,6 +142,26 @@ func configToMap(c *models.Config) map[string]interface{} {
 		return nil
 	}
 
+	// Convert nav items to maps
+	navItems := make([]map[string]interface{}, len(c.Nav))
+	for i, nav := range c.Nav {
+		navItems[i] = map[string]interface{}{
+			"label":    nav.Label,
+			"url":      nav.URL,
+			"external": nav.External,
+		}
+	}
+
+	// Convert footer to map
+	footerMap := map[string]interface{}{
+		"text": c.Footer.Text,
+	}
+	if c.Footer.ShowCopyright != nil {
+		footerMap["show_copyright"] = *c.Footer.ShowCopyright
+	} else {
+		footerMap["show_copyright"] = true // default to true
+	}
+
 	return map[string]interface{}{
 		"output_dir":    c.OutputDir,
 		"url":           c.URL,
@@ -150,6 +170,8 @@ func configToMap(c *models.Config) map[string]interface{} {
 		"author":        c.Author,
 		"assets_dir":    c.AssetsDir,
 		"templates_dir": c.TemplatesDir,
+		"nav":           navItems,
+		"footer":        footerMap,
 	}
 }
 

--- a/pkg/themes/default/static/css/main.css
+++ b/pkg/themes/default/static/css/main.css
@@ -566,7 +566,8 @@ main {
   color: var(--color-text-muted);
 }
 
-.posts {
+.posts,
+.post-list {
   display: flex;
   flex-direction: column;
   gap: var(--space-6);

--- a/templates/base.html
+++ b/templates/base.html
@@ -20,11 +20,19 @@
 </head>
 <body>
     {% block header %}
-    <header>
-        <nav>
-            <a href="/">{{ config.title | default:"Home" }}</a>
-            <a href="/blog/">Blog</a>
-        </nav>
+    <header class="site-header">
+        <div class="container">
+            <a href="/" class="site-title">{{ config.title | default:"Home" }}</a>
+            <nav class="site-nav">
+                {% if config.nav %}
+                    {% for item in config.nav %}
+                <a href="{{ item.url }}"{% if item.external %} target="_blank" rel="noopener noreferrer"{% endif %}>{{ item.label }}</a>
+                    {% endfor %}
+                {% else %}
+                <a href="/blog/">Blog</a>
+                {% endif %}
+            </nav>
+        </div>
     </header>
     {% endblock %}
     
@@ -33,8 +41,14 @@
     </main>
     
     {% block footer %}
-    <footer>
-        <p>&copy; {{ "now" | date:"2006" }} {{ config.author | default:"" }}</p>
+    <footer class="site-footer">
+        <div class="container">
+            {% if config.footer.text %}
+            <p>{{ config.footer.text }}</p>
+            {% else %}
+            <p>&copy; {{ "now" | date:"2006" }} {{ config.author | default:"" }}. Built with <a href="https://github.com/WaylonWalker/markata-go">markata-go</a>.</p>
+            {% endif %}
+        </div>
     </footer>
     {% endblock %}
     


### PR DESCRIPTION
## Summary

Adds configurable navigation and footer to templates with proper centering.

- Add `NavItem` and `FooterConfig` types to models
- Update all config parsers (TOML/YAML/JSON) for nav/footer
- Add external link support with `target="_blank"` and `rel="noopener noreferrer"`
- Add `.post-list` gap for card spacing
- Center header/footer content with container wrapper

## Configuration Example

```toml
[[markata-go.nav]]
label = "Docs"
url = "/docs/"

[[markata-go.nav]]
label = "Blog"
url = "/blog/"

[[markata-go.nav]]
label = "GitHub"
url = "https://github.com/WaylonWalker/markata-go"
external = true

[markata-go.footer]
text = "Built with markata-go"
show_copyright = true
```

Fixes #10