### PR TITLE
fix: resolve lint errors in config parser and plugins

### DIFF
--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -633,6 +633,7 @@ func (p *yamlPostFormatsConfig) toPostFormatsConfig() models.PostFormatsConfig {
 	}
 }
 
+//nolint:dupl // Intentional duplication - each format (YAML/JSON/TOML) has its own conversion method
 func (c *yamlConfig) toConfig() *models.Config {
 	config := &models.Config{
 		OutputDir:     c.OutputDir,
@@ -974,6 +975,7 @@ func (p *jsonPostFormatsConfig) toPostFormatsConfig() models.PostFormatsConfig {
 	}
 }
 
+//nolint:dupl // Intentional duplication - each format (YAML/JSON/TOML) has its own conversion method
 func (c *jsonConfig) toConfig() *models.Config {
 	config := &models.Config{
 		OutputDir:     c.OutputDir,

--- a/pkg/plugins/load.go
+++ b/pkg/plugins/load.go
@@ -225,9 +225,18 @@ func normalizeDateString(s string) string {
 	s = timeFixRegex.ReplaceAllStringFunc(s, func(match string) string {
 		parts := timeFixRegex.FindStringSubmatch(match)
 		if len(parts) == 4 {
-			h, _ := strconv.Atoi(parts[1])
-			m, _ := strconv.Atoi(parts[2])
-			sec, _ := strconv.Atoi(parts[3])
+			h, err := strconv.Atoi(parts[1])
+			if err != nil {
+				return match
+			}
+			m, err := strconv.Atoi(parts[2])
+			if err != nil {
+				return match
+			}
+			sec, err := strconv.Atoi(parts[3])
+			if err != nil {
+				return match
+			}
 			return fmt.Sprintf("%02d:%02d:%02d", h, m, sec)
 		}
 		return match
@@ -239,7 +248,7 @@ func normalizeDateString(s string) string {
 	s = singleDigitHourRegex.ReplaceAllString(s, "${1}0${2}:${3}")
 
 	// Handle time at start of string or after date with space
-	if matched, _ := regexp.MatchString(`^\d:\d{2}`, s); matched {
+	if matched, err := regexp.MatchString(`^\d:\d{2}`, s); err == nil && matched {
 		s = "0" + s
 	}
 

--- a/pkg/plugins/publish_feeds.go
+++ b/pkg/plugins/publish_feeds.go
@@ -113,7 +113,8 @@ func (p *PublishFeedsPlugin) publishFeed(fc *models.FeedConfig, config *lifecycl
 
 // publishHTMLPages publishes HTML pages for a paginated feed.
 func (p *PublishFeedsPlugin) publishHTMLPages(fc *models.FeedConfig, config *lifecycle.Config, feedDir string) error {
-	for _, page := range fc.Pages {
+	for i := range fc.Pages {
+		page := &fc.Pages[i]
 		// Determine output path
 		var pagePath string
 		if page.Number == 1 {
@@ -127,7 +128,7 @@ func (p *PublishFeedsPlugin) publishHTMLPages(fc *models.FeedConfig, config *lif
 		}
 
 		// Generate HTML content
-		html, err := p.generateFeedPageHTML(fc, &page, config)
+		html, err := p.generateFeedPageHTML(fc, page, config)
 		if err != nil {
 			return fmt.Errorf("generating page %d: %w", page.Number, err)
 		}


### PR DESCRIPTION
## Summary

Fixes pre-existing lint errors that were blocking CI:

- Add `nolint:dupl` directive for intentional YAML/JSON config `toConfig()` duplication (each config format has its own conversion method by design)
- Fix unchecked error returns in date normalization (`load.go`)
- Fix `rangeValCopy` in `publishHTMLPages` by using index iteration instead of value copy

## Context

These lint errors were pre-existing and affecting all CI runs. Fixing them will unblock other PRs.