### PR TITLE
feat(cli): Add import command for external content (PESOS pattern)

### DIFF
--- a/cmd/markata-go/cmd/import.go
+++ b/cmd/markata-go/cmd/import.go
@@ -1,0 +1,209 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/WaylonWalker/markata-go/pkg/importer"
+	"github.com/spf13/cobra"
+)
+
+var (
+	// importOutputDir is the output directory for imported posts.
+	importOutputDir string
+
+	// importSince filters posts to only those after this date.
+	importSince string
+
+	// importDryRun previews imports without writing files.
+	importDryRun bool
+
+	// importAddTags are additional tags to add to all imported posts.
+	importAddTags string
+)
+
+// importCmd represents the import command group.
+var importCmd = &cobra.Command{
+	Use:   "import",
+	Short: "Import content from external sources (PESOS pattern)",
+	Long: `Import content from external sources into your markata-go site.
+
+This command implements the PESOS (Publish Elsewhere, Syndicate to Own Site)
+pattern, allowing you to import your content from various platforms and
+consolidate it on your own site.
+
+Subcommands:
+  rss       - Import from RSS/Atom feeds
+  jsonfeed  - Import from JSON Feed format
+
+Example usage:
+  markata-go import rss https://example.com/feed.xml
+  markata-go import jsonfeed https://example.com/feed.json
+  markata-go import rss https://example.com/feed.xml --output posts/imported
+  markata-go import rss https://example.com/feed.xml --since 2024-01-01
+  markata-go import rss https://example.com/feed.xml --dry-run`,
+}
+
+// importRSSCmd imports content from RSS/Atom feeds.
+var importRSSCmd = &cobra.Command{
+	Use:   "rss <url>",
+	Short: "Import content from an RSS/Atom feed",
+	Long: `Import content from an RSS or Atom feed.
+
+The command fetches the feed, parses the entries, and creates markdown files
+with appropriate frontmatter for each post.
+
+Example usage:
+  markata-go import rss https://example.com/feed.xml
+  markata-go import rss https://example.com/feed.xml --output posts/blog
+  markata-go import rss https://example.com/feed.xml --since 2024-01-01 --dry-run`,
+	Args: cobra.ExactArgs(1),
+	RunE: runImportRSSCommand,
+}
+
+// importJSONFeedCmd imports content from JSON Feed format.
+var importJSONFeedCmd = &cobra.Command{
+	Use:   "jsonfeed <url>",
+	Short: "Import content from a JSON Feed",
+	Long: `Import content from a JSON Feed (https://jsonfeed.org).
+
+The command fetches the feed, parses the entries, and creates markdown files
+with appropriate frontmatter for each post.
+
+Example usage:
+  markata-go import jsonfeed https://example.com/feed.json
+  markata-go import jsonfeed https://example.com/feed.json --output posts/external
+  markata-go import jsonfeed https://example.com/feed.json --dry-run`,
+	Args: cobra.ExactArgs(1),
+	RunE: runImportJSONFeedCommand,
+}
+
+func init() {
+	rootCmd.AddCommand(importCmd)
+
+	// Add subcommands
+	importCmd.AddCommand(importRSSCmd)
+	importCmd.AddCommand(importJSONFeedCmd)
+
+	// Common flags for all import subcommands
+	importCmd.PersistentFlags().StringVarP(&importOutputDir, "output", "o", "posts/imported", "Output directory for imported posts")
+	importCmd.PersistentFlags().StringVar(&importSince, "since", "", "Only import posts published after this date (YYYY-MM-DD)")
+	importCmd.PersistentFlags().BoolVar(&importDryRun, "dry-run", false, "Preview imports without writing files")
+	importCmd.PersistentFlags().StringVar(&importAddTags, "tags", "", "Additional tags to add to all imported posts (comma-separated)")
+}
+
+// runImportRSSCommand runs the RSS import.
+func runImportRSSCommand(_ *cobra.Command, args []string) error {
+	url := args[0]
+
+	// Create importer
+	imp, err := importer.NewRSSImporter(url)
+	if err != nil {
+		return err
+	}
+
+	return runImport(imp)
+}
+
+// runImportJSONFeedCommand runs the JSON Feed import.
+func runImportJSONFeedCommand(_ *cobra.Command, args []string) error {
+	url := args[0]
+
+	// Create importer
+	imp, err := importer.NewJSONFeedImporter(url)
+	if err != nil {
+		return err
+	}
+
+	return runImport(imp)
+}
+
+// runImport executes the import with the given importer.
+func runImport(imp importer.Importer) error {
+	// Parse options
+	opts := importer.ImportOptions{
+		DryRun:    importDryRun,
+		OutputDir: importOutputDir,
+	}
+
+	// Parse --since flag
+	if importSince != "" {
+		since, err := time.Parse("2006-01-02", importSince)
+		if err != nil {
+			return fmt.Errorf("invalid date format for --since (use YYYY-MM-DD): %w", err)
+		}
+		opts.Since = &since
+	}
+
+	// Parse --tags flag
+	if importAddTags != "" {
+		for _, tag := range strings.Split(importAddTags, ",") {
+			tag = strings.TrimSpace(tag)
+			if tag != "" {
+				opts.AddTags = append(opts.AddTags, tag)
+			}
+		}
+	}
+
+	// Print header
+	fmt.Printf("Importing from %s feed: %s\n", imp.Name(), imp.SourceURL())
+	if importDryRun {
+		fmt.Println("(dry-run mode - no files will be written)")
+	}
+	fmt.Println(strings.Repeat("-", 60))
+
+	// Fetch and parse feed
+	posts, err := imp.Import(opts)
+	if err != nil {
+		return fmt.Errorf("import failed: %w", err)
+	}
+
+	if len(posts) == 0 {
+		fmt.Println("No posts found to import.")
+		if opts.Since != nil {
+			fmt.Printf("(filtered to posts after %s)\n", opts.Since.Format("2006-01-02"))
+		}
+		return nil
+	}
+
+	fmt.Printf("Found %d post(s) to import\n", len(posts))
+	if opts.Since != nil {
+		fmt.Printf("(filtered to posts after %s)\n", opts.Since.Format("2006-01-02"))
+	}
+	fmt.Println()
+
+	// Write posts
+	writer := importer.NewWriter(opts.OutputDir)
+	result, err := writer.Write(posts, opts.DryRun)
+	if err != nil {
+		return fmt.Errorf("write failed: %w", err)
+	}
+
+	// Print results
+	for _, path := range result.Paths {
+		if opts.DryRun {
+			fmt.Printf("  [dry-run] Would write: %s\n", path)
+		} else {
+			fmt.Printf("  Created: %s\n", path)
+		}
+	}
+
+	if result.Skipped > 0 {
+		fmt.Printf("\nSkipped %d post(s) (already exist)\n", result.Skipped)
+	}
+
+	for _, e := range result.Errors {
+		fmt.Fprintf(os.Stderr, "  Warning: %v\n", e)
+	}
+
+	fmt.Println(strings.Repeat("-", 60))
+	if opts.DryRun {
+		fmt.Printf("Dry run complete: %d post(s) would be imported\n", result.Written)
+	} else {
+		fmt.Printf("Import complete: %d post(s) imported to %s/\n", result.Written, opts.OutputDir)
+	}
+
+	return nil
+}

--- a/pkg/importer/importer.go
+++ b/pkg/importer/importer.go
@@ -1,0 +1,105 @@
+// Package importer provides functionality to import content from external sources.
+//
+// This package implements the PESOS (Publish Elsewhere, Syndicate to Own Site)
+// pattern, allowing users to import their content from various external sources
+// like RSS feeds and JSON Feeds into their markata-go site.
+//
+// # Supported Sources
+//
+// The package currently supports:
+//   - RSS/Atom feeds via the RSSImporter
+//   - JSON Feed format via the JSONFeedImporter
+//
+// # Usage
+//
+//	importer, err := NewRSSImporter(url)
+//	if err != nil {
+//	    return err
+//	}
+//	posts, err := importer.Import(opts)
+package importer
+
+import (
+	"time"
+)
+
+// ImportedPost represents a post imported from an external source.
+type ImportedPost struct {
+	// ID is a unique identifier from the source
+	ID string `json:"id" yaml:"id"`
+
+	// SourceURL is the original URL of the post
+	SourceURL string `json:"source_url" yaml:"source_url"`
+
+	// SourceType indicates the type of source (e.g., "rss", "jsonfeed")
+	SourceType string `json:"source_type" yaml:"source_type"`
+
+	// Title is the post title
+	Title string `json:"title" yaml:"title"`
+
+	// Content is the post content (may be HTML or plain text)
+	Content string `json:"content" yaml:"content"`
+
+	// ContentHTML is the HTML content if available
+	ContentHTML string `json:"content_html,omitempty" yaml:"content_html,omitempty"`
+
+	// Published is when the post was originally published
+	Published time.Time `json:"published" yaml:"published"`
+
+	// Updated is when the post was last updated (if available)
+	Updated *time.Time `json:"updated,omitempty" yaml:"updated,omitempty"`
+
+	// Imported is when the post was imported
+	Imported time.Time `json:"imported" yaml:"imported"`
+
+	// Author is the post author
+	Author string `json:"author,omitempty" yaml:"author,omitempty"`
+
+	// Tags are any tags or categories from the source
+	Tags []string `json:"tags,omitempty" yaml:"tags,omitempty"`
+
+	// Summary is a short summary or description
+	Summary string `json:"summary,omitempty" yaml:"summary,omitempty"`
+
+	// Slug is the URL-safe slug for the post
+	Slug string `json:"slug" yaml:"slug"`
+}
+
+// ImportOptions configures the import operation.
+type ImportOptions struct {
+	// Since filters posts to only include those published after this time
+	Since *time.Time
+
+	// DryRun if true, previews imports without writing files
+	DryRun bool
+
+	// OutputDir is the directory to write imported posts
+	OutputDir string
+
+	// AddTags are additional tags to add to all imported posts
+	AddTags []string
+}
+
+// Importer defines the interface for importing content from external sources.
+type Importer interface {
+	// Name returns the name of the importer (e.g., "rss", "jsonfeed")
+	Name() string
+
+	// Import fetches and returns posts from the source
+	Import(opts ImportOptions) ([]*ImportedPost, error)
+
+	// SourceURL returns the URL being imported from
+	SourceURL() string
+}
+
+// ImportResult holds the result of an import operation.
+type ImportResult struct {
+	// Posts are the successfully imported posts
+	Posts []*ImportedPost
+
+	// Skipped is the number of posts skipped (e.g., already imported, filtered by date)
+	Skipped int
+
+	// Errors contains any non-fatal errors encountered
+	Errors []error
+}

--- a/pkg/importer/importer_test.go
+++ b/pkg/importer/importer_test.go
@@ -1,0 +1,451 @@
+package importer
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestRSSImporter_Import(t *testing.T) {
+	// Sample RSS 2.0 feed
+	rssFeed := `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+  <channel>
+    <title>Test Blog</title>
+    <link>https://example.com</link>
+    <description>A test blog</description>
+    <item>
+      <title>First Post</title>
+      <link>https://example.com/first-post</link>
+      <description>This is the first post.</description>
+      <content:encoded><![CDATA[<p>This is the <strong>full content</strong> of the first post.</p>]]></content:encoded>
+      <pubDate>Mon, 20 Jan 2025 10:00:00 +0000</pubDate>
+      <guid>https://example.com/first-post</guid>
+      <category>tech</category>
+      <category>golang</category>
+    </item>
+    <item>
+      <title>Second Post</title>
+      <link>https://example.com/second-post</link>
+      <description>This is the second post.</description>
+      <pubDate>Tue, 21 Jan 2025 12:00:00 +0000</pubDate>
+      <guid>https://example.com/second-post</guid>
+    </item>
+  </channel>
+</rss>`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/rss+xml")
+		if _, err := w.Write([]byte(rssFeed)); err != nil {
+			return
+		}
+	}))
+	defer server.Close()
+
+	imp, err := NewRSSImporter(server.URL)
+	if err != nil {
+		t.Fatalf("NewRSSImporter() error = %v", err)
+	}
+
+	if imp.Name() != SourceTypeRSS {
+		t.Errorf("Name() = %q, want %q", imp.Name(), SourceTypeRSS)
+	}
+
+	posts, err := imp.Import(ImportOptions{})
+	if err != nil {
+		t.Fatalf("Import() error = %v", err)
+	}
+
+	if len(posts) != 2 {
+		t.Fatalf("Import() returned %d posts, want 2", len(posts))
+	}
+
+	// Check first post
+	post := posts[0]
+	if post.Title != "First Post" {
+		t.Errorf("Title = %q, want %q", post.Title, "First Post")
+	}
+	if post.SourceURL != "https://example.com/first-post" {
+		t.Errorf("SourceURL = %q, want %q", post.SourceURL, "https://example.com/first-post")
+	}
+	if post.SourceType != SourceTypeRSS {
+		t.Errorf("SourceType = %q, want %q", post.SourceType, SourceTypeRSS)
+	}
+	if post.Slug != "first-post" {
+		t.Errorf("Slug = %q, want %q", post.Slug, "first-post")
+	}
+	if len(post.Tags) != 2 || post.Tags[0] != "tech" || post.Tags[1] != "golang" {
+		t.Errorf("Tags = %v, want [tech golang]", post.Tags)
+	}
+}
+
+func TestRSSImporter_ImportWithSinceFilter(t *testing.T) {
+	rssFeed := `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test Blog</title>
+    <item>
+      <title>Old Post</title>
+      <link>https://example.com/old</link>
+      <pubDate>Mon, 01 Jan 2024 10:00:00 +0000</pubDate>
+    </item>
+    <item>
+      <title>New Post</title>
+      <link>https://example.com/new</link>
+      <pubDate>Fri, 20 Jan 2025 10:00:00 +0000</pubDate>
+    </item>
+  </channel>
+</rss>`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if _, err := w.Write([]byte(rssFeed)); err != nil {
+			return
+		}
+	}))
+	defer server.Close()
+
+	imp, err := NewRSSImporter(server.URL)
+	if err != nil {
+		t.Fatalf("NewRSSImporter() error = %v", err)
+	}
+
+	// Filter to posts after Jan 1, 2025
+	since := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	posts, err := imp.Import(ImportOptions{Since: &since})
+	if err != nil {
+		t.Fatalf("Import() error = %v", err)
+	}
+
+	if len(posts) != 1 {
+		t.Fatalf("Import() returned %d posts, want 1 (filtered)", len(posts))
+	}
+	if posts[0].Title != "New Post" {
+		t.Errorf("Expected 'New Post', got %q", posts[0].Title)
+	}
+}
+
+func TestAtomImporter_Import(t *testing.T) {
+	atomFeed := `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test Atom Blog</title>
+  <link href="https://example.com"/>
+  <entry>
+    <title>Atom Post</title>
+    <link href="https://example.com/atom-post"/>
+    <id>https://example.com/atom-post</id>
+    <published>2025-01-21T10:00:00Z</published>
+    <updated>2025-01-21T11:00:00Z</updated>
+    <summary>A short summary</summary>
+    <content type="html"><![CDATA[<p>Full atom content</p>]]></content>
+    <author>
+      <name>John Doe</name>
+    </author>
+    <category term="atom"/>
+    <category term="test"/>
+  </entry>
+</feed>`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/atom+xml")
+		if _, err := w.Write([]byte(atomFeed)); err != nil {
+			return
+		}
+	}))
+	defer server.Close()
+
+	imp, err := NewRSSImporter(server.URL)
+	if err != nil {
+		t.Fatalf("NewRSSImporter() error = %v", err)
+	}
+	posts, err := imp.Import(ImportOptions{})
+	if err != nil {
+		t.Fatalf("Import() error = %v", err)
+	}
+
+	if len(posts) != 1 {
+		t.Fatalf("Import() returned %d posts, want 1", len(posts))
+	}
+
+	post := posts[0]
+	if post.Title != "Atom Post" {
+		t.Errorf("Title = %q, want %q", post.Title, "Atom Post")
+	}
+	if post.SourceType != SourceTypeAtom {
+		t.Errorf("SourceType = %q, want %q", post.SourceType, SourceTypeAtom)
+	}
+	if post.Author != "John Doe" {
+		t.Errorf("Author = %q, want %q", post.Author, "John Doe")
+	}
+	if post.Updated == nil {
+		t.Error("Updated should not be nil")
+	}
+}
+
+func TestJSONFeedImporter_Import(t *testing.T) {
+	jsonFeed := `{
+  "version": "https://jsonfeed.org/version/1.1",
+  "title": "Test JSON Feed",
+  "home_page_url": "https://example.com",
+  "items": [
+    {
+      "id": "1",
+      "url": "https://example.com/json-post",
+      "title": "JSON Post",
+      "content_text": "This is plain text content.",
+      "date_published": "2025-01-22T10:00:00Z",
+      "tags": ["json", "feed"]
+    },
+    {
+      "id": "2",
+      "url": "https://example.com/html-post",
+      "title": "HTML Post",
+      "content_html": "<p>This is <strong>HTML</strong> content.</p>",
+      "date_published": "2025-01-23T10:00:00Z",
+      "authors": [{"name": "Jane Doe"}]
+    }
+  ]
+}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/feed+json")
+		if _, err := w.Write([]byte(jsonFeed)); err != nil {
+			return
+		}
+	}))
+	defer server.Close()
+
+	imp, err := NewJSONFeedImporter(server.URL)
+	if err != nil {
+		t.Fatalf("NewJSONFeedImporter() error = %v", err)
+	}
+
+	if imp.Name() != SourceTypeJSONFeed {
+		t.Errorf("Name() = %q, want %q", imp.Name(), SourceTypeJSONFeed)
+	}
+
+	posts, err := imp.Import(ImportOptions{})
+	if err != nil {
+		t.Fatalf("Import() error = %v", err)
+	}
+
+	if len(posts) != 2 {
+		t.Fatalf("Import() returned %d posts, want 2", len(posts))
+	}
+
+	// Check first post (plain text)
+	post := posts[0]
+	if post.Title != "JSON Post" {
+		t.Errorf("Title = %q, want %q", post.Title, "JSON Post")
+	}
+	if post.Content != "This is plain text content." {
+		t.Errorf("Content = %q, want %q", post.Content, "This is plain text content.")
+	}
+	if post.SourceType != SourceTypeJSONFeed {
+		t.Errorf("SourceType = %q, want %q", post.SourceType, SourceTypeJSONFeed)
+	}
+
+	// Check second post (HTML content)
+	post2 := posts[1]
+	if post2.Author != "Jane Doe" {
+		t.Errorf("Author = %q, want %q", post2.Author, "Jane Doe")
+	}
+	// Content should be stripped HTML
+	if post2.Content != "This is HTML content." {
+		t.Errorf("Content = %q, want %q", post2.Content, "This is HTML content.")
+	}
+}
+
+func TestWriter_Write(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	posts := []*ImportedPost{
+		{
+			Title:      "Test Post",
+			Slug:       "test-post",
+			SourceURL:  "https://example.com/test",
+			SourceType: "rss",
+			Content:    "This is the content.",
+			Published:  time.Date(2025, 1, 20, 10, 0, 0, 0, time.UTC),
+			Imported:   time.Now(),
+			Tags:       []string{"test", "example"},
+		},
+	}
+
+	writer := NewWriter(tmpDir)
+	result, err := writer.Write(posts, false)
+	if err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	if result.Written != 1 {
+		t.Errorf("Written = %d, want 1", result.Written)
+	}
+
+	// Check file was created
+	expectedPath := filepath.Join(tmpDir, "test-post.md")
+	if _, err := os.Stat(expectedPath); os.IsNotExist(err) {
+		t.Errorf("Expected file %s to exist", expectedPath)
+	}
+
+	// Check file content
+	content, err := os.ReadFile(expectedPath)
+	if err != nil {
+		t.Fatalf("Failed to read file: %v", err)
+	}
+
+	contentStr := string(content)
+	if !contains(contentStr, `title: "Test Post"`) {
+		t.Error("File should contain title")
+	}
+	if !contains(contentStr, `source_url: "https://example.com/test"`) {
+		t.Error("File should contain source_url")
+	}
+	if !contains(contentStr, "source_type: rss") {
+		t.Error("File should contain source_type")
+	}
+	if !contains(contentStr, "- imported") {
+		t.Error("File should contain imported tag")
+	}
+	if !contains(contentStr, "This is the content.") {
+		t.Error("File should contain content")
+	}
+}
+
+func TestWriter_WriteDryRun(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	posts := []*ImportedPost{
+		{
+			Title:      "Dry Run Post",
+			Slug:       "dry-run-post",
+			SourceURL:  "https://example.com/dry",
+			SourceType: "rss",
+			Content:    "Content",
+			Published:  time.Now(),
+			Imported:   time.Now(),
+		},
+	}
+
+	writer := NewWriter(tmpDir)
+	result, err := writer.Write(posts, true) // dry-run
+	if err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	if result.Written != 1 {
+		t.Errorf("Written = %d, want 1", result.Written)
+	}
+
+	// File should NOT be created in dry-run
+	expectedPath := filepath.Join(tmpDir, "dry-run-post.md")
+	if _, err := os.Stat(expectedPath); !os.IsNotExist(err) {
+		t.Errorf("File %s should NOT exist in dry-run mode", expectedPath)
+	}
+}
+
+func TestWriter_WriteSkipsExisting(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create existing file
+	existingPath := filepath.Join(tmpDir, "existing-post.md")
+	if err := os.WriteFile(existingPath, []byte("existing content"), 0o600); err != nil {
+		t.Fatalf("Failed to create existing file: %v", err)
+	}
+
+	posts := []*ImportedPost{
+		{
+			Title:      "Existing Post",
+			Slug:       "existing-post",
+			SourceURL:  "https://example.com/existing",
+			SourceType: "rss",
+			Content:    "New content",
+			Published:  time.Now(),
+			Imported:   time.Now(),
+		},
+	}
+
+	writer := NewWriter(tmpDir)
+	result, err := writer.Write(posts, false)
+	if err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	if result.Written != 0 {
+		t.Errorf("Written = %d, want 0", result.Written)
+	}
+	if result.Skipped != 1 {
+		t.Errorf("Skipped = %d, want 1", result.Skipped)
+	}
+
+	// File content should remain unchanged
+	content, err := os.ReadFile(existingPath)
+	if err != nil {
+		t.Fatalf("Failed to read file: %v", err)
+	}
+	if string(content) != "existing content" {
+		t.Error("Existing file should not be overwritten")
+	}
+}
+
+func TestGenerateSlug(t *testing.T) {
+	tests := []struct {
+		title string
+		want  string
+	}{
+		{"Hello World", "hello-world"},
+		{"This is a Test!", "this-is-a-test"},
+		{"  Multiple   Spaces  ", "multiple-spaces"},
+		{"Special@#$Characters", "specialcharacters"},
+		{"Numbers 123 and Words", "numbers-123-and-words"},
+		{"", ""},
+		{"Already-Slugified", "already-slugified"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.title, func(t *testing.T) {
+			got := generateSlug(tt.title)
+			if got != tt.want {
+				t.Errorf("generateSlug(%q) = %q, want %q", tt.title, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStripHTML(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"<p>Hello</p>", "Hello"},
+		{"<strong>Bold</strong> text", "Bold text"},
+		{"<a href='#'>Link</a>", "Link"},
+		{"No tags here", "No tags here"},
+		{"&amp; &lt; &gt;", "& < >"},
+		{"<p>Multiple</p><p>Paragraphs</p>", "MultipleParagraphs"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := stripHTML(tt.input)
+			if got != tt.want {
+				t.Errorf("stripHTML(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || s != "" && containsHelper(s, substr))
+}
+
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/importer/jsonfeed.go
+++ b/pkg/importer/jsonfeed.go
@@ -1,0 +1,164 @@
+package importer
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// JSONFeedImporter imports content from JSON Feed format.
+type JSONFeedImporter struct {
+	url string
+}
+
+// NewJSONFeedImporter creates a new JSON Feed importer for the given URL.
+func NewJSONFeedImporter(url string) (*JSONFeedImporter, error) {
+	if url == "" {
+		return nil, fmt.Errorf("JSON Feed URL is required")
+	}
+	return &JSONFeedImporter{url: url}, nil
+}
+
+// Name returns the importer name.
+func (j *JSONFeedImporter) Name() string {
+	return SourceTypeJSONFeed
+}
+
+// SourceURL returns the feed URL.
+func (j *JSONFeedImporter) SourceURL() string {
+	return j.url
+}
+
+// JSON Feed structures (https://jsonfeed.org/version/1.1)
+type jsonFeed struct {
+	Version     string         `json:"version"`
+	Title       string         `json:"title"`
+	HomePageURL string         `json:"home_page_url"`
+	FeedURL     string         `json:"feed_url"`
+	Description string         `json:"description"`
+	Authors     []jsonAuthor   `json:"authors"`
+	Items       []jsonFeedItem `json:"items"`
+}
+
+type jsonAuthor struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
+type jsonFeedItem struct {
+	ID            string       `json:"id"`
+	URL           string       `json:"url"`
+	Title         string       `json:"title"`
+	ContentHTML   string       `json:"content_html"`
+	ContentText   string       `json:"content_text"`
+	Summary       string       `json:"summary"`
+	DatePublished string       `json:"date_published"`
+	DateModified  string       `json:"date_modified"`
+	Authors       []jsonAuthor `json:"authors"`
+	Tags          []string     `json:"tags"`
+}
+
+// Import fetches and parses the JSON Feed.
+func (j *JSONFeedImporter) Import(opts ImportOptions) ([]*ImportedPost, error) {
+	// Fetch the feed with context
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, j.url, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch JSON Feed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch JSON Feed: status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read JSON Feed: %w", err)
+	}
+
+	var feed jsonFeed
+	if err := json.Unmarshal(body, &feed); err != nil {
+		return nil, fmt.Errorf("failed to parse JSON Feed: %w", err)
+	}
+
+	now := time.Now()
+	posts := make([]*ImportedPost, 0, len(feed.Items))
+
+	for i := range feed.Items {
+		item := &feed.Items[i]
+		// Parse publish date
+		pubDate := parseJSONFeedDate(item.DatePublished)
+
+		// Filter by date if specified
+		if opts.Since != nil && pubDate.Before(*opts.Since) {
+			continue
+		}
+
+		// Determine content
+		content := item.ContentText
+		if content == "" && item.ContentHTML != "" {
+			content = stripHTML(item.ContentHTML)
+		}
+
+		// Determine author
+		author := ""
+		if len(item.Authors) > 0 {
+			author = item.Authors[0].Name
+		} else if len(feed.Authors) > 0 {
+			author = feed.Authors[0].Name
+		}
+
+		// Combine tags
+		tags := item.Tags
+		tags = append(tags, opts.AddTags...)
+
+		post := &ImportedPost{
+			ID:          item.ID,
+			SourceURL:   item.URL,
+			SourceType:  SourceTypeJSONFeed,
+			Title:       item.Title,
+			Content:     content,
+			ContentHTML: item.ContentHTML,
+			Published:   pubDate,
+			Imported:    now,
+			Author:      author,
+			Tags:        tags,
+			Summary:     truncate(item.Summary, 200),
+			Slug:        generateSlug(item.Title),
+		}
+
+		if item.DateModified != "" {
+			modified := parseJSONFeedDate(item.DateModified)
+			if !modified.IsZero() {
+				post.Updated = &modified
+			}
+		}
+
+		posts = append(posts, post)
+	}
+
+	return posts, nil
+}
+
+// parseJSONFeedDate parses JSON Feed date format (RFC3339).
+func parseJSONFeedDate(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		// Try without timezone
+		if parsed, parseErr := time.Parse("2006-01-02T15:04:05", s); parseErr == nil {
+			return parsed
+		}
+	}
+	return t
+}

--- a/pkg/importer/rss.go
+++ b/pkg/importer/rss.go
@@ -1,0 +1,371 @@
+package importer
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Source type constants
+const (
+	SourceTypeRSS      = "rss"
+	SourceTypeAtom     = "atom"
+	SourceTypeJSONFeed = "jsonfeed"
+)
+
+// RSSImporter imports content from RSS/Atom feeds.
+type RSSImporter struct {
+	url string
+}
+
+// NewRSSImporter creates a new RSS importer for the given URL.
+func NewRSSImporter(url string) (*RSSImporter, error) {
+	if url == "" {
+		return nil, fmt.Errorf("RSS feed URL is required")
+	}
+	return &RSSImporter{url: url}, nil
+}
+
+// Name returns the importer name.
+func (r *RSSImporter) Name() string {
+	return SourceTypeRSS
+}
+
+// SourceURL returns the feed URL.
+func (r *RSSImporter) SourceURL() string {
+	return r.url
+}
+
+// Import fetches and parses the RSS feed.
+func (r *RSSImporter) Import(opts ImportOptions) ([]*ImportedPost, error) {
+	// Fetch the feed with context
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.url, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch RSS feed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch RSS feed: status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read RSS feed: %w", err)
+	}
+
+	// Try to parse as RSS 2.0 first, then Atom
+	posts, err := r.parseRSS2(body, opts)
+	if err != nil {
+		posts, err = r.parseAtom(body, opts)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse feed (tried RSS 2.0 and Atom): %w", err)
+		}
+	}
+
+	return posts, nil
+}
+
+// RSS 2.0 structures
+type rss2Feed struct {
+	XMLName xml.Name    `xml:"rss"`
+	Channel rss2Channel `xml:"channel"`
+}
+
+type rss2Channel struct {
+	Title       string     `xml:"title"`
+	Link        string     `xml:"link"`
+	Description string     `xml:"description"`
+	Items       []rss2Item `xml:"item"`
+}
+
+type rss2Item struct {
+	Title       string   `xml:"title"`
+	Link        string   `xml:"link"`
+	Description string   `xml:"description"`
+	Content     string   `xml:"http://purl.org/rss/1.0/modules/content/ encoded"`
+	PubDate     string   `xml:"pubDate"`
+	GUID        string   `xml:"guid"`
+	Author      string   `xml:"author"`
+	Creator     string   `xml:"http://purl.org/dc/elements/1.1/ creator"`
+	Categories  []string `xml:"category"`
+}
+
+// Atom structures
+type atomFeed struct {
+	XMLName xml.Name    `xml:"http://www.w3.org/2005/Atom feed"`
+	Title   string      `xml:"title"`
+	Link    []atomLink  `xml:"link"`
+	Entries []atomEntry `xml:"entry"`
+}
+
+type atomLink struct {
+	Href string `xml:"href,attr"`
+	Rel  string `xml:"rel,attr"`
+	Type string `xml:"type,attr"`
+}
+
+type atomEntry struct {
+	Title     string     `xml:"title"`
+	Link      []atomLink `xml:"link"`
+	ID        string     `xml:"id"`
+	Updated   string     `xml:"updated"`
+	Published string     `xml:"published"`
+	Summary   string     `xml:"summary"`
+	Content   atomText   `xml:"content"`
+	Author    atomAuthor `xml:"author"`
+	Category  []atomCat  `xml:"category"`
+}
+
+type atomText struct {
+	Type string `xml:"type,attr"`
+	Body string `xml:",chardata"`
+}
+
+type atomAuthor struct {
+	Name string `xml:"name"`
+}
+
+type atomCat struct {
+	Term string `xml:"term,attr"`
+}
+
+func (r *RSSImporter) parseRSS2(data []byte, opts ImportOptions) ([]*ImportedPost, error) {
+	var feed rss2Feed
+	if err := xml.Unmarshal(data, &feed); err != nil {
+		return nil, err
+	}
+
+	if feed.XMLName.Local != "rss" {
+		return nil, fmt.Errorf("not an RSS 2.0 feed")
+	}
+
+	now := time.Now()
+	posts := make([]*ImportedPost, 0, len(feed.Channel.Items))
+
+	for i := range feed.Channel.Items {
+		item := &feed.Channel.Items[i]
+		// Parse publish date
+		pubDate := parseRSSDate(item.PubDate)
+
+		// Filter by date if specified
+		if opts.Since != nil && pubDate.Before(*opts.Since) {
+			continue
+		}
+
+		// Determine content - prefer content:encoded over description
+		content := item.Content
+		if content == "" {
+			content = item.Description
+		}
+
+		// Determine author
+		author := item.Author
+		if author == "" {
+			author = item.Creator
+		}
+
+		// Determine ID
+		id := item.GUID
+		if id == "" {
+			id = item.Link
+		}
+
+		tags := item.Categories
+		tags = append(tags, opts.AddTags...)
+
+		post := &ImportedPost{
+			ID:          id,
+			SourceURL:   item.Link,
+			SourceType:  SourceTypeRSS,
+			Title:       item.Title,
+			Content:     stripHTML(content),
+			ContentHTML: content,
+			Published:   pubDate,
+			Imported:    now,
+			Author:      author,
+			Tags:        tags,
+			Summary:     truncate(stripHTML(item.Description), 200),
+			Slug:        generateSlug(item.Title),
+		}
+
+		posts = append(posts, post)
+	}
+
+	return posts, nil
+}
+
+func (r *RSSImporter) parseAtom(data []byte, opts ImportOptions) ([]*ImportedPost, error) {
+	var feed atomFeed
+	if err := xml.Unmarshal(data, &feed); err != nil {
+		return nil, err
+	}
+
+	now := time.Now()
+	posts := make([]*ImportedPost, 0, len(feed.Entries))
+
+	for i := range feed.Entries {
+		entry := &feed.Entries[i]
+		// Parse dates
+		pubDate := parseAtomDate(entry.Published)
+		if pubDate.IsZero() {
+			pubDate = parseAtomDate(entry.Updated)
+		}
+
+		// Filter by date if specified
+		if opts.Since != nil && pubDate.Before(*opts.Since) {
+			continue
+		}
+
+		// Get link
+		link := ""
+		for _, l := range entry.Link {
+			if l.Rel == "" || l.Rel == "alternate" {
+				link = l.Href
+				break
+			}
+		}
+
+		// Determine content
+		content := entry.Content.Body
+		if content == "" {
+			content = entry.Summary
+		}
+
+		// Get tags
+		var tags []string
+		for _, cat := range entry.Category {
+			if cat.Term != "" {
+				tags = append(tags, cat.Term)
+			}
+		}
+		tags = append(tags, opts.AddTags...)
+
+		post := &ImportedPost{
+			ID:          entry.ID,
+			SourceURL:   link,
+			SourceType:  SourceTypeAtom,
+			Title:       entry.Title,
+			Content:     stripHTML(content),
+			ContentHTML: content,
+			Published:   pubDate,
+			Imported:    now,
+			Author:      entry.Author.Name,
+			Tags:        tags,
+			Summary:     truncate(stripHTML(entry.Summary), 200),
+			Slug:        generateSlug(entry.Title),
+		}
+
+		if entry.Updated != "" {
+			updated := parseAtomDate(entry.Updated)
+			if !updated.IsZero() {
+				post.Updated = &updated
+			}
+		}
+
+		posts = append(posts, post)
+	}
+
+	return posts, nil
+}
+
+// parseRSSDate parses common RSS date formats.
+func parseRSSDate(s string) time.Time {
+	formats := []string{
+		time.RFC1123Z,
+		time.RFC1123,
+		time.RFC822Z,
+		time.RFC822,
+		"Mon, 2 Jan 2006 15:04:05 -0700",
+		"Mon, 2 Jan 2006 15:04:05 MST",
+		"2 Jan 2006 15:04:05 -0700",
+		"2006-01-02T15:04:05Z07:00",
+		"2006-01-02",
+	}
+
+	for _, format := range formats {
+		if t, err := time.Parse(format, s); err == nil {
+			return t
+		}
+	}
+
+	return time.Time{}
+}
+
+// parseAtomDate parses Atom date format (RFC3339).
+func parseAtomDate(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		// Try without timezone
+		if parsed, parseErr := time.Parse("2006-01-02T15:04:05", s); parseErr == nil {
+			return parsed
+		}
+	}
+	return t
+}
+
+// stripHTML removes HTML tags from a string.
+func stripHTML(s string) string {
+	// Simple regex-based HTML stripping
+	re := regexp.MustCompile(`<[^>]*>`)
+	s = re.ReplaceAllString(s, "")
+
+	// Decode common HTML entities
+	s = strings.ReplaceAll(s, "&nbsp;", " ")
+	s = strings.ReplaceAll(s, "&amp;", "&")
+	s = strings.ReplaceAll(s, "&lt;", "<")
+	s = strings.ReplaceAll(s, "&gt;", ">")
+	s = strings.ReplaceAll(s, "&quot;", "\"")
+	s = strings.ReplaceAll(s, "&#39;", "'")
+
+	// Collapse whitespace
+	s = regexp.MustCompile(`\s+`).ReplaceAllString(s, " ")
+
+	return strings.TrimSpace(s)
+}
+
+// truncate truncates a string to the specified length.
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return strings.TrimSpace(s[:maxLen]) + "..."
+}
+
+// generateSlug creates a URL-safe slug from a title.
+func generateSlug(title string) string {
+	slug := strings.ToLower(title)
+	slug = strings.ReplaceAll(slug, " ", "-")
+
+	// Remove non-alphanumeric characters (except hyphens)
+	reg := regexp.MustCompile(`[^a-z0-9\-]+`)
+	slug = reg.ReplaceAllString(slug, "")
+
+	// Collapse multiple hyphens
+	reg = regexp.MustCompile(`-+`)
+	slug = reg.ReplaceAllString(slug, "-")
+
+	// Trim hyphens from start and end
+	slug = strings.Trim(slug, "-")
+
+	// Limit length
+	if len(slug) > 80 {
+		slug = slug[:80]
+		slug = strings.TrimRight(slug, "-")
+	}
+
+	return slug
+}

--- a/pkg/importer/writer.go
+++ b/pkg/importer/writer.go
@@ -1,0 +1,144 @@
+package importer
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Writer handles writing imported posts as markdown files.
+type Writer struct {
+	outputDir string
+}
+
+// NewWriter creates a new Writer for the specified output directory.
+func NewWriter(outputDir string) *Writer {
+	return &Writer{outputDir: outputDir}
+}
+
+// WriteResult contains the result of writing posts.
+type WriteResult struct {
+	// Written is the number of files written
+	Written int
+
+	// Skipped is the number of files skipped (already exist)
+	Skipped int
+
+	// Paths contains the paths of written files
+	Paths []string
+
+	// Errors contains any non-fatal errors encountered
+	Errors []error
+}
+
+// Write writes imported posts as markdown files.
+func (w *Writer) Write(posts []*ImportedPost, dryRun bool) (*WriteResult, error) {
+	result := &WriteResult{}
+
+	// Create output directory if it doesn't exist
+	if !dryRun {
+		if err := os.MkdirAll(w.outputDir, 0o755); err != nil {
+			return nil, fmt.Errorf("failed to create output directory: %w", err)
+		}
+	}
+
+	for _, post := range posts {
+		path, err := w.writePost(post, dryRun)
+		if err != nil {
+			if os.IsExist(err) {
+				result.Skipped++
+				continue
+			}
+			result.Errors = append(result.Errors, fmt.Errorf("failed to write %s: %w", post.Slug, err))
+			continue
+		}
+
+		result.Written++
+		result.Paths = append(result.Paths, path)
+	}
+
+	return result, nil
+}
+
+// writePost writes a single post as a markdown file.
+func (w *Writer) writePost(post *ImportedPost, dryRun bool) (string, error) {
+	filename := post.Slug + ".md"
+	path := filepath.Join(w.outputDir, filename)
+
+	// Check if file already exists
+	if _, err := os.Stat(path); err == nil {
+		return path, os.ErrExist
+	}
+
+	if dryRun {
+		return path, nil
+	}
+
+	content := formatPostAsMarkdown(post)
+
+	// Write file with readable permissions (0o644 is appropriate for content files)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil { //nolint:gosec // content files should be readable
+		return "", err
+	}
+
+	return path, nil
+}
+
+// formatPostAsMarkdown formats an imported post as a markdown file with frontmatter.
+func formatPostAsMarkdown(post *ImportedPost) string {
+	var sb strings.Builder
+
+	sb.WriteString("---\n")
+	sb.WriteString(fmt.Sprintf("title: %q\n", post.Title))
+	sb.WriteString(fmt.Sprintf("date: %s\n", post.Published.Format("2006-01-02")))
+	sb.WriteString(fmt.Sprintf("source_url: %q\n", post.SourceURL))
+	sb.WriteString(fmt.Sprintf("source_type: %s\n", post.SourceType))
+	sb.WriteString(fmt.Sprintf("imported: %s\n", post.Imported.Format("2006-01-02")))
+
+	if post.Author != "" {
+		sb.WriteString(fmt.Sprintf("author: %q\n", post.Author))
+	}
+
+	if post.Summary != "" {
+		// Escape quotes in summary for YAML
+		summary := strings.ReplaceAll(post.Summary, "\"", "\\\"")
+		sb.WriteString(fmt.Sprintf("description: %q\n", summary))
+	}
+
+	if len(post.Tags) > 0 {
+		sb.WriteString("tags:\n")
+		// Always add imported and source_type as tags
+		tagsWritten := make(map[string]bool)
+		sb.WriteString("  - imported\n")
+		tagsWritten["imported"] = true
+		sb.WriteString(fmt.Sprintf("  - %s\n", post.SourceType))
+		tagsWritten[post.SourceType] = true
+
+		for _, tag := range post.Tags {
+			tag = strings.TrimSpace(tag)
+			if tag != "" && !tagsWritten[tag] {
+				sb.WriteString(fmt.Sprintf("  - %s\n", tag))
+				tagsWritten[tag] = true
+			}
+		}
+	} else {
+		// Always add imported and source_type tags
+		sb.WriteString("tags:\n")
+		sb.WriteString("  - imported\n")
+		sb.WriteString(fmt.Sprintf("  - %s\n", post.SourceType))
+	}
+
+	sb.WriteString("published: true\n")
+	sb.WriteString("---\n\n")
+
+	// Use content text, not HTML
+	content := post.Content
+	if content == "" {
+		content = stripHTML(post.ContentHTML)
+	}
+	sb.WriteString(content)
+	sb.WriteString("\n")
+
+	return sb.String()
+}


### PR DESCRIPTION
## Summary

Implements Issue #184 by adding a new `import` command for importing content from external sources using the IndieWeb PESOS (Publish Elsewhere, Syndicate to Own Site) pattern.

## Changes

- **New CLI command**: `markata-go import` with subcommands for different feed types
- **New package**: `pkg/importer/` with modular feed importers
- **Comprehensive tests**: Unit tests for all importer functionality

## Supported Sources

- **RSS/Atom feeds**: `markata-go import rss <url>`
- **JSON Feed**: `markata-go import jsonfeed <url>`

## Options

| Flag | Description |
|------|-------------|
| `--output <dir>` | Output directory for imported posts (default: `posts/imported`) |
| `--since <date>` | Only import posts published after this date (YYYY-MM-DD) |
| `--dry-run` | Preview imports without writing files |
| `--tags <tags>` | Additional tags to add to all imported posts (comma-separated) |

## Example Usage

```bash
# Import from RSS feed
markata-go import rss https://example.com/feed.xml

# Import from JSON Feed
markata-go import jsonfeed https://example.com/feed.json

# Preview imports without writing
markata-go import rss https://example.com/feed.xml --dry-run

# Filter to recent posts only
markata-go import rss https://example.com/feed.xml --since 2024-01-01

# Import to a specific directory with extra tags
markata-go import rss https://example.com/feed.xml --output posts/external --tags blog,imported
```

## Output Format

Imported posts are written as markdown files with frontmatter:

```yaml
---
title: "Post Title"
date: 2024-01-21
source_url: "https://example.com/post"
source_type: rss
imported: 2024-01-22
author: "Author Name"
description: "Post summary..."
tags:
  - imported
  - rss
  - original-tag
published: true
---

Content here...
```

## Testing

All tests pass:
```
ok  	github.com/WaylonWalker/markata-go/pkg/importer	0.026s
```

Fixes #184