### PR TITLE
feat: Add configuration wizard for existing projects

### DIFF
--- a/cmd/markata-go/cmd/init.go
+++ b/cmd/markata-go/cmd/init.go
@@ -220,8 +220,9 @@ func addFeatureTheme(reader *bufio.Reader, cfg *models.Config) error {
 	// List some available palettes
 	loader := palettes.NewLoader()
 	availablePalettes, err := loader.Discover()
-
-	if err == nil && len(availablePalettes) > 0 {
+	if err != nil {
+		fmt.Println("(Could not discover palettes, using default)")
+	} else if len(availablePalettes) > 0 {
 		fmt.Println("Available palettes:")
 		// Show a sample of palettes
 		shown := 0
@@ -659,46 +660,4 @@ func runInitCommand(_ *cobra.Command, _ []string) error {
 	fmt.Println()
 
 	return nil
-}
-
-// generateInitConfig creates a TOML config string from the provided values.
-// Deprecated: Use writeConfigTOML instead.
-func generateInitConfig(title, description, author, url string) string {
-	return fmt.Sprintf(`# Markata-go configuration file
-
-# Site metadata
-title = %q
-url = %q
-description = %q
-author = %q
-
-# Output settings
-output_dir = "output"
-templates_dir = "templates"
-assets_dir = "static"
-
-# File discovery
-[glob]
-patterns = ["**/*.md"]
-use_gitignore = true
-
-# Feed defaults
-[feed_defaults]
-items_per_page = 10
-orphan_threshold = 3
-
-[feed_defaults.formats]
-html = true
-rss = true
-atom = false
-json = false
-
-# Define custom feeds
-# [[feeds]]
-# slug = "blog"
-# title = "Blog Posts"
-# filter = "published == true"
-# sort = "date"
-# reverse = true
-`, title, url, description, author)
 }


### PR DESCRIPTION
## Summary

- Enhances the `init` command to detect existing projects and offer interactive configuration options
- Allows adding new features to existing configurations without manual file editing
- Provides automatic config backup before modifications

Fixes #25

## Changes

### New Functionality

When `markata-go init` detects an existing `markata-go.toml`:

1. **Add new features** - Interactive menu to configure:
   - Theme/Palette system (with palette suggestions from built-in palettes)
   - SEO metadata (Twitter handle, default OG image, logo URL)
   - Post output formats (markdown source, OG cards)
   - Advanced feeds (Atom, JSON Feed)

2. **Update site information** - Edit title, URL, description, author

3. **View current configuration** - Display all configured settings

### Safety Features

- Automatic backup of existing config before modifications
- Timestamped backups if previous backup exists
- Feature detection to avoid re-configuring already-enabled features

### New Project Enhancement

- New projects can now optionally configure additional features during initial setup

## User Flow Example

```
$ markata-go init

Found existing markata-go.toml

What would you like to do?
  1) Add new features
  2) Update site information
  3) View current configuration
  4) Exit

Enter choice [1]: 1

Select features to add (enter numbers separated by spaces):

  1) [ ] Theme/Palette system (color schemes)
  2) [ ] SEO metadata (Twitter, Open Graph)
  3) [ ] Post output formats (markdown source, OG cards)
  4) [ ] Advanced feeds (Atom, JSON Feed)

Enter numbers (e.g., 1 3): 2 3

SEO Configuration
-----------------
Twitter/X handle (without @): waylonwalker
Default Open Graph image URL: 
Site logo URL (for Schema.org): 

Post Output Formats
-------------------
Enable markdown source output? (y/N): y
Enable OG card output? (y/N): y

  Backed up config to markata-go.toml.backup
  Updated markata-go.toml with new features

Run 'markata-go build' to apply changes!
```

## Testing

- [x] `go build ./cmd/markata-go` succeeds
- [x] `go test ./...` passes
- [x] `go vet ./cmd/...` passes
- [x] `go fmt ./...` applied