### PR TITLE
feat(migrate): Add migration tool from Python markata

### DIFF
--- a/pkg/migrate/report.go
+++ b/pkg/migrate/report.go
@@ -5,6 +5,14 @@ import (
 	"strings"
 )
 
+// Status symbols for report output.
+const (
+	symbolSuccess = "[OK]"
+	symbolWarning = "[WARN]"
+	symbolError   = "[ERROR]"
+	symbolMigrate = "[MIGRATE]"
+)
+
 // Report generates a human-readable migration report.
 func (r *MigrationResult) Report() string {
 	var sb strings.Builder
@@ -72,8 +80,7 @@ func (r *MigrationResult) writeConfigChanges(sb *strings.Builder) {
 	sb.WriteString(strings.Repeat("-", 80) + "\n\n")
 
 	for _, change := range r.Changes {
-		icon := "[MIGRATE]"
-		fmt.Fprintf(sb, "  %s %s\n", icon, change.Description)
+		fmt.Fprintf(sb, "  %s %s\n", symbolMigrate, change.Description)
 	}
 	sb.WriteString("\n")
 }
@@ -96,9 +103,9 @@ func (r *MigrationResult) writeFilterMigrations(sb *strings.Builder) {
 		fmt.Fprintf(sb, "  Feed: %s\n", feedName)
 
 		if len(fm.Changes) == 0 {
-			fmt.Fprintf(sb, "    [OK] %s (no changes needed)\n", fm.Original)
+			fmt.Fprintf(sb, "    %s %s (no changes needed)\n", symbolSuccess, fm.Original)
 		} else {
-			fmt.Fprintf(sb, "    [MIGRATE] %s\n", fm.Original)
+			fmt.Fprintf(sb, "    %s %s\n", symbolMigrate, fm.Original)
 			fmt.Fprintf(sb, "           -> %s\n", fm.Migrated)
 			for _, c := range fm.Changes {
 				fmt.Fprintf(sb, "           (%s)\n", c)
@@ -106,7 +113,7 @@ func (r *MigrationResult) writeFilterMigrations(sb *strings.Builder) {
 		}
 
 		if !fm.Valid {
-			fmt.Fprintf(sb, "    [ERROR] Invalid: %s\n", fm.Error)
+			fmt.Fprintf(sb, "    %s Invalid: %s\n", symbolError, fm.Error)
 		}
 		sb.WriteString("\n")
 	}
@@ -123,7 +130,7 @@ func (r *MigrationResult) writeWarnings(sb *strings.Builder) {
 	sb.WriteString(strings.Repeat("-", 80) + "\n\n")
 
 	for _, w := range r.Warnings {
-		fmt.Fprintf(sb, "  [WARN] %s\n", w.Message)
+		fmt.Fprintf(sb, "  %s %s\n", symbolWarning, w.Message)
 		if w.Path != "" {
 			fmt.Fprintf(sb, "         Path: %s\n", w.Path)
 		}


### PR DESCRIPTION
## Summary

This PR implements Issue #128: Migration tool from Python markata to markata-go.

- Adds comprehensive config migration with namespace and key renames
- Implements filter expression translation (boolean literals, `in` operator, spacing)
- Includes template compatibility checking for Jinja2 vs Pongo2 differences
- Provides detailed migration reports with warnings and suggestions

## Features

### Config Migration
- Namespace: `[markata]` -> `[markata-go]`
- Key renames: `glob_patterns` -> `patterns`, `author_name` -> `author`, `twitter_creator` -> `twitter_handle`
- Nav map to array conversion
- Feed filter expression migration

### Filter Translation
- `published == 'True'` -> `published == True`
- `templateKey in ['a', 'b']` -> `templateKey == 'a' or templateKey == 'b'`
- Operator spacing fixes

### Template Checking
- Warns about unsupported Jinja2 features (macros, do statements)
- Identifies variable name changes (post.markata -> config)
- Flags Python expression usage

### CLI Commands
```bash
markata-go migrate                     # Full migration report
markata-go migrate config              # Config file only
markata-go migrate filter "expr"       # Translate filter expression
markata-go migrate templates           # Check template compatibility
markata-go migrate --report report.md  # Write report to file
markata-go migrate --json              # JSON output
```

## Testing

- All existing tests pass
- Added new tests for key renames and unsupported hook detection
- Lint passes with `golangci-lint run --timeout=5m ./...`

Fixes #128