### PR TITLE
fix: Style Pagefind search scrollbar to match theme

### DIFF
--- a/themes/default/static/css/components.css
+++ b/themes/default/static/css/components.css
@@ -413,6 +413,28 @@
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12), 0 2px 8px rgba(0, 0, 0, 0.08);
   z-index: 1000;
   padding: 0.75rem;
+  /* Modern browsers (Firefox) */
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-primary) var(--color-background);
+}
+
+/* WebKit browsers (Chrome, Safari, Edge) */
+.search--navbar .pagefind-ui__results-area::-webkit-scrollbar {
+  width: 8px;
+}
+
+.search--navbar .pagefind-ui__results-area::-webkit-scrollbar-track {
+  background: var(--color-background);
+  border-radius: 4px;
+}
+
+.search--navbar .pagefind-ui__results-area::-webkit-scrollbar-thumb {
+  background: var(--color-primary);
+  border-radius: 4px;
+}
+
+.search--navbar .pagefind-ui__results-area::-webkit-scrollbar-thumb:hover {
+  background: var(--color-primary-dark, var(--color-primary));
 }
 
 /* Full-width search for sidebar/footer */


### PR DESCRIPTION
## Summary

- Add custom scrollbar styling to the Pagefind search results dropdown to match the site theme
- Use CSS variables (`--color-primary`, `--color-background`) for theme consistency
- Support both Firefox (`scrollbar-width`, `scrollbar-color`) and WebKit browsers (`::-webkit-scrollbar`)

Fixes #140