### PR TITLE
Fix Pagefind warnings: missing data-pagefind-body and deprecated bundle-dir

### DIFF
--- a/pkg/plugins/pagefind.go
+++ b/pkg/plugins/pagefind.go
@@ -72,12 +72,13 @@ func (p *PagefindPlugin) runPagefind(pagefindPath string, config *lifecycle.Conf
 		"--site", outputDir,
 	}
 
-	// Configure bundle directory (where search index files go)
+	// Configure output subdirectory (where search index files go)
+	// Note: Using --output-subdir instead of deprecated --bundle-dir (deprecated in Pagefind 1.0)
 	bundleDir := searchConfig.Pagefind.BundleDir
 	if bundleDir == "" {
 		bundleDir = defaultBundleDir
 	}
-	args = append(args, "--bundle-dir", bundleDir)
+	args = append(args, "--output-subdir", bundleDir)
 
 	// Configure root selector if specified
 	if searchConfig.Pagefind.RootSelector != "" {

--- a/spec/spec/SEARCH.md
+++ b/spec/spec/SEARCH.md
@@ -288,7 +288,7 @@ func (p *PagefindPlugin) runPagefind(config *lifecycle.Config) error {
     
     args := []string{
         "--site", config.OutputDir,
-        "--bundle-dir", searchConfig.Pagefind.BundleDir,
+        "--output-subdir", searchConfig.Pagefind.BundleDir,
     }
     
     if searchConfig.Pagefind.RootSelector != "" {

--- a/templates/base.html
+++ b/templates/base.html
@@ -155,7 +155,7 @@
 </head>
 <body>
     {% block header %}
-    <header class="site-header">
+    <header class="site-header" data-pagefind-ignore>
         <div class="container">
             <a href="/" class="site-title">{{ config.title | default:"Home" }}</a>
             {% include "components/nav.html" %}
@@ -166,7 +166,7 @@
     </header>
     {% endblock %}
     
-    <main>
+    <main data-pagefind-body>
         {% block content %}{% endblock %}
     </main>
     

--- a/templates/components/doc_sidebar.html
+++ b/templates/components/doc_sidebar.html
@@ -5,7 +5,7 @@
 
 {% with sidebar = config.components.doc_sidebar %}
 {% if sidebar.enabled and post.Extra.toc %}
-<aside class="doc-sidebar doc-sidebar--{{ sidebar.position | default:'right' }}" style="width: {{ sidebar.width | default:'250px' }}">
+<aside class="doc-sidebar doc-sidebar--{{ sidebar.position | default:'right' }}" style="width: {{ sidebar.width | default:'250px' }}" data-pagefind-ignore>
     <nav class="toc" aria-label="Table of Contents">
         <h2 class="toc-title">On this page</h2>
         <ul class="toc-list">

--- a/templates/components/feed_sidebar.html
+++ b/templates/components/feed_sidebar.html
@@ -5,7 +5,7 @@
 
 {% with sidebar = config.components.feed_sidebar %}
 {% if sidebar.enabled %}
-<aside class="feed-sidebar feed-sidebar--{{ sidebar.position | default:'left' }}" style="width: {{ sidebar.width | default:'250px' }}" aria-label="Feed navigation">
+<aside class="feed-sidebar feed-sidebar--{{ sidebar.position | default:'left' }}" style="width: {{ sidebar.width | default:'250px' }}" aria-label="Feed navigation" data-pagefind-ignore>
     <nav class="feed-nav">
         {% if sidebar.title %}
         <h2 class="feed-nav-title">{{ sidebar.title }}</h2>

--- a/templates/components/footer.html
+++ b/templates/components/footer.html
@@ -4,7 +4,7 @@
 
 {% with footer = config.components.footer %}
 {% if footer.enabled %}
-<footer class="site-footer">
+<footer class="site-footer" data-pagefind-ignore>
     <div class="container">
         {% if footer.text %}
         <p class="footer-text">{{ footer.text }}</p>


### PR DESCRIPTION
## Summary
- Add `data-pagefind-body` attribute to main content area to enable proper search indexing
- Add `data-pagefind-ignore` to header, footer, and sidebars to exclude navigation elements
- Replace deprecated `--bundle-dir` CLI option with `--output-subdir` (Pagefind 1.0+)

## Changes
- **pkg/plugins/pagefind.go**: Updated to use `--output-subdir` instead of deprecated `--bundle-dir`
- **templates/base.html**: Added `data-pagefind-body` to `<main>` and `data-pagefind-ignore` to `<header>`
- **templates/components/footer.html**: Added `data-pagefind-ignore` to footer
- **templates/components/doc_sidebar.html**: Added `data-pagefind-ignore` to TOC sidebar
- **templates/components/feed_sidebar.html**: Added `data-pagefind-ignore` to feed navigation sidebar
- **spec/spec/SEARCH.md**: Updated spec to reflect CLI option change

## Testing
- All existing tests pass (`go test ./...`)
- Build succeeds (`go build ./cmd/markata-go`)

Fixes #79