### PR TITLE
feat: add canonical URLs and alternate format links to posts

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -381,6 +381,17 @@ markdown = true   # /slug/index.md (raw source)
 og = true         # /slug/og/index.html (social card)
 ```
 
+**Canonical URLs and Alternate Links**: When post formats are enabled, markata-go automatically adds:
+
+- `<link rel="canonical">` pointing to the post's primary URL (for SEO)
+- `<link rel="alternate">` for each enabled format:
+  - Markdown: `type="text/markdown"` linking to `index.md`
+  - OG Card: `type="text/html"` linking to `og/`
+
+OG card pages automatically include:
+- `<link rel="canonical">` pointing back to the original post
+- `<meta name="robots" content="noindex, nofollow">` to prevent search engine indexing
+
 See the [[post-formats|Post Output Formats Guide]] for detailed usage including social image generation.
 
 ### Feed Defaults (`[markata-go.feed_defaults]`)

--- a/pkg/templates/context.go
+++ b/pkg/templates/context.go
@@ -186,6 +186,9 @@ func configToMap(c *models.Config) map[string]interface{} {
 	// Convert components to map
 	componentsMap := componentsToMap(&c.Components)
 
+	// Convert post_formats to map
+	postFormatsMap := postFormatsToMap(&c.PostFormats)
+
 	return map[string]interface{}{
 		"output_dir":    c.OutputDir,
 		"url":           c.URL,
@@ -200,6 +203,7 @@ func configToMap(c *models.Config) map[string]interface{} {
 		"indieauth":     indieAuthMap,
 		"webmention":    webmentionMap,
 		"components":    componentsMap,
+		"post_formats":  postFormatsMap,
 	}
 }
 
@@ -284,6 +288,24 @@ func componentsToMap(c *models.ComponentsConfig) map[string]interface{} {
 		"footer":       footerMap,
 		"doc_sidebar":  docSidebarMap,
 		"feed_sidebar": feedSidebarMap,
+	}
+}
+
+// postFormatsToMap converts a PostFormatsConfig to a map for template access.
+func postFormatsToMap(p *models.PostFormatsConfig) map[string]interface{} {
+	if p == nil {
+		return nil
+	}
+
+	htmlEnabled := true
+	if p.HTML != nil {
+		htmlEnabled = *p.HTML
+	}
+
+	return map[string]interface{}{
+		"html":     htmlEnabled,
+		"markdown": p.Markdown,
+		"og":       p.OG,
 	}
 }
 

--- a/pkg/themes/default/templates/post.html
+++ b/pkg/themes/default/templates/post.html
@@ -5,13 +5,29 @@
 
 {% block meta %}
 {{ block.super }}
+{# Canonical URL for SEO #}
+<link rel="canonical" href="{{ config.url }}{{ post.href }}">
+
+{# Alternate format links #}
+{% if config.post_formats.markdown %}
+<link rel="alternate" type="text/markdown" title="Markdown Source" href="{{ post.href }}index.md">
+{% endif %}
+{% if config.post_formats.og %}
+<link rel="alternate" type="text/html" title="Social Card" href="{{ post.href }}og/">
+{% endif %}
+
+{# Open Graph meta tags #}
 <meta property="og:title" content="{{ post.title }}">
 <meta property="og:type" content="article">
+<meta property="og:url" content="{{ config.url }}{{ post.href }}">
 {% if post.description %}
 <meta property="og:description" content="{{ post.description }}">
 {% endif %}
 {% if post.date %}
 <meta property="article:published_time" content="{{ post.date | atom_date }}">
+{% endif %}
+{% if config.post_formats.og %}
+<meta property="og:image" content="{{ config.url }}{{ post.href }}og/">
 {% endif %}
 {% endblock %}
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -35,6 +35,23 @@
     {% if config.seo.default_image %}<meta name="twitter:image" content="{{ config.url }}{{ config.seo.default_image }}">{% endif %}
     {% endif %}
     
+    <!-- Canonical URL -->
+    {% if post %}
+    <link rel="canonical" href="{{ config.url }}{{ post.href }}">
+    {% else %}
+    <link rel="canonical" href="{{ config.url }}/">
+    {% endif %}
+    
+    <!-- Alternate Post Formats -->
+    {% if post %}
+    {% if config.post_formats.markdown %}
+    <link rel="alternate" type="text/markdown" title="Markdown Source" href="{{ post.href }}index.md">
+    {% endif %}
+    {% if config.post_formats.og %}
+    <link rel="alternate" type="text/html" title="Social Card" href="{{ post.href }}og/">
+    {% endif %}
+    {% endif %}
+    
     {% block head %}
     <!-- Theme CSS -->
     <link rel="stylesheet" href="{{ 'css/variables.css' | theme_asset }}">


### PR DESCRIPTION
## Summary

Adds canonical URLs and alternate format links to post templates for improved SEO and discoverability.

## Changes

### Template Updates
- **`pkg/themes/default/templates/post.html`**: Added canonical URL and alternate format links to the meta block
- **`templates/base.html`**: Added canonical URL (for posts and site root) and alternate format links

### Context Updates
- **`pkg/templates/context.go`**: Added `postFormatsToMap` function to expose `post_formats` config to templates

### Documentation
- **`docs/guides/configuration.md`**: Updated Post Output Formats section to document the automatic canonical/alternate link behavior

## Features

Posts now automatically include:
- `<link rel="canonical">` pointing to the post's primary URL (for SEO)
- `<link rel="alternate" type="text/markdown">` when markdown format is enabled
- `<link rel="alternate" type="text/html">` for OG cards when OG format is enabled
- Enhanced Open Graph meta tags including og:url

## Example Output

```html
<!-- Canonical URL -->
<link rel="canonical" href="https://example.com/my-post/">

<!-- Alternate formats (when enabled) -->
<link rel="alternate" type="text/markdown" title="Markdown Source" href="/my-post/index.md">
<link rel="alternate" type="text/html" title="Social Card" href="/my-post/og/">
```

Refs #69