### PR TITLE
docs: Fix --watch flag references and add live update patterns

### DIFF
--- a/deploy/docker/docker-compose.dev.yml
+++ b/deploy/docker/docker-compose.dev.yml
@@ -19,11 +19,12 @@ services:
     environment:
       - MARKATA_GO_URL=${SITE_URL:-http://localhost:8000}
       - CGO_ENABLED=0
+    # Note: serve has watch enabled by default, use --no-watch to disable
     command: >
       sh -c "
         go install github.com/WaylonWalker/markata-go/cmd/markata-go@latest &&
         markata-go build --clean &&
-        markata-go serve --port 8000 --host 0.0.0.0 --watch
+        markata-go serve --port 8000 --host 0.0.0.0
       "
     ports:
       - "${PORT:-8000}:8000"

--- a/deploy/systemd/markata-go-watch.service
+++ b/deploy/systemd/markata-go-watch.service
@@ -33,7 +33,8 @@ Environment=PATH=/var/www/mysite/.go/bin:/usr/local/go/bin:/usr/bin:/bin
 Environment=MARKATA_GO_URL=https://example.com
 
 # Watch command (rebuild on file changes)
-ExecStart=/var/www/mysite/.go/bin/markata-go serve --watch --port 8000 --host 127.0.0.1
+# Note: --watch is the default behavior for serve, included here for clarity
+ExecStart=/var/www/mysite/.go/bin/markata-go serve --port 8000 --host 127.0.0.1
 
 # Restart policy
 Restart=always

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -851,11 +851,14 @@ For faster development, markata-go can skip unchanged files:
 # Standard build (processes all files)
 markata-go build
 
-# Watch mode (only rebuilds changed files)
-markata-go serve --watch
+# Serve with watch mode (enabled by default)
+markata-go serve
+
+# Serve without file watching
+markata-go serve --no-watch
 ```
 
-The watch mode tracks file modifications and only reprocesses changed posts, dramatically speeding up iterative development.
+The serve command has file watching enabled by default, tracking file modifications and only reprocessing changed posts for faster iterative development.
 
 ### Caching Strategies
 


### PR DESCRIPTION
## Summary

Fixes #163

- Clarifies that `--watch` is the default behavior for the `serve` command
- Removes redundant `--watch` flag from deployment configs
- Adds comprehensive live update patterns documentation
- Adds detailed health check documentation for self-hosted deployments

## Changes

### Deployment Config Updates
- `deploy/docker/docker-compose.dev.yml`: Removed redundant `--watch` flag, added clarifying comment
- `deploy/systemd/markata-go-watch.service`: Removed redundant `--watch` flag, added clarifying comment

### Documentation Updates
- `docs/guides/self-hosting.md`: Expanded "Automated Rebuilds" into comprehensive "Live Update Patterns" section including:
  - Development mode (watch) explanation
  - Webhook-based rebuild with security (HMAC verification)
  - Scheduled rebuilds with proper systemd timer configuration
  - Improved CI/CD workflow example
  - New "Health Checks" section covering HTTP, Docker, external monitoring, and container orchestration health patterns
- `docs/advanced-usage.md`: Clarified that watch mode is enabled by default

## Testing

- [x] Verified `--watch` flag is valid (defaults to true in serve.go:75)
- [x] Confirmed documentation accurately reflects CLI behavior
- [x] All examples use correct flag syntax