### PR TITLE
feat(pagefind): Suppress verbose logs by default

### DIFF
--- a/cmd/markata-go/cmd/core.go
+++ b/cmd/markata-go/cmd/core.go
@@ -78,6 +78,15 @@ func createManager(cfgPath string) (*lifecycle.Manager, error) {
 	lcConfig.Extra["toc"] = cfg.Toc
 	lcConfig.Extra["header"] = cfg.Header
 
+	// Pass search configuration with verbose flag override from CLI
+	searchConfig := cfg.Search
+	if verbose {
+		// CLI --verbose flag overrides config setting
+		v := true
+		searchConfig.Pagefind.Verbose = &v
+	}
+	lcConfig.Extra["search"] = searchConfig
+
 	m.SetConfig(lcConfig)
 
 	// Set concurrency if specified

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -383,6 +383,10 @@ type PagefindConfig struct {
 
 	// CacheDir is the directory for caching Pagefind binaries (default: XDG cache)
 	CacheDir string `json:"cache_dir,omitempty" yaml:"cache_dir,omitempty" toml:"cache_dir,omitempty"`
+
+	// Verbose enables verbose output from Pagefind (default: false)
+	// When false, only errors are shown. When true or when --verbose CLI flag is used, all output is shown.
+	Verbose *bool `json:"verbose,omitempty" yaml:"verbose,omitempty" toml:"verbose,omitempty"`
 }
 
 // IsAutoInstallEnabled returns whether automatic Pagefind installation is enabled.
@@ -392,6 +396,15 @@ func (p *PagefindConfig) IsAutoInstallEnabled() bool {
 		return true
 	}
 	return *p.AutoInstall
+}
+
+// IsVerbose returns whether verbose output is enabled.
+// Defaults to false if not explicitly set.
+func (p *PagefindConfig) IsVerbose() bool {
+	if p.Verbose == nil {
+		return false
+	}
+	return *p.Verbose
 }
 
 // SearchFeedConfig configures a feed-specific search instance.

--- a/pkg/plugins/pagefind_installer_test.go
+++ b/pkg/plugins/pagefind_installer_test.go
@@ -249,7 +249,7 @@ func TestVerifyChecksum(t *testing.T) {
 		hasher.Write(content)
 		expectedChecksum := hex.EncodeToString(hasher.Sum(nil))
 
-		err := verifyChecksum(filePath, expectedChecksum)
+		err := verifyChecksum(filePath, expectedChecksum, false)
 		if err != nil {
 			t.Errorf("verifyChecksum() unexpected error: %v", err)
 		}
@@ -266,7 +266,7 @@ func TestVerifyChecksum(t *testing.T) {
 		// Use wrong checksum
 		wrongChecksum := "0000000000000000000000000000000000000000000000000000000000000000"
 
-		err := verifyChecksum(filePath, wrongChecksum)
+		err := verifyChecksum(filePath, wrongChecksum, false)
 		if err == nil {
 			t.Error("verifyChecksum() should fail with wrong checksum")
 		}
@@ -280,7 +280,7 @@ func TestVerifyChecksum(t *testing.T) {
 	})
 
 	t.Run("file_not_found", func(t *testing.T) {
-		err := verifyChecksum(filepath.Join(tmpDir, "nonexistent.bin"), "somechecksum")
+		err := verifyChecksum(filepath.Join(tmpDir, "nonexistent.bin"), "somechecksum", false)
 		if err == nil {
 			t.Error("verifyChecksum() should fail for non-existent file")
 		}


### PR DESCRIPTION
## Summary

- Suppress Pagefind output by default during build and serve commands
- Show Pagefind logs when `--verbose` CLI flag is used
- Add optional config option `[search.pagefind] verbose = true`
- Still show Pagefind errors when output is suppressed

## Changes

- Add `Verbose` field to `PagefindConfig` in `pkg/models/config.go`
- Add `IsVerbose()` helper method with default of `false`
- Update `cmd/markata-go/cmd/core.go` to pass CLI `--verbose` flag to search config
- Update `PagefindPlugin` to respect verbose setting
- Update `PagefindInstaller` to respect verbose setting
- Update installer tests for new function signature

## Testing

- `go test ./...` ✅
- `golangci-lint run --timeout=5m ./...` ✅

Fixes #144