### PR TITLE
fix(layout): Improve spacing between sidebars and content

### DIFF
--- a/themes/default/static/css/layouts.css
+++ b/themes/default/static/css/layouts.css
@@ -12,7 +12,9 @@
   /* Layout dimensions */
   --layout-sidebar-width: 280px;
   --layout-toc-width: 220px;
-  --layout-content-max-width: 800px;
+  --layout-content-max-width: 860px;
+  --layout-content-padding: var(--space-6);
+  --layout-gap: var(--space-8);
   --layout-header-height: 64px;
   
   /* Z-index layers */
@@ -50,8 +52,8 @@
 .layout--docs .layout-container {
   grid-template-columns: var(--sidebar-width, var(--layout-sidebar-width)) minmax(0, 1fr) var(--toc-width, var(--layout-toc-width));
   grid-template-areas: "sidebar content toc";
-  gap: var(--space-6);
-  max-width: calc(var(--layout-sidebar-width) + var(--layout-content-max-width) + var(--layout-toc-width) + var(--space-12));
+  gap: var(--layout-gap);
+  max-width: calc(var(--layout-sidebar-width) + var(--layout-content-max-width) + var(--layout-toc-width) + var(--layout-gap) * 2 + var(--layout-content-padding) * 2);
 }
 
 /* Sidebar on right variant */
@@ -79,8 +81,8 @@
 .layout--blog.layout-container--with-toc {
   grid-template-columns: minmax(0, 1fr) var(--toc-width, 200px);
   grid-template-areas: "content toc";
-  gap: var(--space-6);
-  max-width: calc(var(--layout-content-max-width) + 200px + var(--space-6));
+  gap: var(--layout-gap);
+  max-width: calc(var(--layout-content-max-width) + 200px + var(--layout-gap));
 }
 
 /* ==========================================================================
@@ -120,7 +122,7 @@
 .layout-content {
   grid-area: content;
   min-width: 0; /* Prevent overflow */
-  padding: var(--space-8) 0;
+  padding: var(--space-8) var(--layout-content-padding);
 }
 
 .layout-content--blog {


### PR DESCRIPTION
## Summary
- Increase gap between layout columns from 24px to 32px for better visual separation
- Widen content area from 800px to 860px for improved readability
- Add horizontal padding (24px) to content area for breathing room

## Changes
- `--layout-content-max-width`: 800px → 860px
- `--layout-gap`: new variable set to `var(--space-8)` (32px)
- `--layout-content-padding`: new variable set to `var(--space-6)` (24px)
- Updated `.layout-content` padding from `var(--space-8) 0` to `var(--space-8) var(--layout-content-padding)`
- Updated max-width calculations for docs and blog layouts

Fixes #151