### PR TITLE
feat(plugins): Add embed plugin for internal and external post embeds

### DIFF
--- a/docs/guides/embeds.md
+++ b/docs/guides/embeds.md
@@ -1,0 +1,274 @@
+---
+title: "Embeds"
+description: "Embed internal posts and external URLs as rich preview cards"
+date: 2024-01-24
+published: true
+tags:
+  - documentation
+  - plugins
+  - content
+---
+
+# Embeds
+
+The embeds plugin lets you embed rich preview cards for both internal posts and external URLs in your markdown content.
+
+## Quick Start
+
+### Internal Post Embeds
+
+Embed another post from your site using the `![[slug]]` syntax:
+
+```markdown
+Check out this related article:
+
+![[getting-started]]
+```
+
+This creates a preview card showing the embedded post's title, description, and date.
+
+### External URL Embeds
+
+Embed external URLs using `![embed](url)`:
+
+```markdown
+Here's a great resource:
+
+![embed](https://example.com/article)
+```
+
+This fetches the page's Open Graph metadata and displays a card with the title, description, and image.
+
+## Internal Embeds
+
+### Basic Syntax
+
+```markdown
+![[slug]]
+```
+
+The slug is the URL path of the post you want to embed. For example, if a post lives at `/guides/configuration/`, use:
+
+```markdown
+![[guides/configuration]]
+```
+
+### Custom Title
+
+Override the display title with a pipe:
+
+```markdown
+![[guides/configuration|Configuration Guide]]
+```
+
+### What Gets Displayed
+
+Internal embed cards show:
+- **Title** - From the post or your custom title
+- **Description** - First 200 characters
+- **Date** - If the post has a date
+
+### Not Found Behavior
+
+If the embedded post doesn't exist, markata-go leaves the original syntax and adds an HTML comment:
+
+```html
+<!-- embed not found: nonexistent-post -->
+![[nonexistent-post]]
+```
+
+This helps you spot broken embeds without breaking your build.
+
+## External Embeds
+
+### Syntax
+
+```markdown
+![embed](https://example.com/article)
+```
+
+> **Note:** The alt text must be exactly `embed`. Regular images are not affected.
+
+### Open Graph Metadata
+
+External embeds fetch and display:
+- **Title** - `og:title` or `<title>`
+- **Description** - `og:description` or meta description
+- **Image** - `og:image` (optional)
+- **Site name** - `og:site_name`
+
+### Caching
+
+Metadata is cached for 7 days to avoid repeated HTTP requests. Cache files are stored in `.cache/embeds/` by default.
+
+### Fallback Behavior
+
+If metadata can't be fetched:
+- Title shows "External Link" (configurable)
+- No image is displayed
+- Domain name is shown
+
+## Configuration
+
+Add to your `markata-go.toml`:
+
+```toml
+[embeds]
+enabled = true
+
+# CSS classes for styling
+internal_card_class = "embed-card"
+external_card_class = "embed-card embed-card-external"
+
+# External fetch settings
+fetch_external = true        # Set false to skip HTTP requests
+cache_dir = ".cache/embeds"  # Where to store cached metadata
+timeout = 10                 # HTTP timeout in seconds
+
+# Display settings
+fallback_title = "External Link"  # Title when OG is unavailable
+show_image = true                 # Show OG images
+```
+
+### Disabling External Fetching
+
+For faster builds or offline development:
+
+```toml
+[embeds]
+fetch_external = false
+```
+
+External embeds will use the fallback title and show no image.
+
+## Styling
+
+Embed cards use these CSS classes:
+
+| Class | Description |
+|-------|-------------|
+| `.embed-card` | Base container |
+| `.embed-card-external` | Added for external embeds |
+| `.embed-card-link` | The clickable anchor |
+| `.embed-card-image` | Image wrapper (external only) |
+| `.embed-card-content` | Text content area |
+| `.embed-card-title` | Title |
+| `.embed-card-description` | Description |
+| `.embed-card-meta` | Date or domain |
+
+### Custom Styling
+
+Override the default styles in your custom CSS:
+
+```css
+/* Make internal embeds more prominent */
+.embed-card:not(.embed-card-external) {
+  border-left-width: 6px;
+  border-left-color: var(--color-accent);
+}
+
+/* Larger images for external embeds */
+.embed-card-image {
+  width: 250px;
+}
+```
+
+## Code Blocks
+
+Embed syntax inside code blocks is preserved:
+
+````markdown
+Normal embed:
+![[my-post]]
+
+Code example (not processed):
+```
+![[my-post]]
+```
+````
+
+## Examples
+
+### Blog Post with Related Reading
+
+```markdown
+---
+title: "Advanced Configuration"
+---
+
+# Advanced Configuration
+
+This guide builds on the basics. If you're new, start here:
+
+![[getting-started]]
+
+## Deep Dive
+
+...content...
+
+## Further Reading
+
+Check out these external resources:
+
+![embed](https://gohugo.io/getting-started/)
+
+![embed](https://www.markdownguide.org/)
+```
+
+### Documentation with Cross-References
+
+```markdown
+# API Reference
+
+## Authentication
+
+For setup instructions, see:
+
+![[guides/authentication|Authentication Guide]]
+
+## Rate Limiting
+
+Related:
+![[api/errors]]
+![[guides/best-practices]]
+```
+
+## Comparison with Wikilinks
+
+| Feature | Embeds (`![[]]`) | Wikilinks (`[[]]`) |
+|---------|------------------|-------------------|
+| Output | Preview card | Inline link |
+| Shows description | Yes | No |
+| Shows date | Yes | No |
+| Best for | Related content, references | In-text mentions |
+
+Use embeds when you want readers to see a preview. Use wikilinks for inline mentions.
+
+## Troubleshooting
+
+### Embed Not Rendering
+
+1. Check the slug matches the target post's URL path
+2. Ensure the target post is published
+3. Look for `<!-- embed not found -->` comments in the HTML
+
+### External Embed Shows Fallback
+
+1. Check your internet connection
+2. Verify the URL is accessible
+3. Some sites block robots - the fallback is expected
+4. Increase timeout if the site is slow
+
+### Images Not Showing
+
+1. Ensure `show_image = true` in config
+2. The page may not have an `og:image` tag
+3. Image URL may be invalid or blocked
+
+### Build Is Slow
+
+External fetching adds latency. Options:
+
+1. Set `fetch_external = false` during development
+2. Reduce `timeout` value
+3. Let the cache warm up (first build is slowest)

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -908,6 +908,47 @@ func NewYouTubeConfig() YouTubeConfig {
 	}
 }
 
+// EmbedsConfig configures the embeds plugin for embedding internal and external content.
+type EmbedsConfig struct {
+	// Enabled controls whether embed processing is active (default: true)
+	Enabled bool `json:"enabled" yaml:"enabled" toml:"enabled"`
+
+	// InternalCardClass is the CSS class for internal embed cards (default: "embed-card")
+	InternalCardClass string `json:"internal_card_class" yaml:"internal_card_class" toml:"internal_card_class"`
+
+	// ExternalCardClass is the CSS class for external embed cards (default: "embed-card embed-card-external")
+	ExternalCardClass string `json:"external_card_class" yaml:"external_card_class" toml:"external_card_class"`
+
+	// FetchExternal enables fetching OG metadata for external embeds (default: true)
+	FetchExternal bool `json:"fetch_external" yaml:"fetch_external" toml:"fetch_external"`
+
+	// CacheDir is the directory for caching external embed metadata (default: ".cache/embeds")
+	CacheDir string `json:"cache_dir" yaml:"cache_dir" toml:"cache_dir"`
+
+	// Timeout is the HTTP request timeout in seconds for external fetches (default: 10)
+	Timeout int `json:"timeout" yaml:"timeout" toml:"timeout"`
+
+	// FallbackTitle is used when OG title cannot be fetched (default: "External Link")
+	FallbackTitle string `json:"fallback_title" yaml:"fallback_title" toml:"fallback_title"`
+
+	// ShowImage controls whether to display OG images in external embeds (default: true)
+	ShowImage bool `json:"show_image" yaml:"show_image" toml:"show_image"`
+}
+
+// NewEmbedsConfig creates a new EmbedsConfig with default values.
+func NewEmbedsConfig() EmbedsConfig {
+	return EmbedsConfig{
+		Enabled:           true,
+		InternalCardClass: "embed-card",
+		ExternalCardClass: "embed-card embed-card-external",
+		FetchExternal:     true,
+		CacheDir:          ".cache/embeds",
+		Timeout:           10,
+		FallbackTitle:     "External Link",
+		ShowImage:         true,
+	}
+}
+
 // ContentTemplateConfig defines a single content template.
 type ContentTemplateConfig struct {
 	// Name is the template identifier (e.g., "post", "page", "docs")

--- a/pkg/plugins/embeds_test.go
+++ b/pkg/plugins/embeds_test.go
@@ -1,0 +1,587 @@
+package plugins
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
+	"github.com/WaylonWalker/markata-go/pkg/models"
+)
+
+func TestEmbedsPlugin_Name(t *testing.T) {
+	p := NewEmbedsPlugin()
+	if p.Name() != "embeds" {
+		t.Errorf("expected name 'embeds', got '%s'", p.Name())
+	}
+}
+
+func TestEmbedsPlugin_Priority(t *testing.T) {
+	p := NewEmbedsPlugin()
+
+	if p.Priority(lifecycle.StageTransform) != lifecycle.PriorityEarly {
+		t.Errorf("expected PriorityEarly for Transform stage")
+	}
+
+	if p.Priority(lifecycle.StageRender) != lifecycle.PriorityDefault {
+		t.Errorf("expected PriorityDefault for Render stage")
+	}
+}
+
+func TestEmbedsPlugin_InternalEmbed(t *testing.T) {
+	p := NewEmbedsPlugin()
+
+	m := lifecycle.NewManager()
+
+	// Create posts
+	targetTitle := "Target Post"
+	targetDesc := "This is the target post description"
+	targetDate := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
+	targetPost := &models.Post{
+		Path:        "target.md",
+		Slug:        "target-post",
+		Href:        "/target-post/",
+		Title:       &targetTitle,
+		Description: &targetDesc,
+		Date:        &targetDate,
+	}
+
+	sourcePost := &models.Post{
+		Path:    "source.md",
+		Slug:    "source-post",
+		Href:    "/source-post/",
+		Content: "Here is an embed: ![[target-post]]",
+	}
+
+	m.SetPosts([]*models.Post{targetPost, sourcePost})
+
+	err := p.Transform(m)
+	if err != nil {
+		t.Fatalf("Transform failed: %v", err)
+	}
+
+	posts := m.Posts()
+	var result *models.Post
+	for _, post := range posts {
+		if post.Slug == "source-post" {
+			result = post
+			break
+		}
+	}
+
+	if result == nil {
+		t.Fatal("source post not found")
+	}
+
+	// Check that the embed was replaced
+	if contains := result.Content; !containsString(contains, `class="embed-card"`) {
+		t.Errorf("expected embed card class in content, got: %s", contains)
+	}
+
+	if !containsString(result.Content, `href="/target-post/"`) {
+		t.Errorf("expected href to target post in content")
+	}
+
+	if !containsString(result.Content, "Target Post") {
+		t.Errorf("expected target post title in content")
+	}
+
+	if !containsString(result.Content, "This is the target post description") {
+		t.Errorf("expected target post description in content")
+	}
+}
+
+func TestEmbedsPlugin_InternalEmbed_WithDisplayText(t *testing.T) {
+	p := NewEmbedsPlugin()
+
+	m := lifecycle.NewManager()
+
+	targetTitle := "Target Post"
+	targetPost := &models.Post{
+		Path:  "target.md",
+		Slug:  "target-post",
+		Href:  "/target-post/",
+		Title: &targetTitle,
+	}
+
+	sourcePost := &models.Post{
+		Path:    "source.md",
+		Slug:    "source-post",
+		Content: "Here is an embed: ![[target-post|Custom Title]]",
+	}
+
+	m.SetPosts([]*models.Post{targetPost, sourcePost})
+
+	err := p.Transform(m)
+	if err != nil {
+		t.Fatalf("Transform failed: %v", err)
+	}
+
+	posts := m.Posts()
+	var result *models.Post
+	for _, post := range posts {
+		if post.Slug == "source-post" {
+			result = post
+			break
+		}
+	}
+
+	if result == nil {
+		t.Fatal("source post not found")
+	}
+
+	if !containsString(result.Content, "Custom Title") {
+		t.Errorf("expected custom title in content, got: %s", result.Content)
+	}
+}
+
+func TestEmbedsPlugin_InternalEmbed_NotFound(t *testing.T) {
+	p := NewEmbedsPlugin()
+
+	m := lifecycle.NewManager()
+
+	sourcePost := &models.Post{
+		Path:    "source.md",
+		Slug:    "source-post",
+		Content: "Here is an embed: ![[nonexistent-post]]",
+	}
+
+	m.SetPosts([]*models.Post{sourcePost})
+
+	err := p.Transform(m)
+	if err != nil {
+		t.Fatalf("Transform failed: %v", err)
+	}
+
+	posts := m.Posts()
+	result := posts[0]
+
+	// Should have warning comment and original syntax
+	if !containsString(result.Content, "<!-- embed not found: nonexistent-post -->") {
+		t.Errorf("expected not found comment, got: %s", result.Content)
+	}
+
+	if !containsString(result.Content, "![[nonexistent-post]]") {
+		t.Errorf("expected original syntax preserved")
+	}
+}
+
+func TestEmbedsPlugin_InternalEmbed_CannotEmbedSelf(t *testing.T) {
+	p := NewEmbedsPlugin()
+
+	m := lifecycle.NewManager()
+
+	title := "Self Post"
+	selfPost := &models.Post{
+		Path:    "self.md",
+		Slug:    "self-post",
+		Href:    "/self-post/",
+		Title:   &title,
+		Content: "Trying to embed myself: ![[self-post]]",
+	}
+
+	m.SetPosts([]*models.Post{selfPost})
+
+	err := p.Transform(m)
+	if err != nil {
+		t.Fatalf("Transform failed: %v", err)
+	}
+
+	posts := m.Posts()
+	result := posts[0]
+
+	if !containsString(result.Content, "<!-- cannot embed self -->") {
+		t.Errorf("expected self-embed warning, got: %s", result.Content)
+	}
+}
+
+func TestEmbedsPlugin_InternalEmbed_InCodeBlock(t *testing.T) {
+	p := NewEmbedsPlugin()
+
+	m := lifecycle.NewManager()
+
+	targetTitle := "Target Post"
+	targetPost := &models.Post{
+		Path:  "target.md",
+		Slug:  "target-post",
+		Title: &targetTitle,
+	}
+
+	sourcePost := &models.Post{
+		Path: "source.md",
+		Slug: "source-post",
+		Content: `Normal embed: ![[target-post]]
+
+` + "```" + `
+Code block embed: ![[target-post]]
+` + "```",
+	}
+
+	m.SetPosts([]*models.Post{targetPost, sourcePost})
+
+	err := p.Transform(m)
+	if err != nil {
+		t.Fatalf("Transform failed: %v", err)
+	}
+
+	posts := m.Posts()
+	var result *models.Post
+	for _, post := range posts {
+		if post.Slug == "source-post" {
+			result = post
+			break
+		}
+	}
+
+	if result == nil {
+		t.Fatal("source post not found")
+	}
+
+	// First embed should be processed
+	if !containsString(result.Content, `class="embed-card"`) {
+		t.Errorf("expected embed card in normal text")
+	}
+
+	// Code block embed should NOT be processed
+	if !containsString(result.Content, "Code block embed: ![[target-post]]") {
+		t.Errorf("expected code block embed to be preserved, got: %s", result.Content)
+	}
+}
+
+func TestEmbedsPlugin_ExternalEmbed(t *testing.T) {
+	// Create a test server that returns HTML with OG metadata
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		//nolint:errcheck // test helper
+		w.Write([]byte(`<!DOCTYPE html>
+<html>
+<head>
+	<title>Test Page</title>
+	<meta property="og:title" content="OG Test Title">
+	<meta property="og:description" content="OG Test Description">
+	<meta property="og:image" content="https://example.com/image.jpg">
+	<meta property="og:site_name" content="Test Site">
+</head>
+<body></body>
+</html>`))
+	}))
+	defer server.Close()
+
+	p := NewEmbedsPlugin()
+	// Use temp cache dir
+	tmpDir := t.TempDir()
+	p.config.CacheDir = filepath.Join(tmpDir, "cache")
+
+	m := lifecycle.NewManager()
+
+	sourcePost := &models.Post{
+		Path:    "source.md",
+		Slug:    "source-post",
+		Content: "Here is an external embed: ![embed](" + server.URL + ")",
+	}
+
+	m.SetPosts([]*models.Post{sourcePost})
+
+	err := p.Transform(m)
+	if err != nil {
+		t.Fatalf("Transform failed: %v", err)
+	}
+
+	posts := m.Posts()
+	result := posts[0]
+
+	// Check embed card was created
+	if !containsString(result.Content, `class="embed-card embed-card-external"`) {
+		t.Errorf("expected external embed card class, got: %s", result.Content)
+	}
+
+	if !containsString(result.Content, "OG Test Title") {
+		t.Errorf("expected OG title in content")
+	}
+
+	if !containsString(result.Content, "OG Test Description") {
+		t.Errorf("expected OG description in content")
+	}
+
+	if !containsString(result.Content, `src="https://example.com/image.jpg"`) {
+		t.Errorf("expected OG image in content")
+	}
+}
+
+func TestEmbedsPlugin_ExternalEmbed_Caching(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "text/html")
+		//nolint:errcheck // test helper
+		w.Write([]byte(`<!DOCTYPE html>
+<html>
+<head>
+	<meta property="og:title" content="Cached Title">
+</head>
+</html>`))
+	}))
+	defer server.Close()
+
+	tmpDir := t.TempDir()
+
+	// First request
+	p1 := NewEmbedsPlugin()
+	p1.config.CacheDir = filepath.Join(tmpDir, "cache")
+
+	m1 := lifecycle.NewManager()
+	m1.SetPosts([]*models.Post{{
+		Path:    "source.md",
+		Slug:    "source",
+		Content: "![embed](" + server.URL + ")",
+	}})
+
+	if err := p1.Transform(m1); err != nil {
+		t.Fatalf("First transform failed: %v", err)
+	}
+
+	if callCount != 1 {
+		t.Errorf("expected 1 HTTP call, got %d", callCount)
+	}
+
+	// Second request should use cache
+	p2 := NewEmbedsPlugin()
+	p2.config.CacheDir = filepath.Join(tmpDir, "cache")
+
+	m2 := lifecycle.NewManager()
+	m2.SetPosts([]*models.Post{{
+		Path:    "source2.md",
+		Slug:    "source2",
+		Content: "![embed](" + server.URL + ")",
+	}})
+
+	if err := p2.Transform(m2); err != nil {
+		t.Fatalf("Second transform failed: %v", err)
+	}
+
+	if callCount != 1 {
+		t.Errorf("expected still 1 HTTP call (cached), got %d", callCount)
+	}
+
+	// Verify cache file exists
+	cacheDir := filepath.Join(tmpDir, "cache")
+	files, err := os.ReadDir(cacheDir)
+	if err != nil {
+		t.Fatalf("Failed to read cache dir: %v", err)
+	}
+
+	if len(files) != 1 {
+		t.Errorf("expected 1 cache file, got %d", len(files))
+	}
+}
+
+func TestEmbedsPlugin_ExternalEmbed_FetchDisabled(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("HTTP request made when fetch_external is disabled")
+	}))
+	defer server.Close()
+
+	p := NewEmbedsPlugin()
+	p.config.FetchExternal = false
+	p.config.FallbackTitle = "Fallback"
+
+	m := lifecycle.NewManager()
+	m.SetPosts([]*models.Post{{
+		Path:    "source.md",
+		Slug:    "source",
+		Content: "![embed](" + server.URL + ")",
+	}})
+
+	if err := p.Transform(m); err != nil {
+		t.Fatalf("Transform failed: %v", err)
+	}
+
+	posts := m.Posts()
+	result := posts[0]
+
+	if !containsString(result.Content, "Fallback") {
+		t.Errorf("expected fallback title, got: %s", result.Content)
+	}
+}
+
+func TestEmbedsPlugin_ExternalEmbed_InCodeBlock(t *testing.T) {
+	p := NewEmbedsPlugin()
+	p.config.FetchExternal = false
+
+	m := lifecycle.NewManager()
+
+	sourcePost := &models.Post{
+		Path: "source.md",
+		Slug: "source-post",
+		Content: `Normal embed: ![embed](https://example.com)
+
+` + "```" + `
+Code block embed: ![embed](https://example.com/code)
+` + "```",
+	}
+
+	m.SetPosts([]*models.Post{sourcePost})
+
+	err := p.Transform(m)
+	if err != nil {
+		t.Fatalf("Transform failed: %v", err)
+	}
+
+	posts := m.Posts()
+	result := posts[0]
+
+	// Normal embed should be processed
+	if !containsString(result.Content, `class="embed-card embed-card-external"`) {
+		t.Errorf("expected external embed card in normal text")
+	}
+
+	// Code block embed should NOT be processed
+	if !containsString(result.Content, "![embed](https://example.com/code)") {
+		t.Errorf("expected code block embed syntax to be preserved")
+	}
+}
+
+func TestEmbedsPlugin_Configure(t *testing.T) {
+	p := NewEmbedsPlugin()
+
+	m := lifecycle.NewManager()
+	config := m.Config()
+	config.Extra = map[string]interface{}{
+		"embeds": map[string]interface{}{
+			"enabled":             false,
+			"internal_card_class": "custom-internal",
+			"external_card_class": "custom-external",
+			"fetch_external":      false,
+			"cache_dir":           "custom-cache",
+			"timeout":             30,
+			"fallback_title":      "Custom Fallback",
+			"show_image":          false,
+		},
+	}
+
+	err := p.Configure(m)
+	if err != nil {
+		t.Fatalf("Configure failed: %v", err)
+	}
+
+	if p.config.Enabled {
+		t.Error("expected enabled to be false")
+	}
+	if p.config.InternalCardClass != "custom-internal" {
+		t.Errorf("expected internal_card_class 'custom-internal', got '%s'", p.config.InternalCardClass)
+	}
+	if p.config.ExternalCardClass != "custom-external" {
+		t.Errorf("expected external_card_class 'custom-external', got '%s'", p.config.ExternalCardClass)
+	}
+	if p.config.FetchExternal {
+		t.Error("expected fetch_external to be false")
+	}
+	if p.config.CacheDir != "custom-cache" {
+		t.Errorf("expected cache_dir 'custom-cache', got '%s'", p.config.CacheDir)
+	}
+	if p.config.Timeout != 30 {
+		t.Errorf("expected timeout 30, got %d", p.config.Timeout)
+	}
+	if p.config.FallbackTitle != "Custom Fallback" {
+		t.Errorf("expected fallback_title 'Custom Fallback', got '%s'", p.config.FallbackTitle)
+	}
+	if p.config.ShowImage {
+		t.Error("expected show_image to be false")
+	}
+}
+
+func TestEmbedsPlugin_Disabled(t *testing.T) {
+	p := NewEmbedsPlugin()
+	p.config.Enabled = false
+
+	m := lifecycle.NewManager()
+
+	sourcePost := &models.Post{
+		Path:    "source.md",
+		Slug:    "source",
+		Content: "![[target-post]] and ![embed](https://example.com)",
+	}
+
+	m.SetPosts([]*models.Post{sourcePost})
+
+	err := p.Transform(m)
+	if err != nil {
+		t.Fatalf("Transform failed: %v", err)
+	}
+
+	posts := m.Posts()
+	result := posts[0]
+
+	// Content should be unchanged
+	if result.Content != "![[target-post]] and ![embed](https://example.com)" {
+		t.Errorf("expected content to be unchanged when disabled, got: %s", result.Content)
+	}
+}
+
+func TestEmbedsPlugin_SkippedPosts(t *testing.T) {
+	p := NewEmbedsPlugin()
+
+	m := lifecycle.NewManager()
+
+	targetTitle := "Target"
+	targetPost := &models.Post{
+		Path:  "target.md",
+		Slug:  "target-post",
+		Title: &targetTitle,
+	}
+
+	skippedPost := &models.Post{
+		Path:    "skipped.md",
+		Slug:    "skipped",
+		Skip:    true,
+		Content: "![[target-post]]",
+	}
+
+	m.SetPosts([]*models.Post{targetPost, skippedPost})
+
+	err := p.Transform(m)
+	if err != nil {
+		t.Fatalf("Transform failed: %v", err)
+	}
+
+	posts := m.Posts()
+	var result *models.Post
+	for _, post := range posts {
+		if post.Slug == "skipped" {
+			result = post
+			break
+		}
+	}
+
+	// Content should be unchanged for skipped posts
+	if result.Content != "![[target-post]]" {
+		t.Errorf("expected skipped post content unchanged, got: %s", result.Content)
+	}
+}
+
+func TestEmbedsPlugin_Interfaces(_ *testing.T) {
+	p := NewEmbedsPlugin()
+
+	// Verify interface implementations
+	var _ lifecycle.Plugin = p
+	var _ lifecycle.ConfigurePlugin = p
+	var _ lifecycle.TransformPlugin = p
+	var _ lifecycle.PriorityPlugin = p
+}
+
+// Helper function
+func containsString(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || s != "" && containsStringHelper(s, substr))
+}
+
+func containsStringHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/plugins/registry.go
+++ b/pkg/plugins/registry.go
@@ -67,6 +67,7 @@ func registerBuiltinPluginsLocked() {
 	pluginRegistry.constructors["pagefind"] = func() lifecycle.Plugin { return NewPagefindPlugin() }
 	pluginRegistry.constructors["stats"] = func() lifecycle.Plugin { return NewStatsPlugin() }
 	pluginRegistry.constructors["breadcrumbs"] = func() lifecycle.Plugin { return NewBreadcrumbsPlugin() }
+	pluginRegistry.constructors["embeds"] = func() lifecycle.Plugin { return NewEmbedsPlugin() }
 }
 
 // RegisterPluginConstructor registers a plugin constructor with the given name.
@@ -124,6 +125,7 @@ func DefaultPlugins() []lifecycle.Plugin {
 		NewReadingTimePlugin(),    // Calculate reading time
 		NewStatsPlugin(),          // Calculate comprehensive content stats
 		NewBreadcrumbsPlugin(),    // Generate breadcrumb navigation
+		NewEmbedsPlugin(),         // Process embed syntax (before wikilinks)
 		NewWikilinksPlugin(),      // Process wikilinks before rendering
 		NewTocPlugin(),            // Extract TOC before rendering
 		NewJinjaMdPlugin(),        // Process Jinja templates in markdown
@@ -178,6 +180,7 @@ func TransformPlugins() []lifecycle.Plugin {
 		NewReadingTimePlugin(),
 		NewStatsPlugin(),
 		NewBreadcrumbsPlugin(),
+		NewEmbedsPlugin(),
 		NewWikilinksPlugin(),
 		NewTocPlugin(),
 		NewJinjaMdPlugin(),

--- a/pkg/themes/default/static/css/components.css
+++ b/pkg/themes/default/static/css/components.css
@@ -831,3 +831,168 @@
     content: " > ";
   }
 }
+
+/* ==========================================================================
+   Embed Card Component
+   
+   Used by the embeds plugin for internal (![[slug]]) and external
+   (![embed](url)) content embedding.
+   ========================================================================== */
+
+.embed-card {
+  margin: 1.5rem 0;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  overflow: hidden;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.embed-card:hover {
+  border-color: var(--color-primary);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.embed-card-link {
+  display: flex;
+  flex-direction: column;
+  text-decoration: none;
+  color: inherit;
+}
+
+.embed-card-link:hover {
+  text-decoration: none;
+}
+
+/* External embed with image - horizontal layout */
+.embed-card-external .embed-card-link {
+  flex-direction: row;
+}
+
+.embed-card-image {
+  flex-shrink: 0;
+  width: 200px;
+  max-height: 150px;
+  overflow: hidden;
+  background-color: var(--color-background);
+}
+
+.embed-card-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.2s ease;
+}
+
+.embed-card:hover .embed-card-image img {
+  transform: scale(1.02);
+}
+
+.embed-card-content {
+  flex: 1;
+  padding: 1rem 1.25rem;
+  min-width: 0; /* Allow text truncation */
+}
+
+.embed-card-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  line-height: 1.4;
+  color: var(--color-text);
+  margin-bottom: 0.5rem;
+  
+  /* Truncate long titles */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.embed-card:hover .embed-card-title {
+  color: var(--color-primary);
+}
+
+.embed-card-description {
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: var(--color-text-muted);
+  margin-bottom: 0.75rem;
+  
+  /* Truncate long descriptions */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.embed-card-meta {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* Internal embed card (no image) - compact layout */
+.embed-card:not(.embed-card-external) {
+  border-left: 4px solid var(--color-primary);
+}
+
+.embed-card:not(.embed-card-external) .embed-card-content {
+  padding: 1rem 1.25rem 1rem 1rem;
+}
+
+/* Responsive adjustments */
+@media (max-width: 640px) {
+  .embed-card-external .embed-card-link {
+    flex-direction: column;
+  }
+  
+  .embed-card-image {
+    width: 100%;
+    max-height: 180px;
+  }
+  
+  .embed-card-content {
+    padding: 1rem;
+  }
+  
+  .embed-card-title {
+    font-size: 1rem;
+    -webkit-line-clamp: 2;
+  }
+  
+  .embed-card-description {
+    -webkit-line-clamp: 2;
+  }
+}
+
+/* Focus states for accessibility */
+.embed-card-link:focus {
+  outline: none;
+}
+
+.embed-card-link:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+  border-radius: inherit;
+}
+
+/* Print styles */
+@media print {
+  .embed-card {
+    page-break-inside: avoid;
+    border: 1px solid #ccc;
+    box-shadow: none;
+  }
+  
+  .embed-card-image {
+    display: none;
+  }
+  
+  .embed-card-link::after {
+    content: " (" attr(href) ")";
+    font-size: 0.75rem;
+    color: #666;
+  }
+}

--- a/spec/spec/EMBEDS.md
+++ b/spec/spec/EMBEDS.md
@@ -1,0 +1,190 @@
+# Embeds Plugin Specification
+
+The embeds plugin enables rich embedding of both internal posts and external URLs within markdown content.
+
+## Overview
+
+The embeds plugin processes two types of embed syntax:
+
+1. **Internal embeds** (`![[slug]]`) - Embed another post from the same site as a preview card
+2. **External embeds** (`![embed](url)`) - Embed external URLs with Open Graph metadata
+
+## Syntax
+
+### Internal Embeds
+
+```markdown
+![[slug]]           # Basic internal embed
+![[slug|Title]]     # Custom display title
+```
+
+### External Embeds
+
+```markdown
+![embed](https://example.com/article)  # External embed with OG metadata
+```
+
+Note: The alt text must be exactly `embed` to trigger external embedding. Regular images with other alt text are not affected.
+
+## Configuration
+
+```toml
+[embeds]
+enabled = true                                    # Enable/disable the plugin
+internal_card_class = "embed-card"               # CSS class for internal cards
+external_card_class = "embed-card embed-card-external"  # CSS class for external cards
+fetch_external = true                            # Fetch OG metadata from external URLs
+cache_dir = ".cache/embeds"                      # Cache directory for external metadata
+timeout = 10                                     # HTTP timeout in seconds
+fallback_title = "External Link"                 # Title when OG title is unavailable
+show_image = true                                # Show OG images in external embeds
+```
+
+## Internal Embeds
+
+### Behavior
+
+1. The plugin looks up the target post by slug (case-insensitive)
+2. If found, it generates an embed card with:
+   - Linked title (from display text or post title)
+   - Description (truncated to 200 characters)
+   - Date (if available)
+3. If not found, it adds a warning comment and preserves the original syntax
+
+### Self-Reference Protection
+
+A post cannot embed itself. Attempting to do so adds a warning comment:
+
+```html
+<!-- cannot embed self -->
+![[self-slug]]
+```
+
+### Generated HTML
+
+```html
+<div class="embed-card">
+  <a href="/target-post/" class="embed-card-link">
+    <div class="embed-card-content">
+      <div class="embed-card-title">Target Post Title</div>
+      <div class="embed-card-description">Post description...</div>
+      <div class="embed-card-meta">Jan 15, 2024</div>
+    </div>
+  </a>
+</div>
+```
+
+## External Embeds
+
+### Behavior
+
+1. Validates the URL (must be http or https)
+2. Fetches Open Graph metadata from the URL (if enabled)
+3. Caches metadata for 7 days
+4. Generates an embed card with:
+   - OG image (if available and enabled)
+   - OG title (or fallback)
+   - OG description (truncated)
+   - Site name and domain
+
+### Open Graph Metadata Extraction
+
+The plugin extracts:
+- `og:title` - Page title
+- `og:description` - Page description
+- `og:image` - Preview image URL
+- `og:site_name` - Website name
+
+Falls back to `<title>` and `<meta name="description">` if OG tags are missing.
+
+### Caching
+
+External metadata is cached as JSON files:
+- Location: `.cache/embeds/` (configurable)
+- File name: SHA-256 hash of URL (first 8 bytes)
+- Expiration: 7 days
+
+Example cache file:
+```json
+{
+  "title": "Article Title",
+  "description": "Article description",
+  "image": "https://example.com/og-image.jpg",
+  "site_name": "Example Site",
+  "type": "article",
+  "fetched_at": 1705350000
+}
+```
+
+### Generated HTML
+
+```html
+<div class="embed-card embed-card-external">
+  <a href="https://example.com/article" class="embed-card-link" target="_blank" rel="noopener noreferrer">
+    <div class="embed-card-image">
+      <img src="https://example.com/og-image.jpg" alt="" loading="lazy">
+    </div>
+    <div class="embed-card-content">
+      <div class="embed-card-title">Article Title</div>
+      <div class="embed-card-description">Article description...</div>
+      <div class="embed-card-meta">Example Site &middot; example.com</div>
+    </div>
+  </a>
+</div>
+```
+
+## Code Block Protection
+
+Embed syntax inside fenced code blocks is preserved and not processed:
+
+```markdown
+Normal embed: ![[my-post]]
+
+` ` `
+Code example: ![[my-post]]
+` ` `
+```
+
+## Lifecycle Stage
+
+The embeds plugin runs in the **Transform** stage with `PriorityEarly` (-100), ensuring it processes content before:
+- Wikilinks plugin
+- Table of Contents extraction
+- Jinja-MD processing
+
+## Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| Internal embed not found | Warning comment + original syntax preserved |
+| Self-reference | Warning comment + original syntax preserved |
+| External URL invalid | Original syntax preserved |
+| External fetch fails | Uses fallback title, no image |
+| External timeout | Uses fallback title, no image |
+
+## CSS Classes
+
+| Class | Purpose |
+|-------|---------|
+| `.embed-card` | Base container |
+| `.embed-card-external` | External embed modifier |
+| `.embed-card-link` | Clickable anchor |
+| `.embed-card-image` | Image container (external only) |
+| `.embed-card-content` | Text content wrapper |
+| `.embed-card-title` | Title element |
+| `.embed-card-description` | Description element |
+| `.embed-card-meta` | Metadata (date, domain) |
+
+## Performance Considerations
+
+1. **Caching** - External metadata is cached to avoid repeated HTTP requests
+2. **Timeout** - Configurable HTTP timeout (default 10s) prevents slow builds
+3. **Concurrent Processing** - Posts are processed concurrently
+4. **Body Limit** - External pages are limited to 1MB to prevent memory issues
+5. **Disable Fetching** - Set `fetch_external = false` to skip HTTP requests entirely
+
+## Related Features
+
+- **Wikilinks** (`[[slug]]`) - Simple internal links without preview cards
+- **One-line Links** - Automatic link card for standalone URLs
+- **Link Collector** - Tracks outlinks for backlink generation

--- a/templates/partials/embed-card.html
+++ b/templates/partials/embed-card.html
@@ -1,0 +1,16 @@
+{# Embed card partial for internal post embeds #}
+{# Used by the embeds plugin when processing ![[slug]] syntax #}
+
+<div class="{{ card_class|default:'embed-card' }}">
+  <a href="{{ post.href }}" class="embed-card-link">
+    <div class="embed-card-content">
+      <div class="embed-card-title">{{ title|default:post.title }}</div>
+      {% if post.description %}
+      <div class="embed-card-description">{{ post.description|truncate:200 }}</div>
+      {% endif %}
+      {% if post.date %}
+      <div class="embed-card-meta">{{ post.date | date:"Jan 2, 2006" }}</div>
+      {% endif %}
+    </div>
+  </a>
+</div>

--- a/templates/partials/external-embed.html
+++ b/templates/partials/external-embed.html
@@ -1,0 +1,21 @@
+{# External embed card partial for embedding external URLs #}
+{# Used by the embeds plugin when processing ![embed](url) syntax #}
+
+<div class="{{ card_class|default:'embed-card embed-card-external' }}">
+  <a href="{{ url }}" class="embed-card-link" target="_blank" rel="noopener noreferrer">
+    {% if show_image and og_image %}
+    <div class="embed-card-image">
+      <img src="{{ og_image }}" alt="" loading="lazy">
+    </div>
+    {% endif %}
+    <div class="embed-card-content">
+      <div class="embed-card-title">{{ og_title|default:fallback_title }}</div>
+      {% if og_description %}
+      <div class="embed-card-description">{{ og_description|truncate:200 }}</div>
+      {% endif %}
+      <div class="embed-card-meta">
+        {% if og_site_name %}{{ og_site_name }} &middot; {% endif %}{{ domain }}
+      </div>
+    </div>
+  </a>
+</div>

--- a/themes/default/static/css/components.css
+++ b/themes/default/static/css/components.css
@@ -1110,3 +1110,168 @@ kbd {
     content: " > ";
   }
 }
+
+/* ==========================================================================
+   Embed Card Component
+   
+   Used by the embeds plugin for internal (![[slug]]) and external
+   (![embed](url)) content embedding.
+   ========================================================================== */
+
+.embed-card {
+  margin: 1.5rem 0;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  overflow: hidden;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.embed-card:hover {
+  border-color: var(--color-primary);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.embed-card-link {
+  display: flex;
+  flex-direction: column;
+  text-decoration: none;
+  color: inherit;
+}
+
+.embed-card-link:hover {
+  text-decoration: none;
+}
+
+/* External embed with image - horizontal layout */
+.embed-card-external .embed-card-link {
+  flex-direction: row;
+}
+
+.embed-card-image {
+  flex-shrink: 0;
+  width: 200px;
+  max-height: 150px;
+  overflow: hidden;
+  background-color: var(--color-background);
+}
+
+.embed-card-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.2s ease;
+}
+
+.embed-card:hover .embed-card-image img {
+  transform: scale(1.02);
+}
+
+.embed-card-content {
+  flex: 1;
+  padding: 1rem 1.25rem;
+  min-width: 0; /* Allow text truncation */
+}
+
+.embed-card-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  line-height: 1.4;
+  color: var(--color-text);
+  margin-bottom: 0.5rem;
+  
+  /* Truncate long titles */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.embed-card:hover .embed-card-title {
+  color: var(--color-primary);
+}
+
+.embed-card-description {
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: var(--color-text-muted);
+  margin-bottom: 0.75rem;
+  
+  /* Truncate long descriptions */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.embed-card-meta {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* Internal embed card (no image) - compact layout */
+.embed-card:not(.embed-card-external) {
+  border-left: 4px solid var(--color-primary);
+}
+
+.embed-card:not(.embed-card-external) .embed-card-content {
+  padding: 1rem 1.25rem 1rem 1rem;
+}
+
+/* Responsive adjustments */
+@media (max-width: 640px) {
+  .embed-card-external .embed-card-link {
+    flex-direction: column;
+  }
+  
+  .embed-card-image {
+    width: 100%;
+    max-height: 180px;
+  }
+  
+  .embed-card-content {
+    padding: 1rem;
+  }
+  
+  .embed-card-title {
+    font-size: 1rem;
+    -webkit-line-clamp: 2;
+  }
+  
+  .embed-card-description {
+    -webkit-line-clamp: 2;
+  }
+}
+
+/* Focus states for accessibility */
+.embed-card-link:focus {
+  outline: none;
+}
+
+.embed-card-link:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+  border-radius: inherit;
+}
+
+/* Print styles */
+@media print {
+  .embed-card {
+    page-break-inside: avoid;
+    border: 1px solid #ccc;
+    box-shadow: none;
+  }
+  
+  .embed-card-image {
+    display: none;
+  }
+  
+  .embed-card-link::after {
+    content: " (" attr(href) ")";
+    font-size: 0.75rem;
+    color: #666;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new embeds plugin that allows embedding both internal posts and external URLs as rich preview cards in markdown content.

Fixes #181

## Features

- **Internal embeds**: Use `![[slug]]` or `![[slug|display text]]` syntax to embed other posts from your site
- **External embeds**: Use `![embed](https://example.com)` syntax to embed external URLs with OG metadata
- **Smart caching**: OG metadata for external URLs is cached to avoid repeated fetches
- **Code block protection**: Embed syntax inside code blocks is preserved as-is
- **Configurable**: Enable/disable via `[embeds]` section in config

## Changes

### New Files
- `pkg/plugins/embeds.go` - Main plugin implementation
- `pkg/plugins/embeds_test.go` - 15 comprehensive tests (all passing)
- `templates/partials/embed-card.html` - Template for internal embeds
- `templates/partials/external-embed.html` - Template for external embeds
- `spec/spec/EMBEDS.md` - Technical specification
- `docs/guides/embeds.md` - User documentation

### Modified Files
- `pkg/models/config.go` - Added `EmbedsConfig` struct
- `pkg/plugins/registry.go` - Registered plugin in DefaultPlugins and TransformPlugins
- `themes/default/static/css/components.css` - Added embed card styles
- `pkg/themes/default/static/css/components.css` - Added embed card styles (embedded)

## Usage

### Internal Embeds
```markdown
Check out this related post: ![[my-cool-post]]

Or with custom text: ![[my-cool-post|Read more about this topic]]
```

### External Embeds
```markdown
![embed](https://github.com/WaylonWalker/markata-go)
```

## Testing

All 15 tests pass:
```
go test -v ./pkg/plugins/... -run Embed
```