### PR TITLE
feat: Add hardened Docker image for GHCR deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,48 @@
+# Git
+.git
+.gitignore
+.gitattributes
+
+# GitHub
+.github
+
+# Documentation (except README)
+*.md
+!README.md
+docs/
+spec/
+
+# Build artifacts
+public/
+output/
+dist/
+*.exe
+*.test
+*.out
+coverage.out
+markata-go
+
+# IDE/Editor
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Release tooling
+.goreleaser.yml
+Makefile
+
+# Test fixtures that aren't needed
+tests/fixtures/
+tests/testdata/
+
+# Development files
+.env
+.env.*
+*.local
+
+# Temporary files
+tmp/
+*.tmp
+*.log

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,153 @@
+# Docker build and publish workflow for markata-go
+# Builds multi-platform images and pushes to GitHub Container Registry
+
+name: Docker
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "Dockerfile"
+      - ".dockerignore"
+      - ".github/workflows/docker.yml"
+      - "go.mod"
+      - "go.sum"
+      - "cmd/**"
+      - "pkg/**"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    name: Build and Push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # Set latest tag for default branch
+            type=raw,value=latest,enable={{is_default_branch}}
+            # Tag with branch name
+            type=ref,event=branch
+            # Tag with PR number
+            type=ref,event=pr
+            # Tag with semver
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+            # Tag with commit SHA
+            type=sha,prefix=sha-
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            COMMIT=${{ github.sha }}
+            BUILD_DATE=${{ github.event.head_commit.timestamp }}
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+          format: "sarif"
+          output: "trivy-results.sarif"
+          severity: "CRITICAL,HIGH"
+        if: github.event_name != 'pull_request'
+
+      - name: Upload Trivy scan results
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: "trivy-results.sarif"
+        if: github.event_name != 'pull_request'
+
+  # Separate job for PR builds - build only, don't push
+  build-pr:
+    name: Build (PR)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: false
+          tags: markata-go:pr-${{ github.event.number }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            VERSION=pr-${{ github.event.number }}
+            COMMIT=${{ github.sha }}
+            BUILD_DATE=${{ github.event.pull_request.updated_at }}
+          load: true
+
+      - name: Test image
+        run: |
+          # Test basic functionality
+          docker run --rm markata-go:pr-${{ github.event.number }} version
+          docker run --rm markata-go:pr-${{ github.event.number }} --help
+          
+          # Verify image size (should be under 25MB)
+          SIZE=$(docker image inspect markata-go:pr-${{ github.event.number }} --format='{{.Size}}')
+          SIZE_MB=$((SIZE / 1024 / 1024))
+          echo "Image size: ${SIZE_MB}MB"
+          if [ "$SIZE_MB" -gt 25 ]; then
+            echo "Error: Image size ${SIZE_MB}MB exceeds 25MB limit"
+            exit 1
+          fi
+
+      - name: Run Trivy vulnerability scanner (PR)
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: markata-go:pr-${{ github.event.number }}
+          format: "table"
+          exit-code: "1"
+          severity: "CRITICAL"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,73 @@
+# Multi-stage Dockerfile for markata-go
+# Produces a minimal, secure container image for production use
+
+# =============================================================================
+# Build Stage
+# =============================================================================
+FROM golang:1.22-alpine AS builder
+
+# Install ca-certificates for HTTPS support in final image
+RUN apk add --no-cache ca-certificates
+
+WORKDIR /app
+
+# Copy dependency files first for better layer caching
+COPY go.mod go.sum ./
+RUN go mod download && go mod verify
+
+# Copy source code
+COPY . .
+
+# Build arguments for version injection
+ARG VERSION=dev
+ARG COMMIT=none
+ARG BUILD_DATE=unknown
+
+# Build static binary with version information
+# CGO_ENABLED=0 ensures fully static binary
+# -s -w strips debug information for smaller binary
+RUN CGO_ENABLED=0 GOOS=linux go build \
+    -ldflags="-s -w \
+        -X github.com/WaylonWalker/markata-go/cmd/markata-go/cmd.Version=${VERSION} \
+        -X github.com/WaylonWalker/markata-go/cmd/markata-go/cmd.Commit=${COMMIT} \
+        -X github.com/WaylonWalker/markata-go/cmd/markata-go/cmd.Date=${BUILD_DATE}" \
+    -o markata-go \
+    ./cmd/markata-go
+
+# Verify binary was built
+RUN ./markata-go version
+
+# =============================================================================
+# Runtime Stage
+# =============================================================================
+# Using distroless static image for minimal attack surface
+# - No shell, no package manager
+# - Only statically-linked binaries can run
+# - nonroot variant runs as non-root user by default
+FROM gcr.io/distroless/static-debian12:nonroot
+
+# Labels for container registry metadata
+LABEL org.opencontainers.image.title="markata-go"
+LABEL org.opencontainers.image.description="A plugin-driven static site generator written in Go"
+LABEL org.opencontainers.image.url="https://github.com/WaylonWalker/markata-go"
+LABEL org.opencontainers.image.source="https://github.com/WaylonWalker/markata-go"
+LABEL org.opencontainers.image.vendor="Waylon Walker"
+LABEL org.opencontainers.image.licenses="MIT"
+
+# Copy CA certificates for HTTPS support
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+# Copy the binary
+COPY --from=builder /app/markata-go /usr/local/bin/markata-go
+
+# Set working directory for user content
+WORKDIR /site
+
+# Run as non-root user (provided by distroless:nonroot)
+USER nonroot:nonroot
+
+# Default entrypoint
+ENTRYPOINT ["markata-go"]
+
+# Default command shows help
+CMD ["--help"]


### PR DESCRIPTION
## Summary

Adds production-ready Docker image support with deployment to GitHub Container Registry (ghcr.io).

- **Dockerfile**: Multi-stage build using distroless base image for minimal attack surface (~10MB)
- **.dockerignore**: Efficient build context excluding unnecessary files
- **CI workflow**: Automated builds on push/PR with multi-platform support and security scanning

## Features

- **Security hardened**: Uses `gcr.io/distroless/static-debian12:nonroot` base (no shell, no package manager)
- **Non-root execution**: Runs as `nonroot:nonroot` user
- **Multi-platform**: Supports `linux/amd64` and `linux/arm64`
- **Trivy scanning**: Vulnerability detection with SARIF reporting
- **Size validation**: CI enforces image must be under 25MB
- **Version injection**: Build args pass version info to binary

## Usage

```bash
# Pull from GHCR
docker pull ghcr.io/waylonwalker/markata-go:latest

# Build a site
docker run --rm -v "$(pwd):/site" ghcr.io/waylonwalker/markata-go build

# Check version
docker run --rm ghcr.io/waylonwalker/markata-go version
```

## Tags

The workflow generates the following tags:
- `latest` - Default branch builds
- `v0.x.x` - Semantic version from tags
- `sha-abc1234` - Commit SHA for traceability

## Testing

- [x] Dockerfile syntax verified
- [x] Go tests pass (`go test ./...`)
- [x] Workflow YAML validated

Note: Docker build cannot be tested locally in this environment, but the CI workflow will validate the build.

Fixes #96