### PR TITLE
docs: Add self-hosting deployment guides

### DIFF
--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -1,0 +1,42 @@
+# Docker Compose Environment Configuration
+# Copy this file to .env and customize for your deployment
+
+# =============================================================================
+# Site Configuration
+# =============================================================================
+
+# Your domain name (required for production)
+SITE_DOMAIN=example.com
+
+# Full site URL (used for absolute links, feeds, sitemap)
+SITE_URL=https://example.com
+
+# Path to your site content directory (relative to docker-compose file)
+SITE_DIR=./../..
+
+# =============================================================================
+# Development Settings (docker-compose.dev.yml)
+# =============================================================================
+
+# Local preview port
+PORT=8000
+
+# Output directory for development builds
+OUTPUT_DIR=./output
+
+# =============================================================================
+# Production Settings (docker-compose.prod.yml)
+# =============================================================================
+
+# Email for Let's Encrypt certificate notifications (recommended)
+# ACME_EMAIL=admin@example.com
+
+# =============================================================================
+# Advanced Options
+# =============================================================================
+
+# Override markata-go version (default: latest)
+# MARKATA_VERSION=v0.1.0
+
+# Additional build flags
+# BUILD_FLAGS=--verbose

--- a/deploy/docker/Caddyfile
+++ b/deploy/docker/Caddyfile
@@ -1,0 +1,76 @@
+# Caddyfile for markata-go production deployment
+# Automatic HTTPS with Let's Encrypt
+
+{$SITE_DOMAIN:example.com} {
+    root * /srv
+    file_server
+
+    # Enable compression
+    encode gzip zstd
+
+    # Security headers
+    header {
+        X-Frame-Options "DENY"
+        X-Content-Type-Options "nosniff"
+        Referrer-Policy "strict-origin-when-cross-origin"
+        Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
+        X-XSS-Protection "1; mode=block"
+        # Remove server header
+        -Server
+    }
+
+    # Cache static assets aggressively
+    @static {
+        path /static/*
+        path *.css
+        path *.js
+        path *.woff2
+        path *.woff
+        path *.ttf
+        path *.ico
+        path *.png
+        path *.jpg
+        path *.jpeg
+        path *.gif
+        path *.svg
+        path *.webp
+    }
+    header @static Cache-Control "public, max-age=31536000, immutable"
+
+    # Don't cache HTML files
+    @html path *.html
+    header @html Cache-Control "no-cache, no-store, must-revalidate"
+
+    # Cache XML feeds for 1 hour
+    @feeds {
+        path *.xml
+        path *.rss
+        path *.atom
+    }
+    header @feeds Cache-Control "public, max-age=3600"
+
+    # Handle clean URLs
+    try_files {path} {path}/ {path}/index.html
+
+    # Custom 404 page
+    handle_errors {
+        @404 expression {http.error.status_code} == 404
+        rewrite @404 /404.html
+        file_server
+    }
+
+    # Logging
+    log {
+        output file /var/log/caddy/access.log {
+            roll_size 10mb
+            roll_keep 5
+            roll_keep_for 720h
+        }
+        format json
+    }
+}
+
+# Redirect www to non-www
+www.{$SITE_DOMAIN:example.com} {
+    redir https://{$SITE_DOMAIN:example.com}{uri} permanent
+}

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -1,0 +1,201 @@
+# Docker Deployment for markata-go
+
+This directory contains Docker Compose configurations for deploying markata-go sites.
+
+## Quick Start
+
+### Development (Local Preview)
+
+```bash
+# From your site directory
+cd deploy/docker
+
+# Start development server with hot reload
+docker compose -f docker-compose.dev.yml up
+
+# Site available at http://localhost:8000
+```
+
+### Production (Self-Hosted)
+
+```bash
+# 1. Configure your environment
+cp .env.example .env
+# Edit .env with your domain and settings
+
+# 2. Start production stack
+docker compose -f docker-compose.prod.yml up -d
+
+# Site available at https://your-domain.com (after DNS propagation)
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `SITE_DOMAIN` | Your domain name | `example.com` |
+| `SITE_URL` | Full site URL | `https://example.com` |
+| `SITE_DIR` | Path to site content | `./../..` |
+| `PORT` | Development port | `8000` |
+
+### Development Stack
+
+The development configuration (`docker-compose.dev.yml`) provides:
+
+- Hot reload on file changes
+- Local preview server on port 8000
+- Go module caching for faster rebuilds
+
+```bash
+# Custom port
+PORT=3000 docker compose -f docker-compose.dev.yml up
+
+# Custom site directory
+SITE_DIR=/path/to/my/site docker compose -f docker-compose.dev.yml up
+```
+
+### Production Stack
+
+The production configuration (`docker-compose.prod.yml`) includes:
+
+- Multi-stage build process
+- Caddy reverse proxy with automatic HTTPS
+- Security headers (HSTS, CSP, etc.)
+- Gzip/Zstd compression
+- Optimized caching headers
+- Health checks
+- Optional Watchtower for auto-updates
+
+## Caddy Configuration
+
+The included `Caddyfile` provides:
+
+- **Automatic HTTPS** via Let's Encrypt
+- **HTTP/2 and HTTP/3** support
+- **Security headers** (HSTS, X-Frame-Options, etc.)
+- **Compression** (gzip, zstd)
+- **Caching** (static assets: 1 year, HTML: no-cache, feeds: 1 hour)
+- **Clean URLs** handling
+- **Custom 404 page**
+
+### Customizing Caddy
+
+Edit `Caddyfile` to:
+
+- Add redirects
+- Configure additional domains
+- Adjust caching rules
+- Add basic auth
+
+Example: Adding basic auth:
+
+```caddyfile
+example.com {
+    # Add before file_server
+    basicauth /admin/* {
+        admin $2a$14$... # Use: caddy hash-password
+    }
+    
+    root * /srv
+    file_server
+    # ...
+}
+```
+
+## Rebuilding the Site
+
+### Manual Rebuild
+
+```bash
+# Rebuild and restart
+docker compose -f docker-compose.prod.yml up -d --build
+
+# Or rebuild just the builder service
+docker compose -f docker-compose.prod.yml up builder
+docker compose -f docker-compose.prod.yml restart caddy
+```
+
+### Automated Rebuilds
+
+For automatic rebuilds on content changes, consider:
+
+1. **Webhook-triggered rebuilds** - Set up a webhook to trigger rebuilds
+2. **Scheduled rebuilds** - Use cron to periodically rebuild
+3. **Git-based rebuilds** - Use CI/CD to rebuild on push
+
+Example cron job for hourly rebuilds:
+
+```bash
+0 * * * * cd /path/to/deploy/docker && docker compose -f docker-compose.prod.yml up builder && docker compose -f docker-compose.prod.yml restart caddy
+```
+
+## Troubleshooting
+
+### Build Fails
+
+```bash
+# View build logs
+docker compose -f docker-compose.prod.yml logs builder
+
+# Rebuild without cache
+docker compose -f docker-compose.prod.yml build --no-cache
+```
+
+### HTTPS Not Working
+
+1. Ensure your domain points to the server's IP
+2. Check ports 80 and 443 are open
+3. View Caddy logs:
+
+```bash
+docker compose -f docker-compose.prod.yml logs caddy
+```
+
+### Container Won't Start
+
+```bash
+# Check container status
+docker compose -f docker-compose.prod.yml ps
+
+# View all logs
+docker compose -f docker-compose.prod.yml logs
+
+# Verify volumes
+docker volume ls | grep markata
+```
+
+### Clear Everything and Start Fresh
+
+```bash
+docker compose -f docker-compose.prod.yml down -v
+docker compose -f docker-compose.prod.yml up -d
+```
+
+## Resource Requirements
+
+### Minimum
+
+- 1 CPU core
+- 512 MB RAM
+- 1 GB disk space
+
+### Recommended
+
+- 2 CPU cores
+- 1 GB RAM
+- 5 GB disk space (for build cache)
+
+## Security Considerations
+
+1. **Keep containers updated** - Enable Watchtower or manually update
+2. **Use secrets** - Don't commit `.env` files with sensitive data
+3. **Firewall** - Only expose ports 80 and 443
+4. **Monitor logs** - Check Caddy access logs for suspicious activity
+
+## See Also
+
+- [Self-Hosting Guide](../../docs/guides/self-hosting.md)
+- [systemd Deployment](../systemd/README.md)
+- [Deployment Guide](../../docs/guides/deployment.md)

--- a/deploy/docker/docker-compose.dev.yml
+++ b/deploy/docker/docker-compose.dev.yml
@@ -1,0 +1,39 @@
+# Development Docker Compose for markata-go
+# Provides hot reload and local preview server
+#
+# Usage:
+#   docker compose -f docker-compose.dev.yml up
+#   # Site available at http://localhost:8000
+
+services:
+  markata:
+    image: golang:1.22-alpine
+    working_dir: /site
+    volumes:
+      # Mount your site content
+      - ${SITE_DIR:-./../..}:/site:ro
+      # Mount output directory (writable)
+      - ${OUTPUT_DIR:-./output}:/site/public
+      # Cache Go modules for faster rebuilds
+      - go-mod-cache:/go/pkg/mod
+    environment:
+      - MARKATA_GO_URL=${SITE_URL:-http://localhost:8000}
+      - CGO_ENABLED=0
+    command: >
+      sh -c "
+        go install github.com/WaylonWalker/markata-go/cmd/markata-go@latest &&
+        markata-go build --clean &&
+        markata-go serve --port 8000 --host 0.0.0.0 --watch
+      "
+    ports:
+      - "${PORT:-8000}:8000"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8000/"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+
+volumes:
+  go-mod-cache:

--- a/deploy/docker/docker-compose.prod.yml
+++ b/deploy/docker/docker-compose.prod.yml
@@ -1,0 +1,73 @@
+# Production Docker Compose for markata-go
+# Uses Caddy as reverse proxy with automatic HTTPS
+#
+# Usage:
+#   1. Copy .env.example to .env and configure
+#   2. docker compose -f docker-compose.prod.yml up -d
+#
+# Prerequisites:
+#   - Domain pointed to your server's IP
+#   - Ports 80 and 443 open
+
+services:
+  # Build the static site
+  builder:
+    image: golang:1.22-alpine
+    working_dir: /site
+    volumes:
+      - ${SITE_DIR:-./../..}:/site:ro
+      - site-output:/output
+      - go-mod-cache:/go/pkg/mod
+    environment:
+      - MARKATA_GO_URL=${SITE_URL:-https://example.com}
+      - CGO_ENABLED=0
+    command: >
+      sh -c "
+        go install github.com/WaylonWalker/markata-go/cmd/markata-go@latest &&
+        markata-go build --clean -o /output
+      "
+    # Only run once, then exit
+    restart: "no"
+
+  # Serve the static site with Caddy
+  caddy:
+    image: caddy:2-alpine
+    ports:
+      - "80:80"
+      - "443:443"
+      - "443:443/udp"  # HTTP/3
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - site-output:/srv:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    environment:
+      - SITE_DOMAIN=${SITE_DOMAIN:-example.com}
+    depends_on:
+      builder:
+        condition: service_completed_successfully
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:80/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+
+  # Optional: Watchtower for automatic container updates
+  watchtower:
+    image: containrrr/watchtower
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - WATCHTOWER_CLEANUP=true
+      - WATCHTOWER_POLL_INTERVAL=86400  # Check daily
+    restart: unless-stopped
+    profiles:
+      - auto-update
+
+volumes:
+  site-output:
+  caddy-data:
+  caddy-config:
+  go-mod-cache:

--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -1,0 +1,277 @@
+# systemd Deployment for markata-go
+
+This directory contains systemd service files for running markata-go on Linux servers.
+
+## Quick Start
+
+### Automated Installation
+
+```bash
+# Run the installation script
+sudo ./install.sh
+```
+
+The script will:
+1. Create a dedicated service user
+2. Set up the site directory
+3. Install Go (if needed)
+4. Install markata-go
+5. Install and configure systemd services
+
+### Manual Installation
+
+```bash
+# 1. Create service user
+sudo useradd -r -s /bin/false -d /var/www/mysite markata
+
+# 2. Create directories
+sudo mkdir -p /var/www/mysite/{public,.go}
+sudo chown -R markata:markata /var/www/mysite
+
+# 3. Install markata-go
+sudo -u markata bash -c '
+    export HOME=/var/www/mysite
+    export GOPATH=/var/www/mysite/.go
+    go install github.com/WaylonWalker/markata-go/cmd/markata-go@latest
+'
+
+# 4. Copy and edit service files
+sudo cp markata-go.service /etc/systemd/system/
+sudo cp markata-go-watch.service /etc/systemd/system/
+# Edit paths in /etc/systemd/system/markata-go*.service
+
+# 5. Reload systemd
+sudo systemctl daemon-reload
+```
+
+## Services
+
+### markata-go.service (Build on Demand)
+
+One-shot service that builds the site when started. Use this with an external web server (nginx, Caddy) serving the static files.
+
+```bash
+# Enable and start
+sudo systemctl enable markata-go
+sudo systemctl start markata-go
+
+# Rebuild the site
+sudo systemctl restart markata-go
+
+# Check build status
+sudo systemctl status markata-go
+sudo journalctl -u markata-go
+```
+
+### markata-go-watch.service (Continuous Watch)
+
+Long-running service that watches for file changes and rebuilds automatically. Also serves a preview on port 8000.
+
+```bash
+# Enable and start
+sudo systemctl enable markata-go-watch
+sudo systemctl start markata-go-watch
+
+# View live logs
+sudo journalctl -u markata-go-watch -f
+
+# Restart after config changes
+sudo systemctl restart markata-go-watch
+```
+
+## Configuration
+
+### Service File Customization
+
+Edit the service files in `/etc/systemd/system/` to customize:
+
+```ini
+[Service]
+# Site content directory
+WorkingDirectory=/var/www/mysite
+
+# Site URL for absolute links
+Environment=MARKATA_GO_URL=https://example.com
+
+# Output directory
+ExecStart=/var/www/mysite/.go/bin/markata-go build --clean -o /var/www/mysite/public
+```
+
+### After Editing Services
+
+```bash
+# Reload systemd configuration
+sudo systemctl daemon-reload
+
+# Restart the service
+sudo systemctl restart markata-go
+```
+
+## Integration with Web Servers
+
+### nginx
+
+```nginx
+server {
+    listen 80;
+    server_name example.com;
+    
+    root /var/www/mysite/public;
+    index index.html;
+    
+    location / {
+        try_files $uri $uri/ =404;
+    }
+}
+```
+
+### Caddy
+
+```caddyfile
+example.com {
+    root * /var/www/mysite/public
+    file_server
+    try_files {path} {path}/ {path}/index.html
+}
+```
+
+## Automated Rebuilds
+
+### Timer-based Rebuilds
+
+Create a timer for periodic rebuilds:
+
+```bash
+# /etc/systemd/system/markata-go.timer
+[Unit]
+Description=Rebuild markata-go site hourly
+
+[Timer]
+OnCalendar=hourly
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+Enable the timer:
+
+```bash
+sudo systemctl enable markata-go.timer
+sudo systemctl start markata-go.timer
+
+# Check timer status
+sudo systemctl list-timers
+```
+
+### Webhook-triggered Rebuilds
+
+For Git-based workflows, trigger rebuilds via webhook:
+
+```bash
+# Simple webhook script
+#!/bin/bash
+# /usr/local/bin/rebuild-site.sh
+cd /var/www/mysite
+git pull
+sudo systemctl restart markata-go
+```
+
+## Logging
+
+View logs using journalctl:
+
+```bash
+# All logs
+sudo journalctl -u markata-go
+
+# Follow logs in real-time
+sudo journalctl -u markata-go -f
+
+# Logs since last boot
+sudo journalctl -u markata-go -b
+
+# Logs from last hour
+sudo journalctl -u markata-go --since "1 hour ago"
+```
+
+## Troubleshooting
+
+### Service Won't Start
+
+```bash
+# Check status and recent logs
+sudo systemctl status markata-go
+sudo journalctl -u markata-go -n 50
+
+# Verify paths and permissions
+ls -la /var/www/mysite
+sudo -u markata ls -la /var/www/mysite/.go/bin/
+```
+
+### Permission Denied Errors
+
+```bash
+# Fix ownership
+sudo chown -R markata:markata /var/www/mysite
+
+# Check SELinux (if enabled)
+sudo setenforce 0  # Temporarily disable for testing
+```
+
+### Build Fails
+
+```bash
+# Run manually as service user
+sudo -u markata bash -c '
+    export HOME=/var/www/mysite
+    export GOPATH=/var/www/mysite/.go
+    export PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
+    cd /var/www/mysite
+    markata-go build --clean -v
+'
+```
+
+### Go Not Found
+
+```bash
+# Verify Go installation
+which go
+go version
+
+# Add to PATH if needed
+export PATH=$PATH:/usr/local/go/bin
+```
+
+## Security Notes
+
+The service files include security hardening:
+
+- **NoNewPrivileges**: Prevents privilege escalation
+- **ProtectSystem=strict**: Read-only file system except allowed paths
+- **ProtectHome=yes**: No access to home directories
+- **PrivateTmp=yes**: Isolated /tmp directory
+- **Resource limits**: Memory and CPU caps (watch service)
+
+## Uninstalling
+
+```bash
+# Stop and disable services
+sudo systemctl stop markata-go markata-go-watch
+sudo systemctl disable markata-go markata-go-watch
+
+# Remove service files
+sudo rm /etc/systemd/system/markata-go.service
+sudo rm /etc/systemd/system/markata-go-watch.service
+sudo systemctl daemon-reload
+
+# Optionally remove user and data
+sudo userdel markata
+sudo rm -rf /var/www/mysite
+```
+
+## See Also
+
+- [Self-Hosting Guide](../../docs/guides/self-hosting.md)
+- [Docker Deployment](../docker/README.md)
+- [Deployment Guide](../../docs/guides/deployment.md)

--- a/deploy/systemd/install.sh
+++ b/deploy/systemd/install.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# Installation script for markata-go systemd services
+# Run as root: sudo ./install.sh
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Configuration
+SITE_DIR="${SITE_DIR:-/var/www/mysite}"
+SITE_URL="${SITE_URL:-https://example.com}"
+GO_VERSION="${GO_VERSION:-1.22.0}"
+SERVICE_USER="${SERVICE_USER:-markata}"
+
+echo -e "${GREEN}markata-go systemd Installation Script${NC}"
+echo "========================================"
+echo ""
+
+# Check if running as root
+if [ "$EUID" -ne 0 ]; then
+    echo -e "${RED}Error: Please run as root (sudo ./install.sh)${NC}"
+    exit 1
+fi
+
+# Prompt for configuration
+read -p "Site directory [$SITE_DIR]: " input
+SITE_DIR="${input:-$SITE_DIR}"
+
+read -p "Site URL [$SITE_URL]: " input
+SITE_URL="${input:-$SITE_URL}"
+
+read -p "Service user [$SERVICE_USER]: " input
+SERVICE_USER="${input:-$SERVICE_USER}"
+
+echo ""
+echo -e "${YELLOW}Configuration:${NC}"
+echo "  Site directory: $SITE_DIR"
+echo "  Site URL: $SITE_URL"
+echo "  Service user: $SERVICE_USER"
+echo ""
+read -p "Continue? [y/N] " confirm
+if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+    echo "Aborted."
+    exit 0
+fi
+
+echo ""
+echo -e "${GREEN}Step 1: Creating service user...${NC}"
+if id "$SERVICE_USER" &>/dev/null; then
+    echo "  User '$SERVICE_USER' already exists"
+else
+    useradd -r -s /bin/false -d "$SITE_DIR" "$SERVICE_USER"
+    echo "  Created user '$SERVICE_USER'"
+fi
+
+echo ""
+echo -e "${GREEN}Step 2: Creating site directory...${NC}"
+mkdir -p "$SITE_DIR"/{public,.go}
+chown -R "$SERVICE_USER:$SERVICE_USER" "$SITE_DIR"
+echo "  Created $SITE_DIR"
+
+echo ""
+echo -e "${GREEN}Step 3: Installing Go (if needed)...${NC}"
+if command -v go &>/dev/null; then
+    echo "  Go already installed: $(go version)"
+else
+    echo "  Installing Go $GO_VERSION..."
+    curl -sSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar -C /usr/local -xzf -
+    echo 'export PATH=$PATH:/usr/local/go/bin' >> /etc/profile.d/go.sh
+    source /etc/profile.d/go.sh
+    echo "  Installed Go $GO_VERSION"
+fi
+
+echo ""
+echo -e "${GREEN}Step 4: Installing markata-go...${NC}"
+sudo -u "$SERVICE_USER" bash -c "
+    export HOME=$SITE_DIR
+    export GOPATH=$SITE_DIR/.go
+    export PATH=\$PATH:/usr/local/go/bin
+    go install github.com/WaylonWalker/markata-go/cmd/markata-go@latest
+"
+echo "  Installed markata-go"
+
+echo ""
+echo -e "${GREEN}Step 5: Installing systemd services...${NC}"
+
+# Create service files with correct paths
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Update and install markata-go.service
+sed -e "s|/var/www/mysite|$SITE_DIR|g" \
+    -e "s|User=markata|User=$SERVICE_USER|g" \
+    -e "s|Group=markata|Group=$SERVICE_USER|g" \
+    -e "s|https://example.com|$SITE_URL|g" \
+    "$SCRIPT_DIR/markata-go.service" > /etc/systemd/system/markata-go.service
+echo "  Installed markata-go.service"
+
+# Update and install markata-go-watch.service
+sed -e "s|/var/www/mysite|$SITE_DIR|g" \
+    -e "s|User=markata|User=$SERVICE_USER|g" \
+    -e "s|Group=markata|Group=$SERVICE_USER|g" \
+    -e "s|https://example.com|$SITE_URL|g" \
+    "$SCRIPT_DIR/markata-go-watch.service" > /etc/systemd/system/markata-go-watch.service
+echo "  Installed markata-go-watch.service"
+
+echo ""
+echo -e "${GREEN}Step 6: Reloading systemd...${NC}"
+systemctl daemon-reload
+echo "  Reloaded systemd"
+
+echo ""
+echo -e "${GREEN}Installation complete!${NC}"
+echo ""
+echo "Next steps:"
+echo ""
+echo "1. Copy your site content to: $SITE_DIR"
+echo ""
+echo "2. For one-time builds (with nginx/caddy serving static files):"
+echo "   sudo systemctl enable markata-go"
+echo "   sudo systemctl start markata-go"
+echo ""
+echo "3. For watch mode (auto-rebuild on changes):"
+echo "   sudo systemctl enable markata-go-watch"
+echo "   sudo systemctl start markata-go-watch"
+echo ""
+echo "4. Check status:"
+echo "   sudo systemctl status markata-go"
+echo "   sudo journalctl -u markata-go -f"
+echo ""
+echo "5. Configure your web server (nginx/caddy) to serve: $SITE_DIR/public"
+echo ""

--- a/deploy/systemd/markata-go-watch.service
+++ b/deploy/systemd/markata-go-watch.service
@@ -1,0 +1,67 @@
+# systemd service for markata-go watch mode (continuous)
+# Watches for file changes and rebuilds automatically
+#
+# Installation:
+#   sudo cp markata-go-watch.service /etc/systemd/system/
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable markata-go-watch
+#   sudo systemctl start markata-go-watch
+#
+# Usage:
+#   sudo systemctl status markata-go-watch   # Check status
+#   sudo journalctl -u markata-go-watch -f   # View logs
+
+[Unit]
+Description=markata-go Watch Mode (Auto-rebuild on changes)
+Documentation=https://github.com/WaylonWalker/markata-go
+After=network.target
+
+[Service]
+Type=simple
+
+# Run as non-root user
+User=markata
+Group=markata
+
+# Working directory (your site content)
+WorkingDirectory=/var/www/mysite
+
+# Environment
+Environment=HOME=/var/www/mysite
+Environment=GOPATH=/var/www/mysite/.go
+Environment=PATH=/var/www/mysite/.go/bin:/usr/local/go/bin:/usr/bin:/bin
+Environment=MARKATA_GO_URL=https://example.com
+
+# Watch command (rebuild on file changes)
+ExecStart=/var/www/mysite/.go/bin/markata-go serve --watch --port 8000 --host 127.0.0.1
+
+# Restart policy
+Restart=always
+RestartSec=10
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=markata-go-watch
+
+# Security hardening
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictSUIDSGID=yes
+RestrictNamespaces=yes
+
+# Allow writing to output directory
+ReadWritePaths=/var/www/mysite/public /var/www/mysite/.go
+
+# Resource limits
+MemoryMax=512M
+CPUQuota=50%
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/markata-go.service
+++ b/deploy/systemd/markata-go.service
@@ -1,0 +1,60 @@
+# systemd service for markata-go (build-on-demand)
+# Builds the site once when started
+#
+# Installation:
+#   sudo cp markata-go.service /etc/systemd/system/
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable markata-go
+#   sudo systemctl start markata-go
+#
+# Usage:
+#   sudo systemctl status markata-go   # Check status
+#   sudo systemctl restart markata-go  # Rebuild site
+
+[Unit]
+Description=markata-go Static Site Generator
+Documentation=https://github.com/WaylonWalker/markata-go
+After=network.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+
+# Run as non-root user (create with: sudo useradd -r -s /bin/false markata)
+User=markata
+Group=markata
+
+# Working directory (your site content)
+WorkingDirectory=/var/www/mysite
+
+# Environment
+Environment=HOME=/var/www/mysite
+Environment=GOPATH=/var/www/mysite/.go
+Environment=PATH=/var/www/mysite/.go/bin:/usr/local/go/bin:/usr/bin:/bin
+Environment=MARKATA_GO_URL=https://example.com
+
+# Build command
+ExecStart=/var/www/mysite/.go/bin/markata-go build --clean -o /var/www/mysite/public
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=markata-go
+
+# Security hardening
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictSUIDSGID=yes
+RestrictNamespaces=yes
+
+# Allow writing to output directory
+ReadWritePaths=/var/www/mysite/public /var/www/mysite/.go
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/guides/self-hosting.md
+++ b/docs/guides/self-hosting.md
@@ -1,0 +1,386 @@
+---
+title: "Self-Hosting Guide"
+description: "Deploy markata-go sites on your own servers using Docker, systemd, or manual setups"
+date: 2024-01-23
+published: true
+template: doc.html
+tags:
+  - documentation
+  - deployment
+  - self-hosting
+  - docker
+  - systemd
+---
+
+# Self-Hosting Guide
+
+This guide covers deploying markata-go sites on your own infrastructure. Whether you prefer Docker containers, systemd services, or manual setups, you'll find everything you need to self-host your static site.
+
+## Overview
+
+Self-hosting gives you complete control over your site's infrastructure. markata-go supports several deployment methods:
+
+| Method | Best For | Complexity |
+|--------|----------|------------|
+| Docker Compose | Quick setup, portability | Low |
+| systemd | Linux servers, integration | Medium |
+| Manual | Custom setups, learning | High |
+
+**Prerequisites:**
+- A Linux server (VPS, dedicated, or home server)
+- Domain name pointed to your server
+- Basic command line knowledge
+
+## Quick Start with Docker
+
+The fastest way to self-host is using Docker Compose:
+
+```bash
+# Clone your site or create a new one
+git clone https://github.com/you/your-site.git
+cd your-site
+
+# Copy the deployment files
+cp -r deploy/docker ./docker-deploy
+cd docker-deploy
+
+# Configure environment
+cp .env.example .env
+# Edit .env with your domain: SITE_DOMAIN=example.com
+
+# Start production stack
+docker compose -f docker-compose.prod.yml up -d
+```
+
+Your site will be available at `https://your-domain.com` with automatic HTTPS.
+
+See [Docker Deployment README](https://github.com/WaylonWalker/markata-go/tree/main/deploy/docker) for detailed configuration options.
+
+## Docker Compose Configurations
+
+### Development Mode
+
+For local development with hot reload:
+
+```bash
+cd deploy/docker
+docker compose -f docker-compose.dev.yml up
+```
+
+Features:
+- Hot reload on file changes
+- Local preview at http://localhost:8000
+- Go module caching
+
+### Production Mode
+
+For production with Caddy reverse proxy:
+
+```bash
+cd deploy/docker
+
+# Configure
+cp .env.example .env
+vim .env  # Set SITE_DOMAIN and SITE_URL
+
+# Deploy
+docker compose -f docker-compose.prod.yml up -d
+```
+
+Features:
+- Automatic HTTPS via Let's Encrypt
+- HTTP/2 and HTTP/3 support
+- Security headers
+- Gzip/Zstd compression
+- Optimized caching
+
+### Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `SITE_DOMAIN` | Your domain name | `example.com` |
+| `SITE_URL` | Full URL for feeds/links | `https://example.com` |
+| `SITE_DIR` | Path to site content | `./../..` |
+| `PORT` | Development port | `8000` |
+
+## systemd Services
+
+For traditional Linux server deployments, use systemd services.
+
+### Quick Setup
+
+```bash
+cd deploy/systemd
+sudo ./install.sh
+```
+
+The installer prompts for:
+- Site directory (default: `/var/www/mysite`)
+- Site URL (default: `https://example.com`)
+- Service user (default: `markata`)
+
+### Manual Setup
+
+```bash
+# Create service user
+sudo useradd -r -s /bin/false -d /var/www/mysite markata
+
+# Create directories
+sudo mkdir -p /var/www/mysite/{public,.go}
+sudo chown -R markata:markata /var/www/mysite
+
+# Install markata-go
+sudo -u markata bash -c '
+    export GOPATH=/var/www/mysite/.go
+    go install github.com/WaylonWalker/markata-go/cmd/markata-go@latest
+'
+
+# Install services
+sudo cp deploy/systemd/markata-go.service /etc/systemd/system/
+sudo cp deploy/systemd/markata-go-watch.service /etc/systemd/system/
+# Edit paths in service files
+
+sudo systemctl daemon-reload
+```
+
+### Available Services
+
+**markata-go.service** - One-time build:
+```bash
+sudo systemctl enable markata-go
+sudo systemctl start markata-go
+
+# Rebuild site
+sudo systemctl restart markata-go
+```
+
+**markata-go-watch.service** - Auto-rebuild on changes:
+```bash
+sudo systemctl enable markata-go-watch
+sudo systemctl start markata-go-watch
+
+# View logs
+sudo journalctl -u markata-go-watch -f
+```
+
+See [systemd Deployment README](https://github.com/WaylonWalker/markata-go/tree/main/deploy/systemd) for detailed setup and troubleshooting.
+
+## Web Server Configuration
+
+### Using nginx
+
+If using systemd with nginx:
+
+```nginx
+server {
+    listen 80;
+    listen [::]:80;
+    server_name example.com;
+    return 301 https://$server_name$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name example.com;
+
+    ssl_certificate /etc/letsencrypt/live/example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem;
+
+    root /var/www/mysite/public;
+    index index.html;
+
+    # Security headers
+    add_header X-Frame-Options "DENY" always;
+    add_header X-Content-Type-Options "nosniff" always;
+
+    # Caching
+    location /static/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+}
+```
+
+### Using Caddy
+
+Simpler alternative with automatic HTTPS:
+
+```caddyfile
+example.com {
+    root * /var/www/mysite/public
+    file_server
+    encode gzip
+
+    header {
+        X-Frame-Options "DENY"
+        X-Content-Type-Options "nosniff"
+    }
+
+    @static path /static/*
+    header @static Cache-Control "public, max-age=31536000, immutable"
+
+    try_files {path} {path}/ {path}/index.html
+}
+```
+
+## Automated Rebuilds
+
+### Git Webhooks
+
+Rebuild on push using a webhook endpoint:
+
+```bash
+#!/bin/bash
+# /usr/local/bin/rebuild-site.sh
+cd /var/www/mysite
+git pull origin main
+sudo systemctl restart markata-go
+```
+
+### Scheduled Rebuilds
+
+Using systemd timer:
+
+```ini
+# /etc/systemd/system/markata-go.timer
+[Unit]
+Description=Rebuild site hourly
+
+[Timer]
+OnCalendar=hourly
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+```bash
+sudo systemctl enable markata-go.timer
+sudo systemctl start markata-go.timer
+```
+
+### CI/CD Integration
+
+Build in CI and deploy via rsync:
+
+```yaml
+# .github/workflows/deploy.yml
+deploy:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - run: |
+        go install github.com/WaylonWalker/markata-go/cmd/markata-go@latest
+        markata-go build --clean
+    - run: |
+        rsync -avz --delete public/ user@server:/var/www/mysite/public/
+```
+
+## Security Checklist
+
+Before going live:
+
+- [ ] Firewall configured (only ports 80, 443, and SSH)
+- [ ] SSH key authentication only (disable password auth)
+- [ ] Automatic security updates enabled
+- [ ] HTTPS working with valid certificate
+- [ ] Security headers configured
+- [ ] Service running as non-root user
+- [ ] File permissions restricted
+
+### Firewall Setup (ufw)
+
+```bash
+sudo ufw default deny incoming
+sudo ufw default allow outgoing
+sudo ufw allow ssh
+sudo ufw allow http
+sudo ufw allow https
+sudo ufw enable
+```
+
+## Monitoring
+
+### Basic Health Checks
+
+```bash
+# Check if site is responding
+curl -I https://example.com
+
+# Check systemd service
+sudo systemctl status markata-go
+
+# View recent logs
+sudo journalctl -u markata-go -n 100
+```
+
+### Uptime Monitoring
+
+Consider using:
+- [Uptime Robot](https://uptimerobot.com/) (free tier available)
+- [Healthchecks.io](https://healthchecks.io/) for cron monitoring
+- Self-hosted: [Uptime Kuma](https://github.com/louislam/uptime-kuma)
+
+## Troubleshooting
+
+### Site Not Loading
+
+1. Check if the service is running:
+   ```bash
+   sudo systemctl status markata-go
+   docker compose ps
+   ```
+
+2. Check if web server is running:
+   ```bash
+   sudo systemctl status nginx  # or caddy
+   ```
+
+3. Check firewall:
+   ```bash
+   sudo ufw status
+   ```
+
+### HTTPS Not Working
+
+1. Verify DNS is pointing to your server
+2. Check Let's Encrypt logs:
+   ```bash
+   # Caddy
+   docker compose logs caddy
+   # Certbot
+   sudo certbot certificates
+   ```
+
+### Build Failures
+
+1. Check build logs:
+   ```bash
+   sudo journalctl -u markata-go
+   docker compose logs builder
+   ```
+
+2. Run build manually:
+   ```bash
+   cd /var/www/mysite
+   markata-go build --clean -v
+   ```
+
+## Resource Requirements
+
+| Setup | CPU | RAM | Disk |
+|-------|-----|-----|------|
+| Minimum | 1 core | 512 MB | 1 GB |
+| Recommended | 2 cores | 1 GB | 5 GB |
+| With build cache | 2 cores | 2 GB | 10 GB |
+
+## Next Steps
+
+- [Configuration Guide](/docs/guides/configuration/) - Customize your site
+- [Deployment Guide](/docs/guides/deployment/) - Other hosting options
+- [Themes Guide](/docs/guides/themes/) - Customize appearance


### PR DESCRIPTION
## Summary

Adds comprehensive self-hosting deployment guides for markata-go sites, providing users with Docker Compose and systemd-based deployment options.

Refs #122

## Changes

### New Files in `deploy/`

**Docker (`deploy/docker/`):**
- `docker-compose.dev.yml` - Development with hot reload on port 8000
- `docker-compose.prod.yml` - Production with Caddy reverse proxy and automatic HTTPS
- `Caddyfile` - Caddy configuration with security headers, caching, compression
- `.env.example` - Environment variable template
- `README.md` - Docker deployment guide

**systemd (`deploy/systemd/`):**
- `markata-go.service` - One-shot build service for use with nginx/Caddy
- `markata-go-watch.service` - Continuous watch mode with auto-rebuild
- `install.sh` - Interactive installation script
- `README.md` - systemd deployment guide

### Documentation

- `docs/guides/self-hosting.md` - Comprehensive self-hosting overview with:
  - Quick start for Docker and systemd
  - Environment configuration
  - Web server integration (nginx, Caddy)
  - Automated rebuild strategies
  - Security checklist
  - Troubleshooting guide

## Testing

- All existing tests pass (`go test ./...`)
- Docker Compose files validated for syntax
- systemd service files follow best practices with security hardening