### PR TITLE
feat: add comprehensive structured data support (JSON-LD, OpenGraph, Twitter Cards)

### DIFF
--- a/docs/guides/structured-data.md
+++ b/docs/guides/structured-data.md
@@ -1,0 +1,226 @@
+---
+title: "Structured Data & SEO"
+description: "Configure JSON-LD Schema.org markup, OpenGraph, and Twitter Cards for better SEO and social sharing"
+date: 2024-01-15
+published: true
+tags:
+  - documentation
+  - seo
+  - structured-data
+---
+
+# Structured Data & SEO
+
+markata-go automatically generates comprehensive structured data for your posts to improve search engine visibility and social media sharing.
+
+## Features
+
+- **JSON-LD Schema.org** - Structured data for Google Rich Results
+- **OpenGraph** - Meta tags for Facebook, LinkedIn, and general social sharing  
+- **Twitter Cards** - Meta tags for Twitter/X sharing previews
+
+## Quick Start
+
+Structured data is enabled by default. For basic usage, just ensure your posts have good frontmatter:
+
+```yaml
+---
+title: "My Post Title"
+description: "A compelling description for SEO"
+date: 2024-01-15
+tags: ["tag1", "tag2"]
+---
+```
+
+## Configuration
+
+### Site-Level SEO Configuration
+
+Configure SEO settings in your `markata-go.toml`:
+
+```toml
+[markata-go.seo]
+# Twitter/X username (without @)
+twitter_handle = "yourusername"
+
+# Default image for posts without images
+default_image = "/images/og-default.jpg"
+
+# Site logo for Schema.org
+logo_url = "/images/logo.png"
+
+[markata-go.seo.structured_data]
+# Enable/disable structured data (default: true)
+enabled = true
+
+# Publisher information
+[markata-go.seo.structured_data.publisher]
+type = "Organization"  # or "Person"
+name = "Your Site Name"
+url = "https://example.com"
+logo = "/images/logo.png"
+
+# Default author for posts without explicit author
+[markata-go.seo.structured_data.default_author]
+type = "Person"
+name = "Author Name"
+url = "https://example.com/about"
+```
+
+### Frontmatter Fields
+
+Override structured data per-post via frontmatter:
+
+```yaml
+---
+title: "Post Title"
+description: "Post description for meta tags"
+date: 2024-01-15
+
+# Optional fields
+author: "Author Name"          # Override default author
+image: "/images/post.jpg"      # OG/Twitter image
+social_image: "/images/og.jpg" # Specific OG image override
+twitter: "authorhandle"        # Author's Twitter (without @)
+modified: "2024-01-16"         # Last modified date
+tags: ["tag1", "tag2"]
+---
+```
+
+## Generated Output
+
+### JSON-LD Schema
+
+For each post, markata-go generates a `BlogPosting` schema:
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": "Post Title",
+  "description": "Post description",
+  "datePublished": "2024-01-15T00:00:00Z",
+  "dateModified": "2024-01-16T00:00:00Z",
+  "author": {
+    "@type": "Person",
+    "name": "Author Name",
+    "url": "https://example.com/about"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Site Name",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://example.com/logo.png"
+    }
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "https://example.com/post-slug/"
+  },
+  "image": "https://example.com/images/post.jpg",
+  "keywords": ["tag1", "tag2"]
+}
+```
+
+### OpenGraph Tags
+
+Generated tags include:
+
+| Tag | Description |
+|-----|-------------|
+| `og:title` | Post title |
+| `og:description` | Post description |
+| `og:type` | "article" for posts, "website" for pages |
+| `og:url` | Canonical URL |
+| `og:site_name` | Site title |
+| `og:image` | Post or default image |
+| `og:locale` | Content locale |
+| `article:published_time` | Publication date |
+| `article:modified_time` | Last modified date |
+| `article:author` | Author URL |
+| `article:tag` | Post tags |
+
+### Twitter Card Tags
+
+Generated tags include:
+
+| Tag | Description |
+|-----|-------------|
+| `twitter:card` | "summary_large_image" or "summary" |
+| `twitter:site` | Site Twitter handle |
+| `twitter:creator` | Author Twitter handle |
+| `twitter:title` | Post title |
+| `twitter:description` | Post description (truncated to 200 chars) |
+| `twitter:image` | Post or default image |
+
+## Image Priority
+
+Images are selected in this order:
+
+1. `social_image` from frontmatter (OG-specific override)
+2. `image` from frontmatter
+3. `default_image` from SEO config
+
+## Author Priority
+
+Authors are determined in this order:
+
+1. `author` field from frontmatter
+2. `default_author` from structured data config
+3. `author` from site config
+
+## Disabling Structured Data
+
+To disable structured data generation:
+
+```toml
+[markata-go.seo.structured_data]
+enabled = false
+```
+
+## Testing Your Structured Data
+
+Use these tools to validate your structured data:
+
+- [Google Rich Results Test](https://search.google.com/test/rich-results)
+- [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/)
+- [Twitter Card Validator](https://cards-dev.twitter.com/validator)
+- [Schema.org Validator](https://validator.schema.org/)
+
+## Best Practices
+
+1. **Always include descriptions** - Good descriptions improve both SEO and social sharing
+2. **Use quality images** - Social images should be at least 1200x630 pixels
+3. **Keep titles under 60 characters** - Prevents truncation in search results
+4. **Set publication dates** - Helps search engines understand content freshness
+5. **Use relevant tags** - Tags become keywords in schema markup
+
+## Template Access
+
+Structured data is available in templates via `post.structured_data`:
+
+```html
+{# JSON-LD #}
+{% if post.structured_data.jsonld %}
+<script type="application/ld+json">
+{{ post.structured_data.jsonld | safe }}
+</script>
+{% endif %}
+
+{# OpenGraph #}
+{% for meta in post.structured_data.opengraph %}
+<meta property="{{ meta.property }}" content="{{ meta.content }}">
+{% endfor %}
+
+{# Twitter Cards #}
+{% for meta in post.structured_data.twitter %}
+<meta name="{{ meta.name }}" content="{{ meta.content }}">
+{% endfor %}
+```
+
+## See Also
+
+- [Configuration Reference](/docs/guides/configuration/)
+- [Post Formats](/docs/guides/post-formats/)
+- [Themes](/docs/guides/themes/)

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -552,14 +552,62 @@ type SEOConfig struct {
 
 	// LogoURL is the site logo URL for Schema.org structured data
 	LogoURL string `json:"logo_url" yaml:"logo_url" toml:"logo_url"`
+
+	// StructuredData configures JSON-LD Schema.org generation
+	StructuredData StructuredDataConfig `json:"structured_data" yaml:"structured_data" toml:"structured_data"`
+}
+
+// StructuredDataConfig configures JSON-LD Schema.org structured data generation.
+type StructuredDataConfig struct {
+	// Enabled controls whether structured data is generated (default: true)
+	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty" toml:"enabled,omitempty"`
+
+	// Publisher is the site publisher information for Schema.org
+	Publisher *EntityConfig `json:"publisher,omitempty" yaml:"publisher,omitempty" toml:"publisher,omitempty"`
+
+	// DefaultAuthor is the default author for posts without explicit author
+	DefaultAuthor *EntityConfig `json:"default_author,omitempty" yaml:"default_author,omitempty" toml:"default_author,omitempty"`
+}
+
+// IsEnabled returns whether structured data generation is enabled.
+// Defaults to true if not explicitly set.
+func (s *StructuredDataConfig) IsEnabled() bool {
+	if s.Enabled == nil {
+		return true
+	}
+	return *s.Enabled
+}
+
+// EntityConfig represents a Schema.org Person or Organization entity.
+type EntityConfig struct {
+	// Type is "Person" or "Organization" (default: "Organization")
+	Type string `json:"type" yaml:"type" toml:"type"`
+
+	// Name is the entity name
+	Name string `json:"name" yaml:"name" toml:"name"`
+
+	// URL is the entity's web page
+	URL string `json:"url,omitempty" yaml:"url,omitempty" toml:"url,omitempty"`
+
+	// Logo is the logo URL (for Organizations only)
+	Logo string `json:"logo,omitempty" yaml:"logo,omitempty" toml:"logo,omitempty"`
+}
+
+// NewStructuredDataConfig creates a new StructuredDataConfig with default values.
+func NewStructuredDataConfig() StructuredDataConfig {
+	enabled := true
+	return StructuredDataConfig{
+		Enabled: &enabled,
+	}
 }
 
 // NewSEOConfig creates a new SEOConfig with default values.
 func NewSEOConfig() SEOConfig {
 	return SEOConfig{
-		TwitterHandle: "",
-		DefaultImage:  "",
-		LogoURL:       "",
+		TwitterHandle:  "",
+		DefaultImage:   "",
+		LogoURL:        "",
+		StructuredData: NewStructuredDataConfig(),
 	}
 }
 

--- a/pkg/models/structured_data.go
+++ b/pkg/models/structured_data.go
@@ -1,0 +1,160 @@
+package models
+
+// StructuredData holds generated structured data for a post.
+// This is stored in post.Extra["structured_data"] after processing.
+type StructuredData struct {
+	// JSONLD is the JSON-LD script content (without script tags)
+	JSONLD string `json:"jsonld" yaml:"jsonld" toml:"jsonld"`
+
+	// OpenGraph contains OpenGraph meta tags
+	OpenGraph []OpenGraphTag `json:"opengraph" yaml:"opengraph" toml:"opengraph"`
+
+	// Twitter contains Twitter Card meta tags
+	Twitter []TwitterTag `json:"twitter" yaml:"twitter" toml:"twitter"`
+}
+
+// OpenGraphTag represents an OpenGraph meta tag.
+type OpenGraphTag struct {
+	// Property is the og: property name (e.g., "og:title")
+	Property string `json:"property" yaml:"property" toml:"property"`
+
+	// Content is the tag content value
+	Content string `json:"content" yaml:"content" toml:"content"`
+}
+
+// TwitterTag represents a Twitter Card meta tag.
+type TwitterTag struct {
+	// Name is the twitter: name (e.g., "twitter:card")
+	Name string `json:"name" yaml:"name" toml:"name"`
+
+	// Content is the tag content value
+	Content string `json:"content" yaml:"content" toml:"content"`
+}
+
+// NewStructuredData creates a new empty StructuredData.
+func NewStructuredData() *StructuredData {
+	return &StructuredData{
+		OpenGraph: []OpenGraphTag{},
+		Twitter:   []TwitterTag{},
+	}
+}
+
+// AddOpenGraph adds an OpenGraph tag.
+func (s *StructuredData) AddOpenGraph(property, content string) {
+	if content == "" {
+		return
+	}
+	s.OpenGraph = append(s.OpenGraph, OpenGraphTag{
+		Property: property,
+		Content:  content,
+	})
+}
+
+// AddTwitter adds a Twitter Card tag.
+func (s *StructuredData) AddTwitter(name, content string) {
+	if content == "" {
+		return
+	}
+	s.Twitter = append(s.Twitter, TwitterTag{
+		Name:    name,
+		Content: content,
+	})
+}
+
+// BlogPosting represents a Schema.org BlogPosting for JSON-LD.
+type BlogPosting struct {
+	Context          string       `json:"@context"`
+	Type             string       `json:"@type"`
+	Headline         string       `json:"headline"`
+	Description      string       `json:"description,omitempty"`
+	DatePublished    string       `json:"datePublished,omitempty"`
+	DateModified     string       `json:"dateModified,omitempty"`
+	Author           *SchemaAgent `json:"author,omitempty"`
+	Publisher        *SchemaAgent `json:"publisher,omitempty"`
+	MainEntityOfPage *WebPage     `json:"mainEntityOfPage,omitempty"`
+	Image            string       `json:"image,omitempty"`
+	Keywords         []string     `json:"keywords,omitempty"`
+	URL              string       `json:"url,omitempty"`
+}
+
+// WebPage represents a Schema.org WebPage for JSON-LD.
+type WebPage struct {
+	Type string `json:"@type"`
+	ID   string `json:"@id"`
+}
+
+// WebSite represents a Schema.org WebSite for JSON-LD.
+type WebSite struct {
+	Context     string       `json:"@context"`
+	Type        string       `json:"@type"`
+	Name        string       `json:"name"`
+	Description string       `json:"description,omitempty"`
+	URL         string       `json:"url"`
+	Publisher   *SchemaAgent `json:"publisher,omitempty"`
+}
+
+// SchemaAgent represents a Schema.org Person or Organization.
+type SchemaAgent struct {
+	Type string       `json:"@type"`
+	Name string       `json:"name"`
+	URL  string       `json:"url,omitempty"`
+	Logo *ImageObject `json:"logo,omitempty"`
+}
+
+// ImageObject represents a Schema.org ImageObject.
+type ImageObject struct {
+	Type string `json:"@type"`
+	URL  string `json:"url"`
+}
+
+// NewBlogPosting creates a new BlogPosting with required fields.
+func NewBlogPosting(headline, url string) *BlogPosting {
+	return &BlogPosting{
+		Context:  "https://schema.org",
+		Type:     "BlogPosting",
+		Headline: headline,
+		URL:      url,
+		MainEntityOfPage: &WebPage{
+			Type: "WebPage",
+			ID:   url,
+		},
+	}
+}
+
+// NewWebSite creates a new WebSite with required fields.
+func NewWebSite(name, url string) *WebSite {
+	return &WebSite{
+		Context: "https://schema.org",
+		Type:    "WebSite",
+		Name:    name,
+		URL:     url,
+	}
+}
+
+// NewSchemaAgent creates a new SchemaAgent (Person or Organization).
+func NewSchemaAgent(agentType, name string) *SchemaAgent {
+	if agentType == "" {
+		agentType = "Organization"
+	}
+	return &SchemaAgent{
+		Type: agentType,
+		Name: name,
+	}
+}
+
+// WithURL sets the URL on a SchemaAgent and returns it for chaining.
+func (a *SchemaAgent) WithURL(url string) *SchemaAgent {
+	a.URL = url
+	return a
+}
+
+// WithLogo sets the logo on a SchemaAgent and returns it for chaining.
+func (a *SchemaAgent) WithLogo(logoURL string) *SchemaAgent {
+	if logoURL != "" {
+		a.Logo = &ImageObject{
+			Type: "ImageObject",
+			URL:  logoURL,
+		}
+	}
+	return a
+}

--- a/pkg/plugins/registry.go
+++ b/pkg/plugins/registry.go
@@ -63,6 +63,7 @@ func registerBuiltinPluginsLocked() {
 	pluginRegistry.constructors["youtube"] = func() lifecycle.Plugin { return NewYouTubePlugin() }
 	pluginRegistry.constructors["chroma_css"] = func() lifecycle.Plugin { return NewChromaCSSPlugin() }
 	pluginRegistry.constructors["overwrite_check"] = func() lifecycle.Plugin { return NewOverwriteCheckPlugin() }
+	pluginRegistry.constructors["structured_data"] = func() lifecycle.Plugin { return NewStructuredDataPlugin() }
 }
 
 // RegisterPluginConstructor registers a plugin constructor with the given name.
@@ -114,12 +115,13 @@ func DefaultPlugins() []lifecycle.Plugin {
 		NewLoadPlugin(),
 
 		// Transform stage plugins (in order)
-		NewAutoTitlePlugin(),   // Auto-generate titles first
-		NewDescriptionPlugin(), // Auto-generate descriptions early
-		NewReadingTimePlugin(), // Calculate reading time
-		NewWikilinksPlugin(),   // Process wikilinks before rendering
-		NewTocPlugin(),         // Extract TOC before rendering
-		NewJinjaMdPlugin(),     // Process Jinja templates in markdown
+		NewAutoTitlePlugin(),      // Auto-generate titles first
+		NewDescriptionPlugin(),    // Auto-generate descriptions early
+		NewStructuredDataPlugin(), // Generate structured data (needs title, description)
+		NewReadingTimePlugin(),    // Calculate reading time
+		NewWikilinksPlugin(),      // Process wikilinks before rendering
+		NewTocPlugin(),            // Extract TOC before rendering
+		NewJinjaMdPlugin(),        // Process Jinja templates in markdown
 
 		// Render stage plugins
 		NewRenderMarkdownPlugin(),

--- a/pkg/plugins/structured_data.go
+++ b/pkg/plugins/structured_data.go
@@ -1,0 +1,365 @@
+// Package plugins provides lifecycle plugins for markata-go.
+package plugins
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
+	"github.com/WaylonWalker/markata-go/pkg/models"
+)
+
+// StructuredDataPlugin generates JSON-LD Schema.org markup, OpenGraph meta tags,
+// and Twitter Cards for SEO and social media optimization.
+type StructuredDataPlugin struct{}
+
+// NewStructuredDataPlugin creates a new StructuredDataPlugin.
+func NewStructuredDataPlugin() *StructuredDataPlugin {
+	return &StructuredDataPlugin{}
+}
+
+// Name returns the unique name of the plugin.
+func (p *StructuredDataPlugin) Name() string {
+	return "structured_data"
+}
+
+// Priority returns the plugin priority for the given stage.
+// Runs in mid-transform, after description plugin has run.
+func (p *StructuredDataPlugin) Priority(stage lifecycle.Stage) int {
+	if stage == lifecycle.StageTransform {
+		return lifecycle.PriorityDefault // 500
+	}
+	return lifecycle.PriorityDefault
+}
+
+// Transform generates structured data for each post.
+func (p *StructuredDataPlugin) Transform(m *lifecycle.Manager) error {
+	config := m.Config()
+
+	// Check if structured data is enabled
+	seoConfig := getSEOConfig(config)
+	if !seoConfig.StructuredData.IsEnabled() {
+		return nil
+	}
+
+	return m.ProcessPostsConcurrently(func(post *models.Post) error {
+		if post.Skip || post.Draft {
+			return nil
+		}
+
+		// Skip posts without titles (required for structured data)
+		if post.Title == nil || *post.Title == "" {
+			return nil
+		}
+
+		return p.generateStructuredData(post, config, &seoConfig)
+	})
+}
+
+// generateStructuredData creates all structured data for a post.
+func (p *StructuredDataPlugin) generateStructuredData(post *models.Post, config *lifecycle.Config, seoConfig *models.SEOConfig) error {
+	sd := models.NewStructuredData()
+
+	// Generate JSON-LD
+	jsonLD, err := p.generateJSONLD(post, config, seoConfig)
+	if err == nil && jsonLD != "" {
+		sd.JSONLD = jsonLD
+	}
+
+	// Generate OpenGraph tags
+	p.generateOpenGraph(sd, post, config, seoConfig)
+
+	// Generate Twitter Card tags
+	p.generateTwitterCard(sd, post, config, seoConfig)
+
+	// Store in post.Extra
+	post.Set("structured_data", sd)
+
+	return nil
+}
+
+// generateJSONLD creates JSON-LD Schema.org markup for a post.
+func (p *StructuredDataPlugin) generateJSONLD(post *models.Post, config *lifecycle.Config, seoConfig *models.SEOConfig) (string, error) {
+	siteURL := getSiteURL(config)
+	postURL := siteURL + post.Href
+
+	// Create BlogPosting schema
+	bp := models.NewBlogPosting(*post.Title, postURL)
+
+	// Add description
+	if post.Description != nil {
+		bp.Description = *post.Description
+	}
+
+	// Add dates
+	if post.Date != nil {
+		bp.DatePublished = post.Date.Format("2006-01-02T15:04:05Z07:00")
+		bp.DateModified = bp.DatePublished
+
+		// Check for modified date in Extra
+		if modified, ok := post.Extra["modified"]; ok {
+			if modStr, ok := modified.(string); ok {
+				bp.DateModified = modStr
+			}
+		}
+	}
+
+	// Add image
+	imageURL := p.getPostImage(post, seoConfig)
+	if imageURL != "" {
+		bp.Image = p.makeAbsoluteURL(imageURL, siteURL)
+	}
+
+	// Add keywords from tags
+	if len(post.Tags) > 0 {
+		bp.Keywords = post.Tags
+	}
+
+	// Add author
+	bp.Author = p.getAuthor(post, config, seoConfig)
+
+	// Add publisher
+	bp.Publisher = p.getPublisher(config, seoConfig)
+
+	// Marshal to JSON
+	jsonBytes, err := json.MarshalIndent(bp, "", "  ")
+	if err != nil {
+		return "", err
+	}
+
+	return string(jsonBytes), nil
+}
+
+// generateOpenGraph creates OpenGraph meta tags.
+func (p *StructuredDataPlugin) generateOpenGraph(sd *models.StructuredData, post *models.Post, config *lifecycle.Config, seoConfig *models.SEOConfig) {
+	siteURL := getSiteURL(config)
+	siteTitle := getSiteTitle(config)
+	siteDescription := getSiteDescription(config)
+	postURL := siteURL + post.Href
+
+	// Required tags
+	sd.AddOpenGraph("og:title", *post.Title)
+	sd.AddOpenGraph("og:url", postURL)
+	sd.AddOpenGraph("og:site_name", siteTitle)
+
+	// Type - article for posts with dates, website otherwise
+	if post.Date != nil {
+		sd.AddOpenGraph("og:type", "article")
+	} else {
+		sd.AddOpenGraph("og:type", "website")
+	}
+
+	// Description
+	if post.Description != nil {
+		sd.AddOpenGraph("og:description", *post.Description)
+	} else if siteDescription != "" {
+		sd.AddOpenGraph("og:description", siteDescription)
+	}
+
+	// Image
+	imageURL := p.getPostImage(post, seoConfig)
+	if imageURL != "" {
+		absImageURL := p.makeAbsoluteURL(imageURL, siteURL)
+		sd.AddOpenGraph("og:image", absImageURL)
+		sd.AddOpenGraph("og:image:width", "1200")
+		sd.AddOpenGraph("og:image:height", "630")
+	}
+
+	// Locale
+	sd.AddOpenGraph("og:locale", "en_US")
+
+	// Article-specific tags
+	if post.Date != nil {
+		sd.AddOpenGraph("article:published_time", post.Date.Format("2006-01-02T15:04:05Z07:00"))
+
+		// Modified time
+		if modified, ok := post.Extra["modified"]; ok {
+			if modStr, ok := modified.(string); ok {
+				sd.AddOpenGraph("article:modified_time", modStr)
+			}
+		}
+
+		// Author URL
+		author := p.getAuthor(post, config, seoConfig)
+		if author != nil && author.URL != "" {
+			sd.AddOpenGraph("article:author", author.URL)
+		}
+
+		// Tags
+		for _, tag := range post.Tags {
+			sd.AddOpenGraph("article:tag", tag)
+		}
+	}
+}
+
+// generateTwitterCard creates Twitter Card meta tags.
+func (p *StructuredDataPlugin) generateTwitterCard(sd *models.StructuredData, post *models.Post, config *lifecycle.Config, seoConfig *models.SEOConfig) {
+	siteURL := getSiteURL(config)
+
+	// Card type - summary_large_image if we have an image
+	imageURL := p.getPostImage(post, seoConfig)
+	if imageURL != "" {
+		sd.AddTwitter("twitter:card", "summary_large_image")
+		sd.AddTwitter("twitter:image", p.makeAbsoluteURL(imageURL, siteURL))
+	} else {
+		sd.AddTwitter("twitter:card", "summary")
+	}
+
+	// Site handle
+	if seoConfig.TwitterHandle != "" {
+		sd.AddTwitter("twitter:site", "@"+seoConfig.TwitterHandle)
+	}
+
+	// Creator handle (use author's twitter if available, otherwise site handle)
+	creatorHandle := p.getTwitterHandle(post, seoConfig)
+	if creatorHandle != "" {
+		sd.AddTwitter("twitter:creator", "@"+creatorHandle)
+	}
+
+	// Title
+	sd.AddTwitter("twitter:title", *post.Title)
+
+	// Description (truncated to 200 chars for Twitter)
+	if post.Description != nil {
+		desc := *post.Description
+		if len(desc) > 200 {
+			desc = desc[:197] + "..."
+		}
+		sd.AddTwitter("twitter:description", desc)
+	}
+}
+
+// getPostImage returns the image URL for a post.
+// Checks frontmatter image, social_image, then falls back to default.
+func (p *StructuredDataPlugin) getPostImage(post *models.Post, seoConfig *models.SEOConfig) string {
+	// Check for social_image override first
+	if socialImage, ok := post.Extra["social_image"]; ok {
+		if imgStr, ok := socialImage.(string); ok && imgStr != "" {
+			return imgStr
+		}
+	}
+
+	// Check for image in frontmatter
+	if image, ok := post.Extra["image"]; ok {
+		if imgStr, ok := image.(string); ok && imgStr != "" {
+			return imgStr
+		}
+	}
+
+	// Fall back to default image
+	return seoConfig.DefaultImage
+}
+
+// getAuthor returns the author SchemaAgent for a post.
+func (p *StructuredDataPlugin) getAuthor(post *models.Post, config *lifecycle.Config, seoConfig *models.SEOConfig) *models.SchemaAgent {
+	// Check for author in frontmatter
+	var authorName string
+	if author, ok := post.Extra["author"]; ok {
+		if authorStr, ok := author.(string); ok && authorStr != "" {
+			authorName = authorStr
+		}
+	}
+
+	// If we have a custom author name, create a basic agent
+	if authorName != "" {
+		return models.NewSchemaAgent("Person", authorName)
+	}
+
+	// Use default author from config
+	if seoConfig.StructuredData.DefaultAuthor != nil {
+		da := seoConfig.StructuredData.DefaultAuthor
+		return models.NewSchemaAgent(da.Type, da.Name).WithURL(da.URL)
+	}
+
+	// Fall back to site author
+	siteAuthor := getSiteAuthor(config)
+	if siteAuthor != "" {
+		return models.NewSchemaAgent("Person", siteAuthor)
+	}
+
+	return nil
+}
+
+// getPublisher returns the publisher SchemaAgent for the site.
+func (p *StructuredDataPlugin) getPublisher(config *lifecycle.Config, seoConfig *models.SEOConfig) *models.SchemaAgent {
+	siteURL := getSiteURL(config)
+
+	// Use publisher from config
+	if seoConfig.StructuredData.Publisher != nil {
+		pub := seoConfig.StructuredData.Publisher
+		agent := models.NewSchemaAgent(pub.Type, pub.Name).WithURL(pub.URL)
+		if pub.Logo != "" {
+			agent.WithLogo(p.makeAbsoluteURL(pub.Logo, siteURL))
+		} else if seoConfig.LogoURL != "" {
+			agent.WithLogo(p.makeAbsoluteURL(seoConfig.LogoURL, siteURL))
+		}
+		return agent
+	}
+
+	// Fall back to site title as Organization
+	siteTitle := getSiteTitle(config)
+	if siteTitle != "" {
+		agent := models.NewSchemaAgent("Organization", siteTitle).WithURL(siteURL)
+		if seoConfig.LogoURL != "" {
+			agent.WithLogo(p.makeAbsoluteURL(seoConfig.LogoURL, siteURL))
+		}
+		return agent
+	}
+
+	return nil
+}
+
+// getTwitterHandle returns the Twitter handle for the post author or site.
+func (p *StructuredDataPlugin) getTwitterHandle(post *models.Post, seoConfig *models.SEOConfig) string {
+	// Check for author's twitter handle in frontmatter
+	if twitterHandle, ok := post.Extra["twitter"]; ok {
+		if handleStr, ok := twitterHandle.(string); ok && handleStr != "" {
+			// Remove @ if present
+			return strings.TrimPrefix(handleStr, "@")
+		}
+	}
+
+	// Fall back to site handle
+	return seoConfig.TwitterHandle
+}
+
+// makeAbsoluteURL converts a relative URL to an absolute URL.
+func (p *StructuredDataPlugin) makeAbsoluteURL(url, siteURL string) string {
+	if url == "" {
+		return ""
+	}
+
+	// Already absolute
+	if strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://") {
+		return url
+	}
+
+	// Protocol-relative
+	if strings.HasPrefix(url, "//") {
+		return "https:" + url
+	}
+
+	// Relative URL - prepend site URL
+	siteURL = strings.TrimSuffix(siteURL, "/")
+	if !strings.HasPrefix(url, "/") {
+		url = "/" + url
+	}
+	return siteURL + url
+}
+
+// getSEOConfig retrieves the SEOConfig from lifecycle.Config.Extra.
+func getSEOConfig(config *lifecycle.Config) models.SEOConfig {
+	if config.Extra != nil {
+		if seo, ok := config.Extra["seo"].(models.SEOConfig); ok {
+			return seo
+		}
+	}
+	return models.NewSEOConfig()
+}
+
+// Ensure StructuredDataPlugin implements the required interfaces.
+var (
+	_ lifecycle.Plugin          = (*StructuredDataPlugin)(nil)
+	_ lifecycle.TransformPlugin = (*StructuredDataPlugin)(nil)
+	_ lifecycle.PriorityPlugin  = (*StructuredDataPlugin)(nil)
+)

--- a/pkg/plugins/structured_data_test.go
+++ b/pkg/plugins/structured_data_test.go
@@ -1,0 +1,461 @@
+package plugins
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
+	"github.com/WaylonWalker/markata-go/pkg/models"
+)
+
+func TestStructuredDataPlugin_Name(t *testing.T) {
+	plugin := NewStructuredDataPlugin()
+	if got := plugin.Name(); got != "structured_data" {
+		t.Errorf("Name() = %v, want %v", got, "structured_data")
+	}
+}
+
+func TestStructuredDataPlugin_Priority(t *testing.T) {
+	plugin := NewStructuredDataPlugin()
+
+	// Should return default priority for transform stage
+	if got := plugin.Priority(lifecycle.StageTransform); got != lifecycle.PriorityDefault {
+		t.Errorf("Priority(StageTransform) = %v, want %v", got, lifecycle.PriorityDefault)
+	}
+
+	// Should return default priority for other stages
+	if got := plugin.Priority(lifecycle.StageWrite); got != lifecycle.PriorityDefault {
+		t.Errorf("Priority(StageWrite) = %v, want %v", got, lifecycle.PriorityDefault)
+	}
+}
+
+func TestStructuredDataPlugin_Transform(t *testing.T) {
+	plugin := NewStructuredDataPlugin()
+
+	// Create a manager with a test post
+	m := lifecycle.NewManager()
+	m.SetConfig(&lifecycle.Config{
+		OutputDir: "output",
+		Extra: map[string]interface{}{
+			"url":         "https://example.com",
+			"title":       "Test Site",
+			"description": "A test site",
+			"author":      "Test Author",
+			"seo":         models.NewSEOConfig(),
+		},
+	})
+
+	title := "Test Post Title"
+	description := "Test post description"
+	postDate := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
+	post := &models.Post{
+		Path:        "test.md",
+		Title:       &title,
+		Description: &description,
+		Date:        &postDate,
+		Slug:        "test-post",
+		Href:        "/test-post/",
+		Tags:        []string{"go", "testing"},
+		Extra:       make(map[string]interface{}),
+	}
+	m.SetPosts([]*models.Post{post})
+
+	// Run the transform
+	err := plugin.Transform(m)
+	if err != nil {
+		t.Fatalf("Transform() error = %v", err)
+	}
+
+	// Check that structured data was added
+	sd, ok := post.Extra["structured_data"].(*models.StructuredData)
+	if !ok {
+		t.Fatal("structured_data not found in post.Extra")
+	}
+
+	// Verify JSON-LD
+	if sd.JSONLD == "" {
+		t.Error("JSON-LD should not be empty")
+	}
+
+	// Parse JSON-LD to verify structure
+	var jsonLD map[string]interface{}
+	if err := json.Unmarshal([]byte(sd.JSONLD), &jsonLD); err != nil {
+		t.Errorf("JSON-LD should be valid JSON: %v", err)
+	}
+
+	if jsonLD["@context"] != "https://schema.org" {
+		t.Errorf("JSON-LD @context = %v, want https://schema.org", jsonLD["@context"])
+	}
+	if jsonLD["@type"] != "BlogPosting" {
+		t.Errorf("JSON-LD @type = %v, want BlogPosting", jsonLD["@type"])
+	}
+	if jsonLD["headline"] != "Test Post Title" {
+		t.Errorf("JSON-LD headline = %v, want Test Post Title", jsonLD["headline"])
+	}
+
+	// Verify OpenGraph tags
+	if len(sd.OpenGraph) == 0 {
+		t.Error("OpenGraph tags should not be empty")
+	}
+
+	// Check for required OG tags
+	ogTags := make(map[string]string)
+	for _, tag := range sd.OpenGraph {
+		ogTags[tag.Property] = tag.Content
+	}
+
+	if ogTags["og:title"] != "Test Post Title" {
+		t.Errorf("og:title = %v, want Test Post Title", ogTags["og:title"])
+	}
+	if ogTags["og:type"] != "article" {
+		t.Errorf("og:type = %v, want article", ogTags["og:type"])
+	}
+	if ogTags["og:url"] != "https://example.com/test-post/" {
+		t.Errorf("og:url = %v, want https://example.com/test-post/", ogTags["og:url"])
+	}
+
+	// Verify Twitter Card tags
+	if len(sd.Twitter) == 0 {
+		t.Error("Twitter tags should not be empty")
+	}
+
+	twitterTags := make(map[string]string)
+	for _, tag := range sd.Twitter {
+		twitterTags[tag.Name] = tag.Content
+	}
+
+	if twitterTags["twitter:card"] != "summary" {
+		t.Errorf("twitter:card = %v, want summary", twitterTags["twitter:card"])
+	}
+	if twitterTags["twitter:title"] != "Test Post Title" {
+		t.Errorf("twitter:title = %v, want Test Post Title", twitterTags["twitter:title"])
+	}
+}
+
+func TestStructuredDataPlugin_SkipDraft(t *testing.T) {
+	plugin := NewStructuredDataPlugin()
+
+	m := lifecycle.NewManager()
+	m.SetConfig(&lifecycle.Config{
+		OutputDir: "output",
+		Extra: map[string]interface{}{
+			"url":   "https://example.com",
+			"title": "Test Site",
+			"seo":   models.NewSEOConfig(),
+		},
+	})
+
+	title := "Draft Post"
+	post := &models.Post{
+		Path:  "draft.md",
+		Title: &title,
+		Slug:  "draft",
+		Href:  "/draft/",
+		Draft: true,
+		Extra: make(map[string]interface{}),
+	}
+	m.SetPosts([]*models.Post{post})
+
+	err := plugin.Transform(m)
+	if err != nil {
+		t.Fatalf("Transform() error = %v", err)
+	}
+
+	// Draft posts should not have structured data
+	if _, ok := post.Extra["structured_data"]; ok {
+		t.Error("Draft posts should not have structured data")
+	}
+}
+
+func TestStructuredDataPlugin_SkipNoTitle(t *testing.T) {
+	plugin := NewStructuredDataPlugin()
+
+	m := lifecycle.NewManager()
+	m.SetConfig(&lifecycle.Config{
+		OutputDir: "output",
+		Extra: map[string]interface{}{
+			"url":   "https://example.com",
+			"title": "Test Site",
+			"seo":   models.NewSEOConfig(),
+		},
+	})
+
+	post := &models.Post{
+		Path:  "no-title.md",
+		Title: nil, // No title
+		Slug:  "no-title",
+		Href:  "/no-title/",
+		Extra: make(map[string]interface{}),
+	}
+	m.SetPosts([]*models.Post{post})
+
+	err := plugin.Transform(m)
+	if err != nil {
+		t.Fatalf("Transform() error = %v", err)
+	}
+
+	// Posts without titles should not have structured data
+	if _, ok := post.Extra["structured_data"]; ok {
+		t.Error("Posts without titles should not have structured data")
+	}
+}
+
+func TestStructuredDataPlugin_WithImage(t *testing.T) {
+	plugin := NewStructuredDataPlugin()
+
+	m := lifecycle.NewManager()
+	m.SetConfig(&lifecycle.Config{
+		OutputDir: "output",
+		Extra: map[string]interface{}{
+			"url":   "https://example.com",
+			"title": "Test Site",
+			"seo":   models.NewSEOConfig(),
+		},
+	})
+
+	title := "Post With Image"
+	post := &models.Post{
+		Path:  "image-post.md",
+		Title: &title,
+		Slug:  "image-post",
+		Href:  "/image-post/",
+		Extra: map[string]interface{}{
+			"image": "/images/post.jpg",
+		},
+	}
+	m.SetPosts([]*models.Post{post})
+
+	err := plugin.Transform(m)
+	if err != nil {
+		t.Fatalf("Transform() error = %v", err)
+	}
+
+	sd, ok := post.Extra["structured_data"].(*models.StructuredData)
+	if !ok {
+		t.Fatal("structured_data is not *models.StructuredData")
+	}
+
+	// Check OG image
+	ogTags := make(map[string]string)
+	for _, tag := range sd.OpenGraph {
+		ogTags[tag.Property] = tag.Content
+	}
+
+	if !strings.Contains(ogTags["og:image"], "/images/post.jpg") {
+		t.Errorf("og:image should contain /images/post.jpg, got %v", ogTags["og:image"])
+	}
+
+	// Twitter card should be summary_large_image when image is present
+	twitterTags := make(map[string]string)
+	for _, tag := range sd.Twitter {
+		twitterTags[tag.Name] = tag.Content
+	}
+
+	if twitterTags["twitter:card"] != "summary_large_image" {
+		t.Errorf("twitter:card = %v, want summary_large_image", twitterTags["twitter:card"])
+	}
+}
+
+func TestStructuredDataPlugin_Disabled(t *testing.T) {
+	plugin := NewStructuredDataPlugin()
+
+	// Create SEO config with structured data disabled
+	enabled := false
+	seoConfig := models.SEOConfig{
+		StructuredData: models.StructuredDataConfig{
+			Enabled: &enabled,
+		},
+	}
+
+	m := lifecycle.NewManager()
+	m.SetConfig(&lifecycle.Config{
+		OutputDir: "output",
+		Extra: map[string]interface{}{
+			"url":   "https://example.com",
+			"title": "Test Site",
+			"seo":   seoConfig,
+		},
+	})
+
+	title := "Test Post"
+	post := &models.Post{
+		Path:  "test.md",
+		Title: &title,
+		Slug:  "test",
+		Href:  "/test/",
+		Extra: make(map[string]interface{}),
+	}
+	m.SetPosts([]*models.Post{post})
+
+	err := plugin.Transform(m)
+	if err != nil {
+		t.Fatalf("Transform() error = %v", err)
+	}
+
+	// When disabled, no structured data should be added
+	if _, ok := post.Extra["structured_data"]; ok {
+		t.Error("Structured data should not be added when disabled")
+	}
+}
+
+func TestStructuredDataPlugin_WithTwitterHandle(t *testing.T) {
+	plugin := NewStructuredDataPlugin()
+
+	seoConfig := models.SEOConfig{
+		TwitterHandle:  "testhandle",
+		StructuredData: models.NewStructuredDataConfig(),
+	}
+
+	m := lifecycle.NewManager()
+	m.SetConfig(&lifecycle.Config{
+		OutputDir: "output",
+		Extra: map[string]interface{}{
+			"url":   "https://example.com",
+			"title": "Test Site",
+			"seo":   seoConfig,
+		},
+	})
+
+	title := "Test Post"
+	post := &models.Post{
+		Path:  "test.md",
+		Title: &title,
+		Slug:  "test",
+		Href:  "/test/",
+		Extra: make(map[string]interface{}),
+	}
+	m.SetPosts([]*models.Post{post})
+
+	err := plugin.Transform(m)
+	if err != nil {
+		t.Fatalf("Transform() error = %v", err)
+	}
+
+	sd, ok := post.Extra["structured_data"].(*models.StructuredData)
+	if !ok {
+		t.Fatal("structured_data is not *models.StructuredData")
+	}
+
+	twitterTags := make(map[string]string)
+	for _, tag := range sd.Twitter {
+		twitterTags[tag.Name] = tag.Content
+	}
+
+	if twitterTags["twitter:site"] != "@testhandle" {
+		t.Errorf("twitter:site = %v, want @testhandle", twitterTags["twitter:site"])
+	}
+}
+
+func TestStructuredDataPlugin_MakeAbsoluteURL(t *testing.T) {
+	plugin := NewStructuredDataPlugin()
+
+	tests := []struct {
+		name    string
+		url     string
+		siteURL string
+		want    string
+	}{
+		{
+			name:    "already absolute http",
+			url:     "http://other.com/image.jpg",
+			siteURL: "https://example.com",
+			want:    "http://other.com/image.jpg",
+		},
+		{
+			name:    "already absolute https",
+			url:     "https://other.com/image.jpg",
+			siteURL: "https://example.com",
+			want:    "https://other.com/image.jpg",
+		},
+		{
+			name:    "protocol-relative",
+			url:     "//cdn.example.com/image.jpg",
+			siteURL: "https://example.com",
+			want:    "https://cdn.example.com/image.jpg",
+		},
+		{
+			name:    "relative with leading slash",
+			url:     "/images/post.jpg",
+			siteURL: "https://example.com",
+			want:    "https://example.com/images/post.jpg",
+		},
+		{
+			name:    "relative without leading slash",
+			url:     "images/post.jpg",
+			siteURL: "https://example.com",
+			want:    "https://example.com/images/post.jpg",
+		},
+		{
+			name:    "empty url",
+			url:     "",
+			siteURL: "https://example.com",
+			want:    "",
+		},
+		{
+			name:    "site url with trailing slash",
+			url:     "/images/post.jpg",
+			siteURL: "https://example.com/",
+			want:    "https://example.com/images/post.jpg",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := plugin.makeAbsoluteURL(tt.url, tt.siteURL)
+			if got != tt.want {
+				t.Errorf("makeAbsoluteURL(%q, %q) = %q, want %q", tt.url, tt.siteURL, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStructuredDataPlugin_ArticleTags(t *testing.T) {
+	plugin := NewStructuredDataPlugin()
+
+	m := lifecycle.NewManager()
+	m.SetConfig(&lifecycle.Config{
+		OutputDir: "output",
+		Extra: map[string]interface{}{
+			"url":   "https://example.com",
+			"title": "Test Site",
+			"seo":   models.NewSEOConfig(),
+		},
+	})
+
+	title := "Tagged Post"
+	postDate := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
+	post := &models.Post{
+		Path:  "tagged.md",
+		Title: &title,
+		Date:  &postDate,
+		Slug:  "tagged",
+		Href:  "/tagged/",
+		Tags:  []string{"go", "testing", "seo"},
+		Extra: make(map[string]interface{}),
+	}
+	m.SetPosts([]*models.Post{post})
+
+	err := plugin.Transform(m)
+	if err != nil {
+		t.Fatalf("Transform() error = %v", err)
+	}
+
+	sd, ok := post.Extra["structured_data"].(*models.StructuredData)
+	if !ok {
+		t.Fatal("structured_data is not *models.StructuredData")
+	}
+
+	// Count article:tag entries
+	tagCount := 0
+	for _, tag := range sd.OpenGraph {
+		if tag.Property == "article:tag" {
+			tagCount++
+		}
+	}
+
+	if tagCount != 3 {
+		t.Errorf("Expected 3 article:tag entries, got %d", tagCount)
+	}
+}

--- a/pkg/templates/context.go
+++ b/pkg/templates/context.go
@@ -128,6 +128,13 @@ func postToMap(p *models.Post) map[string]interface{} {
 		for k, v := range p.Extra {
 			// Don't override existing keys
 			if _, exists := m[k]; !exists {
+				// Special handling for structured_data
+				if k == "structured_data" {
+					if sd, ok := v.(*models.StructuredData); ok {
+						m[k] = structuredDataToMap(sd)
+						continue
+					}
+				}
 				m[k] = v
 			}
 		}
@@ -364,6 +371,37 @@ func headToMap(h *models.HeadConfig) map[string]interface{} {
 		"link":            linkTags,
 		"script":          scriptTags,
 		"alternate_feeds": alternateFeeds,
+	}
+}
+
+// structuredDataToMap converts a StructuredData to a map for template access.
+func structuredDataToMap(sd *models.StructuredData) map[string]interface{} {
+	if sd == nil {
+		return nil
+	}
+
+	// Convert OpenGraph tags
+	opengraphTags := make([]map[string]interface{}, len(sd.OpenGraph))
+	for i, og := range sd.OpenGraph {
+		opengraphTags[i] = map[string]interface{}{
+			"property": og.Property,
+			"content":  og.Content,
+		}
+	}
+
+	// Convert Twitter tags
+	twitterTags := make([]map[string]interface{}, len(sd.Twitter))
+	for i, tw := range sd.Twitter {
+		twitterTags[i] = map[string]interface{}{
+			"name":    tw.Name,
+			"content": tw.Content,
+		}
+	}
+
+	return map[string]interface{}{
+		"jsonld":    sd.JSONLD,
+		"opengraph": opengraphTags,
+		"twitter":   twitterTags,
 	}
 }
 

--- a/pkg/themes/default/templates/post.html
+++ b/pkg/themes/default/templates/post.html
@@ -16,7 +16,20 @@
 <link rel="alternate" type="text/html" title="Social Card" href="{{ post.href }}og/">
 {% endif %}
 
-{# Open Graph meta tags #}
+{# Structured Data: JSON-LD #}
+{% if post.structured_data.jsonld %}
+<script type="application/ld+json">
+{{ post.structured_data.jsonld | safe }}
+</script>
+{% endif %}
+
+{# Structured Data: OpenGraph meta tags #}
+{% if post.structured_data.opengraph %}
+{% for meta in post.structured_data.opengraph %}
+<meta property="{{ meta.property }}" content="{{ meta.content }}">
+{% endfor %}
+{% else %}
+{# Fallback to basic OG tags if no structured data #}
 <meta property="og:title" content="{{ post.title }}">
 <meta property="og:type" content="article">
 <meta property="og:url" content="{{ config.url }}{{ post.href }}">
@@ -28,6 +41,14 @@
 {% endif %}
 {% if config.post_formats.og %}
 <meta property="og:image" content="{{ config.url }}{{ post.href }}og/">
+{% endif %}
+{% endif %}
+
+{# Structured Data: Twitter Card meta tags #}
+{% if post.structured_data.twitter %}
+{% for meta in post.structured_data.twitter %}
+<meta name="{{ meta.name }}" content="{{ meta.content }}">
+{% endfor %}
 {% endif %}
 {% endblock %}
 

--- a/spec/spec/STRUCTURED_DATA.md
+++ b/spec/spec/STRUCTURED_DATA.md
@@ -1,0 +1,279 @@
+# Structured Data Specification
+
+This document specifies the structured data system for markata-go, providing JSON-LD Schema.org markup, OpenGraph meta tags, and Twitter Cards for SEO and social media optimization.
+
+## Overview
+
+The structured data system automatically generates:
+- **JSON-LD** - Schema.org structured data for search engine rich results
+- **OpenGraph** - Meta tags for Facebook, LinkedIn, and general social sharing
+- **Twitter Cards** - Meta tags for Twitter/X sharing previews
+
+## Configuration
+
+### Site-Level Configuration
+
+Configure structured data in `markata-go.toml`:
+
+```toml
+[markata-go.seo]
+# Twitter/X handle for twitter:site (without @)
+twitter_handle = "username"
+
+# Default OG image for posts without images
+default_image = "/images/og-default.jpg"
+
+# Site logo URL for Schema.org Organization
+logo_url = "/images/logo.png"
+
+[markata-go.seo.structured_data]
+# Enable/disable structured data generation (default: true)
+enabled = true
+
+# Schema.org Organization/Person for publisher
+[markata-go.seo.structured_data.publisher]
+type = "Organization"  # or "Person"
+name = "Site Name"
+url = "https://example.com"
+logo = "/images/logo.png"
+
+# Default author for posts without explicit author
+[markata-go.seo.structured_data.default_author]
+type = "Person"
+name = "Author Name"
+url = "https://example.com/about"
+```
+
+### Frontmatter Fields
+
+Posts can override structured data via frontmatter:
+
+```yaml
+---
+title: "Post Title"
+description: "Post description for meta tags"
+date: 2024-01-15
+modified: 2024-01-16  # For dateModified
+author: "Author Name"  # Override default author
+image: "/images/post.jpg"  # OG/Twitter image
+tags: ["tag1", "tag2"]
+
+# Optional structured data overrides
+schema_type: "BlogPosting"  # Default: auto-detected
+social_image: "/images/og-custom.jpg"  # Override OG image specifically
+---
+```
+
+## Data Models
+
+### StructuredDataConfig
+
+```go
+type StructuredDataConfig struct {
+    // Enabled controls generation (default: true)
+    Enabled *bool `toml:"enabled"`
+    
+    // Publisher is the site publisher info
+    Publisher *EntityConfig `toml:"publisher"`
+    
+    // DefaultAuthor is used when posts don't specify author
+    DefaultAuthor *EntityConfig `toml:"default_author"`
+}
+
+type EntityConfig struct {
+    // Type is "Person" or "Organization"
+    Type string `toml:"type"`
+    
+    // Name is the entity name
+    Name string `toml:"name"`
+    
+    // URL is the entity's web page
+    URL string `toml:"url"`
+    
+    // Logo is the logo URL (Organizations only)
+    Logo string `toml:"logo"`
+}
+```
+
+### Generated Structured Data
+
+The plugin stores generated data in `post.Extra`:
+
+```go
+post.Extra["structured_data"] = &StructuredData{
+    JSONLD:      jsonLDString,      // JSON-LD script content
+    OpenGraph:   []MetaTag{...},    // OG meta tags
+    TwitterCard: []MetaTag{...},    // Twitter meta tags
+}
+```
+
+## JSON-LD Schema
+
+### BlogPosting Schema
+
+Generated for all blog posts:
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": "Post Title",
+  "description": "Post description",
+  "datePublished": "2024-01-15T00:00:00Z",
+  "dateModified": "2024-01-16T00:00:00Z",
+  "author": {
+    "@type": "Person",
+    "name": "Author Name",
+    "url": "https://example.com/about"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Site Name",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://example.com/logo.png"
+    }
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "https://example.com/post-slug/"
+  },
+  "image": "https://example.com/images/post.jpg",
+  "keywords": ["tag1", "tag2"]
+}
+```
+
+### WebSite Schema
+
+Generated for the homepage:
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "name": "Site Title",
+  "description": "Site description",
+  "url": "https://example.com",
+  "publisher": {
+    "@type": "Organization",
+    "name": "Site Name"
+  }
+}
+```
+
+## OpenGraph Tags
+
+Generated meta tags:
+
+| Tag | Source |
+|-----|--------|
+| `og:title` | post.Title or config.Title |
+| `og:description` | post.Description or config.Description |
+| `og:type` | "article" for posts, "website" for pages |
+| `og:url` | Canonical URL |
+| `og:site_name` | config.Title |
+| `og:image` | post.Extra["image"] or seo.default_image |
+| `og:image:width` | 1200 (if image set) |
+| `og:image:height` | 630 (if image set) |
+| `og:locale` | "en_US" (or config.lang) |
+| `article:published_time` | post.Date (articles only) |
+| `article:modified_time` | post.Extra["modified"] (if set) |
+| `article:author` | Author URL |
+| `article:tag` | Each tag separately |
+
+## Twitter Card Tags
+
+Generated meta tags:
+
+| Tag | Source |
+|-----|--------|
+| `twitter:card` | "summary_large_image" or "summary" |
+| `twitter:site` | @{seo.twitter_handle} |
+| `twitter:creator` | @{author handle} or @{seo.twitter_handle} |
+| `twitter:title` | post.Title |
+| `twitter:description` | post.Description (truncated to 200 chars) |
+| `twitter:image` | Same as og:image |
+
+## Plugin Lifecycle
+
+The StructuredDataPlugin runs in the **Transform** stage:
+
+1. Runs after frontmatter parsing (needs title, description, date)
+2. Runs before template rendering (adds data to post.Extra)
+
+### Priority
+
+Priority: 500 (middle of transform stage, after description plugin)
+
+## Template Integration
+
+Templates access structured data via `post` context:
+
+```html
+{# JSON-LD #}
+{% if post.structured_data.jsonld %}
+<script type="application/ld+json">
+{{ post.structured_data.jsonld | safe }}
+</script>
+{% endif %}
+
+{# OpenGraph #}
+{% for meta in post.structured_data.opengraph %}
+<meta property="{{ meta.property }}" content="{{ meta.content }}">
+{% endfor %}
+
+{# Twitter Cards #}
+{% for meta in post.structured_data.twitter %}
+<meta name="{{ meta.name }}" content="{{ meta.content }}">
+{% endfor %}
+```
+
+### Default Template Updates
+
+The default `base.html` template will be updated to automatically include structured data when available.
+
+## URL Handling
+
+All URLs in structured data are made absolute:
+
+- Relative URLs (e.g., `/images/post.jpg`) are prefixed with `config.URL`
+- Protocol-relative URLs are prefixed with `https:`
+- Absolute URLs are used as-is
+
+## Intelligent Defaults
+
+The plugin provides sensible defaults:
+
+| Field | Default |
+|-------|---------|
+| `og:type` | "article" for posts with date, "website" otherwise |
+| `schema_type` | "BlogPosting" for posts with date, "WebPage" otherwise |
+| `og:image` | seo.default_image if set |
+| `author` | seo.structured_data.default_author |
+| `dateModified` | Same as datePublished if not set |
+
+## Error Handling
+
+- Missing required fields (title) - Skip structured data for that post, log warning
+- Invalid URLs - Skip the invalid URL field, continue with others
+- Missing config - Use sensible defaults, structured data still generated
+
+## Testing Requirements
+
+1. Unit tests for JSON-LD generation
+2. Unit tests for OpenGraph tag generation
+3. Unit tests for Twitter Card generation
+4. Integration test with full build pipeline
+5. Validation against Schema.org validator output format
+
+## Future Enhancements
+
+Potential future additions (not in v1):
+
+- BreadcrumbList schema
+- FAQPage schema
+- HowTo schema
+- Event schema
+- Product schema
+- Review schema
+- Custom schema injection via frontmatter

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,23 +6,35 @@
     <title>{% block title %}{% if post %}{{ post.title }} - {% endif %}{{ config.title | default:"My Site" }}{% endblock %}</title>
     {% if post.description %}<meta name="description" content="{{ post.description }}">{% elif config.description %}<meta name="description" content="{{ config.description }}">{% endif %}
     
-    <!-- Open Graph -->
-    {% if post %}
+    <!-- Structured Data: OpenGraph -->
+    {% if post.structured_data.opengraph %}
+    {% for meta in post.structured_data.opengraph %}
+    <meta property="{{ meta.property }}" content="{{ meta.content }}">
+    {% endfor %}
+    {% elif post %}
+    {# Fallback to basic OG tags if no structured data #}
     <meta property="og:title" content="{{ post.title }}">
     <meta property="og:description" content="{{ post.description | default:config.description }}">
     <meta property="og:url" content="{{ config.url }}{{ post.slug }}/">
     <meta property="og:type" content="article">
     {% if post.cover_image %}<meta property="og:image" content="{{ config.url }}{{ post.cover_image }}">{% elif config.seo.default_image %}<meta property="og:image" content="{{ config.url }}{{ config.seo.default_image }}">{% endif %}
+    <meta property="og:site_name" content="{{ config.title }}">
     {% else %}
     <meta property="og:title" content="{{ config.title }}">
     <meta property="og:description" content="{{ config.description }}">
     <meta property="og:url" content="{{ config.url }}">
     <meta property="og:type" content="website">
     {% if config.seo.default_image %}<meta property="og:image" content="{{ config.url }}{{ config.seo.default_image }}">{% endif %}
-    {% endif %}
     <meta property="og:site_name" content="{{ config.title }}">
+    {% endif %}
     
-    <!-- Twitter Card -->
+    <!-- Structured Data: Twitter Card -->
+    {% if post.structured_data.twitter %}
+    {% for meta in post.structured_data.twitter %}
+    <meta name="{{ meta.name }}" content="{{ meta.content }}">
+    {% endfor %}
+    {% else %}
+    {# Fallback to basic Twitter tags if no structured data #}
     <meta name="twitter:card" content="summary_large_image">
     {% if config.seo.twitter_handle %}<meta name="twitter:site" content="@{{ config.seo.twitter_handle }}">{% endif %}
     {% if post %}
@@ -33,6 +45,7 @@
     <meta name="twitter:title" content="{{ config.title }}">
     <meta name="twitter:description" content="{{ config.description }}">
     {% if config.seo.default_image %}<meta name="twitter:image" content="{{ config.url }}{{ config.seo.default_image }}">{% endif %}
+    {% endif %}
     {% endif %}
     
     <!-- Canonical URL -->
@@ -85,8 +98,13 @@
     {% endif %}
     {% endblock %}
     
-    <!-- Schema.org JSON-LD -->
-    {% if post %}
+    <!-- Structured Data: JSON-LD -->
+    {% if post.structured_data.jsonld %}
+    <script type="application/ld+json">
+    {{ post.structured_data.jsonld | safe }}
+    </script>
+    {% elif post %}
+    {# Fallback to static JSON-LD if no structured data #}
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",


### PR DESCRIPTION
## Summary

Implements comprehensive structured data support for improved SEO and social sharing:

- **JSON-LD Schema.org markup** - BlogPosting schema with author, dates, tags
- **OpenGraph meta tags** - For Facebook, LinkedIn, and other platforms
- **Twitter Card meta tags** - For rich Twitter previews

## Changes

### New Files
- `spec/spec/STRUCTURED_DATA.md` - Full specification document
- `pkg/models/structured_data.go` - Data models (StructuredData, OpenGraphTag, TwitterTag, BlogPosting, etc.)
- `pkg/plugins/structured_data.go` - StructuredDataPlugin implementation
- `pkg/plugins/structured_data_test.go` - Comprehensive test suite (10 tests)
- `docs/guides/structured-data.md` - User documentation

### Modified Files
- `pkg/models/config.go` - Added StructuredDataConfig and EntityConfig to SEOConfig
- `pkg/plugins/registry.go` - Registered plugin and added to defaults
- `pkg/templates/context.go` - Added structuredDataToMap() for template access
- `templates/base.html` - Updated to use dynamic structured data
- `pkg/themes/default/templates/post.html` - Updated to use dynamic structured data

## Configuration

```toml
[seo.structured_data]
enabled = true
default_type = "BlogPosting"

[seo.structured_data.publisher]
name = "My Blog"
url = "https://example.com"
logo = "https://example.com/logo.png"

[seo.structured_data.author]
name = "John Doe"
url = "https://example.com/about"
```

## Template Usage

```html
{# JSON-LD #}
{% if post.structured_data and post.structured_data.jsonld %}
<script type="application/ld+json">{{ post.structured_data.jsonld | safe }}</script>
{% endif %}

{# OpenGraph #}
{% for tag in post.structured_data.opengraph %}
<meta property="{{ tag.property }}" content="{{ tag.content }}">
{% endfor %}

{# Twitter Cards #}
{% for tag in post.structured_data.twitter %}
<meta name="{{ tag.name }}" content="{{ tag.content }}">
{% endfor %}
```

Closes #72