### PR TITLE
fix: Lowercase Docker image name for OCI compliance

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build:
@@ -37,6 +36,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Set lowercase image name
+        run: echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
## Summary

Fixes the Docker CI failure on main branch where the Trivy vulnerability scanner was failing with:
```
could not parse reference: ghcr.io/WaylonWalker/markata-go:main
```

## Changes

- Removed global `IMAGE_NAME` env variable that used `github.repository` directly
- Added step to set `IMAGE_NAME` with lowercase conversion using Bash parameter expansion (`${GITHUB_REPOSITORY,,}`)

## Root Cause

OCI image names must be lowercase, but `github.repository` returns `WaylonWalker/markata-go` with uppercase characters. The Trivy scanner couldn't parse this as a valid image reference.