### PR TITLE
feat: Complete docs layout with sidebar and TOC rendering

### DIFF
--- a/cmd/markata-go/cmd/core.go
+++ b/cmd/markata-go/cmd/core.go
@@ -73,6 +73,11 @@ func createManager(cfgPath string) (*lifecycle.Manager, error) {
 	// Pass layout configuration for automatic layout selection
 	lcConfig.Extra["layout"] = &cfg.Layout
 
+	// Pass sidebar, toc, and header configurations
+	lcConfig.Extra["sidebar"] = cfg.Sidebar
+	lcConfig.Extra["toc"] = cfg.Toc
+	lcConfig.Extra["header"] = cfg.Header
+
 	m.SetConfig(lcConfig)
 
 	// Set concurrency if specified

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -3,7 +3,7 @@ title: "Configuration Guide"
 description: "Complete reference for markata-go configuration options, file formats, and environment variables"
 date: 2024-01-15
 published: true
-template: doc.html
+slug: /docs/guides/configuration/
 tags:
   - documentation
   - configuration

--- a/docs/guides/feeds.md
+++ b/docs/guides/feeds.md
@@ -3,7 +3,7 @@ title: "Feeds Guide"
 description: "Deep dive into markata-go's powerful feed system for creating filtered, sorted, paginated collections"
 date: 2024-01-15
 published: true
-template: doc.html
+slug: /docs/guides/feeds/
 tags:
   - documentation
   - feeds

--- a/docs/guides/frontmatter.md
+++ b/docs/guides/frontmatter.md
@@ -3,7 +3,7 @@ title: "Frontmatter Guide"
 description: "Complete guide to post metadata, built-in fields, and custom frontmatter in markata-go"
 date: 2024-01-15
 published: true
-template: doc.html
+slug: /docs/guides/frontmatter/
 tags:
   - documentation
   - frontmatter

--- a/docs/guides/markdown.md
+++ b/docs/guides/markdown.md
@@ -3,7 +3,7 @@ title: "Markdown Features"
 description: "Guide to supported Markdown syntax including GFM, admonitions, wikilinks, and table of contents"
 date: 2024-01-15
 published: true
-template: doc.html
+slug: /docs/guides/markdown/
 css_class: shadow bordered
 tags:
   - documentation

--- a/docs/guides/search.md
+++ b/docs/guides/search.md
@@ -3,6 +3,7 @@ title: "Site Search"
 description: "Add full-text search to your markata-go site using Pagefind"
 date: 2024-01-15
 published: true
+slug: /docs/guides/search/
 tags:
   - documentation
   - search

--- a/docs/guides/sidebars.md
+++ b/docs/guides/sidebars.md
@@ -3,7 +3,7 @@ title: "Sidebar Navigation"
 description: "Complete guide to configuring sidebar navigation with path-based, feed-linked, and multi-feed sidebars"
 date: 2024-01-23
 published: true
-template: doc.html
+slug: /docs/guides/sidebars/
 tags:
   - documentation
   - layout

--- a/docs/guides/templates.md
+++ b/docs/guides/templates.md
@@ -3,7 +3,7 @@ title: "Templates Guide"
 description: "Complete guide to creating and customizing templates with pongo2/Jinja2 syntax"
 date: 2024-01-15
 published: true
-template: doc.html
+slug: /docs/guides/templates/
 tags:
   - documentation
   - templates

--- a/docs/guides/themes.md
+++ b/docs/guides/themes.md
@@ -3,6 +3,7 @@ title: "Themes and Styling"
 description: "Complete guide to customizing your site's appearance with themes, color palettes, and CSS"
 date: 2024-01-15
 published: true
+slug: /docs/guides/themes/
 tags:
   - documentation
   - themes

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ title: "Documentation"
 description: "Complete documentation for markata-go, a fast, plugin-driven static site generator written in Go"
 date: 2024-01-15
 published: true
-template: doc.html
+slug: /docs/
 tags:
   - documentation
 ---

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -3,7 +3,7 @@ title: "CLI Reference"
 description: "Complete reference for all markata-go commands, flags, and options"
 date: 2024-01-15
 published: true
-template: doc.html
+slug: /docs/reference/cli/
 tags:
   - documentation
   - reference

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -3,7 +3,7 @@ title: "Built-in Plugins"
 description: "Reference documentation for all 29 built-in markata-go plugins organized by lifecycle stage"
 date: 2024-01-15
 published: true
-template: doc.html
+slug: /docs/reference/plugins/
 tags:
   - documentation
   - reference

--- a/markata-go.toml
+++ b/markata-go.toml
@@ -94,6 +94,58 @@ palette = "matte-black"
 # palette = "tokyo-night-day"
 # palette = "tokyo-night-storm"
 
+# Layout configuration
+[markata-go.layout]
+name = "docs"  # Default layout: "docs", "blog", "landing", "bare"
+
+[markata-go.layout.docs]
+sidebar_position = "left"
+sidebar_width = "280px"
+toc_position = "right"
+toc_width = "220px"
+content_max_width = "800px"
+header_style = "minimal"
+footer_style = "minimal"
+
+# Sidebar configuration
+[markata-go.sidebar]
+enabled = true
+position = "left"
+title = "Documentation"
+
+[[markata-go.sidebar.nav]]
+title = "Getting Started"
+href = "/docs/"
+
+[[markata-go.sidebar.nav]]
+title = "Guides"
+children = [
+    { title = "Configuration", href = "/docs/guides/configuration/" },
+    { title = "Templates", href = "/docs/guides/templates/" },
+    { title = "Themes", href = "/docs/guides/themes/" },
+    { title = "Feeds", href = "/docs/guides/feeds/" },
+    { title = "Sidebars", href = "/docs/guides/sidebars/" },
+    { title = "Markdown", href = "/docs/guides/markdown/" },
+    { title = "Frontmatter", href = "/docs/guides/frontmatter/" },
+    { title = "Search", href = "/docs/guides/search/" },
+]
+
+[[markata-go.sidebar.nav]]
+title = "Reference"
+children = [
+    { title = "CLI", href = "/docs/reference/cli/" },
+    { title = "Plugins", href = "/docs/reference/plugins/" },
+]
+
+# Table of Contents configuration
+[markata-go.toc]
+enabled = true
+position = "right"
+title = "On this page"
+min_depth = 2
+max_depth = 4
+scroll_spy = true
+
 [markata-go.markdown.highlight]
 enabled = true
 theme = "github-dark"    # Highlight theme

--- a/pkg/config/merge.go
+++ b/pkg/config/merge.go
@@ -81,6 +81,18 @@ func MergeConfigs(base, override *models.Config) *models.Config {
 	// Components - merge
 	result.Components = mergeComponentsConfig(base.Components, override.Components)
 
+	// Layout - merge
+	result.Layout = mergeLayoutConfig(base.Layout, override.Layout)
+
+	// Sidebar - merge
+	result.Sidebar = mergeSidebarConfig(base.Sidebar, override.Sidebar)
+
+	// Toc - merge
+	result.Toc = mergeTocConfig(base.Toc, override.Toc)
+
+	// Header - merge
+	result.Header = mergeHeaderLayoutConfig(base.Header, override.Header)
+
 	return result
 }
 
@@ -341,6 +353,263 @@ func mergeComponentsConfig(base, override models.ComponentsConfig) models.Compon
 	}
 	if override.DocSidebar.MaxDepth != 0 {
 		result.DocSidebar.MaxDepth = override.DocSidebar.MaxDepth
+	}
+
+	return result
+}
+
+// mergeLayoutConfig merges LayoutConfig values.
+func mergeLayoutConfig(base, override models.LayoutConfig) models.LayoutConfig {
+	result := base
+
+	if override.Name != "" {
+		result.Name = override.Name
+	}
+	if len(override.Paths) > 0 {
+		if result.Paths == nil {
+			result.Paths = make(map[string]string)
+		}
+		for k, v := range override.Paths {
+			result.Paths[k] = v
+		}
+	}
+	if len(override.Feeds) > 0 {
+		if result.Feeds == nil {
+			result.Feeds = make(map[string]string)
+		}
+		for k, v := range override.Feeds {
+			result.Feeds[k] = v
+		}
+	}
+
+	// Merge nested layout configs
+	result.Docs = mergeDocsLayoutConfig(base.Docs, override.Docs)
+	result.Blog = mergeBlogLayoutConfig(base.Blog, override.Blog)
+	result.Landing = mergeLandingLayoutConfig(base.Landing, override.Landing)
+	result.Bare = mergeBareLayoutConfig(base.Bare, override.Bare)
+	result.Defaults = mergeLayoutDefaults(base.Defaults, override.Defaults)
+
+	return result
+}
+
+// mergeDocsLayoutConfig merges DocsLayoutConfig values.
+func mergeDocsLayoutConfig(base, override models.DocsLayoutConfig) models.DocsLayoutConfig {
+	result := base
+
+	if override.SidebarPosition != "" {
+		result.SidebarPosition = override.SidebarPosition
+	}
+	if override.SidebarWidth != "" {
+		result.SidebarWidth = override.SidebarWidth
+	}
+	if override.SidebarCollapsible != nil {
+		result.SidebarCollapsible = override.SidebarCollapsible
+	}
+	if override.SidebarDefaultOpen != nil {
+		result.SidebarDefaultOpen = override.SidebarDefaultOpen
+	}
+	if override.TocPosition != "" {
+		result.TocPosition = override.TocPosition
+	}
+	if override.TocWidth != "" {
+		result.TocWidth = override.TocWidth
+	}
+	if override.TocCollapsible != nil {
+		result.TocCollapsible = override.TocCollapsible
+	}
+	if override.TocDefaultOpen != nil {
+		result.TocDefaultOpen = override.TocDefaultOpen
+	}
+	if override.ContentMaxWidth != "" {
+		result.ContentMaxWidth = override.ContentMaxWidth
+	}
+	if override.HeaderStyle != "" {
+		result.HeaderStyle = override.HeaderStyle
+	}
+	if override.FooterStyle != "" {
+		result.FooterStyle = override.FooterStyle
+	}
+
+	return result
+}
+
+// mergeBlogLayoutConfig merges BlogLayoutConfig values.
+func mergeBlogLayoutConfig(base, override models.BlogLayoutConfig) models.BlogLayoutConfig {
+	result := base
+
+	if override.ContentMaxWidth != "" {
+		result.ContentMaxWidth = override.ContentMaxWidth
+	}
+	if override.ShowToc != nil {
+		result.ShowToc = override.ShowToc
+	}
+	if override.TocPosition != "" {
+		result.TocPosition = override.TocPosition
+	}
+	if override.TocWidth != "" {
+		result.TocWidth = override.TocWidth
+	}
+	if override.HeaderStyle != "" {
+		result.HeaderStyle = override.HeaderStyle
+	}
+	if override.FooterStyle != "" {
+		result.FooterStyle = override.FooterStyle
+	}
+	if override.ShowAuthor != nil {
+		result.ShowAuthor = override.ShowAuthor
+	}
+	if override.ShowDate != nil {
+		result.ShowDate = override.ShowDate
+	}
+	if override.ShowTags != nil {
+		result.ShowTags = override.ShowTags
+	}
+	if override.ShowReadingTime != nil {
+		result.ShowReadingTime = override.ShowReadingTime
+	}
+	if override.ShowPrevNext != nil {
+		result.ShowPrevNext = override.ShowPrevNext
+	}
+
+	return result
+}
+
+// mergeLandingLayoutConfig merges LandingLayoutConfig values.
+func mergeLandingLayoutConfig(base, override models.LandingLayoutConfig) models.LandingLayoutConfig {
+	result := base
+
+	if override.ContentMaxWidth != "" {
+		result.ContentMaxWidth = override.ContentMaxWidth
+	}
+	if override.HeaderStyle != "" {
+		result.HeaderStyle = override.HeaderStyle
+	}
+	if override.HeaderSticky != nil {
+		result.HeaderSticky = override.HeaderSticky
+	}
+	if override.FooterStyle != "" {
+		result.FooterStyle = override.FooterStyle
+	}
+	if override.HeroEnabled != nil {
+		result.HeroEnabled = override.HeroEnabled
+	}
+
+	return result
+}
+
+// mergeBareLayoutConfig merges BareLayoutConfig values.
+func mergeBareLayoutConfig(base, override models.BareLayoutConfig) models.BareLayoutConfig {
+	result := base
+
+	if override.ContentMaxWidth != "" {
+		result.ContentMaxWidth = override.ContentMaxWidth
+	}
+
+	return result
+}
+
+// mergeLayoutDefaults merges LayoutDefaults values.
+func mergeLayoutDefaults(base, override models.LayoutDefaults) models.LayoutDefaults {
+	result := base
+
+	if override.ContentMaxWidth != "" {
+		result.ContentMaxWidth = override.ContentMaxWidth
+	}
+	if override.HeaderSticky != nil {
+		result.HeaderSticky = override.HeaderSticky
+	}
+	if override.FooterSticky != nil {
+		result.FooterSticky = override.FooterSticky
+	}
+
+	return result
+}
+
+// mergeSidebarConfig merges SidebarConfig values.
+func mergeSidebarConfig(base, override models.SidebarConfig) models.SidebarConfig {
+	result := base
+
+	if override.Enabled != nil {
+		result.Enabled = override.Enabled
+	}
+	if override.Position != "" {
+		result.Position = override.Position
+	}
+	if override.Width != "" {
+		result.Width = override.Width
+	}
+	if override.Collapsible != nil {
+		result.Collapsible = override.Collapsible
+	}
+	if override.DefaultOpen != nil {
+		result.DefaultOpen = override.DefaultOpen
+	}
+	if len(override.Nav) > 0 {
+		result.Nav = override.Nav
+	}
+	if override.Title != "" {
+		result.Title = override.Title
+	}
+
+	return result
+}
+
+// mergeTocConfig merges TocConfig values.
+func mergeTocConfig(base, override models.TocConfig) models.TocConfig {
+	result := base
+
+	if override.Enabled != nil {
+		result.Enabled = override.Enabled
+	}
+	if override.Position != "" {
+		result.Position = override.Position
+	}
+	if override.Width != "" {
+		result.Width = override.Width
+	}
+	if override.MinDepth != 0 {
+		result.MinDepth = override.MinDepth
+	}
+	if override.MaxDepth != 0 {
+		result.MaxDepth = override.MaxDepth
+	}
+	if override.Collapsible != nil {
+		result.Collapsible = override.Collapsible
+	}
+	if override.DefaultOpen != nil {
+		result.DefaultOpen = override.DefaultOpen
+	}
+	if override.Title != "" {
+		result.Title = override.Title
+	}
+
+	return result
+}
+
+// mergeHeaderLayoutConfig merges HeaderLayoutConfig values.
+func mergeHeaderLayoutConfig(base, override models.HeaderLayoutConfig) models.HeaderLayoutConfig {
+	result := base
+
+	if override.Style != "" {
+		result.Style = override.Style
+	}
+	if override.Sticky != nil {
+		result.Sticky = override.Sticky
+	}
+	if override.ShowLogo != nil {
+		result.ShowLogo = override.ShowLogo
+	}
+	if override.ShowTitle != nil {
+		result.ShowTitle = override.ShowTitle
+	}
+	if override.ShowNav != nil {
+		result.ShowNav = override.ShowNav
+	}
+	if override.ShowSearch != nil {
+		result.ShowSearch = override.ShowSearch
+	}
+	if override.ShowThemeToggle != nil {
+		result.ShowThemeToggle = override.ShowThemeToggle
 	}
 
 	return result

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -56,29 +56,33 @@ func ParseJSON(data []byte) (*models.Config, error) {
 
 // tomlConfig is an internal struct for parsing TOML configuration.
 type tomlConfig struct {
-	OutputDir     string                `toml:"output_dir"`
-	URL           string                `toml:"url"`
-	Title         string                `toml:"title"`
-	Description   string                `toml:"description"`
-	Author        string                `toml:"author"`
-	AssetsDir     string                `toml:"assets_dir"`
-	TemplatesDir  string                `toml:"templates_dir"`
-	Nav           []tomlNavItem         `toml:"nav"`
-	Footer        tomlFooterConfig      `toml:"footer"`
-	Hooks         []string              `toml:"hooks"`
-	DisabledHooks []string              `toml:"disabled_hooks"`
-	Glob          tomlGlobConfig        `toml:"glob"`
-	Markdown      tomlMarkdownConfig    `toml:"markdown"`
-	Feeds         []tomlFeedConfig      `toml:"feeds"`
-	FeedDefaults  tomlFeedDefaults      `toml:"feed_defaults"`
-	Concurrency   int                   `toml:"concurrency"`
-	Theme         tomlThemeConfig       `toml:"theme"`
-	PostFormats   tomlPostFormatsConfig `toml:"post_formats"`
-	SEO           tomlSEOConfig         `toml:"seo"`
-	IndieAuth     tomlIndieAuthConfig   `toml:"indieauth"`
-	Webmention    tomlWebmentionConfig  `toml:"webmention"`
-	Components    tomlComponentsConfig  `toml:"components"`
-	UnknownFields map[string]any        `toml:"-"`
+	OutputDir     string                 `toml:"output_dir"`
+	URL           string                 `toml:"url"`
+	Title         string                 `toml:"title"`
+	Description   string                 `toml:"description"`
+	Author        string                 `toml:"author"`
+	AssetsDir     string                 `toml:"assets_dir"`
+	TemplatesDir  string                 `toml:"templates_dir"`
+	Nav           []tomlNavItem          `toml:"nav"`
+	Footer        tomlFooterConfig       `toml:"footer"`
+	Hooks         []string               `toml:"hooks"`
+	DisabledHooks []string               `toml:"disabled_hooks"`
+	Glob          tomlGlobConfig         `toml:"glob"`
+	Markdown      tomlMarkdownConfig     `toml:"markdown"`
+	Feeds         []tomlFeedConfig       `toml:"feeds"`
+	FeedDefaults  tomlFeedDefaults       `toml:"feed_defaults"`
+	Concurrency   int                    `toml:"concurrency"`
+	Theme         tomlThemeConfig        `toml:"theme"`
+	PostFormats   tomlPostFormatsConfig  `toml:"post_formats"`
+	SEO           tomlSEOConfig          `toml:"seo"`
+	IndieAuth     tomlIndieAuthConfig    `toml:"indieauth"`
+	Webmention    tomlWebmentionConfig   `toml:"webmention"`
+	Components    tomlComponentsConfig   `toml:"components"`
+	Layout        tomlLayoutConfig       `toml:"layout"`
+	Sidebar       tomlSidebarConfig      `toml:"sidebar"`
+	Toc           tomlTocConfig          `toml:"toc"`
+	Header        tomlHeaderLayoutConfig `toml:"header"`
+	UnknownFields map[string]any         `toml:"-"`
 }
 
 type tomlNavItem struct {
@@ -230,6 +234,290 @@ type tomlDocSidebarConfig struct {
 	MaxDepth int    `toml:"max_depth"`
 }
 
+// Layout-related TOML structs
+
+type tomlLayoutConfig struct {
+	Name     string                  `toml:"name"`
+	Paths    map[string]string       `toml:"paths"`
+	Feeds    map[string]string       `toml:"feeds"`
+	Docs     tomlDocsLayoutConfig    `toml:"docs"`
+	Blog     tomlBlogLayoutConfig    `toml:"blog"`
+	Landing  tomlLandingLayoutConfig `toml:"landing"`
+	Bare     tomlBareLayoutConfig    `toml:"bare"`
+	Defaults tomlLayoutDefaults      `toml:"defaults"`
+}
+
+type tomlLayoutDefaults struct {
+	ContentMaxWidth string `toml:"content_max_width"`
+	HeaderSticky    *bool  `toml:"header_sticky"`
+	FooterSticky    *bool  `toml:"footer_sticky"`
+}
+
+type tomlDocsLayoutConfig struct {
+	SidebarPosition    string `toml:"sidebar_position"`
+	SidebarWidth       string `toml:"sidebar_width"`
+	SidebarCollapsible *bool  `toml:"sidebar_collapsible"`
+	SidebarDefaultOpen *bool  `toml:"sidebar_default_open"`
+	TocPosition        string `toml:"toc_position"`
+	TocWidth           string `toml:"toc_width"`
+	TocCollapsible     *bool  `toml:"toc_collapsible"`
+	TocDefaultOpen     *bool  `toml:"toc_default_open"`
+	ContentMaxWidth    string `toml:"content_max_width"`
+	HeaderStyle        string `toml:"header_style"`
+	FooterStyle        string `toml:"footer_style"`
+}
+
+type tomlBlogLayoutConfig struct {
+	ContentMaxWidth string `toml:"content_max_width"`
+	ShowToc         *bool  `toml:"show_toc"`
+	TocPosition     string `toml:"toc_position"`
+	TocWidth        string `toml:"toc_width"`
+	HeaderStyle     string `toml:"header_style"`
+	FooterStyle     string `toml:"footer_style"`
+	ShowAuthor      *bool  `toml:"show_author"`
+	ShowDate        *bool  `toml:"show_date"`
+	ShowTags        *bool  `toml:"show_tags"`
+	ShowReadingTime *bool  `toml:"show_reading_time"`
+	ShowPrevNext    *bool  `toml:"show_prev_next"`
+}
+
+type tomlLandingLayoutConfig struct {
+	ContentMaxWidth string `toml:"content_max_width"`
+	HeaderStyle     string `toml:"header_style"`
+	HeaderSticky    *bool  `toml:"header_sticky"`
+	FooterStyle     string `toml:"footer_style"`
+	HeroEnabled     *bool  `toml:"hero_enabled"`
+}
+
+type tomlBareLayoutConfig struct {
+	ContentMaxWidth string `toml:"content_max_width"`
+}
+
+func (l *tomlLayoutConfig) toLayoutConfig() models.LayoutConfig {
+	return models.LayoutConfig{
+		Name:  l.Name,
+		Paths: l.Paths,
+		Feeds: l.Feeds,
+		Docs: models.DocsLayoutConfig{
+			SidebarPosition:    l.Docs.SidebarPosition,
+			SidebarWidth:       l.Docs.SidebarWidth,
+			SidebarCollapsible: l.Docs.SidebarCollapsible,
+			SidebarDefaultOpen: l.Docs.SidebarDefaultOpen,
+			TocPosition:        l.Docs.TocPosition,
+			TocWidth:           l.Docs.TocWidth,
+			TocCollapsible:     l.Docs.TocCollapsible,
+			TocDefaultOpen:     l.Docs.TocDefaultOpen,
+			ContentMaxWidth:    l.Docs.ContentMaxWidth,
+			HeaderStyle:        l.Docs.HeaderStyle,
+			FooterStyle:        l.Docs.FooterStyle,
+		},
+		Blog: models.BlogLayoutConfig{
+			ContentMaxWidth: l.Blog.ContentMaxWidth,
+			ShowToc:         l.Blog.ShowToc,
+			TocPosition:     l.Blog.TocPosition,
+			TocWidth:        l.Blog.TocWidth,
+			HeaderStyle:     l.Blog.HeaderStyle,
+			FooterStyle:     l.Blog.FooterStyle,
+			ShowAuthor:      l.Blog.ShowAuthor,
+			ShowDate:        l.Blog.ShowDate,
+			ShowTags:        l.Blog.ShowTags,
+			ShowReadingTime: l.Blog.ShowReadingTime,
+			ShowPrevNext:    l.Blog.ShowPrevNext,
+		},
+		Landing: models.LandingLayoutConfig{
+			ContentMaxWidth: l.Landing.ContentMaxWidth,
+			HeaderStyle:     l.Landing.HeaderStyle,
+			HeaderSticky:    l.Landing.HeaderSticky,
+			FooterStyle:     l.Landing.FooterStyle,
+			HeroEnabled:     l.Landing.HeroEnabled,
+		},
+		Bare: models.BareLayoutConfig{
+			ContentMaxWidth: l.Bare.ContentMaxWidth,
+		},
+		Defaults: models.LayoutDefaults{
+			ContentMaxWidth: l.Defaults.ContentMaxWidth,
+			HeaderSticky:    l.Defaults.HeaderSticky,
+			FooterSticky:    l.Defaults.FooterSticky,
+		},
+	}
+}
+
+// Sidebar-related TOML structs
+
+type tomlSidebarConfig struct {
+	Enabled      *bool                             `toml:"enabled"`
+	Position     string                            `toml:"position"`
+	Width        string                            `toml:"width"`
+	Collapsible  *bool                             `toml:"collapsible"`
+	DefaultOpen  *bool                             `toml:"default_open"`
+	Nav          []tomlSidebarNavItem              `toml:"nav"`
+	Title        string                            `toml:"title"`
+	Paths        map[string]*tomlPathSidebarConfig `toml:"paths"`
+	MultiFeed    *bool                             `toml:"multi_feed"`
+	Feeds        []string                          `toml:"feeds"`
+	FeedSections []tomlMultiFeedSection            `toml:"feed_sections"`
+	AutoGenerate *tomlSidebarAutoGenerate          `toml:"auto_generate"`
+}
+
+type tomlSidebarNavItem struct {
+	Title    string               `toml:"title"`
+	Href     string               `toml:"href"`
+	Children []tomlSidebarNavItem `toml:"children"`
+}
+
+type tomlPathSidebarConfig struct {
+	Title        string                   `toml:"title"`
+	AutoGenerate *tomlSidebarAutoGenerate `toml:"auto_generate"`
+	Items        []tomlSidebarNavItem     `toml:"items"`
+	Feed         string                   `toml:"feed"`
+	Position     string                   `toml:"position"`
+	Collapsible  *bool                    `toml:"collapsible"`
+}
+
+type tomlSidebarAutoGenerate struct {
+	Directory string   `toml:"directory"`
+	OrderBy   string   `toml:"order_by"`
+	Reverse   *bool    `toml:"reverse"`
+	MaxDepth  int      `toml:"max_depth"`
+	Exclude   []string `toml:"exclude"`
+}
+
+type tomlMultiFeedSection struct {
+	Feed      string `toml:"feed"`
+	Title     string `toml:"title"`
+	Collapsed *bool  `toml:"collapsed"`
+	MaxItems  int    `toml:"max_items"`
+}
+
+func convertTomlSidebarNavItems(items []tomlSidebarNavItem) []models.SidebarNavItem {
+	result := make([]models.SidebarNavItem, len(items))
+	for i, item := range items {
+		result[i] = models.SidebarNavItem{
+			Title:    item.Title,
+			Href:     item.Href,
+			Children: convertTomlSidebarNavItems(item.Children),
+		}
+	}
+	return result
+}
+
+func (s *tomlSidebarConfig) toSidebarConfig() models.SidebarConfig {
+	config := models.SidebarConfig{
+		Enabled:     s.Enabled,
+		Position:    s.Position,
+		Width:       s.Width,
+		Collapsible: s.Collapsible,
+		DefaultOpen: s.DefaultOpen,
+		Nav:         convertTomlSidebarNavItems(s.Nav),
+		Title:       s.Title,
+		MultiFeed:   s.MultiFeed,
+		Feeds:       s.Feeds,
+	}
+
+	// Convert paths
+	if len(s.Paths) > 0 {
+		config.Paths = make(map[string]*models.PathSidebarConfig)
+		for path, pathConfig := range s.Paths {
+			var autoGen *models.SidebarAutoGenerate
+			if pathConfig.AutoGenerate != nil {
+				autoGen = &models.SidebarAutoGenerate{
+					Directory: pathConfig.AutoGenerate.Directory,
+					OrderBy:   pathConfig.AutoGenerate.OrderBy,
+					Reverse:   pathConfig.AutoGenerate.Reverse,
+					MaxDepth:  pathConfig.AutoGenerate.MaxDepth,
+					Exclude:   pathConfig.AutoGenerate.Exclude,
+				}
+			}
+			config.Paths[path] = &models.PathSidebarConfig{
+				Title:        pathConfig.Title,
+				AutoGenerate: autoGen,
+				Items:        convertTomlSidebarNavItems(pathConfig.Items),
+				Feed:         pathConfig.Feed,
+				Position:     pathConfig.Position,
+				Collapsible:  pathConfig.Collapsible,
+			}
+		}
+	}
+
+	// Convert feed sections
+	if len(s.FeedSections) > 0 {
+		config.FeedSections = make([]models.MultiFeedSection, len(s.FeedSections))
+		for i, section := range s.FeedSections {
+			config.FeedSections[i] = models.MultiFeedSection{
+				Feed:      section.Feed,
+				Title:     section.Title,
+				Collapsed: section.Collapsed,
+				MaxItems:  section.MaxItems,
+			}
+		}
+	}
+
+	// Convert auto-generate
+	if s.AutoGenerate != nil {
+		config.AutoGenerate = &models.SidebarAutoGenerate{
+			Directory: s.AutoGenerate.Directory,
+			OrderBy:   s.AutoGenerate.OrderBy,
+			Reverse:   s.AutoGenerate.Reverse,
+			MaxDepth:  s.AutoGenerate.MaxDepth,
+			Exclude:   s.AutoGenerate.Exclude,
+		}
+	}
+
+	return config
+}
+
+// TOC-related TOML structs
+
+type tomlTocConfig struct {
+	Enabled     *bool  `toml:"enabled"`
+	Position    string `toml:"position"`
+	Width       string `toml:"width"`
+	MinDepth    int    `toml:"min_depth"`
+	MaxDepth    int    `toml:"max_depth"`
+	Title       string `toml:"title"`
+	Collapsible *bool  `toml:"collapsible"`
+	DefaultOpen *bool  `toml:"default_open"`
+	ScrollSpy   *bool  `toml:"scroll_spy"`
+}
+
+func (t *tomlTocConfig) toTocConfig() models.TocConfig {
+	return models.TocConfig{
+		Enabled:     t.Enabled,
+		Position:    t.Position,
+		Width:       t.Width,
+		MinDepth:    t.MinDepth,
+		MaxDepth:    t.MaxDepth,
+		Title:       t.Title,
+		Collapsible: t.Collapsible,
+		DefaultOpen: t.DefaultOpen,
+		ScrollSpy:   t.ScrollSpy,
+	}
+}
+
+// Header layout TOML structs
+
+type tomlHeaderLayoutConfig struct {
+	Style           string `toml:"style"`
+	Sticky          *bool  `toml:"sticky"`
+	ShowLogo        *bool  `toml:"show_logo"`
+	ShowTitle       *bool  `toml:"show_title"`
+	ShowNav         *bool  `toml:"show_nav"`
+	ShowSearch      *bool  `toml:"show_search"`
+	ShowThemeToggle *bool  `toml:"show_theme_toggle"`
+}
+
+func (h *tomlHeaderLayoutConfig) toHeaderLayoutConfig() models.HeaderLayoutConfig {
+	return models.HeaderLayoutConfig{
+		Style:           h.Style,
+		Sticky:          h.Sticky,
+		ShowLogo:        h.ShowLogo,
+		ShowTitle:       h.ShowTitle,
+		ShowNav:         h.ShowNav,
+		ShowSearch:      h.ShowSearch,
+		ShowThemeToggle: h.ShowThemeToggle,
+	}
+}
+
 //nolint:dupl // Intentional duplication - each format has its own conversion method
 func (c *tomlComponentsConfig) toComponentsConfig() models.ComponentsConfig {
 	config := models.ComponentsConfig{
@@ -338,6 +626,18 @@ func (c *tomlConfig) toConfig() *models.Config {
 	// Convert Components config
 	config.Components = c.Components.toComponentsConfig()
 
+	// Convert Layout config
+	config.Layout = c.Layout.toLayoutConfig()
+
+	// Convert Sidebar config
+	config.Sidebar = c.Sidebar.toSidebarConfig()
+
+	// Convert Toc config
+	config.Toc = c.Toc.toTocConfig()
+
+	// Convert Header config
+	config.Header = c.Header.toHeaderLayoutConfig()
+
 	return config
 }
 
@@ -426,27 +726,31 @@ func (d *tomlFeedDefaults) toFeedDefaults() models.FeedDefaults {
 
 // yamlConfig is an internal struct for parsing YAML configuration.
 type yamlConfig struct {
-	OutputDir     string                `yaml:"output_dir"`
-	URL           string                `yaml:"url"`
-	Title         string                `yaml:"title"`
-	Description   string                `yaml:"description"`
-	Author        string                `yaml:"author"`
-	AssetsDir     string                `yaml:"assets_dir"`
-	TemplatesDir  string                `yaml:"templates_dir"`
-	Nav           []yamlNavItem         `yaml:"nav"`
-	Footer        yamlFooterConfig      `yaml:"footer"`
-	Hooks         []string              `yaml:"hooks"`
-	DisabledHooks []string              `yaml:"disabled_hooks"`
-	Glob          yamlGlobConfig        `yaml:"glob"`
-	Markdown      yamlMarkdownConfig    `yaml:"markdown"`
-	Feeds         []yamlFeedConfig      `yaml:"feeds"`
-	FeedDefaults  yamlFeedDefaults      `yaml:"feed_defaults"`
-	Concurrency   int                   `yaml:"concurrency"`
-	PostFormats   yamlPostFormatsConfig `yaml:"post_formats"`
-	IndieAuth     yamlIndieAuthConfig   `yaml:"indieauth"`
-	Webmention    yamlWebmentionConfig  `yaml:"webmention"`
-	SEO           yamlSEOConfig         `yaml:"seo"`
-	Components    yamlComponentsConfig  `yaml:"components"`
+	OutputDir     string                 `yaml:"output_dir"`
+	URL           string                 `yaml:"url"`
+	Title         string                 `yaml:"title"`
+	Description   string                 `yaml:"description"`
+	Author        string                 `yaml:"author"`
+	AssetsDir     string                 `yaml:"assets_dir"`
+	TemplatesDir  string                 `yaml:"templates_dir"`
+	Nav           []yamlNavItem          `yaml:"nav"`
+	Footer        yamlFooterConfig       `yaml:"footer"`
+	Hooks         []string               `yaml:"hooks"`
+	DisabledHooks []string               `yaml:"disabled_hooks"`
+	Glob          yamlGlobConfig         `yaml:"glob"`
+	Markdown      yamlMarkdownConfig     `yaml:"markdown"`
+	Feeds         []yamlFeedConfig       `yaml:"feeds"`
+	FeedDefaults  yamlFeedDefaults       `yaml:"feed_defaults"`
+	Concurrency   int                    `yaml:"concurrency"`
+	PostFormats   yamlPostFormatsConfig  `yaml:"post_formats"`
+	IndieAuth     yamlIndieAuthConfig    `yaml:"indieauth"`
+	Webmention    yamlWebmentionConfig   `yaml:"webmention"`
+	SEO           yamlSEOConfig          `yaml:"seo"`
+	Components    yamlComponentsConfig   `yaml:"components"`
+	Layout        yamlLayoutConfig       `yaml:"layout"`
+	Sidebar       yamlSidebarConfig      `yaml:"sidebar"`
+	Toc           yamlTocConfig          `yaml:"toc"`
+	Header        yamlHeaderLayoutConfig `yaml:"header"`
 }
 
 type yamlNavItem struct {
@@ -591,6 +895,290 @@ type yamlDocSidebarConfig struct {
 	MaxDepth int    `yaml:"max_depth"`
 }
 
+// Layout-related YAML structs
+
+type yamlLayoutConfig struct {
+	Name     string                  `yaml:"name"`
+	Paths    map[string]string       `yaml:"paths"`
+	Feeds    map[string]string       `yaml:"feeds"`
+	Docs     yamlDocsLayoutConfig    `yaml:"docs"`
+	Blog     yamlBlogLayoutConfig    `yaml:"blog"`
+	Landing  yamlLandingLayoutConfig `yaml:"landing"`
+	Bare     yamlBareLayoutConfig    `yaml:"bare"`
+	Defaults yamlLayoutDefaults      `yaml:"defaults"`
+}
+
+type yamlLayoutDefaults struct {
+	ContentMaxWidth string `yaml:"content_max_width"`
+	HeaderSticky    *bool  `yaml:"header_sticky"`
+	FooterSticky    *bool  `yaml:"footer_sticky"`
+}
+
+type yamlDocsLayoutConfig struct {
+	SidebarPosition    string `yaml:"sidebar_position"`
+	SidebarWidth       string `yaml:"sidebar_width"`
+	SidebarCollapsible *bool  `yaml:"sidebar_collapsible"`
+	SidebarDefaultOpen *bool  `yaml:"sidebar_default_open"`
+	TocPosition        string `yaml:"toc_position"`
+	TocWidth           string `yaml:"toc_width"`
+	TocCollapsible     *bool  `yaml:"toc_collapsible"`
+	TocDefaultOpen     *bool  `yaml:"toc_default_open"`
+	ContentMaxWidth    string `yaml:"content_max_width"`
+	HeaderStyle        string `yaml:"header_style"`
+	FooterStyle        string `yaml:"footer_style"`
+}
+
+type yamlBlogLayoutConfig struct {
+	ContentMaxWidth string `yaml:"content_max_width"`
+	ShowToc         *bool  `yaml:"show_toc"`
+	TocPosition     string `yaml:"toc_position"`
+	TocWidth        string `yaml:"toc_width"`
+	HeaderStyle     string `yaml:"header_style"`
+	FooterStyle     string `yaml:"footer_style"`
+	ShowAuthor      *bool  `yaml:"show_author"`
+	ShowDate        *bool  `yaml:"show_date"`
+	ShowTags        *bool  `yaml:"show_tags"`
+	ShowReadingTime *bool  `yaml:"show_reading_time"`
+	ShowPrevNext    *bool  `yaml:"show_prev_next"`
+}
+
+type yamlLandingLayoutConfig struct {
+	ContentMaxWidth string `yaml:"content_max_width"`
+	HeaderStyle     string `yaml:"header_style"`
+	HeaderSticky    *bool  `yaml:"header_sticky"`
+	FooterStyle     string `yaml:"footer_style"`
+	HeroEnabled     *bool  `yaml:"hero_enabled"`
+}
+
+type yamlBareLayoutConfig struct {
+	ContentMaxWidth string `yaml:"content_max_width"`
+}
+
+func (l *yamlLayoutConfig) toLayoutConfig() models.LayoutConfig {
+	return models.LayoutConfig{
+		Name:  l.Name,
+		Paths: l.Paths,
+		Feeds: l.Feeds,
+		Docs: models.DocsLayoutConfig{
+			SidebarPosition:    l.Docs.SidebarPosition,
+			SidebarWidth:       l.Docs.SidebarWidth,
+			SidebarCollapsible: l.Docs.SidebarCollapsible,
+			SidebarDefaultOpen: l.Docs.SidebarDefaultOpen,
+			TocPosition:        l.Docs.TocPosition,
+			TocWidth:           l.Docs.TocWidth,
+			TocCollapsible:     l.Docs.TocCollapsible,
+			TocDefaultOpen:     l.Docs.TocDefaultOpen,
+			ContentMaxWidth:    l.Docs.ContentMaxWidth,
+			HeaderStyle:        l.Docs.HeaderStyle,
+			FooterStyle:        l.Docs.FooterStyle,
+		},
+		Blog: models.BlogLayoutConfig{
+			ContentMaxWidth: l.Blog.ContentMaxWidth,
+			ShowToc:         l.Blog.ShowToc,
+			TocPosition:     l.Blog.TocPosition,
+			TocWidth:        l.Blog.TocWidth,
+			HeaderStyle:     l.Blog.HeaderStyle,
+			FooterStyle:     l.Blog.FooterStyle,
+			ShowAuthor:      l.Blog.ShowAuthor,
+			ShowDate:        l.Blog.ShowDate,
+			ShowTags:        l.Blog.ShowTags,
+			ShowReadingTime: l.Blog.ShowReadingTime,
+			ShowPrevNext:    l.Blog.ShowPrevNext,
+		},
+		Landing: models.LandingLayoutConfig{
+			ContentMaxWidth: l.Landing.ContentMaxWidth,
+			HeaderStyle:     l.Landing.HeaderStyle,
+			HeaderSticky:    l.Landing.HeaderSticky,
+			FooterStyle:     l.Landing.FooterStyle,
+			HeroEnabled:     l.Landing.HeroEnabled,
+		},
+		Bare: models.BareLayoutConfig{
+			ContentMaxWidth: l.Bare.ContentMaxWidth,
+		},
+		Defaults: models.LayoutDefaults{
+			ContentMaxWidth: l.Defaults.ContentMaxWidth,
+			HeaderSticky:    l.Defaults.HeaderSticky,
+			FooterSticky:    l.Defaults.FooterSticky,
+		},
+	}
+}
+
+// Sidebar-related YAML structs
+
+type yamlSidebarConfig struct {
+	Enabled      *bool                             `yaml:"enabled"`
+	Position     string                            `yaml:"position"`
+	Width        string                            `yaml:"width"`
+	Collapsible  *bool                             `yaml:"collapsible"`
+	DefaultOpen  *bool                             `yaml:"default_open"`
+	Nav          []yamlSidebarNavItem              `yaml:"nav"`
+	Title        string                            `yaml:"title"`
+	Paths        map[string]*yamlPathSidebarConfig `yaml:"paths"`
+	MultiFeed    *bool                             `yaml:"multi_feed"`
+	Feeds        []string                          `yaml:"feeds"`
+	FeedSections []yamlMultiFeedSection            `yaml:"feed_sections"`
+	AutoGenerate *yamlSidebarAutoGenerate          `yaml:"auto_generate"`
+}
+
+type yamlSidebarNavItem struct {
+	Title    string               `yaml:"title"`
+	Href     string               `yaml:"href"`
+	Children []yamlSidebarNavItem `yaml:"children"`
+}
+
+type yamlPathSidebarConfig struct {
+	Title        string                   `yaml:"title"`
+	AutoGenerate *yamlSidebarAutoGenerate `yaml:"auto_generate"`
+	Items        []yamlSidebarNavItem     `yaml:"items"`
+	Feed         string                   `yaml:"feed"`
+	Position     string                   `yaml:"position"`
+	Collapsible  *bool                    `yaml:"collapsible"`
+}
+
+type yamlSidebarAutoGenerate struct {
+	Directory string   `yaml:"directory"`
+	OrderBy   string   `yaml:"order_by"`
+	Reverse   *bool    `yaml:"reverse"`
+	MaxDepth  int      `yaml:"max_depth"`
+	Exclude   []string `yaml:"exclude"`
+}
+
+type yamlMultiFeedSection struct {
+	Feed      string `yaml:"feed"`
+	Title     string `yaml:"title"`
+	Collapsed *bool  `yaml:"collapsed"`
+	MaxItems  int    `yaml:"max_items"`
+}
+
+func convertYamlSidebarNavItems(items []yamlSidebarNavItem) []models.SidebarNavItem {
+	result := make([]models.SidebarNavItem, len(items))
+	for i, item := range items {
+		result[i] = models.SidebarNavItem{
+			Title:    item.Title,
+			Href:     item.Href,
+			Children: convertYamlSidebarNavItems(item.Children),
+		}
+	}
+	return result
+}
+
+func (s *yamlSidebarConfig) toSidebarConfig() models.SidebarConfig {
+	config := models.SidebarConfig{
+		Enabled:     s.Enabled,
+		Position:    s.Position,
+		Width:       s.Width,
+		Collapsible: s.Collapsible,
+		DefaultOpen: s.DefaultOpen,
+		Nav:         convertYamlSidebarNavItems(s.Nav),
+		Title:       s.Title,
+		MultiFeed:   s.MultiFeed,
+		Feeds:       s.Feeds,
+	}
+
+	// Convert paths
+	if len(s.Paths) > 0 {
+		config.Paths = make(map[string]*models.PathSidebarConfig)
+		for path, pathConfig := range s.Paths {
+			var autoGen *models.SidebarAutoGenerate
+			if pathConfig.AutoGenerate != nil {
+				autoGen = &models.SidebarAutoGenerate{
+					Directory: pathConfig.AutoGenerate.Directory,
+					OrderBy:   pathConfig.AutoGenerate.OrderBy,
+					Reverse:   pathConfig.AutoGenerate.Reverse,
+					MaxDepth:  pathConfig.AutoGenerate.MaxDepth,
+					Exclude:   pathConfig.AutoGenerate.Exclude,
+				}
+			}
+			config.Paths[path] = &models.PathSidebarConfig{
+				Title:        pathConfig.Title,
+				AutoGenerate: autoGen,
+				Items:        convertYamlSidebarNavItems(pathConfig.Items),
+				Feed:         pathConfig.Feed,
+				Position:     pathConfig.Position,
+				Collapsible:  pathConfig.Collapsible,
+			}
+		}
+	}
+
+	// Convert feed sections
+	if len(s.FeedSections) > 0 {
+		config.FeedSections = make([]models.MultiFeedSection, len(s.FeedSections))
+		for i, section := range s.FeedSections {
+			config.FeedSections[i] = models.MultiFeedSection{
+				Feed:      section.Feed,
+				Title:     section.Title,
+				Collapsed: section.Collapsed,
+				MaxItems:  section.MaxItems,
+			}
+		}
+	}
+
+	// Convert auto-generate
+	if s.AutoGenerate != nil {
+		config.AutoGenerate = &models.SidebarAutoGenerate{
+			Directory: s.AutoGenerate.Directory,
+			OrderBy:   s.AutoGenerate.OrderBy,
+			Reverse:   s.AutoGenerate.Reverse,
+			MaxDepth:  s.AutoGenerate.MaxDepth,
+			Exclude:   s.AutoGenerate.Exclude,
+		}
+	}
+
+	return config
+}
+
+// TOC-related YAML structs
+
+type yamlTocConfig struct {
+	Enabled     *bool  `yaml:"enabled"`
+	Position    string `yaml:"position"`
+	Width       string `yaml:"width"`
+	MinDepth    int    `yaml:"min_depth"`
+	MaxDepth    int    `yaml:"max_depth"`
+	Title       string `yaml:"title"`
+	Collapsible *bool  `yaml:"collapsible"`
+	DefaultOpen *bool  `yaml:"default_open"`
+	ScrollSpy   *bool  `yaml:"scroll_spy"`
+}
+
+func (t *yamlTocConfig) toTocConfig() models.TocConfig {
+	return models.TocConfig{
+		Enabled:     t.Enabled,
+		Position:    t.Position,
+		Width:       t.Width,
+		MinDepth:    t.MinDepth,
+		MaxDepth:    t.MaxDepth,
+		Title:       t.Title,
+		Collapsible: t.Collapsible,
+		DefaultOpen: t.DefaultOpen,
+		ScrollSpy:   t.ScrollSpy,
+	}
+}
+
+// Header layout YAML structs
+
+type yamlHeaderLayoutConfig struct {
+	Style           string `yaml:"style"`
+	Sticky          *bool  `yaml:"sticky"`
+	ShowLogo        *bool  `yaml:"show_logo"`
+	ShowTitle       *bool  `yaml:"show_title"`
+	ShowNav         *bool  `yaml:"show_nav"`
+	ShowSearch      *bool  `yaml:"show_search"`
+	ShowThemeToggle *bool  `yaml:"show_theme_toggle"`
+}
+
+func (h *yamlHeaderLayoutConfig) toHeaderLayoutConfig() models.HeaderLayoutConfig {
+	return models.HeaderLayoutConfig{
+		Style:           h.Style,
+		Sticky:          h.Sticky,
+		ShowLogo:        h.ShowLogo,
+		ShowTitle:       h.ShowTitle,
+		ShowNav:         h.ShowNav,
+		ShowSearch:      h.ShowSearch,
+		ShowThemeToggle: h.ShowThemeToggle,
+	}
+}
+
 //nolint:dupl // Intentional duplication - each format has its own conversion method
 func (c *yamlComponentsConfig) toComponentsConfig() models.ComponentsConfig {
 	config := models.ComponentsConfig{
@@ -699,6 +1287,18 @@ func (c *yamlConfig) toConfig() *models.Config {
 	// Convert Components config
 	config.Components = c.Components.toComponentsConfig()
 
+	// Convert Layout config
+	config.Layout = c.Layout.toLayoutConfig()
+
+	// Convert Sidebar config
+	config.Sidebar = c.Sidebar.toSidebarConfig()
+
+	// Convert Toc config
+	config.Toc = c.Toc.toTocConfig()
+
+	// Convert Header config
+	config.Header = c.Header.toHeaderLayoutConfig()
+
 	return config
 }
 
@@ -774,27 +1374,31 @@ func (d *yamlFeedDefaults) toFeedDefaults() models.FeedDefaults {
 
 // jsonConfig is an internal struct for parsing JSON configuration.
 type jsonConfig struct {
-	OutputDir     string                `json:"output_dir"`
-	URL           string                `json:"url"`
-	Title         string                `json:"title"`
-	Description   string                `json:"description"`
-	Author        string                `json:"author"`
-	AssetsDir     string                `json:"assets_dir"`
-	TemplatesDir  string                `json:"templates_dir"`
-	Nav           []jsonNavItem         `json:"nav"`
-	Footer        jsonFooterConfig      `json:"footer"`
-	Hooks         []string              `json:"hooks"`
-	DisabledHooks []string              `json:"disabled_hooks"`
-	Glob          jsonGlobConfig        `json:"glob"`
-	Markdown      jsonMarkdownConfig    `json:"markdown"`
-	Feeds         []jsonFeedConfig      `json:"feeds"`
-	FeedDefaults  jsonFeedDefaults      `json:"feed_defaults"`
-	Concurrency   int                   `json:"concurrency"`
-	PostFormats   jsonPostFormatsConfig `json:"post_formats"`
-	IndieAuth     jsonIndieAuthConfig   `json:"indieauth"`
-	Webmention    jsonWebmentionConfig  `json:"webmention"`
-	SEO           jsonSEOConfig         `json:"seo"`
-	Components    jsonComponentsConfig  `json:"components"`
+	OutputDir     string                 `json:"output_dir"`
+	URL           string                 `json:"url"`
+	Title         string                 `json:"title"`
+	Description   string                 `json:"description"`
+	Author        string                 `json:"author"`
+	AssetsDir     string                 `json:"assets_dir"`
+	TemplatesDir  string                 `json:"templates_dir"`
+	Nav           []jsonNavItem          `json:"nav"`
+	Footer        jsonFooterConfig       `json:"footer"`
+	Hooks         []string               `json:"hooks"`
+	DisabledHooks []string               `json:"disabled_hooks"`
+	Glob          jsonGlobConfig         `json:"glob"`
+	Markdown      jsonMarkdownConfig     `json:"markdown"`
+	Feeds         []jsonFeedConfig       `json:"feeds"`
+	FeedDefaults  jsonFeedDefaults       `json:"feed_defaults"`
+	Concurrency   int                    `json:"concurrency"`
+	PostFormats   jsonPostFormatsConfig  `json:"post_formats"`
+	IndieAuth     jsonIndieAuthConfig    `json:"indieauth"`
+	Webmention    jsonWebmentionConfig   `json:"webmention"`
+	SEO           jsonSEOConfig          `json:"seo"`
+	Components    jsonComponentsConfig   `json:"components"`
+	Layout        jsonLayoutConfig       `json:"layout"`
+	Sidebar       jsonSidebarConfig      `json:"sidebar"`
+	Toc           jsonTocConfig          `json:"toc"`
+	Header        jsonHeaderLayoutConfig `json:"header"`
 }
 
 type jsonNavItem struct {
@@ -939,6 +1543,290 @@ type jsonDocSidebarConfig struct {
 	MaxDepth int    `json:"max_depth"`
 }
 
+// Layout-related JSON structs
+
+type jsonLayoutConfig struct {
+	Name     string                  `json:"name"`
+	Paths    map[string]string       `json:"paths"`
+	Feeds    map[string]string       `json:"feeds"`
+	Docs     jsonDocsLayoutConfig    `json:"docs"`
+	Blog     jsonBlogLayoutConfig    `json:"blog"`
+	Landing  jsonLandingLayoutConfig `json:"landing"`
+	Bare     jsonBareLayoutConfig    `json:"bare"`
+	Defaults jsonLayoutDefaults      `json:"defaults"`
+}
+
+type jsonLayoutDefaults struct {
+	ContentMaxWidth string `json:"content_max_width"`
+	HeaderSticky    *bool  `json:"header_sticky"`
+	FooterSticky    *bool  `json:"footer_sticky"`
+}
+
+type jsonDocsLayoutConfig struct {
+	SidebarPosition    string `json:"sidebar_position"`
+	SidebarWidth       string `json:"sidebar_width"`
+	SidebarCollapsible *bool  `json:"sidebar_collapsible"`
+	SidebarDefaultOpen *bool  `json:"sidebar_default_open"`
+	TocPosition        string `json:"toc_position"`
+	TocWidth           string `json:"toc_width"`
+	TocCollapsible     *bool  `json:"toc_collapsible"`
+	TocDefaultOpen     *bool  `json:"toc_default_open"`
+	ContentMaxWidth    string `json:"content_max_width"`
+	HeaderStyle        string `json:"header_style"`
+	FooterStyle        string `json:"footer_style"`
+}
+
+type jsonBlogLayoutConfig struct {
+	ContentMaxWidth string `json:"content_max_width"`
+	ShowToc         *bool  `json:"show_toc"`
+	TocPosition     string `json:"toc_position"`
+	TocWidth        string `json:"toc_width"`
+	HeaderStyle     string `json:"header_style"`
+	FooterStyle     string `json:"footer_style"`
+	ShowAuthor      *bool  `json:"show_author"`
+	ShowDate        *bool  `json:"show_date"`
+	ShowTags        *bool  `json:"show_tags"`
+	ShowReadingTime *bool  `json:"show_reading_time"`
+	ShowPrevNext    *bool  `json:"show_prev_next"`
+}
+
+type jsonLandingLayoutConfig struct {
+	ContentMaxWidth string `json:"content_max_width"`
+	HeaderStyle     string `json:"header_style"`
+	HeaderSticky    *bool  `json:"header_sticky"`
+	FooterStyle     string `json:"footer_style"`
+	HeroEnabled     *bool  `json:"hero_enabled"`
+}
+
+type jsonBareLayoutConfig struct {
+	ContentMaxWidth string `json:"content_max_width"`
+}
+
+func (l *jsonLayoutConfig) toLayoutConfig() models.LayoutConfig {
+	return models.LayoutConfig{
+		Name:  l.Name,
+		Paths: l.Paths,
+		Feeds: l.Feeds,
+		Docs: models.DocsLayoutConfig{
+			SidebarPosition:    l.Docs.SidebarPosition,
+			SidebarWidth:       l.Docs.SidebarWidth,
+			SidebarCollapsible: l.Docs.SidebarCollapsible,
+			SidebarDefaultOpen: l.Docs.SidebarDefaultOpen,
+			TocPosition:        l.Docs.TocPosition,
+			TocWidth:           l.Docs.TocWidth,
+			TocCollapsible:     l.Docs.TocCollapsible,
+			TocDefaultOpen:     l.Docs.TocDefaultOpen,
+			ContentMaxWidth:    l.Docs.ContentMaxWidth,
+			HeaderStyle:        l.Docs.HeaderStyle,
+			FooterStyle:        l.Docs.FooterStyle,
+		},
+		Blog: models.BlogLayoutConfig{
+			ContentMaxWidth: l.Blog.ContentMaxWidth,
+			ShowToc:         l.Blog.ShowToc,
+			TocPosition:     l.Blog.TocPosition,
+			TocWidth:        l.Blog.TocWidth,
+			HeaderStyle:     l.Blog.HeaderStyle,
+			FooterStyle:     l.Blog.FooterStyle,
+			ShowAuthor:      l.Blog.ShowAuthor,
+			ShowDate:        l.Blog.ShowDate,
+			ShowTags:        l.Blog.ShowTags,
+			ShowReadingTime: l.Blog.ShowReadingTime,
+			ShowPrevNext:    l.Blog.ShowPrevNext,
+		},
+		Landing: models.LandingLayoutConfig{
+			ContentMaxWidth: l.Landing.ContentMaxWidth,
+			HeaderStyle:     l.Landing.HeaderStyle,
+			HeaderSticky:    l.Landing.HeaderSticky,
+			FooterStyle:     l.Landing.FooterStyle,
+			HeroEnabled:     l.Landing.HeroEnabled,
+		},
+		Bare: models.BareLayoutConfig{
+			ContentMaxWidth: l.Bare.ContentMaxWidth,
+		},
+		Defaults: models.LayoutDefaults{
+			ContentMaxWidth: l.Defaults.ContentMaxWidth,
+			HeaderSticky:    l.Defaults.HeaderSticky,
+			FooterSticky:    l.Defaults.FooterSticky,
+		},
+	}
+}
+
+// Sidebar-related JSON structs
+
+type jsonSidebarConfig struct {
+	Enabled      *bool                             `json:"enabled"`
+	Position     string                            `json:"position"`
+	Width        string                            `json:"width"`
+	Collapsible  *bool                             `json:"collapsible"`
+	DefaultOpen  *bool                             `json:"default_open"`
+	Nav          []jsonSidebarNavItem              `json:"nav"`
+	Title        string                            `json:"title"`
+	Paths        map[string]*jsonPathSidebarConfig `json:"paths"`
+	MultiFeed    *bool                             `json:"multi_feed"`
+	Feeds        []string                          `json:"feeds"`
+	FeedSections []jsonMultiFeedSection            `json:"feed_sections"`
+	AutoGenerate *jsonSidebarAutoGenerate          `json:"auto_generate"`
+}
+
+type jsonSidebarNavItem struct {
+	Title    string               `json:"title"`
+	Href     string               `json:"href"`
+	Children []jsonSidebarNavItem `json:"children"`
+}
+
+type jsonPathSidebarConfig struct {
+	Title        string                   `json:"title"`
+	AutoGenerate *jsonSidebarAutoGenerate `json:"auto_generate"`
+	Items        []jsonSidebarNavItem     `json:"items"`
+	Feed         string                   `json:"feed"`
+	Position     string                   `json:"position"`
+	Collapsible  *bool                    `json:"collapsible"`
+}
+
+type jsonSidebarAutoGenerate struct {
+	Directory string   `json:"directory"`
+	OrderBy   string   `json:"order_by"`
+	Reverse   *bool    `json:"reverse"`
+	MaxDepth  int      `json:"max_depth"`
+	Exclude   []string `json:"exclude"`
+}
+
+type jsonMultiFeedSection struct {
+	Feed      string `json:"feed"`
+	Title     string `json:"title"`
+	Collapsed *bool  `json:"collapsed"`
+	MaxItems  int    `json:"max_items"`
+}
+
+func convertJsonSidebarNavItems(items []jsonSidebarNavItem) []models.SidebarNavItem {
+	result := make([]models.SidebarNavItem, len(items))
+	for i, item := range items {
+		result[i] = models.SidebarNavItem{
+			Title:    item.Title,
+			Href:     item.Href,
+			Children: convertJsonSidebarNavItems(item.Children),
+		}
+	}
+	return result
+}
+
+func (s *jsonSidebarConfig) toSidebarConfig() models.SidebarConfig {
+	config := models.SidebarConfig{
+		Enabled:     s.Enabled,
+		Position:    s.Position,
+		Width:       s.Width,
+		Collapsible: s.Collapsible,
+		DefaultOpen: s.DefaultOpen,
+		Nav:         convertJsonSidebarNavItems(s.Nav),
+		Title:       s.Title,
+		MultiFeed:   s.MultiFeed,
+		Feeds:       s.Feeds,
+	}
+
+	// Convert paths
+	if len(s.Paths) > 0 {
+		config.Paths = make(map[string]*models.PathSidebarConfig)
+		for path, pathConfig := range s.Paths {
+			var autoGen *models.SidebarAutoGenerate
+			if pathConfig.AutoGenerate != nil {
+				autoGen = &models.SidebarAutoGenerate{
+					Directory: pathConfig.AutoGenerate.Directory,
+					OrderBy:   pathConfig.AutoGenerate.OrderBy,
+					Reverse:   pathConfig.AutoGenerate.Reverse,
+					MaxDepth:  pathConfig.AutoGenerate.MaxDepth,
+					Exclude:   pathConfig.AutoGenerate.Exclude,
+				}
+			}
+			config.Paths[path] = &models.PathSidebarConfig{
+				Title:        pathConfig.Title,
+				AutoGenerate: autoGen,
+				Items:        convertJsonSidebarNavItems(pathConfig.Items),
+				Feed:         pathConfig.Feed,
+				Position:     pathConfig.Position,
+				Collapsible:  pathConfig.Collapsible,
+			}
+		}
+	}
+
+	// Convert feed sections
+	if len(s.FeedSections) > 0 {
+		config.FeedSections = make([]models.MultiFeedSection, len(s.FeedSections))
+		for i, section := range s.FeedSections {
+			config.FeedSections[i] = models.MultiFeedSection{
+				Feed:      section.Feed,
+				Title:     section.Title,
+				Collapsed: section.Collapsed,
+				MaxItems:  section.MaxItems,
+			}
+		}
+	}
+
+	// Convert auto-generate
+	if s.AutoGenerate != nil {
+		config.AutoGenerate = &models.SidebarAutoGenerate{
+			Directory: s.AutoGenerate.Directory,
+			OrderBy:   s.AutoGenerate.OrderBy,
+			Reverse:   s.AutoGenerate.Reverse,
+			MaxDepth:  s.AutoGenerate.MaxDepth,
+			Exclude:   s.AutoGenerate.Exclude,
+		}
+	}
+
+	return config
+}
+
+// TOC-related JSON structs
+
+type jsonTocConfig struct {
+	Enabled     *bool  `json:"enabled"`
+	Position    string `json:"position"`
+	Width       string `json:"width"`
+	MinDepth    int    `json:"min_depth"`
+	MaxDepth    int    `json:"max_depth"`
+	Title       string `json:"title"`
+	Collapsible *bool  `json:"collapsible"`
+	DefaultOpen *bool  `json:"default_open"`
+	ScrollSpy   *bool  `json:"scroll_spy"`
+}
+
+func (t *jsonTocConfig) toTocConfig() models.TocConfig {
+	return models.TocConfig{
+		Enabled:     t.Enabled,
+		Position:    t.Position,
+		Width:       t.Width,
+		MinDepth:    t.MinDepth,
+		MaxDepth:    t.MaxDepth,
+		Title:       t.Title,
+		Collapsible: t.Collapsible,
+		DefaultOpen: t.DefaultOpen,
+		ScrollSpy:   t.ScrollSpy,
+	}
+}
+
+// Header layout JSON structs
+
+type jsonHeaderLayoutConfig struct {
+	Style           string `json:"style"`
+	Sticky          *bool  `json:"sticky"`
+	ShowLogo        *bool  `json:"show_logo"`
+	ShowTitle       *bool  `json:"show_title"`
+	ShowNav         *bool  `json:"show_nav"`
+	ShowSearch      *bool  `json:"show_search"`
+	ShowThemeToggle *bool  `json:"show_theme_toggle"`
+}
+
+func (h *jsonHeaderLayoutConfig) toHeaderLayoutConfig() models.HeaderLayoutConfig {
+	return models.HeaderLayoutConfig{
+		Style:           h.Style,
+		Sticky:          h.Sticky,
+		ShowLogo:        h.ShowLogo,
+		ShowTitle:       h.ShowTitle,
+		ShowNav:         h.ShowNav,
+		ShowSearch:      h.ShowSearch,
+		ShowThemeToggle: h.ShowThemeToggle,
+	}
+}
+
 //nolint:dupl // Intentional duplication - each format has its own conversion method
 func (c *jsonComponentsConfig) toComponentsConfig() models.ComponentsConfig {
 	config := models.ComponentsConfig{
@@ -1044,8 +1932,20 @@ func (c *jsonConfig) toConfig() *models.Config {
 	config.IndieAuth = c.IndieAuth.toIndieAuthConfig()
 	config.Webmention = c.Webmention.toWebmentionConfig()
 
-	// Convert components config
+	// Convert Components config
 	config.Components = c.Components.toComponentsConfig()
+
+	// Convert Layout config
+	config.Layout = c.Layout.toLayoutConfig()
+
+	// Convert Sidebar config
+	config.Sidebar = c.Sidebar.toSidebarConfig()
+
+	// Convert Toc config
+	config.Toc = c.Toc.toTocConfig()
+
+	// Convert Header config
+	config.Header = c.Header.toHeaderLayoutConfig()
 
 	return config
 }

--- a/pkg/models/layout.go
+++ b/pkg/models/layout.go
@@ -74,21 +74,21 @@ func (l *LayoutConfig) ResolveLayout(postPath, feedSlug string) string {
 
 // LayoutToTemplate converts a layout name to a template file path.
 // Layout names map to templates as follows:
-//   - "docs" -> "docs.html"
+//   - "docs" -> "layouts/docs.html"
 //   - "blog" -> "post.html"
-//   - "landing" -> "landing.html"
-//   - "bare" -> "bare.html"
+//   - "landing" -> "layouts/landing.html"
+//   - "bare" -> "layouts/bare.html"
 //   - "" (empty) -> "post.html" (default)
 func LayoutToTemplate(layout string) string {
 	switch layout {
 	case "docs":
-		return "docs.html"
+		return "layouts/docs.html"
 	case layoutBlog, "":
 		return "post.html"
 	case "landing":
-		return "landing.html"
+		return "layouts/landing.html"
 	case "bare":
-		return "bare.html"
+		return "layouts/bare.html"
 	default:
 		// For custom layouts, assume the layout name is the template name
 		if strings.HasSuffix(layout, ".html") {

--- a/pkg/models/post.go
+++ b/pkg/models/post.go
@@ -84,7 +84,7 @@ func NewPost(path string) *Post {
 		Draft:     false,
 		Skip:      false,
 		Tags:      []string{},
-		Template:  "post.html",
+		Template:  "", // Empty - let templates plugin resolve from layout config
 		Extra:     make(map[string]interface{}),
 	}
 }

--- a/pkg/models/post_test.go
+++ b/pkg/models/post_test.go
@@ -322,8 +322,8 @@ func TestPost_NewPost(t *testing.T) {
 	if p.Skip != false {
 		t.Error("Skip should default to false")
 	}
-	if p.Template != "post.html" {
-		t.Errorf("Template: got %q, want 'post.html'", p.Template)
+	if p.Template != "" {
+		t.Errorf("Template: got %q, want empty string (templates plugin resolves default)", p.Template)
 	}
 	if p.Tags == nil {
 		t.Error("Tags should be initialized")

--- a/pkg/plugins/templates.go
+++ b/pkg/plugins/templates.go
@@ -198,6 +198,26 @@ func toModelsConfig(config *lifecycle.Config) *models.Config {
 		modelsConfig.Footer = footer
 	}
 
+	// Copy layout config if available
+	if layout, ok := config.Extra["layout"].(*models.LayoutConfig); ok {
+		modelsConfig.Layout = *layout
+	}
+
+	// Copy sidebar config if available
+	if sidebar, ok := config.Extra["sidebar"].(models.SidebarConfig); ok {
+		modelsConfig.Sidebar = sidebar
+	}
+
+	// Copy toc config if available
+	if toc, ok := config.Extra["toc"].(models.TocConfig); ok {
+		modelsConfig.Toc = toc
+	}
+
+	// Copy header config if available
+	if header, ok := config.Extra["header"].(models.HeaderLayoutConfig); ok {
+		modelsConfig.Header = header
+	}
+
 	return modelsConfig
 }
 

--- a/pkg/plugins/templates_test.go
+++ b/pkg/plugins/templates_test.go
@@ -247,7 +247,7 @@ func TestTemplatesPlugin_ResolveTemplate(t *testing.T) {
 			post: &models.Post{
 				Href: "/docs/getting-started/",
 			},
-			want: "docs.html",
+			want: "layouts/docs.html",
 		},
 		{
 			name: "path-based layout with longest prefix wins",
@@ -261,7 +261,7 @@ func TestTemplatesPlugin_ResolveTemplate(t *testing.T) {
 			post: &models.Post{
 				Href: "/docs/api/endpoint/",
 			},
-			want: "bare.html",
+			want: "layouts/bare.html",
 		},
 		{
 			name: "feed-based layout selection",
@@ -273,7 +273,7 @@ func TestTemplatesPlugin_ResolveTemplate(t *testing.T) {
 				Href:         "/some/path/",
 				PrevNextFeed: "documentation",
 			},
-			want: "docs.html",
+			want: "layouts/docs.html",
 		},
 		{
 			name: "path takes priority over feed",
@@ -297,7 +297,7 @@ func TestTemplatesPlugin_ResolveTemplate(t *testing.T) {
 			post: &models.Post{
 				Href: "/unmatched/path/",
 			},
-			want: "docs.html",
+			want: "layouts/docs.html",
 		},
 		{
 			name: "landing layout",
@@ -308,7 +308,7 @@ func TestTemplatesPlugin_ResolveTemplate(t *testing.T) {
 			post: &models.Post{
 				Href: "/",
 			},
-			want: "landing.html",
+			want: "layouts/landing.html",
 		},
 		{
 			name: "feed from Extra field",
@@ -320,7 +320,7 @@ func TestTemplatesPlugin_ResolveTemplate(t *testing.T) {
 				Href:  "/guides/intro/",
 				Extra: map[string]interface{}{"feed": "guides"},
 			},
-			want: "docs.html",
+			want: "layouts/docs.html",
 		},
 		{
 			name:         "nil layout config falls back to post.html",
@@ -409,10 +409,10 @@ func TestLayoutToTemplate(t *testing.T) {
 		layout string
 		want   string
 	}{
-		{"docs", "docs.html"},
+		{"docs", "layouts/docs.html"},
 		{"blog", "post.html"},
-		{"landing", "landing.html"},
-		{"bare", "bare.html"},
+		{"landing", "layouts/landing.html"},
+		{"bare", "layouts/bare.html"},
 		{"", "post.html"},
 		{"custom", "custom.html"},
 		{"already.html", "already.html"},

--- a/templates/base.html
+++ b/templates/base.html
@@ -191,7 +191,7 @@
                     showSubResults: {{ config.search.show_sub_results | default:false | yesno:"true,false" }},
                     resetStyles: false,
                     translations: {
-                        placeholder: "{{ config.search.placeholder | default:'Search (Press / or \u2318K)' }}"
+                        placeholder: "{{ config.search.placeholder | default:'Search' }}"
                     }
                 });
             }

--- a/templates/components/doc_sidebar.html
+++ b/templates/components/doc_sidebar.html
@@ -1,15 +1,15 @@
 {# Document sidebar (Table of Contents) component template #}
 {# Usage: {% include "components/doc_sidebar.html" %} #}
 {# Requires: config.components.doc_sidebar (DocSidebarConfig) #}
-{# Requires: post.Extra.toc ([]TocEntry) from toc plugin #}
+{# Requires: post.toc ([]TocEntry) from toc plugin #}
 
 {% with sidebar = config.components.doc_sidebar %}
-{% if sidebar.enabled and post.Extra.toc %}
+{% if sidebar.enabled and post.toc %}
 <aside class="doc-sidebar doc-sidebar--{{ sidebar.position | default:'right' }}" style="width: {{ sidebar.width | default:'250px' }}" data-pagefind-ignore>
     <nav class="toc" aria-label="Table of Contents">
         <h2 class="toc-title">On this page</h2>
         <ul class="toc-list">
-            {% for entry in post.Extra.toc %}
+            {% for entry in post.toc %}
             {% if entry.Level >= sidebar.min_depth and entry.Level <= sidebar.max_depth %}
             <li class="toc-item toc-item--level-{{ entry.Level }}">
                 <a href="#{{ entry.ID }}" class="toc-link">{{ entry.Text }}</a>

--- a/templates/components/toc_list.html
+++ b/templates/components/toc_list.html
@@ -1,8 +1,8 @@
 {# TOC List Component - Table of contents list from post headings #}
-{% if post.Extra.toc %}
+{% if post.toc %}
 <nav class="toc-nav" aria-label="Table of contents">
     <ul class="toc-list">
-        {% for heading in post.Extra.toc %}
+        {% for heading in post.toc %}
         <li class="toc-item toc-item--h{{ heading.level }}" data-level="{{ heading.level }}">
             <a href="#{{ heading.id }}" class="toc-link">{{ heading.text }}</a>
             {% if heading.children %}

--- a/templates/layouts/blog.html
+++ b/templates/layouts/blog.html
@@ -89,7 +89,7 @@
         </article>
     </main>
     
-    {% if config.layout.blog.show_toc and post.Extra.toc %}
+    {% if config.layout.blog.show_toc and post.toc %}
     <aside class="layout-toc layout-toc--{{ config.layout.blog.toc_position | default:'right' }}" 
            role="complementary" 
            aria-label="Table of Contents"

--- a/templates/layouts/docs.html
+++ b/templates/layouts/docs.html
@@ -68,7 +68,7 @@
         </article>
     </main>
     
-    {% if config.toc.enabled and post.Extra.toc %}
+    {% if config.toc.enabled and post.toc %}
     <aside class="layout-toc layout-toc--{{ config.layout.docs.toc_position | default:'right' }}" 
            role="complementary" 
            aria-label="Table of Contents"

--- a/templates/post.html
+++ b/templates/post.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
-<div class="content-wrapper{% if config.components.doc_sidebar.enabled and post.Extra.toc %} content-wrapper--with-sidebar content-wrapper--sidebar-{{ config.components.doc_sidebar.position | default:'right' }}{% endif %}">
+<div class="content-wrapper{% if config.components.doc_sidebar.enabled and post.toc %} content-wrapper--with-sidebar content-wrapper--sidebar-{{ config.components.doc_sidebar.position | default:'right' }}{% endif %}">
     <article>
         <header>
             <h1>{{ post.title }}</h1>


### PR DESCRIPTION
## Summary

- Fixes layout config not being passed through the config merging pipeline
- Enables the docs layout with left sidebar navigation and right-side table of contents
- Adds proper URL slugs to documentation files for clean `/docs/guides/*` paths

## Changes

### Config Merging (`pkg/config/merge.go`)
- Add merge functions for `Layout`, `Sidebar`, `Toc`, `Header` configs
- Ensures layout configuration flows through the entire pipeline

### Template Context (`pkg/templates/context.go`)
- Add `tocEntriesToMaps()` function using reflection to convert TOC entries to template-friendly maps
- Add layout, sidebar, toc, header configs to template context
- Fix TOC struct fields not being accessible in pongo2 templates

### Post Model (`pkg/models/post.go`)
- Change default `Template` from `"post.html"` to `""` (empty string)
- Allows layout-based template resolution to work correctly

### Templates
- Update `post.toc` references (was `post.Extra.toc`)
- Fix template variable access for TOC rendering

### Documentation
- Add explicit `slug` frontmatter to guide and reference docs
- URLs now match sidebar navigation links (`/docs/guides/configuration/`, etc.)

### Configuration (`markata-go.toml`)
- Add sidebar navigation structure
- Configure TOC settings

## Testing

- All tests pass (`go test ./...`)
- Build succeeds with proper docs layout rendering
- Sidebar links now work correctly
- TOC displays heading text, IDs, and levels properly