### PR TITLE
perf: Parallel file loading and regex pre-compilation

### DIFF
--- a/pkg/lifecycle/manager.go
+++ b/pkg/lifecycle/manager.go
@@ -11,6 +11,19 @@ import (
 	"github.com/WaylonWalker/markata-go/pkg/models"
 )
 
+// Pre-compiled regex patterns for filter expression evaluation.
+// These are compiled once at package init instead of per-call.
+var (
+	// containsOpRegex matches "field contains value" expressions
+	containsOpRegex = regexp.MustCompile(`^(\w+)\s+contains\s+(.+)$`)
+
+	// notEqualsOpRegex matches "field != value" expressions
+	notEqualsOpRegex = regexp.MustCompile(`^(\w+)\s*!=\s*(.+)$`)
+
+	// equalsOpRegex matches "field == value" expressions
+	equalsOpRegex = regexp.MustCompile(`^(\w+)\s*==\s*(.+)$`)
+)
+
 // Cache is an interface for caching data between stages.
 type Cache interface {
 	Get(key string) (interface{}, bool)
@@ -505,21 +518,21 @@ func evaluateCondition(post *models.Post, expr string) (bool, error) {
 	expr = strings.TrimSpace(expr)
 
 	// Contains operator
-	if match := regexp.MustCompile(`^(\w+)\s+contains\s+(.+)$`).FindStringSubmatch(expr); match != nil {
+	if match := containsOpRegex.FindStringSubmatch(expr); match != nil {
 		field := match[1]
 		value := strings.TrimSpace(match[2])
 		return containsValue(post, field, value), nil
 	}
 
 	// Not equals operator
-	if match := regexp.MustCompile(`^(\w+)\s*!=\s*(.+)$`).FindStringSubmatch(expr); match != nil {
+	if match := notEqualsOpRegex.FindStringSubmatch(expr); match != nil {
 		field := match[1]
 		value := strings.TrimSpace(match[2])
 		return !equalsValue(post, field, value), nil
 	}
 
 	// Equals operator
-	if match := regexp.MustCompile(`^(\w+)\s*==\s*(.+)$`).FindStringSubmatch(expr); match != nil {
+	if match := equalsOpRegex.FindStringSubmatch(expr); match != nil {
 		field := match[1]
 		value := strings.TrimSpace(match[2])
 		return equalsValue(post, field, value), nil


### PR DESCRIPTION
## Summary

This PR implements two performance optimizations:

1. **Parallel file loading** - Files are now loaded concurrently using a worker pool
2. **Regex pre-compilation** - Regex patterns are compiled once at package init

## Changes

### Parallel File Loading (`pkg/plugins/load.go`)
- Worker pool with configurable concurrency (uses `Manager.Concurrency()`)
- Preserves deterministic post ordering despite parallel processing
- Falls back to sequential loading for small file counts (≤ worker count)

### Regex Pre-compilation
- **`pkg/plugins/load.go`**: Pre-compile date normalization patterns
  - `timeFixRegex` - fixes malformed time components
  - `singleDigitHourRegex` - normalizes single-digit hours
  - `startSingleDigitHourRegex` - matches time at string start

- **`pkg/lifecycle/manager.go`**: Pre-compile filter expression patterns
  - `containsOpRegex` - "field contains value"
  - `notEqualsOpRegex` - "field != value"  
  - `equalsOpRegex` - "field == value"

## Benchmark Results

| Posts | Build Time | Posts/sec | Memory |
|-------|------------|-----------|--------|
| 10 | 0.96s | 10.4 | 22.8MB |
| 100 | 0.67s | 149.6 | 22.2MB |
| 500 | 0.65s | 775.0 | 24.5MB |
| 1000 | 0.70s | **1428.0** | 25.0MB |

### Stage Breakdown (1000 posts)

| Stage | Time |
|-------|------|
| configure | 0.000s |
| validate | 0.000s |
| glob | 0.026s |
| load | 0.001s |
| transform | 0.087s |
| render | 0.491s |
| collect | 0.001s |
| write | 0.064s |
| cleanup | 0.029s |

## Testing

- All existing tests pass
- `golangci-lint` clean

## Related Issues

Fixes #103 - Parallelize file loading
Fixes #104 - Pre-compile regex patterns