### PR TITLE
feat: implement shadow pages - render unpublished posts

### DIFF
--- a/docs/guides/frontmatter.md
+++ b/docs/guides/frontmatter.md
@@ -192,7 +192,20 @@ published: true
 
 - **Type:** boolean
 - **Default:** `false`
-- **Used for:** Filtering posts in feeds
+- **Used for:** Filtering posts in feeds, sitemaps, and RSS
+
+**Shadow Pages:** Posts with `published: false` are still rendered to HTML and accessible via direct URL. They become "shadow pages" - accessible but not discoverable through normal site navigation.
+
+| `published` | Behavior |
+|-------------|----------|
+| `true` | Rendered + included in feeds, sitemaps, RSS |
+| `false` | Rendered as "shadow page" + NOT in feeds, sitemaps, RSS |
+
+**Use cases for shadow pages:**
+- Draft content accessible to reviewers via direct URL
+- Private documentation not linked publicly
+- Work-in-progress content shared with specific people
+- Admin pages or staging content
 
 **Accepted values:**
 
@@ -203,7 +216,7 @@ published: false   # or: no, off
 
 ### draft (boolean)
 
-Marks the post as a work-in-progress.
+Marks the post as a work-in-progress that should NOT be rendered at all.
 
 ```yaml
 draft: true
@@ -211,9 +224,22 @@ draft: true
 
 - **Type:** boolean
 - **Default:** `false`
-- **Used for:** Filtering, visual indicators in templates
+- **Used for:** Truly private content that shouldn't be accessible
 
-**Note:** `draft: true` doesn't automatically exclude posts from builds. Use `published: false` or feed filters to exclude drafts.
+**Important:** Posts with `draft: true` are **never rendered** to HTML. Use this for content you don't want accessible at all, even via direct URL.
+
+| `draft` | Behavior |
+|---------|----------|
+| `false` | Content is rendered (visibility depends on `published`) |
+| `true` | Content is NOT rendered at all |
+
+**Comparison with `published`:**
+
+| Scenario | `published` | `draft` | Rendered? | In Feeds? |
+|----------|-------------|---------|-----------|-----------|
+| Public post | `true` | `false` | Yes | Yes |
+| Shadow page | `false` | `false` | Yes | No |
+| Private WIP | any | `true` | No | No |
 
 ### tags (list)
 

--- a/pkg/plugins/publish_html.go
+++ b/pkg/plugins/publish_html.go
@@ -47,21 +47,22 @@ func (p *PublishHTMLPlugin) Write(m *lifecycle.Manager) error {
 }
 
 // writePost writes a single post to its output location in all enabled formats.
+// Shadow pages: Unpublished posts are still rendered but not included in feeds.
+// This allows sharing draft content via direct URL while keeping it out of public listings.
 func (p *PublishHTMLPlugin) writePost(post *models.Post, config *lifecycle.Config) error {
 	// Skip posts marked as skip
 	if post.Skip {
 		return nil
 	}
 
-	// Skip unpublished posts
-	if !post.Published {
-		return nil
-	}
-
-	// Skip drafts
+	// Skip drafts - these are truly private work-in-progress content
 	if post.Draft {
 		return nil
 	}
+
+	// Note: Unpublished posts (published: false) are still rendered as "shadow pages"
+	// They won't appear in feeds (which filter by published == True) but can be
+	// accessed via direct URL for review/sharing purposes.
 
 	// Determine output path
 	// Use the slug to create: output_dir/slug/index.html

--- a/pkg/plugins/publish_html_test.go
+++ b/pkg/plugins/publish_html_test.go
@@ -1,0 +1,169 @@
+package plugins
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
+	"github.com/WaylonWalker/markata-go/pkg/models"
+)
+
+// TestPublishHTMLPlugin_ShadowPages tests that unpublished posts are rendered as shadow pages.
+func TestPublishHTMLPlugin_ShadowPages(t *testing.T) {
+	tests := []struct {
+		name          string
+		post          *models.Post
+		wantRendered  bool
+		wantInSitemap bool
+	}{
+		{
+			name: "published post is rendered",
+			post: &models.Post{
+				Path:        "published.md",
+				Slug:        "published-post",
+				HTML:        "<p>Published content</p>",
+				Published:   true,
+				Draft:       false,
+				Skip:        false,
+				ArticleHTML: "<p>Published content</p>",
+			},
+			wantRendered:  true,
+			wantInSitemap: true,
+		},
+		{
+			name: "unpublished post is rendered as shadow page",
+			post: &models.Post{
+				Path:        "unpublished.md",
+				Slug:        "shadow-post",
+				HTML:        "<p>Shadow content</p>",
+				Published:   false,
+				Draft:       false,
+				Skip:        false,
+				ArticleHTML: "<p>Shadow content</p>",
+			},
+			wantRendered:  true,
+			wantInSitemap: false,
+		},
+		{
+			name: "draft post is not rendered",
+			post: &models.Post{
+				Path:        "draft.md",
+				Slug:        "draft-post",
+				HTML:        "<p>Draft content</p>",
+				Published:   false,
+				Draft:       true,
+				Skip:        false,
+				ArticleHTML: "<p>Draft content</p>",
+			},
+			wantRendered:  false,
+			wantInSitemap: false,
+		},
+		{
+			name: "skipped post is not rendered",
+			post: &models.Post{
+				Path:        "skipped.md",
+				Slug:        "skipped-post",
+				HTML:        "<p>Skipped content</p>",
+				Published:   true,
+				Draft:       false,
+				Skip:        true,
+				ArticleHTML: "<p>Skipped content</p>",
+			},
+			wantRendered:  false,
+			wantInSitemap: false,
+		},
+		{
+			name: "published draft is not rendered",
+			post: &models.Post{
+				Path:        "published-draft.md",
+				Slug:        "published-draft",
+				HTML:        "<p>Published draft content</p>",
+				Published:   true,
+				Draft:       true,
+				Skip:        false,
+				ArticleHTML: "<p>Published draft content</p>",
+			},
+			wantRendered:  false,
+			wantInSitemap: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temp directory
+			tempDir := t.TempDir()
+
+			// Create plugin
+			plugin := NewPublishHTMLPlugin()
+
+			// Create config
+			config := &lifecycle.Config{
+				OutputDir: tempDir,
+				Extra:     make(map[string]interface{}),
+			}
+
+			// Write post
+			err := plugin.writePost(tt.post, config)
+			if err != nil {
+				t.Fatalf("writePost() error = %v", err)
+			}
+
+			// Check if file was created
+			outputPath := filepath.Join(tempDir, tt.post.Slug, "index.html")
+			_, statErr := os.Stat(outputPath)
+			wasRendered := statErr == nil
+
+			if wasRendered != tt.wantRendered {
+				t.Errorf("post rendered = %v, want %v", wasRendered, tt.wantRendered)
+			}
+		})
+	}
+}
+
+// TestPublishHTMLPlugin_ShadowPagesDocumentation tests the expected behavior is documented.
+func TestPublishHTMLPlugin_ShadowPagesDocumentation(t *testing.T) {
+	// This test documents the shadow pages behavior:
+	// - published: true → rendered + in feeds + in sitemap
+	// - published: false → rendered (shadow page) + NOT in feeds + NOT in sitemap
+	// - draft: true → NOT rendered (regardless of published status)
+	// - skip: true → NOT rendered (regardless of published status)
+
+	tempDir := t.TempDir()
+	plugin := NewPublishHTMLPlugin()
+	config := &lifecycle.Config{
+		OutputDir: tempDir,
+		Extra:     make(map[string]interface{}),
+	}
+
+	// Shadow page scenario
+	shadowPost := &models.Post{
+		Path:        "shadow.md",
+		Slug:        "shadow-page",
+		HTML:        "<html><body>Shadow content accessible via direct URL</body></html>",
+		Published:   false, // Not in feeds
+		Draft:       false, // Not a draft, so it will be rendered
+		Skip:        false,
+		ArticleHTML: "<p>Shadow content accessible via direct URL</p>",
+	}
+
+	if err := plugin.writePost(shadowPost, config); err != nil {
+		t.Fatalf("writePost() error = %v", err)
+	}
+
+	// Verify shadow page was created
+	outputPath := filepath.Join(tempDir, "shadow-page", "index.html")
+	if _, err := os.Stat(outputPath); os.IsNotExist(err) {
+		t.Error("Shadow page should be rendered even though published=false")
+	}
+
+	// Read and verify content
+	content, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("failed to read shadow page: %v", err)
+	}
+
+	if len(content) == 0 {
+		t.Error("Shadow page content should not be empty")
+	}
+}

--- a/spec/spec/DATA_MODEL.md
+++ b/spec/spec/DATA_MODEL.md
@@ -34,9 +34,9 @@ These fields SHOULD be supported:
 |-------|------|---------|-------------|
 | `title` | string? | null | Content title |
 | `date` | date? | null | Publication date |
-| `published` | bool | false | Is publicly visible |
-| `draft` | bool | false | Is a draft |
-| `skip` | bool | false | Skip during build |
+| `published` | bool | false | Include in feeds (shadow pages if false) |
+| `draft` | bool | false | Work-in-progress (not rendered) |
+| `skip` | bool | false | Skip during build (not rendered) |
 | `tags` | string[] | [] | Content tags/categories |
 | `description` | string? | null | Summary/excerpt |
 | `template` | string | "post.html" | Template to render with |
@@ -45,6 +45,49 @@ These fields SHOULD be supported:
 | `article_html` | string? | null | Rendered content (without template) |
 
 ### Field Behaviors
+
+#### `published` - Shadow Pages
+
+Controls whether content appears in feeds, sitemaps, and RSS. **All non-draft, non-skip content is rendered regardless of published status.**
+
+| `published` | `draft` | Behavior |
+|-------------|---------|----------|
+| `true` | `false` | Rendered + in feeds + in sitemap |
+| `false` | `false` | Rendered as "shadow page" + NOT in feeds + NOT in sitemap |
+| any | `true` | NOT rendered (draft is for private WIP) |
+
+**Shadow Pages** are posts with `published: false` that are:
+- **Rendered** to HTML and accessible via direct URL
+- **Excluded** from feeds, sitemaps, and RSS
+- **Not discoverable** through normal site navigation
+
+**Use cases for shadow pages:**
+- Draft content accessible to reviewers via direct URL
+- Private documentation not linked publicly
+- Work-in-progress shared with specific people
+- Admin pages or development tools
+- Staging versions of pages
+
+**Example:**
+```yaml
+---
+title: "Draft Post - For Review"
+published: false  # Renders to /draft-post/, but not in feeds
+---
+This content is accessible at /draft-post/ but won't appear in 
+the blog feed or sitemap.
+```
+
+#### `draft` - True Private Content
+
+Posts with `draft: true` are **never rendered** regardless of other settings. Use this for truly private work-in-progress content that should not be accessible at all.
+
+```yaml
+---
+title: "Very Early Draft"
+draft: true  # Will NOT be rendered at all
+---
+```
 
 #### `config_overrides`
 


### PR DESCRIPTION
## Summary

Implements shadow pages feature: posts with `published: false` are now rendered as "shadow pages" that are accessible via direct URL but excluded from feeds, sitemaps, and RSS.

## Changes

- **pkg/plugins/publish_html.go**: Remove check that skipped unpublished posts. Now all non-draft, non-skip posts are rendered.
- **pkg/plugins/publish_html_test.go**: Add comprehensive tests for shadow page behavior
- **spec/spec/DATA_MODEL.md**: Document shadow pages behavior in spec
- **docs/guides/frontmatter.md**: Update user documentation with shadow pages explanation

## Behavior Summary

| `published` | `draft` | Rendered? | In Feeds? |
|-------------|---------|-----------|-----------|
| `true` | `false` | Yes | Yes |
| `false` | `false` | Yes (shadow page) | No |
| any | `true` | No | No |

## Use Cases

- Draft content accessible to reviewers via direct URL
- Private documentation not linked publicly  
- Work-in-progress content shared with specific people
- Admin pages or staging content

## Testing

All tests pass:
```
go test ./... 
```

Fixes #39