### PR TITLE
feat: add OverwriteCheckPlugin to default plugins and documentation

### DIFF
--- a/pkg/plugins/registry.go
+++ b/pkg/plugins/registry.go
@@ -62,6 +62,7 @@ func registerBuiltinPluginsLocked() {
 	pluginRegistry.constructors["qrcode"] = func() lifecycle.Plugin { return NewQRCodePlugin() }
 	pluginRegistry.constructors["youtube"] = func() lifecycle.Plugin { return NewYouTubePlugin() }
 	pluginRegistry.constructors["chroma_css"] = func() lifecycle.Plugin { return NewChromaCSSPlugin() }
+	pluginRegistry.constructors["overwrite_check"] = func() lifecycle.Plugin { return NewOverwriteCheckPlugin() }
 }
 
 // RegisterPluginConstructor registers a plugin constructor with the given name.
@@ -131,7 +132,8 @@ func DefaultPlugins() []lifecycle.Plugin {
 		// Collect stage plugins
 		NewFeedsPlugin(),
 		NewAutoFeedsPlugin(),
-		NewPrevNextPlugin(), // Calculate prev/next after feeds are built
+		NewPrevNextPlugin(),       // Calculate prev/next after feeds are built
+		NewOverwriteCheckPlugin(), // Detect conflicting output paths
 
 		// Write stage plugins
 		NewStaticAssetsPlugin(), // Copy static assets first


### PR DESCRIPTION
## Summary

- Register `overwrite_check` plugin in plugin registry
- Add to `DefaultPlugins()` in Collect stage (runs after feeds are built)
- Document plugin comprehensively in `spec/spec/DEFAULT_PLUGINS.md`

## Changes

### Plugin Registration (`pkg/plugins/registry.go`)
- Added `overwrite_check` to plugin registry constructors
- Added `NewOverwriteCheckPlugin()` to `DefaultPlugins()` list in the Collect stage

### Documentation (`spec/spec/DEFAULT_PLUGINS.md`)
- Added `overwrite_check` to the plugin overview diagram
- Added full documentation section including:
  - Configuration options (`warn_only` mode)
  - Output paths checked (posts, feeds, homepage)
  - `PathConflict` structure
  - Common conflict scenarios and resolutions
  - Example hook signature
  - Interface compliance
- Updated plugin load order list to include `overwrite_check`

## Testing

- All existing tests pass
- Build succeeds

Fixes #58