### PR TITLE
chore: Remove explicit template frontmatter from docs

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -3,7 +3,6 @@ title: "Advanced Usage"
 description: "Power user guide covering complex configurations, optimization techniques, and advanced patterns"
 date: 2024-01-15
 published: true
-template: doc.html
 tags:
   - documentation
   - advanced

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -3,7 +3,6 @@ title: "Framework Comparison"
 description: "Comprehensive comparison of markata-go against Hugo, Jekyll, Eleventy, Astro, Zola, and Pelican"
 date: 2024-01-15
 published: true
-template: doc.html
 tags:
   - documentation
   - comparison

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,7 +3,6 @@ title: "Getting Started"
 description: "Complete guide to installing markata-go, creating your first site, and building for production"
 date: 2024-01-15
 published: true
-template: doc.html
 tags:
   - documentation
   - getting-started

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -3,7 +3,6 @@ title: "Deployment Guide"
 description: "Guide to deploying markata-go sites to GitHub Pages, Netlify, Vercel, and self-hosted solutions"
 date: 2024-01-15
 published: true
-template: doc.html
 tags:
   - documentation
   - deployment

--- a/docs/guides/dynamic-content.md
+++ b/docs/guides/dynamic-content.md
@@ -3,7 +3,6 @@ title: "Dynamic Content"
 description: "Using Jinja2 template syntax in Markdown files for dynamic content generation"
 date: 2024-01-15
 published: true
-template: doc.html
 tags:
   - documentation
   - jinja

--- a/docs/guides/plugin-development.md
+++ b/docs/guides/plugin-development.md
@@ -3,7 +3,6 @@ title: "Plugin Development"
 description: "Guide to creating custom plugins for markata-go using the 9-stage lifecycle"
 date: 2024-01-15
 published: true
-template: doc.html
 tags:
   - documentation
   - plugins

--- a/docs/guides/self-hosting.md
+++ b/docs/guides/self-hosting.md
@@ -3,7 +3,6 @@ title: "Self-Hosting Guide"
 description: "Deploy markata-go sites on your own servers using Docker, systemd, or manual setups"
 date: 2024-01-23
 published: true
-template: doc.html
 tags:
   - documentation
   - deployment

--- a/docs/guides/syndication-feeds.md
+++ b/docs/guides/syndication-feeds.md
@@ -3,7 +3,6 @@ title: "Syndication Feeds"
 description: "Guide to generating Sitemap, RSS, Atom, and JSON Feed outputs for your site"
 date: 2024-01-15
 published: true
-template: doc.html
 tags:
   - documentation
   - feeds

--- a/docs/guides/youtube.md
+++ b/docs/guides/youtube.md
@@ -3,7 +3,6 @@ title: "Embedding YouTube Videos"
 description: "How to embed YouTube videos in your posts with a simple one-line URL"
 date: 2024-01-15
 published: true
-template: doc.html
 tags:
   - documentation
   - guides

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -3,7 +3,6 @@ title: "Quickstart"
 description: "Get a markata-go site running in under 5 minutes"
 date: 2024-01-15
 published: true
-template: doc.html
 tags:
   - documentation
   - getting-started

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -3,7 +3,6 @@ title: "Troubleshooting"
 description: "Solutions for common issues when working with markata-go"
 date: 2024-01-15
 published: true
-template: doc.html
 tags:
   - documentation
   - troubleshooting


### PR DESCRIPTION
Layout-based template resolution now handles template selection automatically, so explicit `template: doc.html` is no longer needed in frontmatter.