### PR TITLE
fix(serve): Add --watch flag for consistency with deployment configs

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -133,7 +133,8 @@ markata-go serve [flags]
 |------|-------|-------------|---------|
 | `--port` | `-p` | Port to listen on | `8000` |
 | `--host` | | Host address to bind to | `localhost` |
-| `--no-watch` | | Disable file watching and auto-rebuild | `false` |
+| `--watch` | | Enable file watching and auto-rebuild | `true` |
+| `--no-watch` | | Disable file watching (legacy, overrides --watch) | `false` |
 | `--verbose` | `-v` | Enable verbose logging | `false` |
 
 #### Examples
@@ -149,7 +150,11 @@ markata-go serve --port 3000
 # Bind to all network interfaces (accessible from other devices)
 markata-go serve --host 0.0.0.0
 
+# Explicitly enable file watching (default behavior)
+markata-go serve --watch
+
 # Serve without file watching
+markata-go serve --watch=false
 markata-go serve --no-watch
 
 # Serve with verbose logging


### PR DESCRIPTION
## Summary
- Add explicit `--watch` flag (default: true) to the serve command
- Keep `--no-watch` for backward compatibility (overrides `--watch`)
- Update CLI documentation with new flag and examples
- Fix pre-existing `copyFile` redeclaration in update.go

## Problem
The deployment configurations (systemd service, docker-compose.dev.yml) reference `--watch` flag which didn't exist. The serve command only had `--no-watch` to disable watching, with watching enabled by default.

## Solution
Added `--watch` flag with default `true` so deployment configs work correctly:
- `markata-go serve --watch` - explicitly enable watching (default)
- `markata-go serve --watch=false` - disable watching
- `markata-go serve --no-watch` - disable watching (legacy, backward compatible)

The logic: `shouldWatch = serveWatch && !serveNoWatch`

## Testing
- All tests pass: `go test ./...`
- Linter passes: `golangci-lint run --timeout=5m ./...`
- Binary builds and `serve --help` shows new flag

Fixes #168