### PR TITLE
fix: use empty slug for homepage feed

### DIFF
--- a/markata-go.toml
+++ b/markata-go.toml
@@ -154,7 +154,7 @@ items_per_page = 10
 
 # Home page feed (empty slug = root index.html)
 [[markata-go.feeds]]
-slug = "latst"
+slug = ""
 title = "Latest Posts"
 filter = "published == True"
 sort = "date"


### PR DESCRIPTION
## Summary
Fix typo in markata-go.toml where homepage feed used `slug = "latst"` instead of `slug = ""`.

## Change
- Changed `slug = "latst"` to `slug = ""`

The comment already said "Home page feed (empty slug = root index.html)" but had the wrong slug value.

Fixes #57