### PR TITLE
docs: add YouTube plugin specification and user guide

### DIFF
--- a/docs/guides/youtube.md
+++ b/docs/guides/youtube.md
@@ -1,0 +1,166 @@
+---
+title: "Embedding YouTube Videos"
+description: "How to embed YouTube videos in your posts with a simple one-line URL"
+date: 2024-01-15
+published: true
+template: doc.html
+tags:
+  - documentation
+  - guides
+  - youtube
+  - media
+---
+
+# Embedding YouTube Videos
+
+markata-go automatically converts YouTube URLs into responsive embedded videos. Just paste a YouTube link on its own line, and it becomes a playable video embed.
+
+## Quick Start
+
+Simply paste a YouTube URL on its own line in your markdown:
+
+```markdown
+Check out this video:
+
+https://www.youtube.com/watch?v=dQw4w9WgXcQ
+
+More content below...
+```
+
+That's it! The URL will be converted into a responsive video player.
+
+## Supported URL Formats
+
+All common YouTube URL formats work:
+
+| Format | Example |
+|--------|---------|
+| Standard | `https://www.youtube.com/watch?v=VIDEO_ID` |
+| Short | `https://youtu.be/VIDEO_ID` |
+| Mobile | `https://m.youtube.com/watch?v=VIDEO_ID` |
+
+## Timestamps
+
+Start videos at a specific time by adding a timestamp:
+
+```markdown
+https://youtu.be/dQw4w9WgXcQ?t=1m30s
+```
+
+Supported timestamp formats:
+- Seconds: `?t=90`
+- Minutes and seconds: `?t=1m30s`
+- Hours, minutes, seconds: `?t=1h2m3s`
+- Start parameter: `?start=90`
+
+## Configuration
+
+Configure the YouTube plugin in your `markata-go.toml`:
+
+```toml
+[markata-go.youtube]
+enabled = true              # Enable/disable embeds (default: true)
+privacy_enhanced = true     # Use privacy-enhanced mode (default: true)
+container_class = "youtube-embed"  # CSS class for styling
+lazy_load = true            # Lazy load videos (default: true)
+```
+
+### Privacy-Enhanced Mode
+
+By default, videos use YouTube's privacy-enhanced mode (`youtube-nocookie.com`):
+
+- **No tracking cookies** until the user clicks play
+- **GDPR compliant** - helps meet privacy regulations
+- **Same video experience** - playback works identically
+
+To use standard YouTube embeds:
+
+```toml
+[markata-go.youtube]
+privacy_enhanced = false
+```
+
+### Lazy Loading
+
+Lazy loading (enabled by default) improves page performance by only loading video iframes when they're about to enter the viewport.
+
+## Styling
+
+Videos are automatically responsive with a 16:9 aspect ratio. The default theme includes styling, but you can customize:
+
+```css
+/* Custom video container styling */
+.youtube-embed {
+  margin: 2rem 0;
+  border-radius: 8px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+```
+
+## What Doesn't Get Embedded
+
+The plugin only converts URLs that are **on their own line**. These patterns are NOT converted:
+
+### Inline URLs
+
+```markdown
+Check out https://youtu.be/dQw4w9WgXcQ for more info.
+```
+
+This stays as a regular link because it's inline with other text.
+
+### Code Blocks
+
+```markdown
+To embed a video, use: `https://youtu.be/VIDEO_ID`
+```
+
+URLs in code are preserved for documentation purposes.
+
+### Invalid Video IDs
+
+URLs with invalid video IDs (not exactly 11 characters) are left unchanged.
+
+## Output HTML
+
+The plugin generates this HTML structure:
+
+```html
+<div class="youtube-embed">
+  <iframe
+    src="https://www.youtube-nocookie.com/embed/VIDEO_ID"
+    title="YouTube video player"
+    frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowfullscreen
+    loading="lazy">
+  </iframe>
+</div>
+```
+
+## Tips
+
+1. **One URL per line** - Each video should be on its own line with blank lines before and after
+2. **Use short URLs** - `youtu.be` links are cleaner in your markdown
+3. **Add context** - Include a brief description before your video embed
+4. **Test timestamps** - Preview your post to ensure timestamps work correctly
+
+## Troubleshooting
+
+### Video Not Embedding
+
+- Ensure the URL is on its own line (not inline with text)
+- Check that the video ID is valid (11 characters)
+- Verify the plugin is enabled in your config
+
+### Video Not Playing
+
+- Check if the video is available in your region
+- Some videos may have embedding disabled by the uploader
+- Try with `privacy_enhanced = false` if issues persist
+
+## Related
+
+- [[markdown|Markdown Features]] - Other markdown enhancements
+- [[md-video|Video Embeds]] - Embed local video files
+- [[configuration-guide|Configuration]] - Global settings

--- a/spec/spec/YOUTUBE.md
+++ b/spec/spec/YOUTUBE.md
@@ -1,0 +1,247 @@
+# YouTube Plugin Specification
+
+This document specifies the YouTube embed plugin for markata-go.
+
+## Overview
+
+The YouTube plugin automatically converts YouTube URLs in markdown content into responsive embedded iframes. It processes URLs that appear on their own line (in a `<p>` tag) and replaces them with privacy-enhanced video embeds.
+
+## Plugin Information
+
+| Property | Value |
+|----------|-------|
+| **Name** | `youtube` |
+| **Stage** | Render (with late priority) |
+| **Interfaces** | `Plugin`, `ConfigurePlugin`, `RenderPlugin`, `PriorityPlugin` |
+| **Default Enabled** | Yes |
+
+## Configuration
+
+```toml
+[markata-go.youtube]
+enabled = true              # Enable/disable the plugin (default: true)
+privacy_enhanced = true     # Use youtube-nocookie.com (default: true)
+container_class = "youtube-embed"  # CSS class for container div (default)
+lazy_load = true            # Enable lazy loading of iframe (default: true)
+```
+
+### Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `enabled` | bool | `true` | Enable or disable YouTube URL conversion |
+| `privacy_enhanced` | bool | `true` | Use `youtube-nocookie.com` domain for GDPR compliance |
+| `container_class` | string | `"youtube-embed"` | CSS class applied to the container div |
+| `lazy_load` | bool | `true` | Add `loading="lazy"` attribute to iframe |
+
+## Supported URL Formats
+
+The plugin recognizes the following YouTube URL patterns:
+
+| Format | Example |
+|--------|---------|
+| Standard watch URL | `https://www.youtube.com/watch?v=dQw4w9WgXcQ` |
+| Without www | `https://youtube.com/watch?v=dQw4w9WgXcQ` |
+| Mobile URL | `https://m.youtube.com/watch?v=dQw4w9WgXcQ` |
+| Short URL | `https://youtu.be/dQw4w9WgXcQ` |
+| With timestamp | `https://youtu.be/dQw4w9WgXcQ?t=1h2m3s` |
+| With start param | `https://www.youtube.com/watch?v=dQw4w9WgXcQ&start=123` |
+
+### Video ID Requirements
+
+- Must be exactly 11 characters
+- Alphanumeric plus hyphen (`-`) and underscore (`_`)
+- Invalid IDs are ignored (URL left unchanged)
+
+## Timestamp Support
+
+The plugin extracts and converts timestamps to the embed `start` parameter:
+
+| Input Format | Converted To |
+|--------------|--------------|
+| `?t=123` | `?start=123` |
+| `?t=1h2m3s` | `?start=3723` |
+| `?t=2m30s` | `?start=150` |
+| `?t=45s` | `?start=45` |
+| `?start=123` | `?start=123` (preserved) |
+
+## Behavior
+
+### URL Detection
+
+1. **Standalone URLs only**: URLs must be on their own line, resulting in a `<p>` tag containing only the URL
+2. **Handles autolinked URLs**: Works with both plain URLs and URLs converted to `<a>` tags by the Linkify extension
+3. **Preserves inline URLs**: URLs within text are not converted
+
+### Detection Patterns
+
+The plugin matches URLs in two formats after markdown rendering:
+
+```html
+<!-- Pattern 1: Plain URL (no Linkify) -->
+<p>https://www.youtube.com/watch?v=VIDEO_ID</p>
+
+<!-- Pattern 2: Autolinked URL (with Linkify extension) -->
+<p><a href="https://www.youtube.com/watch?v=VIDEO_ID">https://www.youtube.com/watch?v=VIDEO_ID</a></p>
+```
+
+### Code Block Protection
+
+URLs inside `<code>` blocks are never converted, allowing documentation of YouTube URLs without embedding:
+
+```markdown
+To embed a video, use: `https://youtu.be/VIDEO_ID`
+```
+
+## Output
+
+### HTML Structure
+
+```html
+<div class="youtube-embed">
+  <iframe
+    src="https://www.youtube-nocookie.com/embed/VIDEO_ID"
+    title="YouTube video player"
+    frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowfullscreen
+    loading="lazy">
+  </iframe>
+</div>
+```
+
+### With Timestamp
+
+```html
+<div class="youtube-embed">
+  <iframe
+    src="https://www.youtube-nocookie.com/embed/VIDEO_ID?start=3723"
+    ...>
+  </iframe>
+</div>
+```
+
+### Standard Mode (privacy_enhanced: false)
+
+```html
+<div class="youtube-embed">
+  <iframe
+    src="https://www.youtube.com/embed/VIDEO_ID"
+    ...>
+  </iframe>
+</div>
+```
+
+## CSS Styling
+
+The default theme includes responsive styling for YouTube embeds:
+
+```css
+.youtube-embed {
+  position: relative;
+  padding-bottom: 56.25%; /* 16:9 aspect ratio */
+  height: 0;
+  overflow: hidden;
+  max-width: 100%;
+  margin: 1.5rem 0;
+  border-radius: 0.5rem;
+}
+
+.youtube-embed iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: none;
+  border-radius: 0.5rem;
+}
+```
+
+## Privacy Mode
+
+When `privacy_enhanced` is enabled (default), the plugin uses `youtube-nocookie.com`:
+
+- **No cookies until play**: YouTube does not store cookies until the user clicks play
+- **GDPR compliance**: Helps meet privacy regulations
+- **Same functionality**: Video playback works identically
+
+To use standard YouTube embeds:
+
+```toml
+[markata-go.youtube]
+privacy_enhanced = false
+```
+
+## Processing Order
+
+1. Plugin runs during the **Render** stage with **late priority**
+2. Executes after `render_markdown` (which converts markdown to HTML)
+3. Processes `post.ArticleHTML` for each post
+4. Uses concurrent processing for performance
+
+## Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| Invalid video ID | URL left unchanged |
+| URL in code block | URL left unchanged |
+| Inline URL (not standalone) | URL left unchanged |
+| Malformed URL | URL left unchanged |
+| Empty ArticleHTML | Skipped |
+| Skipped post | Skipped |
+
+## Interface Compliance
+
+```go
+var (
+    _ lifecycle.Plugin          = (*YouTubePlugin)(nil)
+    _ lifecycle.ConfigurePlugin = (*YouTubePlugin)(nil)
+    _ lifecycle.RenderPlugin    = (*YouTubePlugin)(nil)
+    _ lifecycle.PriorityPlugin  = (*YouTubePlugin)(nil)
+)
+```
+
+## Examples
+
+### Basic Usage
+
+```markdown
+Check out this video:
+
+https://www.youtube.com/watch?v=dQw4w9WgXcQ
+
+More content below...
+```
+
+### With Timestamp
+
+```markdown
+Skip to the good part:
+
+https://youtu.be/dQw4w9WgXcQ?t=1m30s
+```
+
+### Short URL
+
+```markdown
+https://youtu.be/dQw4w9WgXcQ
+```
+
+### NOT Converted (inline)
+
+```markdown
+Check out https://youtu.be/dQw4w9WgXcQ for more info.
+```
+
+### NOT Converted (code block)
+
+```markdown
+To embed: `https://youtu.be/VIDEO_ID`
+```
+
+## See Also
+
+- [Configuration Reference](CONFIG.md) - Global configuration options
+- [Lifecycle Stages](LIFECYCLE.md) - Plugin execution order
+- [Default Plugins](DEFAULT_PLUGINS.md) - All built-in plugins


### PR DESCRIPTION
## Summary

Adds comprehensive documentation for the YouTube embed plugin.

## Changes

### Specification (`spec/spec/YOUTUBE.md`)
- Full technical specification for the plugin
- Configuration options and defaults
- Supported URL formats (standard, short, mobile)
- Timestamp support formats
- Autolink handling (from Linkify extension)
- Output HTML structure
- Privacy-enhanced mode details
- CSS styling requirements
- Processing order and interface compliance

### User Guide (`docs/guides/youtube.md`)
- Quick start with simple example
- Supported URL formats table
- Timestamp examples
- Configuration options explained
- Privacy mode explanation
- Styling customization tips
- What doesn't get embedded (inline URLs, code blocks)
- Troubleshooting section

## Checklist

- [x] Plugin detects all supported YouTube URL formats ✅ (already implemented)
- [x] Converts URLs to responsive iframe embeds ✅ (already implemented)
- [x] Preserves timestamp parameters correctly ✅ (already implemented)
- [x] Supports privacy mode configuration ✅ (already implemented)
- [x] Includes comprehensive test coverage ✅ (youtube_test.go exists)
- [x] Documentation in `docs/guides/youtube.md` ✅ (added)
- [x] Spec in `spec/spec/YOUTUBE.md` ✅ (added)

Fixes #41