### PR TITLE
feat: Add comprehensive layout system with 4 presets

### DIFF
--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -241,6 +241,21 @@ type Config struct {
 
 	// Search configures site-wide search functionality using Pagefind
 	Search SearchConfig `json:"search" yaml:"search" toml:"search"`
+
+	// Layout configures the layout system for page structure
+	Layout LayoutConfig `json:"layout" yaml:"layout" toml:"layout"`
+
+	// Sidebar configures the sidebar navigation component
+	Sidebar SidebarConfig `json:"sidebar" yaml:"sidebar" toml:"sidebar"`
+
+	// Toc configures the table of contents component
+	Toc TocConfig `json:"toc" yaml:"toc" toml:"toc"`
+
+	// Header configures the header component for layouts
+	Header HeaderLayoutConfig `json:"header" yaml:"header" toml:"header"`
+
+	// FooterLayout configures the footer component for layouts
+	FooterLayout FooterLayoutConfig `json:"footer_layout" yaml:"footer_layout" toml:"footer_layout"`
 }
 
 // HeadConfig configures elements added to the HTML <head> section.
@@ -901,12 +916,17 @@ func NewConfig() *Config {
 			Palette:   "default-light",
 			Variables: make(map[string]string),
 		},
-		PostFormats: NewPostFormatsConfig(),
-		SEO:         NewSEOConfig(),
-		IndieAuth:   NewIndieAuthConfig(),
-		Webmention:  NewWebmentionConfig(),
-		Components:  NewComponentsConfig(),
-		Search:      NewSearchConfig(),
+		PostFormats:  NewPostFormatsConfig(),
+		SEO:          NewSEOConfig(),
+		IndieAuth:    NewIndieAuthConfig(),
+		Webmention:   NewWebmentionConfig(),
+		Components:   NewComponentsConfig(),
+		Search:       NewSearchConfig(),
+		Layout:       NewLayoutConfig(),
+		Sidebar:      NewSidebarConfig(),
+		Toc:          NewTocConfig(),
+		Header:       NewHeaderLayoutConfig(),
+		FooterLayout: NewFooterLayoutConfig(),
 	}
 }
 

--- a/pkg/models/layout.go
+++ b/pkg/models/layout.go
@@ -1,0 +1,626 @@
+package models
+
+// LayoutConfig configures the site layout system.
+// Layouts control the overall page structure including sidebars, TOC, header, and footer.
+type LayoutConfig struct {
+	// Name is the default layout preset name (default: "blog")
+	// Options: "docs", "blog", "landing", "bare"
+	Name string `json:"name,omitempty" yaml:"name,omitempty" toml:"name,omitempty"`
+
+	// Docs configures the documentation layout
+	Docs DocsLayoutConfig `json:"docs,omitempty" yaml:"docs,omitempty" toml:"docs,omitempty"`
+
+	// Blog configures the blog layout
+	Blog BlogLayoutConfig `json:"blog,omitempty" yaml:"blog,omitempty" toml:"blog,omitempty"`
+
+	// Landing configures the landing page layout
+	Landing LandingLayoutConfig `json:"landing,omitempty" yaml:"landing,omitempty" toml:"landing,omitempty"`
+
+	// Bare configures the bare layout (content only)
+	Bare BareLayoutConfig `json:"bare,omitempty" yaml:"bare,omitempty" toml:"bare,omitempty"`
+
+	// Defaults provides global layout defaults
+	Defaults LayoutDefaults `json:"defaults,omitempty" yaml:"defaults,omitempty" toml:"defaults,omitempty"`
+}
+
+// LayoutDefaults provides global layout defaults.
+type LayoutDefaults struct {
+	// ContentMaxWidth is the maximum width of the content area (default: "800px")
+	ContentMaxWidth string `json:"content_max_width,omitempty" yaml:"content_max_width,omitempty" toml:"content_max_width,omitempty"`
+
+	// HeaderSticky makes the header stick to the top when scrolling (default: true)
+	HeaderSticky *bool `json:"header_sticky,omitempty" yaml:"header_sticky,omitempty" toml:"header_sticky,omitempty"`
+
+	// FooterSticky makes the footer stick to the bottom (default: false)
+	FooterSticky *bool `json:"footer_sticky,omitempty" yaml:"footer_sticky,omitempty" toml:"footer_sticky,omitempty"`
+}
+
+// IsHeaderSticky returns whether the header should be sticky.
+func (d *LayoutDefaults) IsHeaderSticky() bool {
+	if d.HeaderSticky == nil {
+		return true
+	}
+	return *d.HeaderSticky
+}
+
+// IsFooterSticky returns whether the footer should be sticky.
+func (d *LayoutDefaults) IsFooterSticky() bool {
+	if d.FooterSticky == nil {
+		return false
+	}
+	return *d.FooterSticky
+}
+
+// DocsLayoutConfig configures the documentation layout.
+// This is a 3-panel layout with sidebar navigation, content, and table of contents.
+type DocsLayoutConfig struct {
+	// SidebarPosition controls sidebar placement: "left" or "right" (default: "left")
+	SidebarPosition string `json:"sidebar_position,omitempty" yaml:"sidebar_position,omitempty" toml:"sidebar_position,omitempty"`
+
+	// SidebarWidth is the width of the sidebar (default: "280px")
+	SidebarWidth string `json:"sidebar_width,omitempty" yaml:"sidebar_width,omitempty" toml:"sidebar_width,omitempty"`
+
+	// SidebarCollapsible allows the sidebar to be collapsed (default: true)
+	SidebarCollapsible *bool `json:"sidebar_collapsible,omitempty" yaml:"sidebar_collapsible,omitempty" toml:"sidebar_collapsible,omitempty"`
+
+	// SidebarDefaultOpen controls if sidebar is open by default on desktop (default: true)
+	SidebarDefaultOpen *bool `json:"sidebar_default_open,omitempty" yaml:"sidebar_default_open,omitempty" toml:"sidebar_default_open,omitempty"`
+
+	// TocPosition controls TOC placement: "left" or "right" (default: "right")
+	TocPosition string `json:"toc_position,omitempty" yaml:"toc_position,omitempty" toml:"toc_position,omitempty"`
+
+	// TocWidth is the width of the table of contents (default: "220px")
+	TocWidth string `json:"toc_width,omitempty" yaml:"toc_width,omitempty" toml:"toc_width,omitempty"`
+
+	// TocCollapsible allows the TOC to be collapsed (default: true)
+	TocCollapsible *bool `json:"toc_collapsible,omitempty" yaml:"toc_collapsible,omitempty" toml:"toc_collapsible,omitempty"`
+
+	// TocDefaultOpen controls if TOC is open by default on desktop (default: true)
+	TocDefaultOpen *bool `json:"toc_default_open,omitempty" yaml:"toc_default_open,omitempty" toml:"toc_default_open,omitempty"`
+
+	// ContentMaxWidth is the maximum width of the content area (default: "800px")
+	ContentMaxWidth string `json:"content_max_width,omitempty" yaml:"content_max_width,omitempty" toml:"content_max_width,omitempty"`
+
+	// HeaderStyle controls the header appearance: "full", "minimal", "transparent", "none" (default: "minimal")
+	HeaderStyle string `json:"header_style,omitempty" yaml:"header_style,omitempty" toml:"header_style,omitempty"`
+
+	// FooterStyle controls the footer appearance: "full", "minimal", "none" (default: "minimal")
+	FooterStyle string `json:"footer_style,omitempty" yaml:"footer_style,omitempty" toml:"footer_style,omitempty"`
+}
+
+// IsSidebarCollapsible returns whether the sidebar can be collapsed.
+func (d *DocsLayoutConfig) IsSidebarCollapsible() bool {
+	if d.SidebarCollapsible == nil {
+		return true
+	}
+	return *d.SidebarCollapsible
+}
+
+// IsSidebarDefaultOpen returns whether the sidebar is open by default.
+func (d *DocsLayoutConfig) IsSidebarDefaultOpen() bool {
+	if d.SidebarDefaultOpen == nil {
+		return true
+	}
+	return *d.SidebarDefaultOpen
+}
+
+// IsTocCollapsible returns whether the TOC can be collapsed.
+func (d *DocsLayoutConfig) IsTocCollapsible() bool {
+	if d.TocCollapsible == nil {
+		return true
+	}
+	return *d.TocCollapsible
+}
+
+// IsTocDefaultOpen returns whether the TOC is open by default.
+func (d *DocsLayoutConfig) IsTocDefaultOpen() bool {
+	if d.TocDefaultOpen == nil {
+		return true
+	}
+	return *d.TocDefaultOpen
+}
+
+// BlogLayoutConfig configures the blog layout.
+// This is a single-column layout optimized for reading long-form content.
+type BlogLayoutConfig struct {
+	// ContentMaxWidth is the maximum width of the content area (default: "720px")
+	ContentMaxWidth string `json:"content_max_width,omitempty" yaml:"content_max_width,omitempty" toml:"content_max_width,omitempty"`
+
+	// ShowToc enables table of contents for blog posts (default: false)
+	ShowToc *bool `json:"show_toc,omitempty" yaml:"show_toc,omitempty" toml:"show_toc,omitempty"`
+
+	// TocPosition controls TOC placement: "left" or "right" (default: "right")
+	TocPosition string `json:"toc_position,omitempty" yaml:"toc_position,omitempty" toml:"toc_position,omitempty"`
+
+	// TocWidth is the width of the table of contents (default: "200px")
+	TocWidth string `json:"toc_width,omitempty" yaml:"toc_width,omitempty" toml:"toc_width,omitempty"`
+
+	// HeaderStyle controls the header appearance: "full", "minimal", "transparent", "none" (default: "full")
+	HeaderStyle string `json:"header_style,omitempty" yaml:"header_style,omitempty" toml:"header_style,omitempty"`
+
+	// FooterStyle controls the footer appearance: "full", "minimal", "none" (default: "full")
+	FooterStyle string `json:"footer_style,omitempty" yaml:"footer_style,omitempty" toml:"footer_style,omitempty"`
+
+	// ShowAuthor displays the post author (default: true)
+	ShowAuthor *bool `json:"show_author,omitempty" yaml:"show_author,omitempty" toml:"show_author,omitempty"`
+
+	// ShowDate displays the post date (default: true)
+	ShowDate *bool `json:"show_date,omitempty" yaml:"show_date,omitempty" toml:"show_date,omitempty"`
+
+	// ShowTags displays the post tags (default: true)
+	ShowTags *bool `json:"show_tags,omitempty" yaml:"show_tags,omitempty" toml:"show_tags,omitempty"`
+
+	// ShowReadingTime displays estimated reading time (default: true)
+	ShowReadingTime *bool `json:"show_reading_time,omitempty" yaml:"show_reading_time,omitempty" toml:"show_reading_time,omitempty"`
+
+	// ShowPrevNext displays previous/next post navigation (default: true)
+	ShowPrevNext *bool `json:"show_prev_next,omitempty" yaml:"show_prev_next,omitempty" toml:"show_prev_next,omitempty"`
+}
+
+// IsShowToc returns whether to show the table of contents.
+func (b *BlogLayoutConfig) IsShowToc() bool {
+	if b.ShowToc == nil {
+		return false
+	}
+	return *b.ShowToc
+}
+
+// IsShowAuthor returns whether to show the author.
+func (b *BlogLayoutConfig) IsShowAuthor() bool {
+	if b.ShowAuthor == nil {
+		return true
+	}
+	return *b.ShowAuthor
+}
+
+// IsShowDate returns whether to show the date.
+func (b *BlogLayoutConfig) IsShowDate() bool {
+	if b.ShowDate == nil {
+		return true
+	}
+	return *b.ShowDate
+}
+
+// IsShowTags returns whether to show tags.
+func (b *BlogLayoutConfig) IsShowTags() bool {
+	if b.ShowTags == nil {
+		return true
+	}
+	return *b.ShowTags
+}
+
+// IsShowReadingTime returns whether to show reading time.
+func (b *BlogLayoutConfig) IsShowReadingTime() bool {
+	if b.ShowReadingTime == nil {
+		return true
+	}
+	return *b.ShowReadingTime
+}
+
+// IsShowPrevNext returns whether to show previous/next navigation.
+func (b *BlogLayoutConfig) IsShowPrevNext() bool {
+	if b.ShowPrevNext == nil {
+		return true
+	}
+	return *b.ShowPrevNext
+}
+
+// LandingLayoutConfig configures the landing page layout.
+// This is a full-width layout for marketing pages and home pages.
+type LandingLayoutConfig struct {
+	// ContentMaxWidth is the maximum width of the content area (default: "100%")
+	ContentMaxWidth string `json:"content_max_width,omitempty" yaml:"content_max_width,omitempty" toml:"content_max_width,omitempty"`
+
+	// HeaderStyle controls the header appearance: "full", "minimal", "transparent", "none" (default: "transparent")
+	HeaderStyle string `json:"header_style,omitempty" yaml:"header_style,omitempty" toml:"header_style,omitempty"`
+
+	// HeaderSticky makes the header stick when scrolling (default: true)
+	HeaderSticky *bool `json:"header_sticky,omitempty" yaml:"header_sticky,omitempty" toml:"header_sticky,omitempty"`
+
+	// FooterStyle controls the footer appearance: "full", "minimal", "none" (default: "full")
+	FooterStyle string `json:"footer_style,omitempty" yaml:"footer_style,omitempty" toml:"footer_style,omitempty"`
+
+	// HeroEnabled enables the hero section (default: true)
+	HeroEnabled *bool `json:"hero_enabled,omitempty" yaml:"hero_enabled,omitempty" toml:"hero_enabled,omitempty"`
+}
+
+// IsHeaderSticky returns whether the header should be sticky.
+func (l *LandingLayoutConfig) IsHeaderSticky() bool {
+	if l.HeaderSticky == nil {
+		return true
+	}
+	return *l.HeaderSticky
+}
+
+// IsHeroEnabled returns whether the hero section is enabled.
+func (l *LandingLayoutConfig) IsHeroEnabled() bool {
+	if l.HeroEnabled == nil {
+		return true
+	}
+	return *l.HeroEnabled
+}
+
+// BareLayoutConfig configures the bare layout.
+// This is a minimal layout with no chrome - just the content.
+type BareLayoutConfig struct {
+	// ContentMaxWidth is the maximum width of the content area (default: "100%")
+	ContentMaxWidth string `json:"content_max_width,omitempty" yaml:"content_max_width,omitempty" toml:"content_max_width,omitempty"`
+}
+
+// SidebarNavItem represents a navigation item in the sidebar.
+type SidebarNavItem struct {
+	// Title is the display text for the navigation item
+	Title string `json:"title" yaml:"title" toml:"title"`
+
+	// Href is the link destination (can be relative or absolute)
+	Href string `json:"href,omitempty" yaml:"href,omitempty" toml:"href,omitempty"`
+
+	// Children are nested navigation items
+	Children []SidebarNavItem `json:"children,omitempty" yaml:"children,omitempty" toml:"children,omitempty"`
+}
+
+// SidebarConfig configures the sidebar navigation component.
+type SidebarConfig struct {
+	// Enabled controls whether the sidebar is displayed (default: true for docs layout)
+	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty" toml:"enabled,omitempty"`
+
+	// Position controls sidebar placement: "left" or "right" (default: "left")
+	Position string `json:"position,omitempty" yaml:"position,omitempty" toml:"position,omitempty"`
+
+	// Width is the sidebar width (default: "280px")
+	Width string `json:"width,omitempty" yaml:"width,omitempty" toml:"width,omitempty"`
+
+	// Collapsible allows the sidebar to be collapsed (default: true)
+	Collapsible *bool `json:"collapsible,omitempty" yaml:"collapsible,omitempty" toml:"collapsible,omitempty"`
+
+	// DefaultOpen controls if sidebar is open by default (default: true)
+	DefaultOpen *bool `json:"default_open,omitempty" yaml:"default_open,omitempty" toml:"default_open,omitempty"`
+
+	// Nav is the navigation structure (auto-generated from feeds if not specified)
+	Nav []SidebarNavItem `json:"nav,omitempty" yaml:"nav,omitempty" toml:"nav,omitempty"`
+}
+
+// IsEnabled returns whether the sidebar is enabled.
+func (s *SidebarConfig) IsEnabled() bool {
+	if s.Enabled == nil {
+		return true
+	}
+	return *s.Enabled
+}
+
+// IsCollapsible returns whether the sidebar can be collapsed.
+func (s *SidebarConfig) IsCollapsible() bool {
+	if s.Collapsible == nil {
+		return true
+	}
+	return *s.Collapsible
+}
+
+// IsDefaultOpen returns whether the sidebar is open by default.
+func (s *SidebarConfig) IsDefaultOpen() bool {
+	if s.DefaultOpen == nil {
+		return true
+	}
+	return *s.DefaultOpen
+}
+
+// TocConfig configures the table of contents component.
+type TocConfig struct {
+	// Enabled controls whether the TOC is displayed (default: true for docs layout)
+	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty" toml:"enabled,omitempty"`
+
+	// Position controls TOC placement: "left" or "right" (default: "right")
+	Position string `json:"position,omitempty" yaml:"position,omitempty" toml:"position,omitempty"`
+
+	// Width is the TOC width (default: "220px")
+	Width string `json:"width,omitempty" yaml:"width,omitempty" toml:"width,omitempty"`
+
+	// MinDepth is the minimum heading level to include (default: 2)
+	MinDepth int `json:"min_depth,omitempty" yaml:"min_depth,omitempty" toml:"min_depth,omitempty"`
+
+	// MaxDepth is the maximum heading level to include (default: 4)
+	MaxDepth int `json:"max_depth,omitempty" yaml:"max_depth,omitempty" toml:"max_depth,omitempty"`
+
+	// Title is the TOC section title (default: "On this page")
+	Title string `json:"title,omitempty" yaml:"title,omitempty" toml:"title,omitempty"`
+
+	// Collapsible allows the TOC to be collapsed (default: true)
+	Collapsible *bool `json:"collapsible,omitempty" yaml:"collapsible,omitempty" toml:"collapsible,omitempty"`
+
+	// DefaultOpen controls if TOC is open by default (default: true)
+	DefaultOpen *bool `json:"default_open,omitempty" yaml:"default_open,omitempty" toml:"default_open,omitempty"`
+
+	// ScrollSpy enables highlighting the current section (default: true)
+	ScrollSpy *bool `json:"scroll_spy,omitempty" yaml:"scroll_spy,omitempty" toml:"scroll_spy,omitempty"`
+}
+
+// IsEnabled returns whether the TOC is enabled.
+func (t *TocConfig) IsEnabled() bool {
+	if t.Enabled == nil {
+		return true
+	}
+	return *t.Enabled
+}
+
+// IsCollapsible returns whether the TOC can be collapsed.
+func (t *TocConfig) IsCollapsible() bool {
+	if t.Collapsible == nil {
+		return true
+	}
+	return *t.Collapsible
+}
+
+// IsDefaultOpen returns whether the TOC is open by default.
+func (t *TocConfig) IsDefaultOpen() bool {
+	if t.DefaultOpen == nil {
+		return true
+	}
+	return *t.DefaultOpen
+}
+
+// IsScrollSpy returns whether scroll spy is enabled.
+func (t *TocConfig) IsScrollSpy() bool {
+	if t.ScrollSpy == nil {
+		return true
+	}
+	return *t.ScrollSpy
+}
+
+// HeaderLayoutConfig configures the header component for layouts.
+type HeaderLayoutConfig struct {
+	// Style controls the header appearance: "full", "minimal", "transparent", "none" (default: "full")
+	Style string `json:"style,omitempty" yaml:"style,omitempty" toml:"style,omitempty"`
+
+	// Sticky makes the header stick to the top when scrolling (default: true)
+	Sticky *bool `json:"sticky,omitempty" yaml:"sticky,omitempty" toml:"sticky,omitempty"`
+
+	// ShowLogo displays the site logo (default: true)
+	ShowLogo *bool `json:"show_logo,omitempty" yaml:"show_logo,omitempty" toml:"show_logo,omitempty"`
+
+	// ShowTitle displays the site title (default: true)
+	ShowTitle *bool `json:"show_title,omitempty" yaml:"show_title,omitempty" toml:"show_title,omitempty"`
+
+	// ShowNav displays the navigation links (default: true)
+	ShowNav *bool `json:"show_nav,omitempty" yaml:"show_nav,omitempty" toml:"show_nav,omitempty"`
+
+	// ShowSearch displays the search box (default: true)
+	ShowSearch *bool `json:"show_search,omitempty" yaml:"show_search,omitempty" toml:"show_search,omitempty"`
+
+	// ShowThemeToggle displays the theme toggle button (default: true)
+	ShowThemeToggle *bool `json:"show_theme_toggle,omitempty" yaml:"show_theme_toggle,omitempty" toml:"show_theme_toggle,omitempty"`
+}
+
+// IsSticky returns whether the header should be sticky.
+func (h *HeaderLayoutConfig) IsSticky() bool {
+	if h.Sticky == nil {
+		return true
+	}
+	return *h.Sticky
+}
+
+// IsShowLogo returns whether to show the logo.
+func (h *HeaderLayoutConfig) IsShowLogo() bool {
+	if h.ShowLogo == nil {
+		return true
+	}
+	return *h.ShowLogo
+}
+
+// IsShowTitle returns whether to show the title.
+func (h *HeaderLayoutConfig) IsShowTitle() bool {
+	if h.ShowTitle == nil {
+		return true
+	}
+	return *h.ShowTitle
+}
+
+// IsShowNav returns whether to show navigation.
+func (h *HeaderLayoutConfig) IsShowNav() bool {
+	if h.ShowNav == nil {
+		return true
+	}
+	return *h.ShowNav
+}
+
+// IsShowSearch returns whether to show the search box.
+func (h *HeaderLayoutConfig) IsShowSearch() bool {
+	if h.ShowSearch == nil {
+		return true
+	}
+	return *h.ShowSearch
+}
+
+// IsShowThemeToggle returns whether to show the theme toggle.
+func (h *HeaderLayoutConfig) IsShowThemeToggle() bool {
+	if h.ShowThemeToggle == nil {
+		return true
+	}
+	return *h.ShowThemeToggle
+}
+
+// FooterLayoutConfig configures the footer component for layouts.
+type FooterLayoutConfig struct {
+	// Style controls the footer appearance: "full", "minimal", "none" (default: "full")
+	Style string `json:"style,omitempty" yaml:"style,omitempty" toml:"style,omitempty"`
+
+	// Sticky makes the footer stick to the bottom (default: false)
+	Sticky *bool `json:"sticky,omitempty" yaml:"sticky,omitempty" toml:"sticky,omitempty"`
+
+	// ShowCopyright displays the copyright notice (default: true)
+	ShowCopyright *bool `json:"show_copyright,omitempty" yaml:"show_copyright,omitempty" toml:"show_copyright,omitempty"`
+
+	// CopyrightText is the copyright text (default: auto-generated)
+	CopyrightText string `json:"copyright_text,omitempty" yaml:"copyright_text,omitempty" toml:"copyright_text,omitempty"`
+
+	// ShowSocialLinks displays social media links (default: true)
+	ShowSocialLinks *bool `json:"show_social_links,omitempty" yaml:"show_social_links,omitempty" toml:"show_social_links,omitempty"`
+
+	// ShowNavLinks displays navigation links in footer (default: true)
+	ShowNavLinks *bool `json:"show_nav_links,omitempty" yaml:"show_nav_links,omitempty" toml:"show_nav_links,omitempty"`
+}
+
+// IsSticky returns whether the footer should be sticky.
+func (f *FooterLayoutConfig) IsSticky() bool {
+	if f.Sticky == nil {
+		return false
+	}
+	return *f.Sticky
+}
+
+// IsShowCopyright returns whether to show the copyright.
+func (f *FooterLayoutConfig) IsShowCopyright() bool {
+	if f.ShowCopyright == nil {
+		return true
+	}
+	return *f.ShowCopyright
+}
+
+// IsShowSocialLinks returns whether to show social links.
+func (f *FooterLayoutConfig) IsShowSocialLinks() bool {
+	if f.ShowSocialLinks == nil {
+		return true
+	}
+	return *f.ShowSocialLinks
+}
+
+// IsShowNavLinks returns whether to show nav links in footer.
+func (f *FooterLayoutConfig) IsShowNavLinks() bool {
+	if f.ShowNavLinks == nil {
+		return true
+	}
+	return *f.ShowNavLinks
+}
+
+// NewLayoutConfig creates a new LayoutConfig with default values.
+func NewLayoutConfig() LayoutConfig {
+	sidebarCollapsible := true
+	sidebarDefaultOpen := true
+	tocCollapsible := true
+	tocDefaultOpen := true
+	headerSticky := true
+	footerSticky := false
+	heroEnabled := true
+	showToc := false
+	showAuthor := true
+	showDate := true
+	showTags := true
+	showReadingTime := true
+	showPrevNext := true
+
+	return LayoutConfig{
+		Name: "blog",
+		Docs: DocsLayoutConfig{
+			SidebarPosition:    "left",
+			SidebarWidth:       "280px",
+			SidebarCollapsible: &sidebarCollapsible,
+			SidebarDefaultOpen: &sidebarDefaultOpen,
+			TocPosition:        "right",
+			TocWidth:           "220px",
+			TocCollapsible:     &tocCollapsible,
+			TocDefaultOpen:     &tocDefaultOpen,
+			ContentMaxWidth:    "800px",
+			HeaderStyle:        "minimal",
+			FooterStyle:        "minimal",
+		},
+		Blog: BlogLayoutConfig{
+			ContentMaxWidth: "720px",
+			ShowToc:         &showToc,
+			TocPosition:     "right",
+			TocWidth:        "200px",
+			HeaderStyle:     "full",
+			FooterStyle:     "full",
+			ShowAuthor:      &showAuthor,
+			ShowDate:        &showDate,
+			ShowTags:        &showTags,
+			ShowReadingTime: &showReadingTime,
+			ShowPrevNext:    &showPrevNext,
+		},
+		Landing: LandingLayoutConfig{
+			ContentMaxWidth: "100%",
+			HeaderStyle:     "transparent",
+			HeaderSticky:    &headerSticky,
+			FooterStyle:     "full",
+			HeroEnabled:     &heroEnabled,
+		},
+		Bare: BareLayoutConfig{
+			ContentMaxWidth: "100%",
+		},
+		Defaults: LayoutDefaults{
+			ContentMaxWidth: "800px",
+			HeaderSticky:    &headerSticky,
+			FooterSticky:    &footerSticky,
+		},
+	}
+}
+
+// NewSidebarConfig creates a new SidebarConfig with default values.
+func NewSidebarConfig() SidebarConfig {
+	enabled := true
+	collapsible := true
+	defaultOpen := true
+
+	return SidebarConfig{
+		Enabled:     &enabled,
+		Position:    "left",
+		Width:       "280px",
+		Collapsible: &collapsible,
+		DefaultOpen: &defaultOpen,
+		Nav:         []SidebarNavItem{},
+	}
+}
+
+// NewTocConfig creates a new TocConfig with default values.
+func NewTocConfig() TocConfig {
+	enabled := true
+	collapsible := true
+	defaultOpen := true
+	scrollSpy := true
+
+	return TocConfig{
+		Enabled:     &enabled,
+		Position:    "right",
+		Width:       "220px",
+		MinDepth:    2,
+		MaxDepth:    4,
+		Title:       "On this page",
+		Collapsible: &collapsible,
+		DefaultOpen: &defaultOpen,
+		ScrollSpy:   &scrollSpy,
+	}
+}
+
+// NewHeaderLayoutConfig creates a new HeaderLayoutConfig with default values.
+func NewHeaderLayoutConfig() HeaderLayoutConfig {
+	sticky := true
+	showLogo := true
+	showTitle := true
+	showNav := true
+	showSearch := true
+	showThemeToggle := true
+
+	return HeaderLayoutConfig{
+		Style:           "full",
+		Sticky:          &sticky,
+		ShowLogo:        &showLogo,
+		ShowTitle:       &showTitle,
+		ShowNav:         &showNav,
+		ShowSearch:      &showSearch,
+		ShowThemeToggle: &showThemeToggle,
+	}
+}
+
+// NewFooterLayoutConfig creates a new FooterLayoutConfig with default values.
+func NewFooterLayoutConfig() FooterLayoutConfig {
+	sticky := false
+	showCopyright := true
+	showSocialLinks := true
+	showNavLinks := true
+
+	return FooterLayoutConfig{
+		Style:           "full",
+		Sticky:          &sticky,
+		ShowCopyright:   &showCopyright,
+		ShowSocialLinks: &showSocialLinks,
+		ShowNavLinks:    &showNavLinks,
+	}
+}

--- a/pkg/themes/default/static/css/layouts.css
+++ b/pkg/themes/default/static/css/layouts.css
@@ -1,0 +1,775 @@
+/* ==========================================================================
+   Layout System Styles
+   
+   CSS Grid-based layout system for docs, blog, landing, and bare layouts.
+   ========================================================================== */
+
+/* ==========================================================================
+   CSS Custom Properties for Layout
+   ========================================================================== */
+
+:root {
+  /* Layout dimensions */
+  --layout-sidebar-width: 280px;
+  --layout-toc-width: 220px;
+  --layout-content-max-width: 800px;
+  --layout-header-height: 64px;
+  
+  /* Z-index layers */
+  --z-header: 100;
+  --z-sidebar: 90;
+  --z-overlay: 80;
+  --z-toc: 70;
+  
+  /* Transitions */
+  --layout-transition: 0.2s ease;
+}
+
+/* ==========================================================================
+   Base Layout Classes
+   ========================================================================== */
+
+.layout {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.layout-container {
+  flex: 1;
+  display: grid;
+  max-width: 100%;
+  margin: 0 auto;
+  padding: 0 var(--space-4);
+}
+
+/* ==========================================================================
+   Docs Layout - 3-panel with sidebar, content, TOC
+   ========================================================================== */
+
+.layout--docs .layout-container {
+  grid-template-columns: var(--sidebar-width, var(--layout-sidebar-width)) minmax(0, 1fr) var(--toc-width, var(--layout-toc-width));
+  grid-template-areas: "sidebar content toc";
+  gap: var(--space-6);
+  max-width: calc(var(--layout-sidebar-width) + var(--layout-content-max-width) + var(--layout-toc-width) + var(--space-12));
+}
+
+/* Sidebar on right variant */
+.layout--docs .layout-sidebar--right ~ .layout-content {
+  grid-area: content;
+}
+
+.layout--docs .layout-sidebar--right {
+  grid-area: toc;
+}
+
+.layout--docs .layout-toc--left {
+  grid-area: sidebar;
+}
+
+/* ==========================================================================
+   Blog Layout - Single column with optional TOC
+   ========================================================================== */
+
+.layout--blog .layout-container {
+  grid-template-columns: minmax(0, 1fr);
+  max-width: var(--content-max-width, var(--layout-content-max-width));
+}
+
+.layout--blog.layout-container--with-toc {
+  grid-template-columns: minmax(0, 1fr) var(--toc-width, 200px);
+  grid-template-areas: "content toc";
+  gap: var(--space-6);
+  max-width: calc(var(--layout-content-max-width) + 200px + var(--space-6));
+}
+
+/* ==========================================================================
+   Landing Layout - Full width
+   ========================================================================== */
+
+.layout--landing .layout-container {
+  grid-template-columns: 1fr;
+  max-width: 100%;
+  padding: 0;
+}
+
+.layout--landing .layout-content {
+  max-width: var(--content-max-width, 100%);
+  margin: 0 auto;
+  width: 100%;
+}
+
+/* ==========================================================================
+   Bare Layout - Content only
+   ========================================================================== */
+
+.layout--bare {
+  display: block;
+}
+
+.layout--bare .layout-content {
+  max-width: var(--content-max-width, 100%);
+  margin: 0 auto;
+  padding: var(--space-4);
+}
+
+/* ==========================================================================
+   Layout Content Area
+   ========================================================================== */
+
+.layout-content {
+  grid-area: content;
+  min-width: 0; /* Prevent overflow */
+  padding: var(--space-8) 0;
+}
+
+.layout-content--blog {
+  margin: 0 auto;
+}
+
+.layout-content--landing {
+  padding: 0;
+}
+
+.layout-content--bare {
+  padding: var(--space-4);
+}
+
+/* ==========================================================================
+   Sidebar Component
+   ========================================================================== */
+
+.layout-sidebar {
+  grid-area: sidebar;
+  position: sticky;
+  top: calc(var(--layout-header-height) + var(--space-4));
+  height: fit-content;
+  max-height: calc(100vh - var(--layout-header-height) - var(--space-8));
+  overflow-y: auto;
+  padding: var(--space-4) 0;
+  
+  /* Scrollbar styling */
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-border) transparent;
+}
+
+.layout-sidebar::-webkit-scrollbar {
+  width: 6px;
+}
+
+.layout-sidebar::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.layout-sidebar::-webkit-scrollbar-thumb {
+  background-color: var(--color-border);
+  border-radius: 3px;
+}
+
+.sidebar-content {
+  padding-right: var(--space-4);
+}
+
+/* Sidebar Navigation */
+.sidebar-nav-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.sidebar-nav-item {
+  margin-bottom: var(--space-1);
+}
+
+.sidebar-nav-item--active > .sidebar-nav-link {
+  color: var(--color-primary);
+  font-weight: 600;
+  background-color: var(--color-surface);
+  border-radius: var(--radius);
+}
+
+.sidebar-nav-link {
+  display: block;
+  padding: var(--space-2) var(--space-3);
+  color: var(--color-text-muted);
+  text-decoration: none;
+  border-radius: var(--radius);
+  transition: color var(--layout-transition), background-color var(--layout-transition);
+}
+
+.sidebar-nav-link:hover {
+  color: var(--color-primary);
+  background-color: var(--color-surface);
+  text-decoration: none;
+}
+
+.sidebar-nav-link--active {
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+.sidebar-nav-label {
+  display: block;
+  padding: var(--space-2) var(--space-3);
+  font-weight: 600;
+  font-size: var(--text-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text);
+  margin-top: var(--space-4);
+}
+
+.sidebar-nav-item:first-child .sidebar-nav-label {
+  margin-top: 0;
+}
+
+.sidebar-nav-children {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  padding-left: var(--space-4);
+}
+
+.sidebar-empty {
+  color: var(--color-text-muted);
+  font-style: italic;
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-sm);
+}
+
+/* ==========================================================================
+   Table of Contents Component
+   ========================================================================== */
+
+.layout-toc {
+  grid-area: toc;
+  position: sticky;
+  top: calc(var(--layout-header-height) + var(--space-4));
+  height: fit-content;
+  max-height: calc(100vh - var(--layout-header-height) - var(--space-8));
+  overflow-y: auto;
+  padding: var(--space-4) 0;
+  
+  /* Scrollbar styling */
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-border) transparent;
+}
+
+.layout-toc::-webkit-scrollbar {
+  width: 6px;
+}
+
+.layout-toc::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.layout-toc::-webkit-scrollbar-thumb {
+  background-color: var(--color-border);
+  border-radius: 3px;
+}
+
+.toc-content {
+  padding-left: var(--space-4);
+  border-left: 1px solid var(--color-border);
+}
+
+.toc-title {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+  margin: 0 0 var(--space-3) 0;
+}
+
+.toc-nav {
+  font-size: var(--text-sm);
+}
+
+.toc-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.toc-list--nested {
+  padding-left: var(--space-3);
+  margin-top: var(--space-1);
+}
+
+.toc-item {
+  margin-bottom: var(--space-1);
+}
+
+.toc-item--h3 .toc-link {
+  font-size: 0.9375rem;
+}
+
+.toc-item--h4 .toc-link {
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+}
+
+.toc-link {
+  display: block;
+  padding: var(--space-1) 0;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  transition: color var(--layout-transition);
+}
+
+.toc-link:hover {
+  color: var(--color-primary);
+}
+
+/* Scroll spy active state */
+.toc-link--active {
+  color: var(--color-primary);
+  font-weight: 500;
+}
+
+/* ==========================================================================
+   Header Styles for Layouts
+   ========================================================================== */
+
+.site-header--sticky {
+  position: sticky;
+  top: 0;
+  z-index: var(--z-header);
+}
+
+.site-header--minimal {
+  padding: var(--space-3) var(--space-4);
+  background: var(--color-background);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.site-header--transparent {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  background: transparent;
+  border-bottom: none;
+}
+
+.site-header--transparent .site-title,
+.site-header--transparent .nav-link {
+  color: var(--color-text);
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+/* ==========================================================================
+   Footer Styles for Layouts
+   ========================================================================== */
+
+.site-footer--minimal {
+  padding: var(--space-4);
+  background: var(--color-surface);
+  border-top: 1px solid var(--color-border);
+  text-align: center;
+  font-size: var(--text-sm);
+}
+
+.site-footer--full {
+  padding: var(--space-8) var(--space-4);
+  background: var(--color-surface);
+  border-top: 1px solid var(--color-border);
+}
+
+/* ==========================================================================
+   Mobile Menu Toggle
+   ========================================================================== */
+
+.mobile-menu-toggle {
+  display: none;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 40px;
+  height: 40px;
+  padding: var(--space-2);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  gap: 4px;
+}
+
+.hamburger-line {
+  display: block;
+  width: 20px;
+  height: 2px;
+  background-color: var(--color-text);
+  transition: transform var(--layout-transition), opacity var(--layout-transition);
+}
+
+/* Hamburger animation when open */
+.mobile-menu-toggle[aria-expanded="true"] .hamburger-line:nth-child(1) {
+  transform: translateY(6px) rotate(45deg);
+}
+
+.mobile-menu-toggle[aria-expanded="true"] .hamburger-line:nth-child(2) {
+  opacity: 0;
+}
+
+.mobile-menu-toggle[aria-expanded="true"] .hamburger-line:nth-child(3) {
+  transform: translateY(-6px) rotate(-45deg);
+}
+
+/* ==========================================================================
+   Sidebar Overlay (Mobile)
+   ========================================================================== */
+
+.sidebar-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  top: var(--layout-header-height);
+  background: rgba(0, 0, 0, 0.5);
+  z-index: var(--z-overlay);
+  opacity: 0;
+  transition: opacity var(--layout-transition);
+}
+
+.sidebar-open .sidebar-overlay {
+  display: block;
+  opacity: 1;
+}
+
+/* ==========================================================================
+   Hero Section (Landing Layout)
+   ========================================================================== */
+
+.hero {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-8);
+  align-items: center;
+  padding: var(--space-16) var(--space-8);
+  max-width: var(--page-width);
+  margin: 0 auto;
+}
+
+.hero-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.hero-title {
+  font-size: var(--text-5xl);
+  font-weight: 800;
+  line-height: 1.1;
+  margin: 0;
+}
+
+.hero-subtitle {
+  font-size: var(--text-xl);
+  color: var(--color-text-muted);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.hero-actions {
+  display: flex;
+  gap: var(--space-4);
+  margin-top: var(--space-4);
+}
+
+.hero-image img {
+  width: 100%;
+  height: auto;
+  border-radius: var(--radius-lg);
+}
+
+/* ==========================================================================
+   Buttons (for Hero and general use)
+   ========================================================================== */
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-3) var(--space-6);
+  font-size: var(--text-base);
+  font-weight: 600;
+  text-decoration: none;
+  border-radius: var(--radius);
+  transition: all var(--layout-transition);
+  cursor: pointer;
+  border: 2px solid transparent;
+}
+
+.btn--primary {
+  background-color: var(--color-primary);
+  color: white;
+  border-color: var(--color-primary);
+}
+
+.btn--primary:hover {
+  background-color: var(--color-primary-dark);
+  border-color: var(--color-primary-dark);
+  text-decoration: none;
+}
+
+.btn--secondary {
+  background-color: transparent;
+  color: var(--color-text);
+  border-color: var(--color-border);
+}
+
+.btn--secondary:hover {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+/* ==========================================================================
+   Post Navigation (Blog Layout)
+   ========================================================================== */
+
+.post-nav {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-4);
+  margin-top: var(--space-8);
+  padding-top: var(--space-6);
+  border-top: 1px solid var(--color-border);
+}
+
+.post-nav-link {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-4);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  text-decoration: none;
+  transition: border-color var(--layout-transition);
+}
+
+.post-nav-link:hover {
+  border-color: var(--color-primary);
+  text-decoration: none;
+}
+
+.post-nav-link--prev {
+  text-align: left;
+}
+
+.post-nav-link--next {
+  text-align: right;
+  grid-column: 2;
+}
+
+.post-nav-label {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.post-nav-title {
+  color: var(--color-text);
+  font-weight: 500;
+}
+
+/* ==========================================================================
+   Skip Links (Accessibility)
+   ========================================================================== */
+
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: var(--space-4);
+  padding: var(--space-2) var(--space-4);
+  background: var(--color-primary);
+  color: white;
+  text-decoration: none;
+  z-index: 9999;
+  border-radius: var(--radius);
+  transition: top var(--layout-transition);
+}
+
+.skip-link:focus {
+  top: var(--space-4);
+}
+
+/* ==========================================================================
+   Theme Toggle Button
+   ========================================================================== */
+
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: border-color var(--layout-transition);
+}
+
+.theme-toggle:hover {
+  border-color: var(--color-primary);
+}
+
+.theme-toggle-icon::before {
+  content: "\263C"; /* Sun symbol */
+  font-size: 1.25rem;
+}
+
+/* Dark theme icon */
+[data-theme="dark"] .theme-toggle-icon::before {
+  content: "\263E"; /* Moon symbol */
+}
+
+/* ==========================================================================
+   Responsive Breakpoints
+   
+   xl: 1280px - Full 3-panel layout
+   lg: 1024px - Hide TOC, 2-panel
+   md: 768px  - Collapsible sidebar
+   sm: 640px  - Single column
+   ========================================================================== */
+
+/* Large screens: Hide TOC */
+@media (max-width: 1280px) {
+  .layout--docs .layout-container {
+    grid-template-columns: var(--sidebar-width, var(--layout-sidebar-width)) minmax(0, 1fr);
+    grid-template-areas: "sidebar content";
+  }
+  
+  .layout-toc {
+    display: none;
+  }
+}
+
+/* Medium screens: Collapsible sidebar */
+@media (max-width: 1024px) {
+  .mobile-menu-toggle {
+    display: flex;
+  }
+  
+  .layout--docs .layout-container,
+  .layout--blog .layout-container {
+    grid-template-columns: 1fr;
+    grid-template-areas: "content";
+  }
+  
+  .layout-sidebar {
+    position: fixed;
+    top: var(--layout-header-height);
+    left: 0;
+    bottom: 0;
+    width: var(--sidebar-width, var(--layout-sidebar-width));
+    background: var(--color-background);
+    border-right: 1px solid var(--color-border);
+    z-index: var(--z-sidebar);
+    transform: translateX(-100%);
+    transition: transform var(--layout-transition);
+    max-height: none;
+    overflow-y: auto;
+  }
+  
+  .layout-sidebar[data-open="true"],
+  .sidebar-open .layout-sidebar {
+    transform: translateX(0);
+  }
+  
+  .sidebar-content {
+    padding: var(--space-4);
+  }
+}
+
+/* Small screens */
+@media (max-width: 768px) {
+  :root {
+    --layout-header-height: 56px;
+  }
+  
+  .layout-container {
+    padding: 0 var(--space-3);
+  }
+  
+  .layout-content {
+    padding: var(--space-6) 0;
+  }
+  
+  .hero {
+    grid-template-columns: 1fr;
+    padding: var(--space-8) var(--space-4);
+    text-align: center;
+  }
+  
+  .hero-title {
+    font-size: var(--text-3xl);
+  }
+  
+  .hero-actions {
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+  
+  .hero-image {
+    order: -1;
+  }
+  
+  .post-nav {
+    grid-template-columns: 1fr;
+  }
+  
+  .post-nav-link--next {
+    grid-column: 1;
+    text-align: left;
+  }
+}
+
+/* Extra small screens */
+@media (max-width: 640px) {
+  .layout-sidebar {
+    width: 100%;
+  }
+  
+  .btn {
+    width: 100%;
+  }
+  
+  .hero-actions {
+    flex-direction: column;
+  }
+}
+
+/* ==========================================================================
+   Print Styles
+   ========================================================================== */
+
+@media print {
+  .layout-sidebar,
+  .layout-toc,
+  .site-header,
+  .site-footer,
+  .mobile-menu-toggle,
+  .skip-link,
+  .theme-toggle {
+    display: none !important;
+  }
+  
+  .layout-container {
+    display: block;
+  }
+  
+  .layout-content {
+    max-width: 100%;
+    padding: 0;
+  }
+}

--- a/pkg/themes/default/static/js/layout.js
+++ b/pkg/themes/default/static/js/layout.js
@@ -1,0 +1,167 @@
+/**
+ * Layout System JavaScript
+ * Handles sidebar toggle, mobile menu, and keyboard navigation
+ */
+
+(function() {
+  'use strict';
+
+  // DOM elements
+  const toggle = document.querySelector('.mobile-menu-toggle');
+  const sidebar = document.querySelector('.layout-sidebar');
+  const overlay = document.querySelector('.sidebar-overlay');
+  const body = document.body;
+
+  if (!toggle || !sidebar) return;
+
+  /**
+   * Toggle sidebar open/closed state
+   */
+  function toggleSidebar() {
+    const isOpen = sidebar.dataset.open === 'true';
+    setSidebarState(!isOpen);
+  }
+
+  /**
+   * Set sidebar state
+   * @param {boolean} open - Whether sidebar should be open
+   */
+  function setSidebarState(open) {
+    sidebar.dataset.open = open;
+    toggle.setAttribute('aria-expanded', open);
+    body.classList.toggle('sidebar-open', open);
+
+    if (open) {
+      // Focus first link in sidebar for accessibility
+      const firstLink = sidebar.querySelector('a');
+      if (firstLink) {
+        firstLink.focus();
+      }
+    } else {
+      // Return focus to toggle button
+      toggle.focus();
+    }
+  }
+
+  /**
+   * Close sidebar
+   */
+  function closeSidebar() {
+    setSidebarState(false);
+  }
+
+  // Toggle button click
+  toggle.addEventListener('click', toggleSidebar);
+
+  // Overlay click closes sidebar
+  if (overlay) {
+    overlay.addEventListener('click', closeSidebar);
+  }
+
+  // Escape key closes sidebar
+  document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape' && sidebar.dataset.open === 'true') {
+      closeSidebar();
+    }
+  });
+
+  // Close sidebar when clicking a link (mobile)
+  sidebar.addEventListener('click', function(e) {
+    if (e.target.matches('a') && window.innerWidth < 1024) {
+      closeSidebar();
+    }
+  });
+
+  // Handle window resize
+  let resizeTimeout;
+  window.addEventListener('resize', function() {
+    clearTimeout(resizeTimeout);
+    resizeTimeout = setTimeout(function() {
+      // Close mobile sidebar if window is resized to desktop
+      if (window.innerWidth >= 1024 && sidebar.dataset.open === 'true') {
+        closeSidebar();
+      }
+    }, 100);
+  });
+
+  // Trap focus within sidebar when open (accessibility)
+  sidebar.addEventListener('keydown', function(e) {
+    if (e.key !== 'Tab' || sidebar.dataset.open !== 'true') return;
+
+    const focusableElements = sidebar.querySelectorAll(
+      'a[href], button, [tabindex]:not([tabindex="-1"])'
+    );
+    const firstElement = focusableElements[0];
+    const lastElement = focusableElements[focusableElements.length - 1];
+
+    if (e.shiftKey && document.activeElement === firstElement) {
+      e.preventDefault();
+      lastElement.focus();
+    } else if (!e.shiftKey && document.activeElement === lastElement) {
+      e.preventDefault();
+      firstElement.focus();
+    }
+  });
+})();
+
+/**
+ * Theme Toggle
+ * Handles light/dark theme switching with localStorage persistence
+ */
+(function() {
+  'use strict';
+
+  const toggle = document.querySelector('.theme-toggle');
+  if (!toggle) return;
+
+  const STORAGE_KEY = 'theme';
+  const DARK_CLASS = 'dark';
+
+  /**
+   * Get current theme preference
+   * @returns {string} 'dark' or 'light'
+   */
+  function getTheme() {
+    // Check localStorage first
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) return stored;
+
+    // Fall back to system preference
+    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      return 'dark';
+    }
+    return 'light';
+  }
+
+  /**
+   * Set theme
+   * @param {string} theme - 'dark' or 'light'
+   */
+  function setTheme(theme) {
+    document.documentElement.dataset.theme = theme;
+    document.documentElement.classList.toggle(DARK_CLASS, theme === 'dark');
+    localStorage.setItem(STORAGE_KEY, theme);
+  }
+
+  /**
+   * Toggle between light and dark themes
+   */
+  function toggleTheme() {
+    const current = getTheme();
+    setTheme(current === 'dark' ? 'light' : 'dark');
+  }
+
+  // Initialize theme on page load
+  setTheme(getTheme());
+
+  // Toggle button click
+  toggle.addEventListener('click', toggleTheme);
+
+  // Listen for system theme changes
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function(e) {
+    // Only auto-switch if user hasn't set a preference
+    if (!localStorage.getItem(STORAGE_KEY)) {
+      setTheme(e.matches ? 'dark' : 'light');
+    }
+  });
+})();

--- a/pkg/themes/default/static/js/scroll-spy.js
+++ b/pkg/themes/default/static/js/scroll-spy.js
@@ -1,0 +1,122 @@
+/**
+ * Scroll Spy for Table of Contents
+ * Highlights the current section in the TOC as user scrolls
+ */
+
+(function() {
+  'use strict';
+
+  const tocLinks = document.querySelectorAll('.toc-link');
+  if (!tocLinks.length) return;
+
+  // Get all heading IDs from TOC links
+  const headingIds = Array.from(tocLinks).map(link => {
+    const href = link.getAttribute('href');
+    return href ? href.substring(1) : null;
+  }).filter(Boolean);
+
+  // Get corresponding heading elements
+  const headings = headingIds.map(id => document.getElementById(id)).filter(Boolean);
+
+  if (!headings.length) return;
+
+  const ACTIVE_CLASS = 'toc-link--active';
+  const OFFSET = 100; // Offset from top of viewport
+
+  let ticking = false;
+
+  /**
+   * Get the current active heading based on scroll position
+   * @returns {Element|null} The currently visible heading
+   */
+  function getCurrentHeading() {
+    const scrollTop = window.scrollY;
+    let current = null;
+
+    for (const heading of headings) {
+      const rect = heading.getBoundingClientRect();
+      const offsetTop = rect.top + scrollTop;
+
+      if (offsetTop - OFFSET <= scrollTop) {
+        current = heading;
+      } else {
+        break;
+      }
+    }
+
+    return current;
+  }
+
+  /**
+   * Update TOC link active states
+   */
+  function updateActiveLink() {
+    const currentHeading = getCurrentHeading();
+
+    tocLinks.forEach(link => {
+      const href = link.getAttribute('href');
+      const isActive = currentHeading && href === `#${currentHeading.id}`;
+      
+      link.classList.toggle(ACTIVE_CLASS, isActive);
+      
+      // Also highlight parent items if nested
+      const parentItem = link.closest('.toc-item');
+      if (parentItem) {
+        const parentList = parentItem.closest('.toc-list--nested');
+        if (parentList) {
+          const parentLink = parentList.previousElementSibling;
+          if (parentLink && parentLink.classList.contains('toc-link')) {
+            // Keep parent highlighted if any child is active
+            const hasActiveChild = parentList.querySelector(`.${ACTIVE_CLASS}`);
+            parentLink.classList.toggle(ACTIVE_CLASS, isActive || hasActiveChild);
+          }
+        }
+      }
+    });
+
+    ticking = false;
+  }
+
+  /**
+   * Request animation frame for scroll handler
+   */
+  function onScroll() {
+    if (!ticking) {
+      requestAnimationFrame(updateActiveLink);
+      ticking = true;
+    }
+  }
+
+  // Listen for scroll events
+  window.addEventListener('scroll', onScroll, { passive: true });
+
+  // Initial update
+  updateActiveLink();
+
+  // Smooth scroll to heading when clicking TOC links
+  tocLinks.forEach(link => {
+    link.addEventListener('click', function(e) {
+      const href = this.getAttribute('href');
+      if (!href || !href.startsWith('#')) return;
+
+      const target = document.getElementById(href.substring(1));
+      if (!target) return;
+
+      e.preventDefault();
+
+      // Calculate scroll position with offset
+      const offsetTop = target.getBoundingClientRect().top + window.scrollY - OFFSET + 20;
+
+      window.scrollTo({
+        top: offsetTop,
+        behavior: 'smooth'
+      });
+
+      // Update URL hash without jumping
+      history.pushState(null, '', href);
+
+      // Update active state immediately
+      setTimeout(updateActiveLink, 100);
+    });
+  });
+})();

--- a/templates/base.html
+++ b/templates/base.html
@@ -75,6 +75,7 @@
     <link rel="stylesheet" href="{{ 'css/variables.css' | theme_asset }}">
     <link rel="stylesheet" href="{{ 'css/main.css' | theme_asset }}">
     <link rel="stylesheet" href="{{ 'css/components.css' | theme_asset }}">
+    <link rel="stylesheet" href="{{ 'css/layouts.css' | theme_asset }}">
     <link rel="stylesheet" href="{{ 'css/admonitions.css' | theme_asset }}">
     <link rel="stylesheet" href="{{ 'css/code.css' | theme_asset }}">
     <link rel="stylesheet" href="/css/chroma.css">
@@ -148,7 +149,7 @@
     </script>
     {% endif %}
 </head>
-<body>
+<body class="{% block body_class %}{% endblock %}">
     {% block header %}
     <header class="site-header" data-pagefind-ignore>
         <div class="container">

--- a/templates/components/sidebar_nav.html
+++ b/templates/components/sidebar_nav.html
@@ -1,0 +1,59 @@
+{# Sidebar Navigation Component - Hierarchical navigation for docs layout #}
+<nav class="sidebar-nav" aria-label="Sidebar navigation">
+    {% if config.sidebar.nav %}
+    <ul class="sidebar-nav-list">
+        {% for item in config.sidebar.nav %}
+        <li class="sidebar-nav-item{% if item.children %} sidebar-nav-item--has-children{% endif %}{% if post.href == item.href %} sidebar-nav-item--active{% endif %}">
+            {% if item.href %}
+            <a href="{{ item.href }}" class="sidebar-nav-link{% if post.href == item.href %} sidebar-nav-link--active{% endif %}">
+                {{ item.title }}
+            </a>
+            {% else %}
+            <span class="sidebar-nav-label">{{ item.title }}</span>
+            {% endif %}
+            
+            {% if item.children %}
+            <ul class="sidebar-nav-children">
+                {% for child in item.children %}
+                <li class="sidebar-nav-item{% if child.children %} sidebar-nav-item--has-children{% endif %}{% if post.href == child.href %} sidebar-nav-item--active{% endif %}">
+                    {% if child.href %}
+                    <a href="{{ child.href }}" class="sidebar-nav-link{% if post.href == child.href %} sidebar-nav-link--active{% endif %}">
+                        {{ child.title }}
+                    </a>
+                    {% else %}
+                    <span class="sidebar-nav-label">{{ child.title }}</span>
+                    {% endif %}
+                    
+                    {% if child.children %}
+                    <ul class="sidebar-nav-children">
+                        {% for grandchild in child.children %}
+                        <li class="sidebar-nav-item{% if post.href == grandchild.href %} sidebar-nav-item--active{% endif %}">
+                            <a href="{{ grandchild.href }}" class="sidebar-nav-link{% if post.href == grandchild.href %} sidebar-nav-link--active{% endif %}">
+                                {{ grandchild.title }}
+                            </a>
+                        </li>
+                        {% endfor %}
+                    </ul>
+                    {% endif %}
+                </li>
+                {% endfor %}
+            </ul>
+            {% endif %}
+        </li>
+        {% endfor %}
+    </ul>
+    {% elif feed_sidebar_posts %}
+    {# Auto-generated navigation from feed posts #}
+    <ul class="sidebar-nav-list">
+        {% for nav_post in feed_sidebar_posts %}
+        <li class="sidebar-nav-item{% if post.href == nav_post.href %} sidebar-nav-item--active{% endif %}">
+            <a href="{{ nav_post.href }}" class="sidebar-nav-link{% if post.href == nav_post.href %} sidebar-nav-link--active{% endif %}">
+                {{ nav_post.title }}
+            </a>
+        </li>
+        {% endfor %}
+    </ul>
+    {% else %}
+    <p class="sidebar-empty">No navigation configured.</p>
+    {% endif %}
+</nav>

--- a/templates/components/toc_list.html
+++ b/templates/components/toc_list.html
@@ -1,0 +1,30 @@
+{# TOC List Component - Table of contents list from post headings #}
+{% if post.Extra.toc %}
+<nav class="toc-nav" aria-label="Table of contents">
+    <ul class="toc-list">
+        {% for heading in post.Extra.toc %}
+        <li class="toc-item toc-item--h{{ heading.level }}" data-level="{{ heading.level }}">
+            <a href="#{{ heading.id }}" class="toc-link">{{ heading.text }}</a>
+            {% if heading.children %}
+            <ul class="toc-list toc-list--nested">
+                {% for child in heading.children %}
+                <li class="toc-item toc-item--h{{ child.level }}" data-level="{{ child.level }}">
+                    <a href="#{{ child.id }}" class="toc-link">{{ child.text }}</a>
+                    {% if child.children %}
+                    <ul class="toc-list toc-list--nested">
+                        {% for grandchild in child.children %}
+                        <li class="toc-item toc-item--h{{ grandchild.level }}" data-level="{{ grandchild.level }}">
+                            <a href="#{{ grandchild.id }}" class="toc-link">{{ grandchild.text }}</a>
+                        </li>
+                        {% endfor %}
+                    </ul>
+                    {% endif %}
+                </li>
+                {% endfor %}
+            </ul>
+            {% endif %}
+        </li>
+        {% endfor %}
+    </ul>
+</nav>
+{% endif %}

--- a/templates/layouts/bare.html
+++ b/templates/layouts/bare.html
@@ -1,0 +1,20 @@
+{# Bare Layout - Minimal layout with content only #}
+{% extends "base.html" %}
+
+{% block body_class %}layout layout--bare{% endblock %}
+
+{% block header %}
+{# No header in bare layout #}
+{% endblock %}
+
+{% block content %}
+<main class="layout-content layout-content--bare" id="main-content" style="--content-max-width: {{ config.layout.bare.content_max_width | default:'100%' }}">
+    <div class="post-content{% if post.css_class %} {{ post.css_class }}{% endif %}">
+        {{ body | safe }}
+    </div>
+</main>
+{% endblock %}
+
+{% block footer %}
+{# No footer in bare layout #}
+{% endblock %}

--- a/templates/layouts/blog.html
+++ b/templates/layouts/blog.html
@@ -1,0 +1,112 @@
+{# Blog Layout - Single-column layout optimized for reading #}
+{% extends "base.html" %}
+
+{% block body_class %}layout layout--blog{% endblock %}
+
+{% block header %}
+<header class="site-header site-header--{{ config.layout.blog.header_style | default:'full' }}{% if config.header.sticky %} site-header--sticky{% endif %}" data-pagefind-ignore>
+    <div class="container">
+        {% if config.header.show_logo or config.header.show_title %}
+        <a href="/" class="site-title">
+            {% if config.header.show_logo and config.logo %}
+            <img src="{{ config.logo }}" alt="{{ config.title }}" class="site-logo">
+            {% endif %}
+            {% if config.header.show_title %}{{ config.title | default:"Home" }}{% endif %}
+        </a>
+        {% endif %}
+        {% if config.header.show_nav %}
+        {% include "components/nav.html" %}
+        {% endif %}
+        <div class="header-actions">
+            {% if config.search.enabled and config.header.show_search %}
+            {% include "components/search.html" %}
+            {% endif %}
+            {% if config.header.show_theme_toggle %}
+            <button class="theme-toggle" aria-label="Toggle theme">
+                <span class="theme-toggle-icon"></span>
+            </button>
+            {% endif %}
+        </div>
+    </div>
+</header>
+{% endblock %}
+
+{% block content %}
+<div class="layout-container layout-container--blog">
+    <main class="layout-content layout-content--blog" id="main-content" style="--content-max-width: {{ config.layout.blog.content_max_width | default:'720px' }}">
+        <a href="#main-content" class="skip-link">Skip to main content</a>
+        <article class="post post--blog">
+            <header class="post-header">
+                <h1>{{ post.title }}</h1>
+                <div class="post-meta">
+                    {% if config.layout.blog.show_date and post.date %}
+                    <time datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+                    {% endif %}
+                    {% if config.layout.blog.show_author and post.author %}
+                    <span class="post-author">by {{ post.author }}</span>
+                    {% elif config.layout.blog.show_author and config.author %}
+                    <span class="post-author">by {{ config.author }}</span>
+                    {% endif %}
+                    {% if config.layout.blog.show_reading_time and post.reading_time %}
+                    <span class="post-reading-time">{{ post.reading_time }} min read</span>
+                    {% endif %}
+                </div>
+                {% if config.layout.blog.show_tags and post.tags %}
+                <div class="tags">
+                    {% for tag in post.tags %}
+                    <a href="/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+                    {% endfor %}
+                </div>
+                {% endif %}
+            </header>
+            
+            {% if post.cover_image %}
+            <figure class="post-cover">
+                <img src="{{ post.cover_image }}" alt="{{ post.title }}">
+            </figure>
+            {% endif %}
+            
+            <div class="post-content{% if post.css_class %} {{ post.css_class }}{% endif %}">
+                {{ body | safe }}
+            </div>
+            
+            {% if config.layout.blog.show_prev_next %}
+            <nav class="post-nav" aria-label="Post navigation">
+                {% if post.prev %}
+                <a href="{{ post.prev.href }}" class="post-nav-link post-nav-link--prev">
+                    <span class="post-nav-label">Previous</span>
+                    <span class="post-nav-title">{{ post.prev.title }}</span>
+                </a>
+                {% endif %}
+                {% if post.next %}
+                <a href="{{ post.next.href }}" class="post-nav-link post-nav-link--next">
+                    <span class="post-nav-label">Next</span>
+                    <span class="post-nav-title">{{ post.next.title }}</span>
+                </a>
+                {% endif %}
+            </nav>
+            {% endif %}
+        </article>
+    </main>
+    
+    {% if config.layout.blog.show_toc and post.Extra.toc %}
+    <aside class="layout-toc layout-toc--{{ config.layout.blog.toc_position | default:'right' }}" 
+           role="complementary" 
+           aria-label="Table of Contents"
+           style="--toc-width: {{ config.layout.blog.toc_width | default:'200px' }}">
+        <div class="toc-content">
+            <h2 class="toc-title">{{ config.toc.title | default:'On this page' }}</h2>
+            {% include "components/toc_list.html" %}
+        </div>
+    </aside>
+    {% endif %}
+</div>
+{% endblock %}
+
+{% block footer %}
+{% if config.layout.blog.footer_style != 'none' %}
+<footer class="site-footer site-footer--{{ config.layout.blog.footer_style | default:'full' }}" role="contentinfo">
+    {% include "components/footer.html" %}
+</footer>
+{% endif %}
+{% endblock %}

--- a/templates/layouts/docs.html
+++ b/templates/layouts/docs.html
@@ -1,0 +1,101 @@
+{# Documentation Layout - 3-panel layout with sidebar, content, and TOC #}
+{% extends "base.html" %}
+
+{% block body_class %}layout layout--docs{% endblock %}
+
+{% block header %}
+<header class="site-header site-header--{{ config.layout.docs.header_style | default:'minimal' }}{% if config.header.sticky %} site-header--sticky{% endif %}" data-pagefind-ignore>
+    <div class="container">
+        {% if config.header.show_logo or config.header.show_title %}
+        <a href="/" class="site-title">
+            {% if config.header.show_logo and config.logo %}
+            <img src="{{ config.logo }}" alt="{{ config.title }}" class="site-logo">
+            {% endif %}
+            {% if config.header.show_title %}{{ config.title | default:"Home" }}{% endif %}
+        </a>
+        {% endif %}
+        {% if config.header.show_nav %}
+        {% include "components/nav.html" %}
+        {% endif %}
+        <div class="header-actions">
+            {% if config.search.enabled and config.header.show_search %}
+            {% include "components/search.html" %}
+            {% endif %}
+            {% if config.header.show_theme_toggle %}
+            <button class="theme-toggle" aria-label="Toggle theme">
+                <span class="theme-toggle-icon"></span>
+            </button>
+            {% endif %}
+            <button class="mobile-menu-toggle" aria-label="Toggle navigation" aria-expanded="false" aria-controls="sidebar">
+                <span class="hamburger-line"></span>
+                <span class="hamburger-line"></span>
+                <span class="hamburger-line"></span>
+            </button>
+        </div>
+    </div>
+</header>
+{% endblock %}
+
+{% block content %}
+<div class="layout-container">
+    {% if config.sidebar.enabled %}
+    <aside class="layout-sidebar layout-sidebar--{{ config.layout.docs.sidebar_position | default:'left' }}" 
+           id="sidebar" 
+           role="navigation" 
+           aria-label="Documentation navigation"
+           data-collapsible="{{ config.layout.docs.sidebar_collapsible | default:true | yesno:'true,false' }}"
+           data-open="{{ config.layout.docs.sidebar_default_open | default:true | yesno:'true,false' }}"
+           style="--sidebar-width: {{ config.layout.docs.sidebar_width | default:'280px' }}">
+        <div class="sidebar-content">
+            {% include "components/sidebar_nav.html" %}
+        </div>
+    </aside>
+    <div class="sidebar-overlay"></div>
+    {% endif %}
+    
+    <main class="layout-content" id="main-content" style="--content-max-width: {{ config.layout.docs.content_max_width | default:'800px' }}">
+        <a href="#main-content" class="skip-link">Skip to main content</a>
+        <article class="post">
+            <header class="post-header">
+                <h1>{{ post.title }}</h1>
+                {% if post.description %}
+                <p class="post-description">{{ post.description }}</p>
+                {% endif %}
+            </header>
+            <div class="post-content{% if post.css_class %} {{ post.css_class }}{% endif %}">
+                {{ body | safe }}
+            </div>
+        </article>
+    </main>
+    
+    {% if config.toc.enabled and post.Extra.toc %}
+    <aside class="layout-toc layout-toc--{{ config.layout.docs.toc_position | default:'right' }}" 
+           role="complementary" 
+           aria-label="Table of Contents"
+           data-collapsible="{{ config.layout.docs.toc_collapsible | default:true | yesno:'true,false' }}"
+           data-open="{{ config.layout.docs.toc_default_open | default:true | yesno:'true,false' }}"
+           style="--toc-width: {{ config.layout.docs.toc_width | default:'220px' }}">
+        <div class="toc-content">
+            <h2 class="toc-title">{{ config.toc.title | default:'On this page' }}</h2>
+            {% include "components/toc_list.html" %}
+        </div>
+    </aside>
+    {% endif %}
+</div>
+{% endblock %}
+
+{% block footer %}
+{% if config.layout.docs.footer_style != 'none' %}
+<footer class="site-footer site-footer--{{ config.layout.docs.footer_style | default:'minimal' }}" role="contentinfo">
+    {% include "components/footer.html" %}
+</footer>
+{% endif %}
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script src="{{ 'js/layout.js' | theme_asset }}" defer></script>
+{% if config.toc.scroll_spy %}
+<script src="{{ 'js/scroll-spy.js' | theme_asset }}" defer></script>
+{% endif %}
+{% endblock %}

--- a/templates/layouts/landing.html
+++ b/templates/layouts/landing.html
@@ -1,0 +1,79 @@
+{# Landing Layout - Full-width layout for marketing pages #}
+{% extends "base.html" %}
+
+{% block body_class %}layout layout--landing{% endblock %}
+
+{% block header %}
+<header class="site-header site-header--{{ config.layout.landing.header_style | default:'transparent' }}{% if config.layout.landing.header_sticky %} site-header--sticky{% endif %}" data-pagefind-ignore>
+    <div class="container">
+        {% if config.header.show_logo or config.header.show_title %}
+        <a href="/" class="site-title">
+            {% if config.header.show_logo and config.logo %}
+            <img src="{{ config.logo }}" alt="{{ config.title }}" class="site-logo">
+            {% endif %}
+            {% if config.header.show_title %}{{ config.title | default:"Home" }}{% endif %}
+        </a>
+        {% endif %}
+        {% if config.header.show_nav %}
+        {% include "components/nav.html" %}
+        {% endif %}
+        <div class="header-actions">
+            {% if config.search.enabled and config.header.show_search %}
+            {% include "components/search.html" %}
+            {% endif %}
+            {% if config.header.show_theme_toggle %}
+            <button class="theme-toggle" aria-label="Toggle theme">
+                <span class="theme-toggle-icon"></span>
+            </button>
+            {% endif %}
+        </div>
+    </div>
+</header>
+{% endblock %}
+
+{% block content %}
+<div class="layout-container layout-container--landing">
+    {% if config.layout.landing.hero_enabled and post.hero %}
+    <section class="hero" aria-label="Hero">
+        <div class="hero-content">
+            {% if post.hero.title %}
+            <h1 class="hero-title">{{ post.hero.title }}</h1>
+            {% endif %}
+            {% if post.hero.subtitle %}
+            <p class="hero-subtitle">{{ post.hero.subtitle }}</p>
+            {% endif %}
+            {% if post.hero.cta_primary or post.hero.cta_secondary %}
+            <div class="hero-actions">
+                {% if post.hero.cta_primary %}
+                <a href="{{ post.hero.cta_primary.href }}" class="btn btn--primary">{{ post.hero.cta_primary.text }}</a>
+                {% endif %}
+                {% if post.hero.cta_secondary %}
+                <a href="{{ post.hero.cta_secondary.href }}" class="btn btn--secondary">{{ post.hero.cta_secondary.text }}</a>
+                {% endif %}
+            </div>
+            {% endif %}
+        </div>
+        {% if post.hero.image %}
+        <div class="hero-image">
+            <img src="{{ post.hero.image }}" alt="{{ post.hero.title | default:post.title }}">
+        </div>
+        {% endif %}
+    </section>
+    {% endif %}
+    
+    <main class="layout-content layout-content--landing" id="main-content" style="--content-max-width: {{ config.layout.landing.content_max_width | default:'100%' }}">
+        <a href="#main-content" class="skip-link">Skip to main content</a>
+        <div class="post-content{% if post.css_class %} {{ post.css_class }}{% endif %}">
+            {{ body | safe }}
+        </div>
+    </main>
+</div>
+{% endblock %}
+
+{% block footer %}
+{% if config.layout.landing.footer_style != 'none' %}
+<footer class="site-footer site-footer--{{ config.layout.landing.footer_style | default:'full' }}" role="contentinfo">
+    {% include "components/footer.html" %}
+</footer>
+{% endif %}
+{% endblock %}

--- a/themes/default/static/css/layouts.css
+++ b/themes/default/static/css/layouts.css
@@ -1,0 +1,775 @@
+/* ==========================================================================
+   Layout System Styles
+   
+   CSS Grid-based layout system for docs, blog, landing, and bare layouts.
+   ========================================================================== */
+
+/* ==========================================================================
+   CSS Custom Properties for Layout
+   ========================================================================== */
+
+:root {
+  /* Layout dimensions */
+  --layout-sidebar-width: 280px;
+  --layout-toc-width: 220px;
+  --layout-content-max-width: 800px;
+  --layout-header-height: 64px;
+  
+  /* Z-index layers */
+  --z-header: 100;
+  --z-sidebar: 90;
+  --z-overlay: 80;
+  --z-toc: 70;
+  
+  /* Transitions */
+  --layout-transition: 0.2s ease;
+}
+
+/* ==========================================================================
+   Base Layout Classes
+   ========================================================================== */
+
+.layout {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.layout-container {
+  flex: 1;
+  display: grid;
+  max-width: 100%;
+  margin: 0 auto;
+  padding: 0 var(--space-4);
+}
+
+/* ==========================================================================
+   Docs Layout - 3-panel with sidebar, content, TOC
+   ========================================================================== */
+
+.layout--docs .layout-container {
+  grid-template-columns: var(--sidebar-width, var(--layout-sidebar-width)) minmax(0, 1fr) var(--toc-width, var(--layout-toc-width));
+  grid-template-areas: "sidebar content toc";
+  gap: var(--space-6);
+  max-width: calc(var(--layout-sidebar-width) + var(--layout-content-max-width) + var(--layout-toc-width) + var(--space-12));
+}
+
+/* Sidebar on right variant */
+.layout--docs .layout-sidebar--right ~ .layout-content {
+  grid-area: content;
+}
+
+.layout--docs .layout-sidebar--right {
+  grid-area: toc;
+}
+
+.layout--docs .layout-toc--left {
+  grid-area: sidebar;
+}
+
+/* ==========================================================================
+   Blog Layout - Single column with optional TOC
+   ========================================================================== */
+
+.layout--blog .layout-container {
+  grid-template-columns: minmax(0, 1fr);
+  max-width: var(--content-max-width, var(--layout-content-max-width));
+}
+
+.layout--blog.layout-container--with-toc {
+  grid-template-columns: minmax(0, 1fr) var(--toc-width, 200px);
+  grid-template-areas: "content toc";
+  gap: var(--space-6);
+  max-width: calc(var(--layout-content-max-width) + 200px + var(--space-6));
+}
+
+/* ==========================================================================
+   Landing Layout - Full width
+   ========================================================================== */
+
+.layout--landing .layout-container {
+  grid-template-columns: 1fr;
+  max-width: 100%;
+  padding: 0;
+}
+
+.layout--landing .layout-content {
+  max-width: var(--content-max-width, 100%);
+  margin: 0 auto;
+  width: 100%;
+}
+
+/* ==========================================================================
+   Bare Layout - Content only
+   ========================================================================== */
+
+.layout--bare {
+  display: block;
+}
+
+.layout--bare .layout-content {
+  max-width: var(--content-max-width, 100%);
+  margin: 0 auto;
+  padding: var(--space-4);
+}
+
+/* ==========================================================================
+   Layout Content Area
+   ========================================================================== */
+
+.layout-content {
+  grid-area: content;
+  min-width: 0; /* Prevent overflow */
+  padding: var(--space-8) 0;
+}
+
+.layout-content--blog {
+  margin: 0 auto;
+}
+
+.layout-content--landing {
+  padding: 0;
+}
+
+.layout-content--bare {
+  padding: var(--space-4);
+}
+
+/* ==========================================================================
+   Sidebar Component
+   ========================================================================== */
+
+.layout-sidebar {
+  grid-area: sidebar;
+  position: sticky;
+  top: calc(var(--layout-header-height) + var(--space-4));
+  height: fit-content;
+  max-height: calc(100vh - var(--layout-header-height) - var(--space-8));
+  overflow-y: auto;
+  padding: var(--space-4) 0;
+  
+  /* Scrollbar styling */
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-border) transparent;
+}
+
+.layout-sidebar::-webkit-scrollbar {
+  width: 6px;
+}
+
+.layout-sidebar::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.layout-sidebar::-webkit-scrollbar-thumb {
+  background-color: var(--color-border);
+  border-radius: 3px;
+}
+
+.sidebar-content {
+  padding-right: var(--space-4);
+}
+
+/* Sidebar Navigation */
+.sidebar-nav-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.sidebar-nav-item {
+  margin-bottom: var(--space-1);
+}
+
+.sidebar-nav-item--active > .sidebar-nav-link {
+  color: var(--color-primary);
+  font-weight: 600;
+  background-color: var(--color-surface);
+  border-radius: var(--radius);
+}
+
+.sidebar-nav-link {
+  display: block;
+  padding: var(--space-2) var(--space-3);
+  color: var(--color-text-muted);
+  text-decoration: none;
+  border-radius: var(--radius);
+  transition: color var(--layout-transition), background-color var(--layout-transition);
+}
+
+.sidebar-nav-link:hover {
+  color: var(--color-primary);
+  background-color: var(--color-surface);
+  text-decoration: none;
+}
+
+.sidebar-nav-link--active {
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+.sidebar-nav-label {
+  display: block;
+  padding: var(--space-2) var(--space-3);
+  font-weight: 600;
+  font-size: var(--text-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text);
+  margin-top: var(--space-4);
+}
+
+.sidebar-nav-item:first-child .sidebar-nav-label {
+  margin-top: 0;
+}
+
+.sidebar-nav-children {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  padding-left: var(--space-4);
+}
+
+.sidebar-empty {
+  color: var(--color-text-muted);
+  font-style: italic;
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-sm);
+}
+
+/* ==========================================================================
+   Table of Contents Component
+   ========================================================================== */
+
+.layout-toc {
+  grid-area: toc;
+  position: sticky;
+  top: calc(var(--layout-header-height) + var(--space-4));
+  height: fit-content;
+  max-height: calc(100vh - var(--layout-header-height) - var(--space-8));
+  overflow-y: auto;
+  padding: var(--space-4) 0;
+  
+  /* Scrollbar styling */
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-border) transparent;
+}
+
+.layout-toc::-webkit-scrollbar {
+  width: 6px;
+}
+
+.layout-toc::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.layout-toc::-webkit-scrollbar-thumb {
+  background-color: var(--color-border);
+  border-radius: 3px;
+}
+
+.toc-content {
+  padding-left: var(--space-4);
+  border-left: 1px solid var(--color-border);
+}
+
+.toc-title {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+  margin: 0 0 var(--space-3) 0;
+}
+
+.toc-nav {
+  font-size: var(--text-sm);
+}
+
+.toc-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.toc-list--nested {
+  padding-left: var(--space-3);
+  margin-top: var(--space-1);
+}
+
+.toc-item {
+  margin-bottom: var(--space-1);
+}
+
+.toc-item--h3 .toc-link {
+  font-size: 0.9375rem;
+}
+
+.toc-item--h4 .toc-link {
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+}
+
+.toc-link {
+  display: block;
+  padding: var(--space-1) 0;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  transition: color var(--layout-transition);
+}
+
+.toc-link:hover {
+  color: var(--color-primary);
+}
+
+/* Scroll spy active state */
+.toc-link--active {
+  color: var(--color-primary);
+  font-weight: 500;
+}
+
+/* ==========================================================================
+   Header Styles for Layouts
+   ========================================================================== */
+
+.site-header--sticky {
+  position: sticky;
+  top: 0;
+  z-index: var(--z-header);
+}
+
+.site-header--minimal {
+  padding: var(--space-3) var(--space-4);
+  background: var(--color-background);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.site-header--transparent {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  background: transparent;
+  border-bottom: none;
+}
+
+.site-header--transparent .site-title,
+.site-header--transparent .nav-link {
+  color: var(--color-text);
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+/* ==========================================================================
+   Footer Styles for Layouts
+   ========================================================================== */
+
+.site-footer--minimal {
+  padding: var(--space-4);
+  background: var(--color-surface);
+  border-top: 1px solid var(--color-border);
+  text-align: center;
+  font-size: var(--text-sm);
+}
+
+.site-footer--full {
+  padding: var(--space-8) var(--space-4);
+  background: var(--color-surface);
+  border-top: 1px solid var(--color-border);
+}
+
+/* ==========================================================================
+   Mobile Menu Toggle
+   ========================================================================== */
+
+.mobile-menu-toggle {
+  display: none;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 40px;
+  height: 40px;
+  padding: var(--space-2);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  gap: 4px;
+}
+
+.hamburger-line {
+  display: block;
+  width: 20px;
+  height: 2px;
+  background-color: var(--color-text);
+  transition: transform var(--layout-transition), opacity var(--layout-transition);
+}
+
+/* Hamburger animation when open */
+.mobile-menu-toggle[aria-expanded="true"] .hamburger-line:nth-child(1) {
+  transform: translateY(6px) rotate(45deg);
+}
+
+.mobile-menu-toggle[aria-expanded="true"] .hamburger-line:nth-child(2) {
+  opacity: 0;
+}
+
+.mobile-menu-toggle[aria-expanded="true"] .hamburger-line:nth-child(3) {
+  transform: translateY(-6px) rotate(-45deg);
+}
+
+/* ==========================================================================
+   Sidebar Overlay (Mobile)
+   ========================================================================== */
+
+.sidebar-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  top: var(--layout-header-height);
+  background: rgba(0, 0, 0, 0.5);
+  z-index: var(--z-overlay);
+  opacity: 0;
+  transition: opacity var(--layout-transition);
+}
+
+.sidebar-open .sidebar-overlay {
+  display: block;
+  opacity: 1;
+}
+
+/* ==========================================================================
+   Hero Section (Landing Layout)
+   ========================================================================== */
+
+.hero {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-8);
+  align-items: center;
+  padding: var(--space-16) var(--space-8);
+  max-width: var(--page-width);
+  margin: 0 auto;
+}
+
+.hero-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.hero-title {
+  font-size: var(--text-5xl);
+  font-weight: 800;
+  line-height: 1.1;
+  margin: 0;
+}
+
+.hero-subtitle {
+  font-size: var(--text-xl);
+  color: var(--color-text-muted);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.hero-actions {
+  display: flex;
+  gap: var(--space-4);
+  margin-top: var(--space-4);
+}
+
+.hero-image img {
+  width: 100%;
+  height: auto;
+  border-radius: var(--radius-lg);
+}
+
+/* ==========================================================================
+   Buttons (for Hero and general use)
+   ========================================================================== */
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-3) var(--space-6);
+  font-size: var(--text-base);
+  font-weight: 600;
+  text-decoration: none;
+  border-radius: var(--radius);
+  transition: all var(--layout-transition);
+  cursor: pointer;
+  border: 2px solid transparent;
+}
+
+.btn--primary {
+  background-color: var(--color-primary);
+  color: white;
+  border-color: var(--color-primary);
+}
+
+.btn--primary:hover {
+  background-color: var(--color-primary-dark);
+  border-color: var(--color-primary-dark);
+  text-decoration: none;
+}
+
+.btn--secondary {
+  background-color: transparent;
+  color: var(--color-text);
+  border-color: var(--color-border);
+}
+
+.btn--secondary:hover {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+/* ==========================================================================
+   Post Navigation (Blog Layout)
+   ========================================================================== */
+
+.post-nav {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-4);
+  margin-top: var(--space-8);
+  padding-top: var(--space-6);
+  border-top: 1px solid var(--color-border);
+}
+
+.post-nav-link {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-4);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  text-decoration: none;
+  transition: border-color var(--layout-transition);
+}
+
+.post-nav-link:hover {
+  border-color: var(--color-primary);
+  text-decoration: none;
+}
+
+.post-nav-link--prev {
+  text-align: left;
+}
+
+.post-nav-link--next {
+  text-align: right;
+  grid-column: 2;
+}
+
+.post-nav-label {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.post-nav-title {
+  color: var(--color-text);
+  font-weight: 500;
+}
+
+/* ==========================================================================
+   Skip Links (Accessibility)
+   ========================================================================== */
+
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: var(--space-4);
+  padding: var(--space-2) var(--space-4);
+  background: var(--color-primary);
+  color: white;
+  text-decoration: none;
+  z-index: 9999;
+  border-radius: var(--radius);
+  transition: top var(--layout-transition);
+}
+
+.skip-link:focus {
+  top: var(--space-4);
+}
+
+/* ==========================================================================
+   Theme Toggle Button
+   ========================================================================== */
+
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: border-color var(--layout-transition);
+}
+
+.theme-toggle:hover {
+  border-color: var(--color-primary);
+}
+
+.theme-toggle-icon::before {
+  content: "\263C"; /* Sun symbol */
+  font-size: 1.25rem;
+}
+
+/* Dark theme icon */
+[data-theme="dark"] .theme-toggle-icon::before {
+  content: "\263E"; /* Moon symbol */
+}
+
+/* ==========================================================================
+   Responsive Breakpoints
+   
+   xl: 1280px - Full 3-panel layout
+   lg: 1024px - Hide TOC, 2-panel
+   md: 768px  - Collapsible sidebar
+   sm: 640px  - Single column
+   ========================================================================== */
+
+/* Large screens: Hide TOC */
+@media (max-width: 1280px) {
+  .layout--docs .layout-container {
+    grid-template-columns: var(--sidebar-width, var(--layout-sidebar-width)) minmax(0, 1fr);
+    grid-template-areas: "sidebar content";
+  }
+  
+  .layout-toc {
+    display: none;
+  }
+}
+
+/* Medium screens: Collapsible sidebar */
+@media (max-width: 1024px) {
+  .mobile-menu-toggle {
+    display: flex;
+  }
+  
+  .layout--docs .layout-container,
+  .layout--blog .layout-container {
+    grid-template-columns: 1fr;
+    grid-template-areas: "content";
+  }
+  
+  .layout-sidebar {
+    position: fixed;
+    top: var(--layout-header-height);
+    left: 0;
+    bottom: 0;
+    width: var(--sidebar-width, var(--layout-sidebar-width));
+    background: var(--color-background);
+    border-right: 1px solid var(--color-border);
+    z-index: var(--z-sidebar);
+    transform: translateX(-100%);
+    transition: transform var(--layout-transition);
+    max-height: none;
+    overflow-y: auto;
+  }
+  
+  .layout-sidebar[data-open="true"],
+  .sidebar-open .layout-sidebar {
+    transform: translateX(0);
+  }
+  
+  .sidebar-content {
+    padding: var(--space-4);
+  }
+}
+
+/* Small screens */
+@media (max-width: 768px) {
+  :root {
+    --layout-header-height: 56px;
+  }
+  
+  .layout-container {
+    padding: 0 var(--space-3);
+  }
+  
+  .layout-content {
+    padding: var(--space-6) 0;
+  }
+  
+  .hero {
+    grid-template-columns: 1fr;
+    padding: var(--space-8) var(--space-4);
+    text-align: center;
+  }
+  
+  .hero-title {
+    font-size: var(--text-3xl);
+  }
+  
+  .hero-actions {
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+  
+  .hero-image {
+    order: -1;
+  }
+  
+  .post-nav {
+    grid-template-columns: 1fr;
+  }
+  
+  .post-nav-link--next {
+    grid-column: 1;
+    text-align: left;
+  }
+}
+
+/* Extra small screens */
+@media (max-width: 640px) {
+  .layout-sidebar {
+    width: 100%;
+  }
+  
+  .btn {
+    width: 100%;
+  }
+  
+  .hero-actions {
+    flex-direction: column;
+  }
+}
+
+/* ==========================================================================
+   Print Styles
+   ========================================================================== */
+
+@media print {
+  .layout-sidebar,
+  .layout-toc,
+  .site-header,
+  .site-footer,
+  .mobile-menu-toggle,
+  .skip-link,
+  .theme-toggle {
+    display: none !important;
+  }
+  
+  .layout-container {
+    display: block;
+  }
+  
+  .layout-content {
+    max-width: 100%;
+    padding: 0;
+  }
+}

--- a/themes/default/static/js/layout.js
+++ b/themes/default/static/js/layout.js
@@ -1,0 +1,167 @@
+/**
+ * Layout System JavaScript
+ * Handles sidebar toggle, mobile menu, and keyboard navigation
+ */
+
+(function() {
+  'use strict';
+
+  // DOM elements
+  const toggle = document.querySelector('.mobile-menu-toggle');
+  const sidebar = document.querySelector('.layout-sidebar');
+  const overlay = document.querySelector('.sidebar-overlay');
+  const body = document.body;
+
+  if (!toggle || !sidebar) return;
+
+  /**
+   * Toggle sidebar open/closed state
+   */
+  function toggleSidebar() {
+    const isOpen = sidebar.dataset.open === 'true';
+    setSidebarState(!isOpen);
+  }
+
+  /**
+   * Set sidebar state
+   * @param {boolean} open - Whether sidebar should be open
+   */
+  function setSidebarState(open) {
+    sidebar.dataset.open = open;
+    toggle.setAttribute('aria-expanded', open);
+    body.classList.toggle('sidebar-open', open);
+
+    if (open) {
+      // Focus first link in sidebar for accessibility
+      const firstLink = sidebar.querySelector('a');
+      if (firstLink) {
+        firstLink.focus();
+      }
+    } else {
+      // Return focus to toggle button
+      toggle.focus();
+    }
+  }
+
+  /**
+   * Close sidebar
+   */
+  function closeSidebar() {
+    setSidebarState(false);
+  }
+
+  // Toggle button click
+  toggle.addEventListener('click', toggleSidebar);
+
+  // Overlay click closes sidebar
+  if (overlay) {
+    overlay.addEventListener('click', closeSidebar);
+  }
+
+  // Escape key closes sidebar
+  document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape' && sidebar.dataset.open === 'true') {
+      closeSidebar();
+    }
+  });
+
+  // Close sidebar when clicking a link (mobile)
+  sidebar.addEventListener('click', function(e) {
+    if (e.target.matches('a') && window.innerWidth < 1024) {
+      closeSidebar();
+    }
+  });
+
+  // Handle window resize
+  let resizeTimeout;
+  window.addEventListener('resize', function() {
+    clearTimeout(resizeTimeout);
+    resizeTimeout = setTimeout(function() {
+      // Close mobile sidebar if window is resized to desktop
+      if (window.innerWidth >= 1024 && sidebar.dataset.open === 'true') {
+        closeSidebar();
+      }
+    }, 100);
+  });
+
+  // Trap focus within sidebar when open (accessibility)
+  sidebar.addEventListener('keydown', function(e) {
+    if (e.key !== 'Tab' || sidebar.dataset.open !== 'true') return;
+
+    const focusableElements = sidebar.querySelectorAll(
+      'a[href], button, [tabindex]:not([tabindex="-1"])'
+    );
+    const firstElement = focusableElements[0];
+    const lastElement = focusableElements[focusableElements.length - 1];
+
+    if (e.shiftKey && document.activeElement === firstElement) {
+      e.preventDefault();
+      lastElement.focus();
+    } else if (!e.shiftKey && document.activeElement === lastElement) {
+      e.preventDefault();
+      firstElement.focus();
+    }
+  });
+})();
+
+/**
+ * Theme Toggle
+ * Handles light/dark theme switching with localStorage persistence
+ */
+(function() {
+  'use strict';
+
+  const toggle = document.querySelector('.theme-toggle');
+  if (!toggle) return;
+
+  const STORAGE_KEY = 'theme';
+  const DARK_CLASS = 'dark';
+
+  /**
+   * Get current theme preference
+   * @returns {string} 'dark' or 'light'
+   */
+  function getTheme() {
+    // Check localStorage first
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) return stored;
+
+    // Fall back to system preference
+    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      return 'dark';
+    }
+    return 'light';
+  }
+
+  /**
+   * Set theme
+   * @param {string} theme - 'dark' or 'light'
+   */
+  function setTheme(theme) {
+    document.documentElement.dataset.theme = theme;
+    document.documentElement.classList.toggle(DARK_CLASS, theme === 'dark');
+    localStorage.setItem(STORAGE_KEY, theme);
+  }
+
+  /**
+   * Toggle between light and dark themes
+   */
+  function toggleTheme() {
+    const current = getTheme();
+    setTheme(current === 'dark' ? 'light' : 'dark');
+  }
+
+  // Initialize theme on page load
+  setTheme(getTheme());
+
+  // Toggle button click
+  toggle.addEventListener('click', toggleTheme);
+
+  // Listen for system theme changes
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function(e) {
+    // Only auto-switch if user hasn't set a preference
+    if (!localStorage.getItem(STORAGE_KEY)) {
+      setTheme(e.matches ? 'dark' : 'light');
+    }
+  });
+})();

--- a/themes/default/static/js/scroll-spy.js
+++ b/themes/default/static/js/scroll-spy.js
@@ -1,0 +1,122 @@
+/**
+ * Scroll Spy for Table of Contents
+ * Highlights the current section in the TOC as user scrolls
+ */
+
+(function() {
+  'use strict';
+
+  const tocLinks = document.querySelectorAll('.toc-link');
+  if (!tocLinks.length) return;
+
+  // Get all heading IDs from TOC links
+  const headingIds = Array.from(tocLinks).map(link => {
+    const href = link.getAttribute('href');
+    return href ? href.substring(1) : null;
+  }).filter(Boolean);
+
+  // Get corresponding heading elements
+  const headings = headingIds.map(id => document.getElementById(id)).filter(Boolean);
+
+  if (!headings.length) return;
+
+  const ACTIVE_CLASS = 'toc-link--active';
+  const OFFSET = 100; // Offset from top of viewport
+
+  let ticking = false;
+
+  /**
+   * Get the current active heading based on scroll position
+   * @returns {Element|null} The currently visible heading
+   */
+  function getCurrentHeading() {
+    const scrollTop = window.scrollY;
+    let current = null;
+
+    for (const heading of headings) {
+      const rect = heading.getBoundingClientRect();
+      const offsetTop = rect.top + scrollTop;
+
+      if (offsetTop - OFFSET <= scrollTop) {
+        current = heading;
+      } else {
+        break;
+      }
+    }
+
+    return current;
+  }
+
+  /**
+   * Update TOC link active states
+   */
+  function updateActiveLink() {
+    const currentHeading = getCurrentHeading();
+
+    tocLinks.forEach(link => {
+      const href = link.getAttribute('href');
+      const isActive = currentHeading && href === `#${currentHeading.id}`;
+      
+      link.classList.toggle(ACTIVE_CLASS, isActive);
+      
+      // Also highlight parent items if nested
+      const parentItem = link.closest('.toc-item');
+      if (parentItem) {
+        const parentList = parentItem.closest('.toc-list--nested');
+        if (parentList) {
+          const parentLink = parentList.previousElementSibling;
+          if (parentLink && parentLink.classList.contains('toc-link')) {
+            // Keep parent highlighted if any child is active
+            const hasActiveChild = parentList.querySelector(`.${ACTIVE_CLASS}`);
+            parentLink.classList.toggle(ACTIVE_CLASS, isActive || hasActiveChild);
+          }
+        }
+      }
+    });
+
+    ticking = false;
+  }
+
+  /**
+   * Request animation frame for scroll handler
+   */
+  function onScroll() {
+    if (!ticking) {
+      requestAnimationFrame(updateActiveLink);
+      ticking = true;
+    }
+  }
+
+  // Listen for scroll events
+  window.addEventListener('scroll', onScroll, { passive: true });
+
+  // Initial update
+  updateActiveLink();
+
+  // Smooth scroll to heading when clicking TOC links
+  tocLinks.forEach(link => {
+    link.addEventListener('click', function(e) {
+      const href = this.getAttribute('href');
+      if (!href || !href.startsWith('#')) return;
+
+      const target = document.getElementById(href.substring(1));
+      if (!target) return;
+
+      e.preventDefault();
+
+      // Calculate scroll position with offset
+      const offsetTop = target.getBoundingClientRect().top + window.scrollY - OFFSET + 20;
+
+      window.scrollTo({
+        top: offsetTop,
+        behavior: 'smooth'
+      });
+
+      // Update URL hash without jumping
+      history.pushState(null, '', href);
+
+      // Update active state immediately
+      setTimeout(updateActiveLink, 100);
+    });
+  });
+})();


### PR DESCRIPTION
## Summary

Implements the layout system specified in LAYOUTS.md (#106 Epic), providing configurable page structures for different content types.

## What's Included

### 4 Layout Presets

| Layout | Description | Use Case |
|--------|-------------|----------|
| `docs` | 3-panel with sidebar, content, TOC | Documentation sites |
| `blog` | Single-column with optional TOC | Blog posts, articles |
| `landing` | Full-width with hero support | Home pages, marketing |
| `bare` | Content only, no chrome | Embeds, custom pages |

### Config Structs (`pkg/models/layout.go`)

- `LayoutConfig` - Main configuration with preset selection
- `DocsLayoutConfig` - Sidebar position, TOC width, collapsible panels
- `BlogLayoutConfig` - Show author/date/tags, prev/next navigation
- `LandingLayoutConfig` - Transparent header, hero section
- `BareLayoutConfig` - Minimal content-only
- Helper methods for all boolean fields with sensible defaults

### Templates (`templates/layouts/`)

- `docs.html` - 3-panel layout with sticky sidebar and TOC
- `blog.html` - Single column with post meta and navigation
- `landing.html` - Full-width with hero section support
- `bare.html` - Minimal content-only layout

### Components

- `sidebar_nav.html` - Hierarchical navigation for docs layout
- `toc_list.html` - Table of contents from post headings

### CSS (`layouts.css`)

- CSS Grid-based responsive layout system
- Breakpoints: xl (1280px), lg (1024px), md (768px), sm (640px)
- Mobile-first with collapsible sidebar
- Skip links, theme toggle, scroll spy support
- Hero section, buttons, post navigation styles

### JavaScript

- `layout.js` - Sidebar toggle, mobile menu, theme switching with localStorage
- `scroll-spy.js` - TOC highlighting based on scroll position

## Related Issues

- Refs #106 (Epic: Comprehensive Layout System)
- Fixes #108 (Named Layout Presets)
- Fixes #109 (Sidebar Navigation Component)
- Fixes #110 (Table of Contents Component)
- Fixes #111 (Header/Navbar Component)
- Fixes #113 (Responsive Layout)
- Fixes #114 (Per-Page Layout Override)

## Testing

- All existing tests pass
- `go build ./...` succeeds
- `golangci-lint run` clean

## Usage Example

```toml
[layout]
name = "docs"

[layout.docs]
sidebar_position = "left"
sidebar_width = "280px"
toc_position = "right"
header_style = "minimal"

[sidebar]
enabled = true

[[sidebar.nav]]
title = "Getting Started"
href = "/docs/getting-started/"

[[sidebar.nav]]
title = "Guides"
children = [
  { title = "Configuration", href = "/docs/guides/configuration/" },
  { title = "Themes", href = "/docs/guides/themes/" },
]
```

Per-page override in frontmatter:
```yaml
---
title: My Landing Page
layout: landing
---
```