### PR TITLE
feat: implement layout components template system

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -39,6 +39,7 @@
     <!-- Theme CSS -->
     <link rel="stylesheet" href="{{ 'css/variables.css' | theme_asset }}">
     <link rel="stylesheet" href="{{ 'css/main.css' | theme_asset }}">
+    <link rel="stylesheet" href="{{ 'css/components.css' | theme_asset }}">
     <link rel="stylesheet" href="{{ 'css/admonitions.css' | theme_asset }}">
     <link rel="stylesheet" href="{{ 'css/code.css' | theme_asset }}">
     <link rel="stylesheet" href="/css/chroma.css">
@@ -110,15 +111,7 @@
     <header class="site-header">
         <div class="container">
             <a href="/" class="site-title">{{ config.title | default:"Home" }}</a>
-            <nav class="site-nav">
-                {% if config.nav %}
-                    {% for item in config.nav %}
-                <a href="{{ item.url }}"{% if item.external %} target="_blank" rel="noopener noreferrer"{% endif %}>{{ item.label }}</a>
-                    {% endfor %}
-                {% else %}
-                <a href="/blog/">Blog</a>
-                {% endif %}
-            </nav>
+            {% include "components/nav.html" %}
         </div>
     </header>
     {% endblock %}
@@ -128,15 +121,7 @@
     </main>
     
     {% block footer %}
-    <footer class="site-footer">
-        <div class="container">
-            {% if config.footer.text %}
-            <p>{{ config.footer.text }}</p>
-            {% else %}
-            <p>&copy; {{ "now" | date:"2006" }} {{ config.author | default:"" }}. Built with <a href="https://github.com/WaylonWalker/markata-go">markata-go</a>.</p>
-            {% endif %}
-        </div>
-    </footer>
+    {% include "components/footer.html" %}
     {% endblock %}
     
     {% block htmx %}{% endblock %}

--- a/templates/components/doc_sidebar.html
+++ b/templates/components/doc_sidebar.html
@@ -1,0 +1,34 @@
+{# Document sidebar (Table of Contents) component template #}
+{# Usage: {% include "components/doc_sidebar.html" %} #}
+{# Requires: config.components.doc_sidebar (DocSidebarConfig) #}
+{# Requires: post.Extra.toc ([]TocEntry) from toc plugin #}
+
+{% with sidebar = config.components.doc_sidebar %}
+{% if sidebar.enabled and post.Extra.toc %}
+<aside class="doc-sidebar doc-sidebar--{{ sidebar.position | default:'right' }}" style="width: {{ sidebar.width | default:'250px' }}">
+    <nav class="toc" aria-label="Table of Contents">
+        <h2 class="toc-title">On this page</h2>
+        <ul class="toc-list">
+            {% for entry in post.Extra.toc %}
+            {% if entry.Level >= sidebar.min_depth and entry.Level <= sidebar.max_depth %}
+            <li class="toc-item toc-item--level-{{ entry.Level }}">
+                <a href="#{{ entry.ID }}" class="toc-link">{{ entry.Text }}</a>
+                {% if entry.Children %}
+                <ul class="toc-list toc-list--nested">
+                    {% for child in entry.Children %}
+                    {% if child.Level >= sidebar.min_depth and child.Level <= sidebar.max_depth %}
+                    <li class="toc-item toc-item--level-{{ child.Level }}">
+                        <a href="#{{ child.ID }}" class="toc-link">{{ child.Text }}</a>
+                    </li>
+                    {% endif %}
+                    {% endfor %}
+                </ul>
+                {% endif %}
+            </li>
+            {% endif %}
+            {% endfor %}
+        </ul>
+    </nav>
+</aside>
+{% endif %}
+{% endwith %}

--- a/templates/components/footer.html
+++ b/templates/components/footer.html
@@ -1,0 +1,27 @@
+{# Footer component template #}
+{# Usage: {% include "components/footer.html" %} #}
+{# Requires: config.components.footer (FooterComponentConfig) #}
+
+{% with footer = config.components.footer %}
+{% if footer.enabled %}
+<footer class="site-footer">
+    <div class="container">
+        {% if footer.text %}
+        <p class="footer-text">{{ footer.text }}</p>
+        {% endif %}
+        
+        {% if footer.links %}
+        <nav class="footer-links">
+            {% for link in footer.links %}
+            <a href="{{ link.url }}"{% if link.external %} target="_blank" rel="noopener noreferrer"{% endif %}>{{ link.label }}</a>
+            {% endfor %}
+        </nav>
+        {% endif %}
+        
+        {% if footer.show_copyright %}
+        <p class="footer-copyright">&copy; {{ "now" | date:"2006" }} {{ config.author | default:"" }}. Built with <a href="https://github.com/WaylonWalker/markata-go">markata-go</a>.</p>
+        {% endif %}
+    </div>
+</footer>
+{% endif %}
+{% endwith %}

--- a/templates/components/nav.html
+++ b/templates/components/nav.html
@@ -1,0 +1,22 @@
+{# Navigation component template #}
+{# Usage: {% include "components/nav.html" %} #}
+{# Requires: config.components.nav (NavComponentConfig) #}
+
+{% with nav = config.components.nav %}
+{% if nav.enabled %}
+<nav class="site-nav site-nav--{{ nav.position | default:'header' }} site-nav--{{ nav.style | default:'horizontal' }}">
+    {% if nav.items %}
+        {% for item in nav.items %}
+    <a href="{{ item.url }}"{% if item.external %} target="_blank" rel="noopener noreferrer"{% endif %} class="nav-link">{{ item.label }}</a>
+        {% endfor %}
+    {% elif config.nav %}
+        {# Fallback to legacy config.nav for backward compatibility #}
+        {% for item in config.nav %}
+    <a href="{{ item.url }}"{% if item.external %} target="_blank" rel="noopener noreferrer"{% endif %} class="nav-link">{{ item.label }}</a>
+        {% endfor %}
+    {% else %}
+    <a href="/blog/" class="nav-link">Blog</a>
+    {% endif %}
+</nav>
+{% endif %}
+{% endwith %}

--- a/templates/post.html
+++ b/templates/post.html
@@ -1,22 +1,26 @@
 {% extends "base.html" %}
 
 {% block content %}
-<article>
-    <header>
-        <h1>{{ post.title }}</h1>
-        {% if post.date %}
-        <time datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
-        {% endif %}
-        {% if post.tags %}
-        <div class="tags">
-            {% for tag in post.tags %}
-            <a href="/tags/{{ tag | slugify }}/">{{ tag }}</a>
-            {% endfor %}
+<div class="content-wrapper{% if config.components.doc_sidebar.enabled and post.Extra.toc %} content-wrapper--with-sidebar content-wrapper--sidebar-{{ config.components.doc_sidebar.position | default:'right' }}{% endif %}">
+    <article>
+        <header>
+            <h1>{{ post.title }}</h1>
+            {% if post.date %}
+            <time datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+            {% endif %}
+            {% if post.tags %}
+            <div class="tags">
+                {% for tag in post.tags %}
+                <a href="/tags/{{ tag | slugify }}/">{{ tag }}</a>
+                {% endfor %}
+            </div>
+            {% endif %}
+        </header>
+        <div class="post-content{% if post.css_class %} {{ post.css_class }}{% endif %}">
+            {{ body | safe }}
         </div>
-        {% endif %}
-    </header>
-    <div class="post-content{% if post.css_class %} {{ post.css_class }}{% endif %}">
-        {{ body | safe }}
-    </div>
-</article>
+    </article>
+    
+    {% include "components/doc_sidebar.html" %}
+</div>
 {% endblock %}

--- a/themes/default/static/css/components.css
+++ b/themes/default/static/css/components.css
@@ -1,0 +1,200 @@
+/* ==========================================================================
+   Component Styles - Layout Components System
+   ========================================================================== */
+
+/* ==========================================================================
+   Navigation Component
+   ========================================================================== */
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+}
+
+/* Horizontal navigation (default, for header) */
+.site-nav--header,
+.site-nav--horizontal {
+  flex-direction: row;
+  align-items: center;
+}
+
+/* Vertical navigation (for sidebar) */
+.site-nav--sidebar,
+.site-nav--vertical {
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.nav-link {
+  color: var(--color-text);
+  text-decoration: none;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  transition: background-color 0.2s, color 0.2s;
+}
+
+.nav-link:hover {
+  color: var(--color-primary);
+  background-color: var(--color-surface);
+}
+
+/* ==========================================================================
+   Footer Component
+   ========================================================================== */
+
+.site-footer {
+  margin-top: auto;
+  padding: 2rem 0;
+  background-color: var(--color-surface);
+  border-top: 1px solid var(--color-border);
+}
+
+.footer-text {
+  margin-bottom: 1rem;
+}
+
+.footer-links {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.footer-links a {
+  color: var(--color-text-muted);
+  text-decoration: none;
+}
+
+.footer-links a:hover {
+  color: var(--color-primary);
+}
+
+.footer-copyright {
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+}
+
+.footer-copyright a {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.footer-copyright a:hover {
+  text-decoration: underline;
+}
+
+/* ==========================================================================
+   Document Sidebar (Table of Contents)
+   ========================================================================== */
+
+.content-wrapper {
+  display: block;
+}
+
+.content-wrapper--with-sidebar {
+  display: grid;
+  gap: 2rem;
+  max-width: 100%;
+}
+
+/* Sidebar on the right (default) */
+.content-wrapper--sidebar-right {
+  grid-template-columns: 1fr 250px;
+}
+
+.content-wrapper--sidebar-right article {
+  order: 1;
+}
+
+.content-wrapper--sidebar-right .doc-sidebar {
+  order: 2;
+}
+
+/* Sidebar on the left */
+.content-wrapper--sidebar-left {
+  grid-template-columns: 250px 1fr;
+}
+
+.content-wrapper--sidebar-left article {
+  order: 2;
+}
+
+.content-wrapper--sidebar-left .doc-sidebar {
+  order: 1;
+}
+
+.doc-sidebar {
+  position: sticky;
+  top: 1rem;
+  height: fit-content;
+  max-height: calc(100vh - 2rem);
+  overflow-y: auto;
+}
+
+.toc {
+  padding: 1rem;
+  background-color: var(--color-surface);
+  border-radius: 8px;
+  border: 1px solid var(--color-border);
+}
+
+.toc-title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+  margin-bottom: 0.75rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.toc-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.toc-list--nested {
+  margin-left: 1rem;
+  margin-top: 0.25rem;
+}
+
+.toc-item {
+  margin-bottom: 0.25rem;
+}
+
+.toc-item--level-2 {
+  /* Top-level items */
+}
+
+.toc-item--level-3 {
+  font-size: 0.9375rem;
+}
+
+.toc-item--level-4 {
+  font-size: 0.875rem;
+}
+
+.toc-link {
+  color: var(--color-text-muted);
+  text-decoration: none;
+  display: block;
+  padding: 0.25rem 0;
+  transition: color 0.2s;
+}
+
+.toc-link:hover {
+  color: var(--color-primary);
+}
+
+/* Responsive: Hide sidebar on mobile */
+@media (max-width: 1024px) {
+  .content-wrapper--with-sidebar {
+    display: block;
+  }
+  
+  .doc-sidebar {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary

Completes the template integration for the configurable layout components system. The data models and config parsing were already implemented in a previous PR.

## Changes

### New Component Templates (`templates/components/`)

| Template | Purpose |
|----------|---------|
| `nav.html` | Navigation with position/style support, backward compatible with `config.nav` |
| `footer.html` | Footer with custom text, links, and copyright |
| `doc_sidebar.html` | Document TOC sidebar with heading level filtering |

### Template Updates

- **`base.html`**: Now uses `{% include "components/nav.html" %}` and `{% include "components/footer.html" %}`
- **`post.html`**: Added content wrapper with doc_sidebar support and positioning classes

### New CSS (`themes/default/static/css/components.css`)

- Navigation styles (horizontal/vertical, header/sidebar positions)
- Footer styles with links grid
- Document sidebar with sticky positioning
- Grid-based content wrapper for sidebar layouts
- Responsive design (sidebar hidden on mobile < 1024px)

## Configuration Examples

```toml
# Enable components (all enabled by default except doc_sidebar)
[markata-go.components.nav]
enabled = true
position = "header"  # or "sidebar"
style = "horizontal" # or "vertical"

[[markata-go.components.nav.items]]
label = "Blog"
url = "/blog/"

[markata-go.components.footer]
enabled = true
text = "Custom footer text"

[[markata-go.components.footer.links]]
label = "GitHub"
url = "https://github.com/user"
external = true

[markata-go.components.doc_sidebar]
enabled = true
position = "right"  # or "left"
min_depth = 2
max_depth = 4
```

## Backward Compatibility

- `config.nav` (legacy array format) still works
- Footer falls back to default copyright if not configured
- Components default to sensible values

## Remaining Work (separate PRs)

According to Issue #29, these items are still pending:
- [ ] Feed sidebar component (series/collection navigation)
- [ ] Migration guide from legacy config format
- [ ] Frontmatter-based per-page component overrides

Refs #29