### PR TITLE
fix: use CSS classes instead of inline styles for syntax highlighting

### DIFF
--- a/pkg/plugins/chroma_css.go
+++ b/pkg/plugins/chroma_css.go
@@ -1,0 +1,164 @@
+// Package plugins provides lifecycle plugins for markata-go.
+package plugins
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/alecthomas/chroma/v2"
+	chromahtml "github.com/alecthomas/chroma/v2/formatters/html"
+	"github.com/alecthomas/chroma/v2/styles"
+
+	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
+	"github.com/WaylonWalker/markata-go/pkg/palettes"
+)
+
+// ChromaCSSPlugin generates CSS for syntax highlighting from Chroma themes.
+// It runs during the Write stage and creates css/chroma.css with the
+// syntax highlighting styles that correspond to the configured theme.
+//
+// This plugin works in conjunction with RenderMarkdownPlugin which uses
+// CSS classes for syntax highlighting (via WithClasses option).
+type ChromaCSSPlugin struct {
+	chromaTheme string
+}
+
+// NewChromaCSSPlugin creates a new ChromaCSSPlugin.
+func NewChromaCSSPlugin() *ChromaCSSPlugin {
+	return &ChromaCSSPlugin{
+		chromaTheme: palettes.DefaultChromaThemeDark,
+	}
+}
+
+// Name returns the unique name of the plugin.
+func (p *ChromaCSSPlugin) Name() string {
+	return "chroma_css"
+}
+
+// Configure reads the highlight theme configuration.
+func (p *ChromaCSSPlugin) Configure(m *lifecycle.Manager) error {
+	config := m.Config()
+	extra := config.Extra
+
+	// Try to get explicit highlight config from markdown.highlight.theme
+	if markdown, ok := extra["markdown"].(map[string]interface{}); ok {
+		if highlight, ok := markdown["highlight"].(map[string]interface{}); ok {
+			if theme, ok := highlight["theme"].(string); ok && theme != "" {
+				p.chromaTheme = theme
+				return nil
+			}
+		}
+	}
+
+	// Derive from palette if not explicitly set
+	paletteName := p.getPaletteName(extra)
+	if paletteName != "" {
+		chromaTheme := palettes.ChromaTheme(paletteName)
+		if chromaTheme != "" {
+			p.chromaTheme = chromaTheme
+			return nil
+		}
+
+		// Fallback based on variant
+		variant := p.getPaletteVariant(paletteName)
+		p.chromaTheme = palettes.ChromaThemeForVariant(variant)
+	}
+
+	return nil
+}
+
+// Write generates the Chroma CSS file.
+func (p *ChromaCSSPlugin) Write(m *lifecycle.Manager) error {
+	config := m.Config()
+	outputDir := config.OutputDir
+
+	// Get the style
+	style := styles.Get(p.chromaTheme)
+	if style == nil {
+		style = styles.Fallback
+	}
+
+	// Generate CSS using Chroma's formatter
+	css, err := p.generateCSS(style)
+	if err != nil {
+		return fmt.Errorf("generating chroma CSS: %w", err)
+	}
+
+	// Write to output directory
+	cssDir := filepath.Join(outputDir, "css")
+	if err := os.MkdirAll(cssDir, 0o755); err != nil {
+		return fmt.Errorf("creating css directory: %w", err)
+	}
+
+	cssPath := filepath.Join(cssDir, "chroma.css")
+	//nolint:gosec // G306: chroma.css is a public CSS file, 0644 is appropriate
+	if err := os.WriteFile(cssPath, []byte(css), 0o644); err != nil {
+		return fmt.Errorf("writing chroma CSS: %w", err)
+	}
+
+	return nil
+}
+
+// generateCSS creates CSS from a Chroma style.
+func (p *ChromaCSSPlugin) generateCSS(style *chroma.Style) (string, error) {
+	formatter := chromahtml.New(chromahtml.WithClasses(true), chromahtml.WithAllClasses(true))
+
+	var sb strings.Builder
+	sb.WriteString("/* Syntax highlighting - generated from Chroma theme: ")
+	sb.WriteString(p.chromaTheme)
+	sb.WriteString(" */\n\n")
+
+	// Write the CSS for the style
+	if err := formatter.WriteCSS(&sb, style); err != nil {
+		return "", err
+	}
+
+	return sb.String(), nil
+}
+
+// getPaletteName extracts the palette name from config.Extra.
+func (p *ChromaCSSPlugin) getPaletteName(extra map[string]interface{}) string {
+	if extra == nil {
+		return ""
+	}
+
+	if theme, ok := extra["theme"].(map[string]interface{}); ok {
+		if palette, ok := theme["palette"].(string); ok && palette != "" {
+			return palette
+		}
+	}
+
+	return ""
+}
+
+// getPaletteVariant determines the variant (light/dark) of a palette by name.
+func (p *ChromaCSSPlugin) getPaletteVariant(paletteName string) palettes.Variant {
+	lightPatterns := []string{
+		"-light", "-latte", "-dawn", "-day", "-lotus",
+	}
+	for _, pattern := range lightPatterns {
+		if strings.Contains(paletteName, pattern) {
+			return palettes.VariantLight
+		}
+	}
+	return palettes.VariantDark
+}
+
+// Priority returns the plugin priority for the write stage.
+// Should run after static_assets so it can add to the css directory.
+func (p *ChromaCSSPlugin) Priority(stage lifecycle.Stage) int {
+	if stage == lifecycle.StageWrite {
+		return lifecycle.PriorityDefault // After static_assets (PriorityEarly)
+	}
+	return lifecycle.PriorityDefault
+}
+
+// Ensure ChromaCSSPlugin implements the required interfaces.
+var (
+	_ lifecycle.Plugin          = (*ChromaCSSPlugin)(nil)
+	_ lifecycle.ConfigurePlugin = (*ChromaCSSPlugin)(nil)
+	_ lifecycle.WritePlugin     = (*ChromaCSSPlugin)(nil)
+	_ lifecycle.PriorityPlugin  = (*ChromaCSSPlugin)(nil)
+)

--- a/pkg/plugins/chroma_css_test.go
+++ b/pkg/plugins/chroma_css_test.go
@@ -1,0 +1,185 @@
+package plugins
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
+)
+
+func TestChromaCSSPlugin_Name(t *testing.T) {
+	p := NewChromaCSSPlugin()
+	if got := p.Name(); got != "chroma_css" {
+		t.Errorf("Name() = %q, want %q", got, "chroma_css")
+	}
+}
+
+func TestChromaCSSPlugin_Configure(t *testing.T) {
+	tests := []struct {
+		name      string
+		extra     map[string]interface{}
+		wantTheme string
+	}{
+		{
+			name:      "default theme",
+			extra:     map[string]interface{}{},
+			wantTheme: "github-dark",
+		},
+		{
+			name: "explicit theme",
+			extra: map[string]interface{}{
+				"markdown": map[string]interface{}{
+					"highlight": map[string]interface{}{
+						"theme": "monokai",
+					},
+				},
+			},
+			wantTheme: "monokai",
+		},
+		{
+			name: "theme from palette",
+			extra: map[string]interface{}{
+				"theme": map[string]interface{}{
+					"palette": "catppuccin-mocha",
+				},
+			},
+			wantTheme: "catppuccin-mocha", // From palette mapping
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewChromaCSSPlugin()
+			m := lifecycle.NewManager()
+			m.Config().Extra = tt.extra
+
+			err := p.Configure(m)
+			if err != nil {
+				t.Fatalf("Configure error: %v", err)
+			}
+
+			if p.chromaTheme != tt.wantTheme {
+				t.Errorf("chromaTheme = %q, want %q", p.chromaTheme, tt.wantTheme)
+			}
+		})
+	}
+}
+
+func TestChromaCSSPlugin_Write(t *testing.T) {
+	// Create a temp directory for output
+	tmpDir := t.TempDir()
+
+	p := NewChromaCSSPlugin()
+	m := lifecycle.NewManager()
+	m.SetConfig(&lifecycle.Config{
+		OutputDir: tmpDir,
+		Extra:     map[string]interface{}{},
+	})
+
+	// Configure first
+	if err := p.Configure(m); err != nil {
+		t.Fatalf("Configure error: %v", err)
+	}
+
+	// Write the CSS
+	if err := p.Write(m); err != nil {
+		t.Fatalf("Write error: %v", err)
+	}
+
+	// Check the file was created
+	cssPath := filepath.Join(tmpDir, "css", "chroma.css")
+	content, err := os.ReadFile(cssPath)
+	if err != nil {
+		t.Fatalf("failed to read chroma.css: %v", err)
+	}
+
+	// Verify content
+	css := string(content)
+	if !strings.Contains(css, "/* Syntax highlighting") {
+		t.Error("expected header comment in CSS")
+	}
+	if !strings.Contains(css, ".chroma") {
+		t.Error("expected .chroma class in CSS")
+	}
+	// Check for typical chroma classes
+	if !strings.Contains(css, ".kd") { // keyword declaration
+		t.Error("expected .kd class in CSS")
+	}
+}
+
+func TestChromaCSSPlugin_Write_DifferentThemes(t *testing.T) {
+	tests := []struct {
+		name      string
+		theme     string
+		wantClass string // A class that should exist in the CSS
+	}{
+		{
+			name:      "github-dark",
+			theme:     "github-dark",
+			wantClass: ".chroma",
+		},
+		{
+			name:      "dracula",
+			theme:     "dracula",
+			wantClass: ".chroma",
+		},
+		{
+			name:      "monokai",
+			theme:     "monokai",
+			wantClass: ".chroma",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+
+			p := NewChromaCSSPlugin()
+			m := lifecycle.NewManager()
+			m.SetConfig(&lifecycle.Config{
+				OutputDir: tmpDir,
+				Extra: map[string]interface{}{
+					"markdown": map[string]interface{}{
+						"highlight": map[string]interface{}{
+							"theme": tt.theme,
+						},
+					},
+				},
+			})
+
+			if err := p.Configure(m); err != nil {
+				t.Fatalf("Configure error: %v", err)
+			}
+
+			if err := p.Write(m); err != nil {
+				t.Fatalf("Write error: %v", err)
+			}
+
+			cssPath := filepath.Join(tmpDir, "css", "chroma.css")
+			content, err := os.ReadFile(cssPath)
+			if err != nil {
+				t.Fatalf("failed to read chroma.css: %v", err)
+			}
+
+			if !strings.Contains(string(content), tt.wantClass) {
+				t.Errorf("expected %q class in CSS for theme %s", tt.wantClass, tt.theme)
+			}
+
+			// Verify theme name is in header
+			if !strings.Contains(string(content), tt.theme) {
+				t.Errorf("expected theme name %q in CSS header", tt.theme)
+			}
+		})
+	}
+}
+
+func TestChromaCSSPlugin_Priority(t *testing.T) {
+	p := NewChromaCSSPlugin()
+
+	// Should have default priority for write stage
+	if got := p.Priority(lifecycle.StageWrite); got != lifecycle.PriorityDefault {
+		t.Errorf("Priority(StageWrite) = %d, want %d", got, lifecycle.PriorityDefault)
+	}
+}

--- a/pkg/plugins/registry.go
+++ b/pkg/plugins/registry.go
@@ -61,6 +61,7 @@ func registerBuiltinPluginsLocked() {
 	pluginRegistry.constructors["wikilink_hover"] = func() lifecycle.Plugin { return NewWikilinkHoverPlugin() }
 	pluginRegistry.constructors["qrcode"] = func() lifecycle.Plugin { return NewQRCodePlugin() }
 	pluginRegistry.constructors["youtube"] = func() lifecycle.Plugin { return NewYouTubePlugin() }
+	pluginRegistry.constructors["chroma_css"] = func() lifecycle.Plugin { return NewChromaCSSPlugin() }
 }
 
 // RegisterPluginConstructor registers a plugin constructor with the given name.
@@ -135,6 +136,7 @@ func DefaultPlugins() []lifecycle.Plugin {
 		// Write stage plugins
 		NewStaticAssetsPlugin(), // Copy static assets first
 		NewPaletteCSSPlugin(),   // Generate palette CSS (overwrites variables.css)
+		NewChromaCSSPlugin(),    // Generate syntax highlighting CSS
 		NewPublishFeedsPlugin(),
 		NewPublishHTMLPlugin(),
 		NewRedirectsPlugin(), // Generate redirect pages

--- a/pkg/plugins/render_markdown.go
+++ b/pkg/plugins/render_markdown.go
@@ -5,6 +5,8 @@ import (
 	"bytes"
 	"strings"
 
+	chromahtml "github.com/alecthomas/chroma/v2/formatters/html"
+
 	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
 	"github.com/WaylonWalker/markata-go/pkg/models"
 	"github.com/WaylonWalker/markata-go/pkg/palettes"
@@ -38,10 +40,21 @@ func NewRenderMarkdownPlugin() *RenderMarkdownPlugin {
 }
 
 // createMarkdownRenderer creates a goldmark instance with the specified highlighting options.
-func createMarkdownRenderer(chromaTheme string, _ bool) goldmark.Markdown {
+func createMarkdownRenderer(chromaTheme string, lineNumbers bool) goldmark.Markdown {
+	// Use CSS classes instead of inline styles for syntax highlighting.
+	// This enables theme customization via external CSS files.
+	formatOptions := []chromahtml.Option{
+		chromahtml.WithClasses(true),
+		chromahtml.WithAllClasses(true),
+	}
+
+	if lineNumbers {
+		formatOptions = append(formatOptions, chromahtml.WithLineNumbers(true))
+	}
+
 	highlightOpts := []highlighting.Option{
 		highlighting.WithStyle(chromaTheme),
-		highlighting.WithFormatOptions(),
+		highlighting.WithFormatOptions(formatOptions...),
 	}
 
 	return goldmark.New(

--- a/pkg/plugins/render_markdown_test.go
+++ b/pkg/plugins/render_markdown_test.go
@@ -449,7 +449,7 @@ func TestRenderMarkdownPlugin_ConfigureWithPalette(t *testing.T) {
 					"palette": "catppuccin-mocha",
 				},
 			},
-			wantContain: "background-color:", // Chroma adds inline styles
+			wantContain: `class="chroma"`, // Uses CSS classes, not inline styles
 		},
 		{
 			name: "explicit theme override",
@@ -463,12 +463,12 @@ func TestRenderMarkdownPlugin_ConfigureWithPalette(t *testing.T) {
 					},
 				},
 			},
-			wantContain: "#282a36", // Dracula background color
+			wantContain: `class="kd"`, // keyword declaration class
 		},
 		{
 			name:        "no config uses default",
 			extra:       map[string]interface{}{},
-			wantContain: "background-color:",
+			wantContain: `class="chroma"`, // Uses CSS classes
 		},
 	}
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -41,6 +41,7 @@
     <link rel="stylesheet" href="{{ 'css/main.css' | theme_asset }}">
     <link rel="stylesheet" href="{{ 'css/admonitions.css' | theme_asset }}">
     <link rel="stylesheet" href="{{ 'css/code.css' | theme_asset }}">
+    <link rel="stylesheet" href="/css/chroma.css">
     
     <!-- RSS/Atom Feeds -->
     <link rel="alternate" type="application/rss+xml" title="RSS Feed" href="/rss.xml">


### PR DESCRIPTION
## Summary
- Switch from inline styles to CSS classes for syntax highlighting
- Add new ChromaCSSPlugin to generate theme-specific CSS
- Include chroma.css in base template

## Changes

### RenderMarkdownPlugin
- Uses `chromahtml.WithClasses(true)` and `chromahtml.WithAllClasses(true)` for class-based output
- Line numbers now work properly via config

### New ChromaCSSPlugin
- Generates `css/chroma.css` during Write stage
- Reads theme from `markdown.highlight.theme` config or derives from palette
- CSS contains all Chroma token type styles

### Template
- Base template now includes `/css/chroma.css`

## Benefits
- Users can customize syntax highlighting via CSS overrides
- Smaller HTML output (no repeated inline styles)
- Better browser caching of syntax highlighting styles
- Theme switching without rebuilding the site

Fixes #53