### PR TITLE
feat: Add keyboard shortcut system for site output

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -170,9 +170,13 @@
     {% include "components/footer.html" %}
     {% endblock %}
     
+    {# Keyboard Shortcuts Modal #}
+    {% include "partials/shortcuts-modal.html" %}
+    
     {% block htmx %}{% endblock %}
     {% block scripts %}{% endblock %}
     <script src="{{ 'js/tooltips.js' | theme_asset }}" defer></script>
+    <script src="{{ 'js/shortcuts.js' | theme_asset }}" defer></script>
     
     <!-- Pagefind Search JS -->
     {% if config.search.enabled %}
@@ -186,7 +190,7 @@
                     excerptLength: {{ config.search.excerpt_length | default:120 }},
                     showSubResults: true,
                     translations: {
-                        placeholder: "{{ config.search.placeholder | default:'Search...' }}"
+                        placeholder: "{{ config.search.placeholder | default:'Search (Press / or \u2318K)' }}"
                     }
                 });
             }

--- a/templates/components/footer.html
+++ b/templates/components/footer.html
@@ -18,9 +18,12 @@
         </nav>
         {% endif %}
         
-        {% if footer.show_copyright %}
-        <p class="footer-copyright">&copy; {{ "now" | date:"2006" }} {{ config.author | default:"" }}. Built with <a href="https://github.com/WaylonWalker/markata-go">markata-go</a>.</p>
-        {% endif %}
+        <div class="footer-bottom">
+            {% if footer.show_copyright %}
+            <p class="footer-copyright">&copy; {{ "now" | date:"2006" }} {{ config.author | default:"" }}. Built with <a href="https://github.com/WaylonWalker/markata-go">markata-go</a>.</p>
+            {% endif %}
+            <p class="footer-shortcuts-hint">Press <kbd>?</kbd> for keyboard shortcuts</p>
+        </div>
     </div>
 </footer>
 {% endif %}

--- a/templates/partials/shortcuts-modal.html
+++ b/templates/partials/shortcuts-modal.html
@@ -1,0 +1,52 @@
+{# Keyboard Shortcuts Help Modal #}
+{# Usage: {% include "partials/shortcuts-modal.html" %} #}
+{# Displays available keyboard shortcuts and allows disabling them #}
+
+<div id="shortcuts-modal" class="shortcuts-modal" aria-hidden="true" role="dialog" aria-labelledby="shortcuts-modal-title">
+    <div class="shortcuts-modal-content">
+        <header class="shortcuts-modal-header">
+            <h2 id="shortcuts-modal-title">Keyboard Shortcuts</h2>
+            <button type="button" class="shortcuts-modal-close" aria-label="Close shortcuts help">
+                <span aria-hidden="true">&times;</span>
+            </button>
+        </header>
+        
+        <div class="shortcuts-modal-body">
+            <table class="shortcuts-table">
+                <thead>
+                    <tr>
+                        <th>Shortcut</th>
+                        <th>Action</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td><kbd>/</kbd></td>
+                        <td>Focus search input</td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <kbd class="kbd-mac">&#8984;</kbd><kbd class="kbd-win">Ctrl</kbd><kbd>K</kbd>
+                        </td>
+                        <td>Focus search (alternative)</td>
+                    </tr>
+                    <tr>
+                        <td><kbd>Esc</kbd></td>
+                        <td>Close search / modals</td>
+                    </tr>
+                    <tr>
+                        <td><kbd>?</kbd></td>
+                        <td>Show this help</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+        
+        <footer class="shortcuts-modal-footer">
+            <button type="button" id="shortcuts-toggle" class="shortcuts-toggle-btn" aria-pressed="true">
+                Disable Shortcuts
+            </button>
+            <p class="shortcuts-hint">Shortcuts are disabled when typing in input fields</p>
+        </footer>
+    </div>
+</div>

--- a/themes/default/static/css/components.css
+++ b/themes/default/static/css/components.css
@@ -708,3 +708,239 @@
     justify-content: center;
   }
 }
+
+/* ==========================================================================
+   Keyboard Shortcut Styles
+   ========================================================================== */
+
+/* Keyboard key styling */
+kbd {
+  display: inline-block;
+  padding: 0.125rem 0.375rem;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace);
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1.4;
+  color: var(--color-text);
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05), inset 0 -1px 0 rgba(0, 0, 0, 0.1);
+  white-space: nowrap;
+}
+
+/* Platform-specific modifier keys - hidden by default, shown via JS */
+.kbd-mac,
+.kbd-win {
+  display: none;
+}
+
+/* ==========================================================================
+   Shortcuts Modal
+   ========================================================================== */
+
+.shortcuts-modal {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 10000;
+  background-color: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.shortcuts-modal--open {
+  display: flex;
+}
+
+.shortcuts-modal-content {
+  background-color: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.15), 0 8px 16px rgba(0, 0, 0, 0.1);
+  max-width: 420px;
+  width: 100%;
+  max-height: calc(100vh - 2rem);
+  overflow-y: auto;
+}
+
+.shortcuts-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.shortcuts-modal-header h2 {
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.shortcuts-modal-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  color: var(--color-text-muted);
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.shortcuts-modal-close:hover {
+  background-color: var(--color-surface);
+  color: var(--color-text);
+}
+
+.shortcuts-modal-close:focus {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.shortcuts-modal-body {
+  padding: 1rem 1.25rem;
+}
+
+/* Shortcuts table */
+.shortcuts-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.shortcuts-table th,
+.shortcuts-table td {
+  padding: 0.625rem 0;
+  text-align: left;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.shortcuts-table th {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+}
+
+.shortcuts-table td:first-child {
+  white-space: nowrap;
+  padding-right: 1rem;
+}
+
+.shortcuts-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.shortcuts-table kbd + kbd {
+  margin-left: 0.25rem;
+}
+
+.shortcuts-modal-footer {
+  padding: 1rem 1.25rem;
+  border-top: 1px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.shortcuts-toggle-btn {
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-text);
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color 0.15s, border-color 0.15s;
+}
+
+.shortcuts-toggle-btn:hover {
+  background-color: var(--color-border);
+}
+
+.shortcuts-toggle-btn:focus {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.shortcuts-hint {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  text-align: center;
+}
+
+/* Footer shortcuts hint */
+.footer-bottom {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem 1rem;
+}
+
+.footer-shortcuts-hint {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.footer-shortcuts-hint kbd {
+  font-size: 0.625rem;
+  padding: 0.0625rem 0.25rem;
+}
+
+/* Responsive adjustments */
+@media (max-width: 480px) {
+  .shortcuts-modal-content {
+    max-width: 100%;
+    margin: 0 0.5rem;
+  }
+  
+  .footer-bottom {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+/* Animation for modal (respects reduced motion preference) */
+@media (prefers-reduced-motion: no-preference) {
+  .shortcuts-modal {
+    animation: fadeIn 0.15s ease-out;
+  }
+  
+  .shortcuts-modal-content {
+    animation: slideUp 0.15s ease-out;
+  }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes slideUp {
+  from { 
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to { 
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/themes/default/static/js/shortcuts.js
+++ b/themes/default/static/js/shortcuts.js
@@ -1,0 +1,305 @@
+/**
+ * Keyboard Shortcuts System for markata-go
+ * 
+ * Provides keyboard navigation shortcuts for the generated site:
+ * - `/` or `Cmd/Ctrl+K` - Focus search input
+ * - `Escape` - Close search/modals
+ * - `?` - Show shortcuts help modal
+ * 
+ * Accessibility: Shortcuts can be disabled via localStorage
+ * WCAG 2.1.4 compliant - shortcuts are ignored when typing in inputs
+ */
+
+(function() {
+  'use strict';
+
+  // Storage key for disabled state
+  var STORAGE_KEY = 'markata-shortcuts-disabled';
+
+  /**
+   * Check if shortcuts are disabled via localStorage
+   * @returns {boolean}
+   */
+  function areShortcutsDisabled() {
+    try {
+      return localStorage.getItem(STORAGE_KEY) === 'true';
+    } catch (e) {
+      // localStorage may be unavailable (e.g., private browsing)
+      return false;
+    }
+  }
+
+  /**
+   * Toggle shortcuts enabled/disabled state
+   * @returns {boolean} New state (true = disabled)
+   */
+  function toggleShortcuts() {
+    try {
+      var currentlyDisabled = areShortcutsDisabled();
+      localStorage.setItem(STORAGE_KEY, (!currentlyDisabled).toString());
+      updateToggleButton();
+      return !currentlyDisabled;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  /**
+   * Update the toggle button state in the modal
+   */
+  function updateToggleButton() {
+    var toggleBtn = document.getElementById('shortcuts-toggle');
+    if (toggleBtn) {
+      var disabled = areShortcutsDisabled();
+      toggleBtn.textContent = disabled ? 'Enable Shortcuts' : 'Disable Shortcuts';
+      toggleBtn.setAttribute('aria-pressed', (!disabled).toString());
+    }
+  }
+
+  /**
+   * Detect if the user is on a Mac platform
+   * @returns {boolean}
+   */
+  function isMacPlatform() {
+    // Check userAgentData first (modern browsers)
+    if (navigator.userAgentData && navigator.userAgentData.platform) {
+      return navigator.userAgentData.platform.toUpperCase().indexOf('MAC') >= 0;
+    }
+    // Fallback to navigator.platform
+    return navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+  }
+
+  /**
+   * Update the modifier key display in the modal based on platform
+   */
+  function updateModifierKeyDisplay() {
+    var isMac = isMacPlatform();
+    var macKeys = document.querySelectorAll('.kbd-mac');
+    var winKeys = document.querySelectorAll('.kbd-win');
+    
+    macKeys.forEach(function(el) {
+      el.style.display = isMac ? 'inline-block' : 'none';
+    });
+    
+    winKeys.forEach(function(el) {
+      el.style.display = isMac ? 'none' : 'inline-block';
+    });
+  }
+
+  /**
+   * Focus the search input (Pagefind)
+   */
+  function focusSearch() {
+    // Try Pagefind's input first
+    var pagefindInput = document.querySelector('.pagefind-ui__search-input');
+    if (pagefindInput) {
+      pagefindInput.focus();
+      return true;
+    }
+    
+    // Fallback to any search input
+    var searchInput = document.querySelector('#pagefind-search input, #search input, [type="search"]');
+    if (searchInput) {
+      searchInput.focus();
+      return true;
+    }
+    
+    return false;
+  }
+
+  /**
+   * Show the shortcuts help modal
+   */
+  function showShortcutsModal() {
+    var modal = document.getElementById('shortcuts-modal');
+    if (modal) {
+      modal.classList.add('shortcuts-modal--open');
+      modal.setAttribute('aria-hidden', 'false');
+      // Focus the close button for accessibility
+      var closeBtn = modal.querySelector('.shortcuts-modal-close');
+      if (closeBtn) {
+        closeBtn.focus();
+      }
+      // Prevent body scrolling while modal is open
+      document.body.style.overflow = 'hidden';
+    }
+  }
+
+  /**
+   * Hide the shortcuts help modal
+   */
+  function hideShortcutsModal() {
+    var modal = document.getElementById('shortcuts-modal');
+    if (modal && modal.classList.contains('shortcuts-modal--open')) {
+      modal.classList.remove('shortcuts-modal--open');
+      modal.setAttribute('aria-hidden', 'true');
+      document.body.style.overflow = '';
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Close all open modals and clear search focus
+   */
+  function closeModals() {
+    var closed = false;
+    
+    // Close shortcuts modal
+    if (hideShortcutsModal()) {
+      closed = true;
+    }
+    
+    // Blur search input if focused
+    var activeElement = document.activeElement;
+    if (activeElement && (activeElement.tagName === 'INPUT' || activeElement.tagName === 'TEXTAREA')) {
+      activeElement.blur();
+      closed = true;
+    }
+    
+    // Clear Pagefind results if present
+    var pagefindResults = document.querySelector('.pagefind-ui__results-area');
+    if (pagefindResults && pagefindResults.children.length > 0) {
+      var pagefindInput = document.querySelector('.pagefind-ui__search-input');
+      if (pagefindInput) {
+        pagefindInput.value = '';
+        pagefindInput.dispatchEvent(new Event('input', { bubbles: true }));
+        closed = true;
+      }
+    }
+    
+    return closed;
+  }
+
+  /**
+   * Check if the current element is an input field where typing should be allowed
+   * @param {Element} element 
+   * @returns {boolean}
+   */
+  function isInputElement(element) {
+    if (!element) return false;
+    
+    var tagName = element.tagName;
+    if (tagName === 'INPUT' || tagName === 'TEXTAREA' || tagName === 'SELECT') {
+      return true;
+    }
+    
+    // Check for contenteditable
+    if (element.isContentEditable) {
+      return true;
+    }
+    
+    return false;
+  }
+
+  /**
+   * Main keyboard event handler
+   * @param {KeyboardEvent} e 
+   */
+  function handleKeyDown(e) {
+    var target = e.target;
+    
+    // Always allow Escape to work, even in inputs
+    if (e.key === 'Escape') {
+      if (closeModals()) {
+        e.preventDefault();
+      }
+      return;
+    }
+    
+    // Skip other shortcuts when typing in input fields
+    if (isInputElement(target)) {
+      return;
+    }
+    
+    // Check if shortcuts are disabled (except for Escape which always works)
+    if (areShortcutsDisabled()) {
+      return;
+    }
+    
+    // Detect platform for modifier key
+    var modifier = isMacPlatform() ? e.metaKey : e.ctrlKey;
+    
+    // Cmd/Ctrl+K - Focus search
+    if (modifier && e.key === 'k') {
+      e.preventDefault();
+      focusSearch();
+      return;
+    }
+    
+    // Don't process other shortcuts if modifier keys are held (except the ones we handle)
+    if (e.ctrlKey || e.metaKey || e.altKey) {
+      return;
+    }
+    
+    // Handle single-key shortcuts
+    switch (e.key) {
+      case '/':
+        e.preventDefault();
+        focusSearch();
+        break;
+        
+      case '?':
+        e.preventDefault();
+        showShortcutsModal();
+        break;
+    }
+  }
+
+  /**
+   * Handle click outside modal to close it
+   * @param {MouseEvent} e 
+   */
+  function handleModalBackdropClick(e) {
+    var modal = document.getElementById('shortcuts-modal');
+    if (modal && e.target === modal) {
+      hideShortcutsModal();
+    }
+  }
+
+  /**
+   * Initialize the keyboard shortcuts system
+   */
+  function init() {
+    // Update modifier key display for the current platform
+    updateModifierKeyDisplay();
+    
+    // Add keyboard event listener
+    document.addEventListener('keydown', handleKeyDown);
+    
+    // Setup modal close button
+    var closeBtn = document.querySelector('.shortcuts-modal-close');
+    if (closeBtn) {
+      closeBtn.addEventListener('click', hideShortcutsModal);
+    }
+    
+    // Setup toggle button
+    var toggleBtn = document.getElementById('shortcuts-toggle');
+    if (toggleBtn) {
+      toggleBtn.addEventListener('click', toggleShortcuts);
+      updateToggleButton();
+    }
+    
+    // Close modal on backdrop click
+    var modal = document.getElementById('shortcuts-modal');
+    if (modal) {
+      modal.addEventListener('click', handleModalBackdropClick);
+    }
+  }
+
+  // Initialize when DOM is ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+
+  // Expose functions for external use if needed
+  window.markataShortcuts = {
+    focusSearch: focusSearch,
+    showShortcutsModal: showShortcutsModal,
+    hideShortcutsModal: hideShortcutsModal,
+    toggleShortcuts: toggleShortcuts,
+    areShortcutsDisabled: areShortcutsDisabled
+  };
+})();


### PR DESCRIPTION
## Summary

Implements keyboard shortcuts for generated sites to improve navigation and user experience.

Fixes #135

## Changes

### New Files
- `themes/default/static/js/shortcuts.js` - Keyboard shortcut handler with platform detection
- `templates/partials/shortcuts-modal.html` - Accessible help modal displaying all shortcuts

### Modified Files
- `templates/base.html` - Include shortcuts script and modal
- `templates/components/footer.html` - Add hint about keyboard shortcuts
- `themes/default/static/css/components.css` - Add kbd styling and modal styles

## Keyboard Shortcuts

| Shortcut | Action |
|----------|--------|
| `/` | Focus search input |
| `Cmd/Ctrl+K` | Focus search (alternative) |
| `Escape` | Close search/modals |
| `?` | Show shortcuts help modal |

## Accessibility (WCAG 2.1.4)

- Shortcuts can be disabled via localStorage toggle in the help modal
- Shortcuts are automatically ignored when typing in input fields (except Escape)
- Platform-aware modifier key display (Cmd on Mac, Ctrl on Windows/Linux)
- Modal has proper ARIA attributes and focus management

## Discovery UX

- Search bar placeholder updated to: "Search (Press / or ⌘K)"
- Footer text: "Press ? for keyboard shortcuts"

## Screenshots

The help modal displays available shortcuts and allows users to disable them:

```
┌─────────────────────────────────────┐
│ Keyboard Shortcuts              [×] │
├─────────────────────────────────────┤
│ Shortcut    Action                  │
│ /           Focus search input      │
│ ⌘K          Focus search (alt)      │
│ Esc         Close search / modals   │
│ ?           Show this help          │
├─────────────────────────────────────┤
│ [Disable Shortcuts]                 │
│ Shortcuts disabled in input fields  │
└─────────────────────────────────────┘
```