### PR TITLE
feat: implement pagination_type config for HTMX/manual pagination

### DIFF
--- a/markata-go.toml
+++ b/markata-go.toml
@@ -142,6 +142,7 @@ filter = ""
 sort = "date"
 reverse = true
 items_per_page = 10
+# pagination_type = "htmx"  # Options: manual (default), htmx, js
 
 [[markata-go.feeds]]
 slug = "docs"

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -117,6 +117,7 @@ type tomlFeedConfig struct {
 	Reverse         bool              `toml:"reverse"`
 	ItemsPerPage    int               `toml:"items_per_page"`
 	OrphanThreshold int               `toml:"orphan_threshold"`
+	PaginationType  string            `toml:"pagination_type"`
 	Formats         tomlFeedFormats   `toml:"formats"`
 	Templates       tomlFeedTemplates `toml:"templates"`
 }
@@ -141,6 +142,7 @@ type tomlFeedTemplates struct {
 type tomlFeedDefaults struct {
 	ItemsPerPage    int                   `toml:"items_per_page"`
 	OrphanThreshold int                   `toml:"orphan_threshold"`
+	PaginationType  string                `toml:"pagination_type"`
 	Formats         tomlFeedFormats       `toml:"formats"`
 	Templates       tomlFeedTemplates     `toml:"templates"`
 	Syndication     tomlSyndicationConfig `toml:"syndication"`
@@ -367,6 +369,7 @@ func (f *tomlFeedConfig) toFeedConfig() models.FeedConfig {
 		Reverse:         f.Reverse,
 		ItemsPerPage:    f.ItemsPerPage,
 		OrphanThreshold: f.OrphanThreshold,
+		PaginationType:  models.PaginationType(f.PaginationType),
 		Formats:         f.Formats.toFeedFormats(),
 		Templates:       f.Templates.toFeedTemplates(),
 	}
@@ -409,6 +412,7 @@ func (d *tomlFeedDefaults) toFeedDefaults() models.FeedDefaults {
 	return models.FeedDefaults{
 		ItemsPerPage:    d.ItemsPerPage,
 		OrphanThreshold: d.OrphanThreshold,
+		PaginationType:  models.PaginationType(d.PaginationType),
 		Formats:         d.Formats.toFeedFormats(),
 		Templates:       d.Templates.toFeedTemplates(),
 		Syndication: models.SyndicationConfig{
@@ -472,6 +476,7 @@ type yamlFeedConfig struct {
 	Reverse         bool              `yaml:"reverse"`
 	ItemsPerPage    int               `yaml:"items_per_page"`
 	OrphanThreshold int               `yaml:"orphan_threshold"`
+	PaginationType  string            `yaml:"pagination_type"`
 	Formats         yamlFeedFormats   `yaml:"formats"`
 	Templates       yamlFeedTemplates `yaml:"templates"`
 }
@@ -496,6 +501,7 @@ type yamlFeedTemplates struct {
 type yamlFeedDefaults struct {
 	ItemsPerPage    int                   `yaml:"items_per_page"`
 	OrphanThreshold int                   `yaml:"orphan_threshold"`
+	PaginationType  string                `yaml:"pagination_type"`
 	Formats         yamlFeedFormats       `yaml:"formats"`
 	Templates       yamlFeedTemplates     `yaml:"templates"`
 	Syndication     yamlSyndicationConfig `yaml:"syndication"`
@@ -709,6 +715,7 @@ func (f *yamlFeedConfig) toFeedConfig() models.FeedConfig {
 		Reverse:         f.Reverse,
 		ItemsPerPage:    f.ItemsPerPage,
 		OrphanThreshold: f.OrphanThreshold,
+		PaginationType:  models.PaginationType(f.PaginationType),
 		Formats:         f.Formats.toFeedFormats(),
 		Templates:       f.Templates.toFeedTemplates(),
 	}
@@ -751,6 +758,7 @@ func (d *yamlFeedDefaults) toFeedDefaults() models.FeedDefaults {
 	return models.FeedDefaults{
 		ItemsPerPage:    d.ItemsPerPage,
 		OrphanThreshold: d.OrphanThreshold,
+		PaginationType:  models.PaginationType(d.PaginationType),
 		Formats:         d.Formats.toFeedFormats(),
 		Templates:       d.Templates.toFeedTemplates(),
 		Syndication: models.SyndicationConfig{
@@ -814,6 +822,7 @@ type jsonFeedConfig struct {
 	Reverse         bool              `json:"reverse"`
 	ItemsPerPage    int               `json:"items_per_page"`
 	OrphanThreshold int               `json:"orphan_threshold"`
+	PaginationType  string            `json:"pagination_type"`
 	Formats         jsonFeedFormats   `json:"formats"`
 	Templates       jsonFeedTemplates `json:"templates"`
 }
@@ -838,6 +847,7 @@ type jsonFeedTemplates struct {
 type jsonFeedDefaults struct {
 	ItemsPerPage    int                   `json:"items_per_page"`
 	OrphanThreshold int                   `json:"orphan_threshold"`
+	PaginationType  string                `json:"pagination_type"`
 	Formats         jsonFeedFormats       `json:"formats"`
 	Templates       jsonFeedTemplates     `json:"templates"`
 	Syndication     jsonSyndicationConfig `json:"syndication"`
@@ -1051,6 +1061,7 @@ func (f *jsonFeedConfig) toFeedConfig() models.FeedConfig {
 		Reverse:         f.Reverse,
 		ItemsPerPage:    f.ItemsPerPage,
 		OrphanThreshold: f.OrphanThreshold,
+		PaginationType:  models.PaginationType(f.PaginationType),
 		Formats:         f.Formats.toFeedFormats(),
 		Templates:       f.Templates.toFeedTemplates(),
 	}
@@ -1093,6 +1104,7 @@ func (d *jsonFeedDefaults) toFeedDefaults() models.FeedDefaults {
 	return models.FeedDefaults{
 		ItemsPerPage:    d.ItemsPerPage,
 		OrphanThreshold: d.OrphanThreshold,
+		PaginationType:  models.PaginationType(d.PaginationType),
 		Formats:         d.Formats.toFeedFormats(),
 		Templates:       d.Templates.toFeedTemplates(),
 		Syndication: models.SyndicationConfig{

--- a/pkg/themes/default/templates/base.html
+++ b/pkg/themes/default/templates/base.html
@@ -90,6 +90,7 @@
   {% include "partials/footer.html" %}
   {% endblock %}
   
+  {% block htmx %}{% endblock %}
   {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/pkg/themes/default/templates/feed.html
+++ b/pkg/themes/default/templates/feed.html
@@ -2,6 +2,12 @@
 
 {% block title %}{{ feed.title | default:config.title | default:'Posts' }}{% endblock %}
 
+{% block htmx %}
+{% if page.pagination_type == "htmx" %}
+<script src="https://unpkg.com/htmx.org@1.9.10" integrity="sha384-D1Kt99CQMDuVetoL1lrYwg5t+9QdHe7NLX/SoJYkXDFfX37iInKRy5xLSi8nO7UC" crossorigin="anonymous"></script>
+{% endif %}
+{% endblock %}
+
 {% block content %}
 <div class="feed">
   {% if feed.title %}
@@ -11,7 +17,7 @@
   </header>
   {% endif %}
   
-  <div class="posts">
+  <div class="posts posts-list" id="posts-list">
     {% for post in page.posts %}
     {% include "partials/card.html" %}
     {% endfor %}

--- a/templates/partials/pagination.html
+++ b/templates/partials/pagination.html
@@ -1,0 +1,80 @@
+{# Pagination partial - auto-selects template based on pagination_type #}
+{% if page.total_pages > 1 %}
+{% if page.pagination_type == "htmx" %}
+{# HTMX Pagination - uses hx-* attributes for AJAX loading #}
+<nav class="pagination pagination-htmx" aria-label="Pagination" hx-boost="true">
+  {# Previous button #}
+  {% if page.has_prev %}
+  <a href="{{ page.prev_url }}" 
+     class="pagination-prev" 
+     rel="prev"
+     hx-get="{{ page.prev_url }}"
+     hx-target=".posts-list"
+     hx-select=".posts-list"
+     hx-swap="outerHTML"
+     hx-push-url="true">&laquo; Newer</a>
+  {% else %}
+  <span class="pagination-prev disabled">&laquo; Newer</span>
+  {% endif %}
+  
+  {# Page numbers #}
+  <div class="pagination-pages">
+    {% for url in page.page_urls %}
+    {% if forloop.Counter == page.number %}
+    <span class="pagination-page current" aria-current="page">{{ forloop.Counter }}</span>
+    {% else %}
+    <a href="{{ url }}" 
+       class="pagination-page"
+       hx-get="{{ url }}"
+       hx-target=".posts-list"
+       hx-select=".posts-list"
+       hx-swap="outerHTML"
+       hx-push-url="true">{{ forloop.Counter }}</a>
+    {% endif %}
+    {% endfor %}
+  </div>
+  
+  {# Next button #}
+  {% if page.has_next %}
+  <a href="{{ page.next_url }}" 
+     class="pagination-next" 
+     rel="next"
+     hx-get="{{ page.next_url }}"
+     hx-target=".posts-list"
+     hx-select=".posts-list"
+     hx-swap="outerHTML"
+     hx-push-url="true">Older &raquo;</a>
+  {% else %}
+  <span class="pagination-next disabled">Older &raquo;</span>
+  {% endif %}
+</nav>
+{% else %}
+{# Manual Pagination (default) - traditional page links #}
+<nav class="pagination" aria-label="Pagination">
+  {# Previous button #}
+  {% if page.has_prev %}
+  <a href="{{ page.prev_url }}" class="pagination-prev" rel="prev">&laquo; Newer</a>
+  {% else %}
+  <span class="pagination-prev disabled">&laquo; Newer</span>
+  {% endif %}
+  
+  {# Page numbers #}
+  <div class="pagination-pages">
+    {% for url in page.page_urls %}
+    {% if forloop.Counter == page.number %}
+    <span class="pagination-page current" aria-current="page">{{ forloop.Counter }}</span>
+    {% else %}
+    <a href="{{ url }}" class="pagination-page">{{ forloop.Counter }}</a>
+    {% endif %}
+    {% endfor %}
+  </div>
+  
+  {# Next button #}
+  {% if page.has_next %}
+  <a href="{{ page.next_url }}" class="pagination-next" rel="next">Older &raquo;</a>
+  {% else %}
+  <span class="pagination-next disabled">Older &raquo;</span>
+  {% endif %}
+</nav>
+{% endif %}
+{% endif %}


### PR DESCRIPTION
## Summary

Implements the `pagination_type` configuration option for feeds, enabling HTMX-based pagination as an alternative to traditional page reloads.

Fixes #42

## Changes

- **Added** `templates/partials/pagination.html` - Pagination template supporting both manual and HTMX modes
- **Added** `pagination_type` field to feed config parser (TOML, YAML, JSON)
- **Added** `pagination_type` to FeedDefaults config structs
- **Added** `{% block htmx %}` to default theme `base.html`
- **Updated** embedded `feed.html` to:
  - Include HTMX script conditionally when `pagination_type == "htmx"`
  - Add `posts-list` class and ID for HTMX targeting

## Pagination Types

| Type | Description |
|------|-------------|
| `manual` (default) | Traditional page reloads |
| `htmx` | AJAX-based pagination with URL push state |

## Usage

```toml
[[markata-go.feeds]]
slug = "blog"
title = "Blog"
pagination_type = "htmx"  # or "manual" (default)
```

## Testing

- [x] Build passes
- [x] All tests pass
- [x] Manual pagination works correctly
- [x] HTMX pagination loads correctly with `hx-*` attributes
- [x] HTMX script is conditionally included

## Notes

- JS pagination type is planned but not yet implemented (will be a separate PR)
- The HTMX implementation uses `hx-select` to extract just the posts list from full page responses, which works without dedicated partial endpoints