### PR TITLE
Update installation docs and create install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ markata-go is a static site generator written in Go that processes Markdown file
 ### Quick Install (Recommended)
 
 ```bash
+# One-liner install script (Linux/macOS)
+curl -sSL https://waylonwalker.github.io/markata-go/install.sh | bash
+
 # Using jpillora/installer (Linux/macOS)
 curl -sL https://i.jpillora.com/WaylonWalker/markata-go | bash
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,28 +14,48 @@ tags:
 
 This guide will walk you through installing markata-go, creating your first site, and building it for production.
 
-## Prerequisites
-
-- **Go 1.22 or later** - [Download Go](https://go.dev/dl/)
-
-Verify your Go installation:
-
-```bash
-go version
-# go version go1.22.2 linux/amd64
-```
-
 ## Installation
 
-Install markata-go using `go install`:
+markata-go is distributed as a single binary with no dependencies. Choose the installation method that works best for you.
+
+### Quick Install (Recommended)
 
 ```bash
-go install github.com/example/markata-go/cmd/markata-go@latest
+# One-liner install script (Linux/macOS)
+curl -sSL https://waylonwalker.github.io/markata-go/install.sh | bash
+
+# Using jpillora/installer (Linux/macOS)
+curl -sL https://i.jpillora.com/WaylonWalker/markata-go | bash
+
+# Using eget
+eget WaylonWalker/markata-go
+
+# Using mise (installs from GitHub releases)
+mise use -g github:WaylonWalker/markata-go
 ```
 
-Verify the installation:
+### Go Install
+
+If you have Go 1.22+ installed:
 
 ```bash
+go install github.com/WaylonWalker/markata-go/cmd/markata-go@latest
+```
+
+Note: This installs to `$GOPATH/bin` (usually `~/go/bin`). Ensure this is in your `PATH`.
+
+### Manual Download
+
+Download pre-built binaries from [GitHub Releases](https://github.com/WaylonWalker/markata-go/releases).
+
+Available platforms: Linux (amd64, arm64, armv7), macOS (Intel, Apple Silicon), Windows (amd64), FreeBSD (amd64).
+
+See [Installation Guide](installation.md) for detailed installation instructions.
+
+### Verify Installation
+
+```bash
+markata-go version
 markata-go --help
 ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,6 +14,32 @@ markata-go is distributed as a single binary with no dependencies. Choose the in
 
 ## Quick Install (Recommended)
 
+### One-liner Install Script
+
+The easiest way to install markata-go on Linux and macOS:
+
+```bash
+curl -sSL https://waylonwalker.github.io/markata-go/install.sh | bash
+```
+
+This script:
+- Automatically detects your OS and architecture
+- Downloads the correct binary from GitHub releases
+- Installs to `/usr/local/bin` or `~/.local/bin`
+- Verifies the installation
+
+**Custom installation directory:**
+
+```bash
+INSTALL_DIR=/opt/bin curl -sSL https://waylonwalker.github.io/markata-go/install.sh | bash
+```
+
+**Install a specific version:**
+
+```bash
+VERSION=v0.1.0 curl -sSL https://waylonwalker.github.io/markata-go/install.sh | bash
+```
+
 ### Using jpillora/installer
 
 The fastest way to install on Linux and macOS:

--- a/static/install.sh
+++ b/static/install.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+# Install markata-go
+# Usage: curl -sSL https://waylonwalker.github.io/markata-go/install.sh | bash
+#
+# Environment variables:
+#   INSTALL_DIR - Installation directory (default: /usr/local/bin or ~/.local/bin)
+#   VERSION     - Specific version to install (default: latest)
+
+set -e
+
+REPO="WaylonWalker/markata-go"
+BINARY_NAME="markata-go"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+info() {
+    echo -e "${GREEN}==>${NC} $1"
+}
+
+warn() {
+    echo -e "${YELLOW}Warning:${NC} $1"
+}
+
+error() {
+    echo -e "${RED}Error:${NC} $1" >&2
+    exit 1
+}
+
+# Detect OS
+detect_os() {
+    OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+    case "$OS" in
+        linux) OS="linux" ;;
+        darwin) OS="darwin" ;;
+        freebsd) OS="freebsd" ;;
+        mingw*|msys*|cygwin*) OS="windows" ;;
+        *) error "Unsupported operating system: $OS" ;;
+    esac
+    echo "$OS"
+}
+
+# Detect architecture
+detect_arch() {
+    ARCH=$(uname -m)
+    case "$ARCH" in
+        x86_64|amd64) ARCH="amd64" ;;
+        aarch64|arm64) ARCH="arm64" ;;
+        armv7l|armv7) ARCH="armv7" ;;
+        *) error "Unsupported architecture: $ARCH" ;;
+    esac
+    echo "$ARCH"
+}
+
+# Determine install directory
+get_install_dir() {
+    if [ -n "$INSTALL_DIR" ]; then
+        echo "$INSTALL_DIR"
+        return
+    fi
+
+    # Try /usr/local/bin first if we have write access
+    if [ -w "/usr/local/bin" ]; then
+        echo "/usr/local/bin"
+    elif [ -d "$HOME/.local/bin" ] || mkdir -p "$HOME/.local/bin" 2>/dev/null; then
+        echo "$HOME/.local/bin"
+    else
+        error "Cannot determine install directory. Set INSTALL_DIR environment variable."
+    fi
+}
+
+# Get the latest release version from GitHub
+get_latest_version() {
+    if [ -n "$VERSION" ]; then
+        echo "$VERSION"
+        return
+    fi
+
+    # Try to get the latest release tag
+    local version
+    if command -v curl &> /dev/null; then
+        version=$(curl -sL "https://api.github.com/repos/$REPO/releases/latest" | grep '"tag_name"' | head -1 | cut -d'"' -f4)
+    elif command -v wget &> /dev/null; then
+        version=$(wget -qO- "https://api.github.com/repos/$REPO/releases/latest" | grep '"tag_name"' | head -1 | cut -d'"' -f4)
+    else
+        error "Neither curl nor wget found. Please install one of them."
+    fi
+
+    if [ -z "$version" ]; then
+        error "Could not determine latest version. Please set VERSION environment variable."
+    fi
+
+    echo "$version"
+}
+
+# Download and install
+install() {
+    local os=$(detect_os)
+    local arch=$(detect_arch)
+    local install_dir=$(get_install_dir)
+    local version=$(get_latest_version)
+
+    # Remove 'v' prefix for archive name if present
+    local version_num="${version#v}"
+
+    info "Installing $BINARY_NAME $version for $os/$arch"
+
+    # Construct download URL
+    # GoReleaser uses format: markata-go_0.1.0_linux_amd64.tar.gz
+    local archive_ext="tar.gz"
+    if [ "$os" = "windows" ]; then
+        archive_ext="zip"
+    fi
+
+    local archive_name="${BINARY_NAME}_${version_num}_${os}_${arch}.${archive_ext}"
+    local url="https://github.com/$REPO/releases/download/${version}/${archive_name}"
+
+    info "Downloading from $url"
+
+    # Create temp directory
+    local tmp_dir=$(mktemp -d)
+    trap "rm -rf $tmp_dir" EXIT
+
+    # Download
+    if command -v curl &> /dev/null; then
+        curl -sL "$url" -o "$tmp_dir/$archive_name" || error "Download failed. Check if the version exists."
+    elif command -v wget &> /dev/null; then
+        wget -q "$url" -O "$tmp_dir/$archive_name" || error "Download failed. Check if the version exists."
+    fi
+
+    # Verify download succeeded
+    if [ ! -f "$tmp_dir/$archive_name" ]; then
+        error "Download failed"
+    fi
+
+    # Extract
+    info "Extracting archive"
+    cd "$tmp_dir"
+    if [ "$archive_ext" = "zip" ]; then
+        unzip -q "$archive_name" || error "Extraction failed"
+    else
+        tar xzf "$archive_name" || error "Extraction failed"
+    fi
+
+    # Find the binary (it might be in the root or a subdirectory)
+    local binary_path
+    if [ -f "$BINARY_NAME" ]; then
+        binary_path="$BINARY_NAME"
+    elif [ -f "${BINARY_NAME}.exe" ]; then
+        binary_path="${BINARY_NAME}.exe"
+    else
+        error "Binary not found in archive"
+    fi
+
+    # Install
+    info "Installing to $install_dir"
+    if [ -w "$install_dir" ]; then
+        mv "$binary_path" "$install_dir/"
+        chmod +x "$install_dir/$BINARY_NAME"
+    else
+        warn "Need elevated permissions to install to $install_dir"
+        sudo mv "$binary_path" "$install_dir/"
+        sudo chmod +x "$install_dir/$BINARY_NAME"
+    fi
+
+    # Verify installation
+    if command -v "$BINARY_NAME" &> /dev/null; then
+        info "Successfully installed $BINARY_NAME"
+        echo ""
+        "$BINARY_NAME" version
+    else
+        warn "Installation complete, but $BINARY_NAME is not in PATH"
+        echo ""
+        echo "Add $install_dir to your PATH:"
+        echo "  export PATH=\"\$PATH:$install_dir\""
+        echo ""
+        echo "Then verify with:"
+        echo "  $BINARY_NAME version"
+    fi
+}
+
+# Run installation
+install


### PR DESCRIPTION
## Summary

- Update `docs/getting-started.md` to match README installation section (removes outdated `github.com/example/markata-go` path)
- Add one-liner curl install method to README and `docs/installation.md`
- Create `static/install.sh` that auto-detects OS/arch and downloads correct binary from GitHub releases

## Install Script Features

The new install script (`static/install.sh`):
- Detects OS (Linux, macOS, FreeBSD, Windows)
- Detects architecture (amd64, arm64, armv7)
- Downloads correct binary from GitHub releases
- Installs to `/usr/local/bin` or `~/.local/bin`
- Supports custom install directory via `INSTALL_DIR` env var
- Supports specific version via `VERSION` env var
- Handles both sudo and non-sudo installs
- Provides colored output and helpful error messages

## Usage

Once deployed, users can install with:
```bash
curl -sSL https://waylonwalker.github.io/markata-go/install.sh | bash
```

Or with options:
```bash
INSTALL_DIR=/opt/bin VERSION=v0.1.0 curl -sSL https://waylonwalker.github.io/markata-go/install.sh | bash
```

Fixes #12