### PR TITLE
fix: resolve missing tooltips.js 404 error

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -139,6 +139,6 @@
     {% endblock %}
     
     {% block scripts %}{% endblock %}
-    <script src="/static/js/tooltips.js" defer></script>
+    <script src="{{ 'js/tooltips.js' | theme_asset }}" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Fixes the 404 error for tooltips.js that occurred due to two separate issues.

Fixes #44

## Root Cause

1. **Template path was wrong**: `templates/base.html` referenced `/static/js/tooltips.js` but static assets are output to `/js/`, not `/static/js/`

2. **Incomplete theme override issue**: When a filesystem theme exists (even if incomplete), the StaticAssetsPlugin was skipping all embedded files. This meant the JS files only present in the embedded theme were never copied.

## Changes

### `templates/base.html`
- Changed `<script src="/static/js/tooltips.js">` to use the `theme_asset` filter for consistency: `<script src="{{ 'js/tooltips.js' | theme_asset }}">`

### `pkg/plugins/static_assets.go`
- Changed from "either/or" logic to a layered approach:
  1. **Layer 1**: Copy embedded static files (base layer for default theme)
  2. **Layer 2**: Copy filesystem theme files (overrides embedded)
  3. **Layer 3**: Copy project static files (highest priority)

This ensures all default theme assets are present even when users have a partial filesystem theme.

## Testing

```bash
go test ./...  # All tests pass
go run ./cmd/markata-go build  # Build succeeds
ls public/js/tooltips.js  # File now exists
grep "tooltips.js" public/hello-world/index.html  # References /js/tooltips.js
```