### PR TITLE
feat: Add configurable layout components system

### DIFF
--- a/pkg/config/merge.go
+++ b/pkg/config/merge.go
@@ -75,6 +75,12 @@ func MergeConfigs(base, override *models.Config) *models.Config {
 	// PostFormats - merge if override has any formats enabled
 	result.PostFormats = mergePostFormatsConfig(base.PostFormats, override.PostFormats)
 
+	// SEO - merge
+	result.SEO = mergeSEOConfig(base.SEO, override.SEO)
+
+	// Components - merge
+	result.Components = mergeComponentsConfig(base.Components, override.Components)
+
 	return result
 }
 
@@ -266,4 +272,73 @@ func AppendGlobPatterns(config *models.Config, patterns ...string) {
 // AppendFeeds appends feeds to the configuration's Feeds slice.
 func AppendFeeds(config *models.Config, feeds ...models.FeedConfig) {
 	config.Feeds = MergeSlice(config.Feeds, feeds, true)
+}
+
+// mergeSEOConfig merges SEOConfig values.
+func mergeSEOConfig(base, override models.SEOConfig) models.SEOConfig {
+	result := base
+
+	if override.TwitterHandle != "" {
+		result.TwitterHandle = override.TwitterHandle
+	}
+	if override.DefaultImage != "" {
+		result.DefaultImage = override.DefaultImage
+	}
+	if override.LogoURL != "" {
+		result.LogoURL = override.LogoURL
+	}
+
+	return result
+}
+
+// mergeComponentsConfig merges ComponentsConfig values.
+func mergeComponentsConfig(base, override models.ComponentsConfig) models.ComponentsConfig {
+	result := base
+
+	// Merge Nav component
+	if override.Nav.Enabled != nil {
+		result.Nav.Enabled = override.Nav.Enabled
+	}
+	if override.Nav.Position != "" {
+		result.Nav.Position = override.Nav.Position
+	}
+	if override.Nav.Style != "" {
+		result.Nav.Style = override.Nav.Style
+	}
+	if len(override.Nav.Items) > 0 {
+		result.Nav.Items = override.Nav.Items
+	}
+
+	// Merge Footer component
+	if override.Footer.Enabled != nil {
+		result.Footer.Enabled = override.Footer.Enabled
+	}
+	if override.Footer.Text != "" {
+		result.Footer.Text = override.Footer.Text
+	}
+	if override.Footer.ShowCopyright != nil {
+		result.Footer.ShowCopyright = override.Footer.ShowCopyright
+	}
+	if len(override.Footer.Links) > 0 {
+		result.Footer.Links = override.Footer.Links
+	}
+
+	// Merge DocSidebar component
+	if override.DocSidebar.Enabled != nil {
+		result.DocSidebar.Enabled = override.DocSidebar.Enabled
+	}
+	if override.DocSidebar.Position != "" {
+		result.DocSidebar.Position = override.DocSidebar.Position
+	}
+	if override.DocSidebar.Width != "" {
+		result.DocSidebar.Width = override.DocSidebar.Width
+	}
+	if override.DocSidebar.MinDepth != 0 {
+		result.DocSidebar.MinDepth = override.DocSidebar.MinDepth
+	}
+	if override.DocSidebar.MaxDepth != 0 {
+		result.DocSidebar.MaxDepth = override.DocSidebar.MaxDepth
+	}
+
+	return result
 }

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -175,30 +175,6 @@ type tomlWebmentionConfig struct {
 	Endpoint string `toml:"endpoint"`
 }
 
-type tomlComponentsConfig struct {
-	Nav        tomlNavComponentConfig        `toml:"nav"`
-	Footer     tomlFooterComponentConfig     `toml:"footer"`
-	DocSidebar tomlDocSidebarComponentConfig `toml:"doc_sidebar"`
-}
-
-type tomlNavComponentConfig struct {
-	Enabled  *bool  `toml:"enabled"`
-	Position string `toml:"position"`
-	Style    string `toml:"style"`
-}
-
-type tomlFooterComponentConfig struct {
-	Enabled *bool  `toml:"enabled"`
-	Content string `toml:"content"`
-}
-
-type tomlDocSidebarComponentConfig struct {
-	Enabled  *bool  `toml:"enabled"`
-	Position string `toml:"position"`
-	MinDepth int    `toml:"min_depth"`
-	MaxDepth int    `toml:"max_depth"`
-}
-
 func (s *tomlSEOConfig) toSEOConfig() models.SEOConfig {
 	return models.SEOConfig{
 		TwitterHandle: s.TwitterHandle,
@@ -223,24 +199,75 @@ func (w *tomlWebmentionConfig) toWebmentionConfig() models.WebmentionConfig {
 	}
 }
 
+type tomlComponentsConfig struct {
+	Nav        tomlNavComponentConfig    `toml:"nav"`
+	Footer     tomlFooterComponentConfig `toml:"footer"`
+	DocSidebar tomlDocSidebarConfig      `toml:"doc_sidebar"`
+}
+
+type tomlNavComponentConfig struct {
+	Enabled  *bool         `toml:"enabled"`
+	Position string        `toml:"position"`
+	Style    string        `toml:"style"`
+	Items    []tomlNavItem `toml:"items"`
+}
+
+type tomlFooterComponentConfig struct {
+	Enabled       *bool         `toml:"enabled"`
+	Text          string        `toml:"text"`
+	ShowCopyright *bool         `toml:"show_copyright"`
+	Links         []tomlNavItem `toml:"links"`
+}
+
+type tomlDocSidebarConfig struct {
+	Enabled  *bool  `toml:"enabled"`
+	Position string `toml:"position"`
+	Width    string `toml:"width"`
+	MinDepth int    `toml:"min_depth"`
+	MaxDepth int    `toml:"max_depth"`
+}
+
+//nolint:dupl // Intentional duplication - each format has its own conversion method
 func (c *tomlComponentsConfig) toComponentsConfig() models.ComponentsConfig {
-	return models.ComponentsConfig{
+	config := models.ComponentsConfig{
 		Nav: models.NavComponentConfig{
 			Enabled:  c.Nav.Enabled,
 			Position: c.Nav.Position,
 			Style:    c.Nav.Style,
 		},
 		Footer: models.FooterComponentConfig{
-			Enabled: c.Footer.Enabled,
-			Content: c.Footer.Content,
+			Enabled:       c.Footer.Enabled,
+			Text:          c.Footer.Text,
+			ShowCopyright: c.Footer.ShowCopyright,
 		},
-		DocSidebar: models.DocSidebarComponentConfig{
+		DocSidebar: models.DocSidebarConfig{
 			Enabled:  c.DocSidebar.Enabled,
 			Position: c.DocSidebar.Position,
+			Width:    c.DocSidebar.Width,
 			MinDepth: c.DocSidebar.MinDepth,
 			MaxDepth: c.DocSidebar.MaxDepth,
 		},
 	}
+
+	// Convert nav items
+	for _, item := range c.Nav.Items {
+		config.Nav.Items = append(config.Nav.Items, models.NavItem{
+			Label:    item.Label,
+			URL:      item.URL,
+			External: item.External,
+		})
+	}
+
+	// Convert footer links
+	for _, link := range c.Footer.Links {
+		config.Footer.Links = append(config.Footer.Links, models.NavItem{
+			Label:    link.Label,
+			URL:      link.URL,
+			External: link.External,
+		})
+	}
+
+	return config
 }
 
 func (p *tomlPostFormatsConfig) toPostFormatsConfig() models.PostFormatsConfig {
@@ -412,8 +439,8 @@ type yamlConfig struct {
 	PostFormats   yamlPostFormatsConfig `yaml:"post_formats"`
 	IndieAuth     yamlIndieAuthConfig   `yaml:"indieauth"`
 	Webmention    yamlWebmentionConfig  `yaml:"webmention"`
-	Components    yamlComponentsConfig  `yaml:"components"`
 	SEO           yamlSEOConfig         `yaml:"seo"`
+	Components    yamlComponentsConfig  `yaml:"components"`
 }
 
 type yamlNavItem struct {
@@ -503,30 +530,6 @@ type yamlWebmentionConfig struct {
 	Endpoint string `yaml:"endpoint"`
 }
 
-type yamlComponentsConfig struct {
-	Nav        yamlNavComponentConfig        `yaml:"nav"`
-	Footer     yamlFooterComponentConfig     `yaml:"footer"`
-	DocSidebar yamlDocSidebarComponentConfig `yaml:"doc_sidebar"`
-}
-
-type yamlNavComponentConfig struct {
-	Enabled  *bool  `yaml:"enabled"`
-	Position string `yaml:"position"`
-	Style    string `yaml:"style"`
-}
-
-type yamlFooterComponentConfig struct {
-	Enabled *bool  `yaml:"enabled"`
-	Content string `yaml:"content"`
-}
-
-type yamlDocSidebarComponentConfig struct {
-	Enabled  *bool  `yaml:"enabled"`
-	Position string `yaml:"position"`
-	MinDepth int    `yaml:"min_depth"`
-	MaxDepth int    `yaml:"max_depth"`
-}
-
 func (s *yamlSEOConfig) toSEOConfig() models.SEOConfig {
 	return models.SEOConfig{
 		TwitterHandle: s.TwitterHandle,
@@ -551,24 +554,75 @@ func (w *yamlWebmentionConfig) toWebmentionConfig() models.WebmentionConfig {
 	}
 }
 
+type yamlComponentsConfig struct {
+	Nav        yamlNavComponentConfig    `yaml:"nav"`
+	Footer     yamlFooterComponentConfig `yaml:"footer"`
+	DocSidebar yamlDocSidebarConfig      `yaml:"doc_sidebar"`
+}
+
+type yamlNavComponentConfig struct {
+	Enabled  *bool         `yaml:"enabled"`
+	Position string        `yaml:"position"`
+	Style    string        `yaml:"style"`
+	Items    []yamlNavItem `yaml:"items"`
+}
+
+type yamlFooterComponentConfig struct {
+	Enabled       *bool         `yaml:"enabled"`
+	Text          string        `yaml:"text"`
+	ShowCopyright *bool         `yaml:"show_copyright"`
+	Links         []yamlNavItem `yaml:"links"`
+}
+
+type yamlDocSidebarConfig struct {
+	Enabled  *bool  `yaml:"enabled"`
+	Position string `yaml:"position"`
+	Width    string `yaml:"width"`
+	MinDepth int    `yaml:"min_depth"`
+	MaxDepth int    `yaml:"max_depth"`
+}
+
+//nolint:dupl // Intentional duplication - each format has its own conversion method
 func (c *yamlComponentsConfig) toComponentsConfig() models.ComponentsConfig {
-	return models.ComponentsConfig{
+	config := models.ComponentsConfig{
 		Nav: models.NavComponentConfig{
 			Enabled:  c.Nav.Enabled,
 			Position: c.Nav.Position,
 			Style:    c.Nav.Style,
 		},
 		Footer: models.FooterComponentConfig{
-			Enabled: c.Footer.Enabled,
-			Content: c.Footer.Content,
+			Enabled:       c.Footer.Enabled,
+			Text:          c.Footer.Text,
+			ShowCopyright: c.Footer.ShowCopyright,
 		},
-		DocSidebar: models.DocSidebarComponentConfig{
+		DocSidebar: models.DocSidebarConfig{
 			Enabled:  c.DocSidebar.Enabled,
 			Position: c.DocSidebar.Position,
+			Width:    c.DocSidebar.Width,
 			MinDepth: c.DocSidebar.MinDepth,
 			MaxDepth: c.DocSidebar.MaxDepth,
 		},
 	}
+
+	// Convert nav items
+	for _, item := range c.Nav.Items {
+		config.Nav.Items = append(config.Nav.Items, models.NavItem{
+			Label:    item.Label,
+			URL:      item.URL,
+			External: item.External,
+		})
+	}
+
+	// Convert footer links
+	for _, link := range c.Footer.Links {
+		config.Footer.Links = append(config.Footer.Links, models.NavItem{
+			Label:    link.Label,
+			URL:      link.URL,
+			External: link.External,
+		})
+	}
+
+	return config
 }
 
 func (p *yamlPostFormatsConfig) toPostFormatsConfig() models.PostFormatsConfig {
@@ -727,6 +781,7 @@ type jsonConfig struct {
 	IndieAuth     jsonIndieAuthConfig   `json:"indieauth"`
 	Webmention    jsonWebmentionConfig  `json:"webmention"`
 	SEO           jsonSEOConfig         `json:"seo"`
+	Components    jsonComponentsConfig  `json:"components"`
 }
 
 type jsonNavItem struct {
@@ -840,6 +895,77 @@ func (w *jsonWebmentionConfig) toWebmentionConfig() models.WebmentionConfig {
 	}
 }
 
+type jsonComponentsConfig struct {
+	Nav        jsonNavComponentConfig    `json:"nav"`
+	Footer     jsonFooterComponentConfig `json:"footer"`
+	DocSidebar jsonDocSidebarConfig      `json:"doc_sidebar"`
+}
+
+type jsonNavComponentConfig struct {
+	Enabled  *bool         `json:"enabled"`
+	Position string        `json:"position"`
+	Style    string        `json:"style"`
+	Items    []jsonNavItem `json:"items"`
+}
+
+type jsonFooterComponentConfig struct {
+	Enabled       *bool         `json:"enabled"`
+	Text          string        `json:"text"`
+	ShowCopyright *bool         `json:"show_copyright"`
+	Links         []jsonNavItem `json:"links"`
+}
+
+type jsonDocSidebarConfig struct {
+	Enabled  *bool  `json:"enabled"`
+	Position string `json:"position"`
+	Width    string `json:"width"`
+	MinDepth int    `json:"min_depth"`
+	MaxDepth int    `json:"max_depth"`
+}
+
+//nolint:dupl // Intentional duplication - each format has its own conversion method
+func (c *jsonComponentsConfig) toComponentsConfig() models.ComponentsConfig {
+	config := models.ComponentsConfig{
+		Nav: models.NavComponentConfig{
+			Enabled:  c.Nav.Enabled,
+			Position: c.Nav.Position,
+			Style:    c.Nav.Style,
+		},
+		Footer: models.FooterComponentConfig{
+			Enabled:       c.Footer.Enabled,
+			Text:          c.Footer.Text,
+			ShowCopyright: c.Footer.ShowCopyright,
+		},
+		DocSidebar: models.DocSidebarConfig{
+			Enabled:  c.DocSidebar.Enabled,
+			Position: c.DocSidebar.Position,
+			Width:    c.DocSidebar.Width,
+			MinDepth: c.DocSidebar.MinDepth,
+			MaxDepth: c.DocSidebar.MaxDepth,
+		},
+	}
+
+	// Convert nav items
+	for _, item := range c.Nav.Items {
+		config.Nav.Items = append(config.Nav.Items, models.NavItem{
+			Label:    item.Label,
+			URL:      item.URL,
+			External: item.External,
+		})
+	}
+
+	// Convert footer links
+	for _, link := range c.Footer.Links {
+		config.Footer.Links = append(config.Footer.Links, models.NavItem{
+			Label:    link.Label,
+			URL:      link.URL,
+			External: link.External,
+		})
+	}
+
+	return config
+}
+
 func (p *jsonPostFormatsConfig) toPostFormatsConfig() models.PostFormatsConfig {
 	return models.PostFormatsConfig{
 		HTML:     p.HTML,
@@ -899,6 +1025,9 @@ func (c *jsonConfig) toConfig() *models.Config {
 	// Convert IndieAuth and Webmention config
 	config.IndieAuth = c.IndieAuth.toIndieAuthConfig()
 	config.Webmention = c.Webmention.toWebmentionConfig()
+
+	// Convert components config
+	config.Components = c.Components.toComponentsConfig()
 
 	return config
 }

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -21,6 +21,118 @@ type FooterConfig struct {
 	ShowCopyright *bool `json:"show_copyright,omitempty" yaml:"show_copyright,omitempty" toml:"show_copyright,omitempty"`
 }
 
+// ComponentsConfig configures the layout components system.
+// This enables configuration-driven control over common UI elements.
+type ComponentsConfig struct {
+	// Nav configures the navigation component
+	Nav NavComponentConfig `json:"nav" yaml:"nav" toml:"nav"`
+
+	// Footer configures the footer component
+	Footer FooterComponentConfig `json:"footer" yaml:"footer" toml:"footer"`
+
+	// DocSidebar configures the document sidebar (table of contents)
+	DocSidebar DocSidebarConfig `json:"doc_sidebar" yaml:"doc_sidebar" toml:"doc_sidebar"`
+}
+
+// NavComponentConfig configures the navigation component.
+type NavComponentConfig struct {
+	// Enabled controls whether navigation is displayed (default: true)
+	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty" toml:"enabled,omitempty"`
+
+	// Position controls where navigation appears: "header", "sidebar" (default: "header")
+	Position string `json:"position,omitempty" yaml:"position,omitempty" toml:"position,omitempty"`
+
+	// Style controls the navigation style: "horizontal", "vertical" (default: "horizontal")
+	Style string `json:"style,omitempty" yaml:"style,omitempty" toml:"style,omitempty"`
+
+	// Items are the navigation links (overrides top-level nav if set)
+	Items []NavItem `json:"items,omitempty" yaml:"items,omitempty" toml:"items,omitempty"`
+}
+
+// FooterComponentConfig configures the footer component.
+type FooterComponentConfig struct {
+	// Enabled controls whether footer is displayed (default: true)
+	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty" toml:"enabled,omitempty"`
+
+	// Text is the footer text (supports template variables)
+	Text string `json:"text,omitempty" yaml:"text,omitempty" toml:"text,omitempty"`
+
+	// ShowCopyright shows the copyright line (default: true)
+	ShowCopyright *bool `json:"show_copyright,omitempty" yaml:"show_copyright,omitempty" toml:"show_copyright,omitempty"`
+
+	// Links are additional footer links
+	Links []NavItem `json:"links,omitempty" yaml:"links,omitempty" toml:"links,omitempty"`
+}
+
+// DocSidebarConfig configures the document sidebar (table of contents).
+type DocSidebarConfig struct {
+	// Enabled controls whether the TOC sidebar is displayed (default: false)
+	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty" toml:"enabled,omitempty"`
+
+	// Position controls sidebar position: "left", "right" (default: "right")
+	Position string `json:"position,omitempty" yaml:"position,omitempty" toml:"position,omitempty"`
+
+	// Width is the sidebar width (default: "250px")
+	Width string `json:"width,omitempty" yaml:"width,omitempty" toml:"width,omitempty"`
+
+	// MinDepth is the minimum heading level to include (default: 2)
+	MinDepth int `json:"min_depth,omitempty" yaml:"min_depth,omitempty" toml:"min_depth,omitempty"`
+
+	// MaxDepth is the maximum heading level to include (default: 4)
+	MaxDepth int `json:"max_depth,omitempty" yaml:"max_depth,omitempty" toml:"max_depth,omitempty"`
+}
+
+// NewComponentsConfig creates a new ComponentsConfig with default values.
+func NewComponentsConfig() ComponentsConfig {
+	navEnabled := true
+	footerEnabled := true
+	docSidebarEnabled := false
+	showCopyright := true
+
+	return ComponentsConfig{
+		Nav: NavComponentConfig{
+			Enabled:  &navEnabled,
+			Position: "header",
+			Style:    "horizontal",
+		},
+		Footer: FooterComponentConfig{
+			Enabled:       &footerEnabled,
+			ShowCopyright: &showCopyright,
+		},
+		DocSidebar: DocSidebarConfig{
+			Enabled:  &docSidebarEnabled,
+			Position: "right",
+			Width:    "250px",
+			MinDepth: 2,
+			MaxDepth: 4,
+		},
+	}
+}
+
+// IsNavEnabled returns whether navigation is enabled.
+func (c *ComponentsConfig) IsNavEnabled() bool {
+	if c.Nav.Enabled == nil {
+		return true
+	}
+	return *c.Nav.Enabled
+}
+
+// IsFooterEnabled returns whether footer is enabled.
+func (c *ComponentsConfig) IsFooterEnabled() bool {
+	if c.Footer.Enabled == nil {
+		return true
+	}
+	return *c.Footer.Enabled
+}
+
+// IsDocSidebarEnabled returns whether the document sidebar is enabled.
+func (c *ComponentsConfig) IsDocSidebarEnabled() bool {
+	if c.DocSidebar.Enabled == nil {
+		return false
+	}
+	return *c.DocSidebar.Enabled
+}
+
 // Config represents the site configuration for markata-go.
 type Config struct {
 	// OutputDir is the directory where generated files are written (default: "output")
@@ -396,107 +508,6 @@ func NewWebmentionConfig() WebmentionConfig {
 	return WebmentionConfig{
 		Enabled:  false,
 		Endpoint: "",
-	}
-}
-
-// ComponentsConfig configures layout components.
-// This allows users to customize navigation, footer, and sidebar behavior.
-type ComponentsConfig struct {
-	// Nav configures the navigation component
-	Nav NavComponentConfig `json:"nav" yaml:"nav" toml:"nav"`
-
-	// Footer configures the footer component
-	Footer FooterComponentConfig `json:"footer" yaml:"footer" toml:"footer"`
-
-	// DocSidebar configures the documentation sidebar component
-	DocSidebar DocSidebarComponentConfig `json:"doc_sidebar" yaml:"doc_sidebar" toml:"doc_sidebar"`
-}
-
-// NavComponentConfig configures the navigation component.
-type NavComponentConfig struct {
-	// Enabled controls whether the nav component is rendered (default: true)
-	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty" toml:"enabled,omitempty"`
-
-	// Position is where the nav is rendered: "header" or "sidebar" (default: "header")
-	Position string `json:"position" yaml:"position" toml:"position"`
-
-	// Style is the nav style: "horizontal" or "vertical" (default: "horizontal")
-	Style string `json:"style" yaml:"style" toml:"style"`
-}
-
-// IsEnabled returns whether the nav component is enabled.
-// Defaults to true if not explicitly set.
-func (n *NavComponentConfig) IsEnabled() bool {
-	if n.Enabled == nil {
-		return true
-	}
-	return *n.Enabled
-}
-
-// FooterComponentConfig configures the footer component.
-type FooterComponentConfig struct {
-	// Enabled controls whether the footer component is rendered (default: true)
-	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty" toml:"enabled,omitempty"`
-
-	// Content is custom footer content (supports template variables)
-	Content string `json:"content,omitempty" yaml:"content,omitempty" toml:"content,omitempty"`
-}
-
-// IsEnabled returns whether the footer component is enabled.
-// Defaults to true if not explicitly set.
-func (f *FooterComponentConfig) IsEnabled() bool {
-	if f.Enabled == nil {
-		return true
-	}
-	return *f.Enabled
-}
-
-// DocSidebarComponentConfig configures the documentation sidebar component.
-// The sidebar displays a table of contents for the current page.
-type DocSidebarComponentConfig struct {
-	// Enabled controls whether the doc sidebar is rendered (default: false)
-	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty" toml:"enabled,omitempty"`
-
-	// Position is where the sidebar is rendered: "left" or "right" (default: "right")
-	Position string `json:"position" yaml:"position" toml:"position"`
-
-	// MinDepth is the minimum heading level to include (default: 2)
-	MinDepth int `json:"min_depth" yaml:"min_depth" toml:"min_depth"`
-
-	// MaxDepth is the maximum heading level to include (default: 4)
-	MaxDepth int `json:"max_depth" yaml:"max_depth" toml:"max_depth"`
-}
-
-// IsEnabled returns whether the doc sidebar component is enabled.
-// Defaults to false if not explicitly set (requires opt-in).
-func (d *DocSidebarComponentConfig) IsEnabled() bool {
-	if d.Enabled == nil {
-		return false
-	}
-	return *d.Enabled
-}
-
-// NewComponentsConfig creates a new ComponentsConfig with default values.
-func NewComponentsConfig() ComponentsConfig {
-	navEnabled := true
-	footerEnabled := true
-	sidebarEnabled := false
-	return ComponentsConfig{
-		Nav: NavComponentConfig{
-			Enabled:  &navEnabled,
-			Position: "header",
-			Style:    "horizontal",
-		},
-		Footer: FooterComponentConfig{
-			Enabled: &footerEnabled,
-			Content: "",
-		},
-		DocSidebar: DocSidebarComponentConfig{
-			Enabled:  &sidebarEnabled,
-			Position: "right",
-			MinDepth: 2,
-			MaxDepth: 4,
-		},
 	}
 }
 

--- a/pkg/templates/context.go
+++ b/pkg/templates/context.go
@@ -183,6 +183,9 @@ func configToMap(c *models.Config) map[string]interface{} {
 		"endpoint": c.Webmention.Endpoint,
 	}
 
+	// Convert components to map
+	componentsMap := componentsToMap(&c.Components)
+
 	return map[string]interface{}{
 		"output_dir":    c.OutputDir,
 		"url":           c.URL,
@@ -196,6 +199,77 @@ func configToMap(c *models.Config) map[string]interface{} {
 		"seo":           seoMap,
 		"indieauth":     indieAuthMap,
 		"webmention":    webmentionMap,
+		"components":    componentsMap,
+	}
+}
+
+// componentsToMap converts a ComponentsConfig to a map for template access.
+func componentsToMap(c *models.ComponentsConfig) map[string]interface{} {
+	if c == nil {
+		return nil
+	}
+
+	// Convert nav component
+	navEnabled := true
+	if c.Nav.Enabled != nil {
+		navEnabled = *c.Nav.Enabled
+	}
+	navItems := make([]map[string]interface{}, len(c.Nav.Items))
+	for i, item := range c.Nav.Items {
+		navItems[i] = map[string]interface{}{
+			"label":    item.Label,
+			"url":      item.URL,
+			"external": item.External,
+		}
+	}
+	navMap := map[string]interface{}{
+		"enabled":  navEnabled,
+		"position": c.Nav.Position,
+		"style":    c.Nav.Style,
+		"items":    navItems,
+	}
+
+	// Convert footer component
+	footerEnabled := true
+	if c.Footer.Enabled != nil {
+		footerEnabled = *c.Footer.Enabled
+	}
+	showCopyright := true
+	if c.Footer.ShowCopyright != nil {
+		showCopyright = *c.Footer.ShowCopyright
+	}
+	footerLinks := make([]map[string]interface{}, len(c.Footer.Links))
+	for i, link := range c.Footer.Links {
+		footerLinks[i] = map[string]interface{}{
+			"label":    link.Label,
+			"url":      link.URL,
+			"external": link.External,
+		}
+	}
+	footerMap := map[string]interface{}{
+		"enabled":        footerEnabled,
+		"text":           c.Footer.Text,
+		"show_copyright": showCopyright,
+		"links":          footerLinks,
+	}
+
+	// Convert doc_sidebar component
+	docSidebarEnabled := false
+	if c.DocSidebar.Enabled != nil {
+		docSidebarEnabled = *c.DocSidebar.Enabled
+	}
+	docSidebarMap := map[string]interface{}{
+		"enabled":   docSidebarEnabled,
+		"position":  c.DocSidebar.Position,
+		"width":     c.DocSidebar.Width,
+		"min_depth": c.DocSidebar.MinDepth,
+		"max_depth": c.DocSidebar.MaxDepth,
+	}
+
+	return map[string]interface{}{
+		"nav":         navMap,
+		"footer":      footerMap,
+		"doc_sidebar": docSidebarMap,
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements Phase 1 of the layout components system (#29) - configuration-driven component control.

### Changes
- Add `ComponentsConfig` with Nav, Footer, and DocSidebar sub-configs
- Each component has enabled/position/style options
- Support all three config formats (TOML, YAML, JSON)
- Add merge logic for deep merging component configs
- Expose components to templates via `config.components`
- Add helper methods for checking enabled state (`IsNavEnabled()`, `IsFooterEnabled()`, `IsDocSidebarEnabled()`)

### Example Configuration

```toml
[components.nav]
enabled = true
position = "header"
style = "horizontal"
items = [
  { label = "Home", url = "/" },
  { label = "Blog", url = "/blog/" }
]

[components.footer]
enabled = true
text = "© 2024 My Site"
show_copyright = true

[components.doc_sidebar]
enabled = false
position = "right"
width = "250px"
min_depth = 2
max_depth = 4
```

### Template Access

```html
{% if config.components.nav.enabled %}
  <nav>
    {% for item in config.components.nav.items %}
      <a href="{{ item.url }}">{{ item.label }}</a>
    {% endfor %}
  </nav>
{% endif %}
```

### Next Steps (Future PRs)
- Phase 2: Feed sidebar and document TOC with heading extraction
- Phase 3: Component template override system and frontmatter control

Fixes #29