### PR TITLE
docs: Restructure deployment docs by platform

### DIFF
--- a/docs/guides/deployment/aws-s3.md
+++ b/docs/guides/deployment/aws-s3.md
@@ -1,0 +1,412 @@
+---
+title: "Deploy to AWS S3"
+description: "Step-by-step guide to deploy markata-go sites on AWS S3 with CloudFront"
+date: 2026-01-24
+published: true
+tags:
+  - documentation
+  - deployment
+  - aws-s3
+---
+
+# Deploy to AWS S3
+
+Amazon S3 provides highly durable object storage that's ideal for hosting static websites. Combined with CloudFront CDN, it offers enterprise-grade performance and security.
+
+## Prerequisites
+
+- An AWS account
+- AWS CLI installed and configured
+- Your markata-go site ready to build
+
+## Cost
+
+| Service | Free Tier | After Free Tier |
+|---------|-----------|-----------------|
+| S3 Storage | 5 GB (12 months) | ~$0.023/GB/month |
+| S3 Requests | 20,000 GET (12 months) | ~$0.0004/1000 requests |
+| CloudFront | 1 TB transfer (12 months) | ~$0.085/GB |
+| Route 53 | N/A | $0.50/hosted zone/month |
+
+A typical blog costs $1-5/month after the free tier expires.
+
+## Architecture Options
+
+| Setup | Complexity | HTTPS | Custom Domain | CDN |
+|-------|------------|-------|---------------|-----|
+| S3 only | Low | No | Limited | No |
+| S3 + CloudFront | Medium | Yes | Yes | Yes |
+| S3 + CloudFront + Route 53 | High | Yes | Yes (apex) | Yes |
+
+This guide covers the recommended S3 + CloudFront setup.
+
+## Step 1: Create S3 Bucket
+
+### Using AWS Console
+
+1. Go to [S3 Console](https://s3.console.aws.amazon.com/)
+2. Click **Create bucket**
+3. Enter bucket name (e.g., `my-site-bucket`)
+4. Choose a region close to your audience
+5. Uncheck **Block all public access** (we'll use CloudFront for access)
+6. Click **Create bucket**
+
+### Using AWS CLI
+
+```bash
+# Create bucket
+aws s3 mb s3://my-site-bucket --region us-east-1
+
+# Enable static website hosting
+aws s3 website s3://my-site-bucket --index-document index.html --error-document 404.html
+```
+
+## Step 2: Configure Bucket Policy
+
+Create a bucket policy to allow CloudFront access:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowCloudFrontAccess",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "cloudfront.amazonaws.com"
+      },
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::my-site-bucket/*",
+      "Condition": {
+        "StringEquals": {
+          "AWS:SourceArn": "arn:aws:cloudfront::ACCOUNT_ID:distribution/DISTRIBUTION_ID"
+        }
+      }
+    }
+  ]
+}
+```
+
+You'll update this policy after creating the CloudFront distribution.
+
+## Step 3: Create CloudFront Distribution
+
+### Using AWS Console
+
+1. Go to [CloudFront Console](https://console.aws.amazon.com/cloudfront/)
+2. Click **Create distribution**
+3. Configure origin:
+   - **Origin domain**: Select your S3 bucket
+   - **Origin access**: Origin access control settings (recommended)
+   - Click **Create control setting** > Create
+4. Configure default cache behavior:
+   - **Viewer protocol policy**: Redirect HTTP to HTTPS
+   - **Allowed HTTP methods**: GET, HEAD
+   - **Cache policy**: CachingOptimized
+5. Configure settings:
+   - **Price class**: Use all edge locations (or choose based on audience)
+   - **Default root object**: `index.html`
+6. Click **Create distribution**
+
+### Update S3 Bucket Policy
+
+After creating the distribution, update the bucket policy with the correct ARN:
+
+```bash
+# Get distribution ARN from CloudFront console
+# Update bucket policy with the distribution ARN
+```
+
+## Step 4: Build and Deploy
+
+### Build Your Site
+
+```bash
+# Set the CloudFront URL (or custom domain)
+export MARKATA_GO_URL=https://d1234abcd.cloudfront.net
+
+# Build
+markata-go build --clean
+```
+
+### Deploy to S3
+
+```bash
+# Sync all files
+aws s3 sync public/ s3://my-site-bucket --delete
+
+# With cache headers for static assets
+aws s3 sync public/static/ s3://my-site-bucket/static/ \
+  --cache-control "public, max-age=31536000, immutable"
+
+# HTML files with no-cache
+aws s3 sync public/ s3://my-site-bucket \
+  --exclude "static/*" \
+  --cache-control "public, max-age=0, must-revalidate"
+```
+
+### Invalidate CloudFront Cache
+
+After deploying, invalidate the cache to see changes immediately:
+
+```bash
+aws cloudfront create-invalidation \
+  --distribution-id YOUR_DISTRIBUTION_ID \
+  --paths "/*"
+```
+
+## Step 5: Custom Domain Setup
+
+### Option A: Using Route 53 (Recommended)
+
+1. **Create Hosted Zone**
+   ```bash
+   aws route53 create-hosted-zone --name example.com --caller-reference $(date +%s)
+   ```
+
+2. **Update Domain Nameservers**
+   
+   Get the nameservers from Route 53 and update them at your registrar.
+
+3. **Request SSL Certificate**
+   
+   In AWS Certificate Manager (ACM) - **must be in us-east-1 for CloudFront**:
+   ```bash
+   aws acm request-certificate \
+     --domain-name example.com \
+     --subject-alternative-names "*.example.com" \
+     --validation-method DNS \
+     --region us-east-1
+   ```
+
+4. **Add Certificate to CloudFront**
+   
+   Update your distribution:
+   - **Alternate domain names**: `example.com`, `www.example.com`
+   - **Custom SSL certificate**: Select your ACM certificate
+
+5. **Create DNS Records**
+   
+   In Route 53, create A records as aliases to your CloudFront distribution.
+
+### Option B: External DNS
+
+1. Request ACM certificate (as above)
+2. Validate via DNS by adding CNAME records at your registrar
+3. Add alternate domain names to CloudFront
+4. Create CNAME record pointing to your CloudFront domain:
+   ```
+   www.example.com -> d1234abcd.cloudfront.net
+   ```
+
+Note: Apex domains (example.com without www) require Route 53 or a DNS provider that supports ALIAS/ANAME records.
+
+## Automation with GitHub Actions
+
+Create `.github/workflows/deploy.yml`:
+
+```yaml
+name: Deploy to AWS
+
+on:
+  push:
+    branches: [main]
+
+env:
+  AWS_REGION: us-east-1
+  S3_BUCKET: my-site-bucket
+  CLOUDFRONT_DISTRIBUTION_ID: E1234567890ABC
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::ACCOUNT_ID:role/GitHubActionsRole
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Build
+        run: |
+          go install github.com/WaylonWalker/markata-go/cmd/markata-go@latest
+          markata-go build --clean
+        env:
+          MARKATA_GO_URL: https://example.com
+
+      - name: Deploy to S3
+        run: |
+          # Static assets with long cache
+          aws s3 sync public/static/ s3://${{ env.S3_BUCKET }}/static/ \
+            --cache-control "public, max-age=31536000, immutable"
+          
+          # Everything else
+          aws s3 sync public/ s3://${{ env.S3_BUCKET }} \
+            --exclude "static/*" \
+            --cache-control "public, max-age=0, must-revalidate" \
+            --delete
+
+      - name: Invalidate CloudFront
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id ${{ env.CLOUDFRONT_DISTRIBUTION_ID }} \
+            --paths "/*"
+```
+
+### IAM Role for GitHub Actions
+
+Create an IAM role with OIDC trust for GitHub:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::ACCOUNT_ID:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+        },
+        "StringLike": {
+          "token.actions.githubusercontent.com:sub": "repo:YOUR_ORG/YOUR_REPO:*"
+        }
+      }
+    }
+  ]
+}
+```
+
+Attach a policy allowing S3 and CloudFront access:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:DeleteObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::my-site-bucket",
+        "arn:aws:s3:::my-site-bucket/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "cloudfront:CreateInvalidation",
+      "Resource": "arn:aws:cloudfront::ACCOUNT_ID:distribution/DISTRIBUTION_ID"
+    }
+  ]
+}
+```
+
+## Troubleshooting
+
+### Access Denied Errors
+
+1. Check bucket policy allows CloudFront access
+2. Verify Origin Access Control is configured
+3. Ensure the distribution ARN in bucket policy is correct
+
+### 404 on Subpages
+
+Configure CloudFront error pages:
+
+1. Go to your distribution > **Error pages**
+2. Create custom error response:
+   - HTTP error code: 403
+   - Response page path: `/index.html`
+   - HTTP response code: 200
+
+Or use a CloudFront Function for clean URLs (see below).
+
+### CloudFront Function for Clean URLs
+
+Create a function to handle clean URLs:
+
+```javascript
+function handler(event) {
+  var request = event.request;
+  var uri = request.uri;
+  
+  // Check whether the URI is missing a file extension
+  if (!uri.includes('.')) {
+    // If URI doesn't end with /, add it
+    if (!uri.endsWith('/')) {
+      uri += '/';
+    }
+    // Append index.html
+    request.uri = uri + 'index.html';
+  }
+  
+  return request;
+}
+```
+
+Attach to your distribution's viewer request.
+
+### Changes Not Appearing
+
+1. Wait for CloudFront cache to expire, or
+2. Create a cache invalidation:
+   ```bash
+   aws cloudfront create-invalidation \
+     --distribution-id YOUR_DISTRIBUTION_ID \
+     --paths "/*"
+   ```
+
+### SSL Certificate Issues
+
+- ACM certificate must be in **us-east-1** region
+- Certificate must be validated (check ACM console)
+- Alternate domain names must match certificate
+
+## Cost Optimization
+
+### Reduce CloudFront Costs
+
+- Use **Price Class 100** (North America and Europe only) for regional sites
+- Enable **Compress objects automatically**
+- Set appropriate cache TTLs
+
+### Reduce S3 Costs
+
+- Enable **S3 Intelligent-Tiering** for rarely accessed sites
+- Use **S3 Standard** for frequently accessed content
+- Clean up old versions if versioning is enabled
+
+### Monitor Costs
+
+Set up AWS Budgets to alert you:
+
+```bash
+aws budgets create-budget \
+  --account-id YOUR_ACCOUNT_ID \
+  --budget file://budget.json \
+  --notifications-with-subscribers file://notifications.json
+```
+
+## Next Steps
+
+- [AWS S3 Docs](https://docs.aws.amazon.com/s3/) - Official S3 documentation
+- [CloudFront Docs](https://docs.aws.amazon.com/cloudfront/) - CDN configuration
+- [Configuration Guide](../configuration/) - Customize your markata-go site

--- a/docs/guides/deployment/cloudflare-pages.md
+++ b/docs/guides/deployment/cloudflare-pages.md
@@ -1,0 +1,334 @@
+---
+title: "Deploy to Cloudflare Pages"
+description: "Step-by-step guide to deploy markata-go sites on Cloudflare Pages"
+date: 2026-01-24
+published: true
+tags:
+  - documentation
+  - deployment
+  - cloudflare-pages
+---
+
+# Deploy to Cloudflare Pages
+
+Cloudflare Pages provides fast global CDN deployment with unlimited bandwidth and Workers integration. It's an excellent choice for high-traffic sites.
+
+## Prerequisites
+
+- A Cloudflare account (free tier available)
+- Your markata-go site in a Git repository (GitHub or GitLab)
+
+## Cost
+
+| Tier | Bandwidth | Builds | Sites | Price |
+|------|-----------|--------|-------|-------|
+| Free | Unlimited | 500/mo | Unlimited | $0 |
+| Pro | Unlimited | 5,000/mo | Unlimited | $20/mo |
+| Business | Unlimited | 20,000/mo | Unlimited | $200/mo |
+
+The free tier offers unlimited bandwidth, making it ideal for high-traffic sites.
+
+## Method 1: Git Integration (Recommended)
+
+### Step 1: Connect Repository
+
+1. Log in to the [Cloudflare Dashboard](https://dash.cloudflare.com)
+2. Go to **Workers & Pages** > **Create application** > **Pages**
+3. Click **Connect to Git**
+4. Select your Git provider and repository
+
+### Step 2: Configure Build Settings
+
+| Setting | Value |
+|---------|-------|
+| Framework preset | None |
+| Build command | See below |
+| Build output directory | `public` |
+| Root directory | (leave empty) |
+
+**Build Command:**
+```bash
+curl -sSL https://go.dev/dl/go1.22.0.linux-amd64.tar.gz | tar -xzf - && ./go/bin/go install github.com/WaylonWalker/markata-go/cmd/markata-go@latest && ~/go/bin/markata-go build --clean
+```
+
+### Step 3: Set Environment Variables
+
+Click **Environment variables** and add:
+
+| Variable | Value |
+|----------|-------|
+| `MARKATA_GO_URL` | `https://your-project.pages.dev` |
+
+Set this for both **Production** and **Preview** environments.
+
+### Step 4: Deploy
+
+Click **Save and Deploy**. Cloudflare will build and deploy your site.
+
+## Method 2: Wrangler CLI
+
+Deploy using the Wrangler CLI for more control:
+
+```bash
+# Install wrangler
+npm install -g wrangler
+
+# Login to Cloudflare
+wrangler login
+
+# Build your site locally
+MARKATA_GO_URL=https://example.com markata-go build --clean
+
+# Create a new Pages project (first time)
+wrangler pages project create my-site
+
+# Deploy
+wrangler pages deploy public --project-name=my-site
+```
+
+For subsequent deployments:
+
+```bash
+markata-go build --clean
+wrangler pages deploy public --project-name=my-site
+```
+
+## Custom Domain Setup
+
+### Step 1: Add Domain to Cloudflare
+
+If your domain isn't already on Cloudflare:
+
+1. Go to **Websites** > **Add a Site**
+2. Enter your domain
+3. Update nameservers at your registrar to Cloudflare's
+
+### Step 2: Connect Domain to Pages
+
+1. Go to your Pages project
+2. Click **Custom domains** > **Set up a custom domain**
+3. Enter your domain (e.g., `example.com`)
+4. Click **Activate domain**
+
+Cloudflare automatically configures DNS and provisions SSL certificates.
+
+### Step 3: Add www Subdomain (Optional)
+
+1. Add `www.example.com` as another custom domain
+2. Or create a redirect rule in **Rules** > **Redirect Rules**:
+   - If hostname equals `www.example.com`
+   - Then redirect to `https://example.com`
+
+### Step 4: Update Configuration
+
+Update your `markata-go.toml`:
+
+```toml
+[markata-go]
+url = "https://example.com"
+```
+
+## Headers and Redirects
+
+### Using _headers File
+
+Create `static/_headers` (copied to output during build):
+
+```
+/*
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()
+
+/static/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.html
+  Cache-Control: public, max-age=0, must-revalidate
+
+/*.xml
+  Cache-Control: public, max-age=3600
+```
+
+### Using _redirects File
+
+Create `static/_redirects`:
+
+```
+# Redirect old URLs
+/old-path/* /new-path/:splat 301
+/blog/old-post /blog/new-post 301
+
+# Proxy API requests
+/api/* https://api.example.com/:splat 200
+```
+
+## Preview Deployments
+
+Cloudflare Pages automatically creates preview deployments for:
+
+- Every branch push
+- Every pull request
+
+Preview URLs follow this pattern:
+```
+<commit-hash>.<project-name>.pages.dev
+```
+
+You can also access branch-specific previews:
+```
+<branch-name>.<project-name>.pages.dev
+```
+
+## Workers Integration
+
+### Adding a Worker
+
+Create `functions/` directory for Pages Functions (Workers):
+
+```javascript
+// functions/api/hello.js
+export async function onRequest(context) {
+  return new Response(JSON.stringify({
+    message: "Hello from Cloudflare Workers!"
+  }), {
+    headers: { "Content-Type": "application/json" }
+  });
+}
+```
+
+Access at `/api/hello`.
+
+### Adding Middleware
+
+Create `functions/_middleware.js` for all routes:
+
+```javascript
+export async function onRequest(context) {
+  // Add security headers
+  const response = await context.next();
+  response.headers.set("X-Custom-Header", "value");
+  return response;
+}
+```
+
+## Environment Variables
+
+### Setting Variables
+
+In the Cloudflare dashboard:
+
+1. Go to your Pages project
+2. Click **Settings** > **Environment variables**
+3. Add variables for **Production** and **Preview** separately
+
+| Variable | Production | Preview |
+|----------|------------|---------|
+| `MARKATA_GO_URL` | `https://example.com` | (empty) |
+
+### Accessing in Workers
+
+```javascript
+// functions/api/config.js
+export async function onRequest(context) {
+  const url = context.env.MARKATA_GO_URL;
+  return new Response(JSON.stringify({ url }));
+}
+```
+
+## Troubleshooting
+
+### Build Fails: Go Not Found
+
+The build environment doesn't have Go pre-installed. Use the build command that installs Go:
+
+```bash
+curl -sSL https://go.dev/dl/go1.22.0.linux-amd64.tar.gz | tar -xzf - && ./go/bin/go install github.com/WaylonWalker/markata-go/cmd/markata-go@latest && ~/go/bin/markata-go build --clean
+```
+
+### Build Timeout
+
+Free tier builds timeout after 20 minutes. Optimize by:
+
+1. Caching Go installation (not currently supported)
+2. Pre-building locally and deploying:
+   ```bash
+   markata-go build --clean
+   wrangler pages deploy public
+   ```
+
+### 404 on Subpages
+
+Ensure your `_redirects` file doesn't interfere. Cloudflare Pages serves `index.html` files automatically for clean URLs.
+
+### Headers Not Applied
+
+Verify `_headers` file is in your output directory:
+
+```bash
+markata-go build --clean
+cat public/_headers
+```
+
+### Custom Domain Not Working
+
+1. Ensure domain is added to Cloudflare (not just Pages)
+2. Check DNS is proxied (orange cloud enabled)
+3. Wait for SSL certificate provisioning
+
+## Performance Features
+
+### Automatic Optimizations
+
+Cloudflare Pages automatically provides:
+
+- Global CDN distribution
+- Brotli compression
+- HTTP/2 and HTTP/3
+- Early Hints
+- Smart caching
+
+### Web Analytics
+
+Enable Cloudflare Web Analytics (free):
+
+1. Go to **Analytics** in your Cloudflare dashboard
+2. Click **Web Analytics** > **Add a site**
+3. Add the script to your template:
+
+```html
+<script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "your-token"}'></script>
+```
+
+### Page Rules
+
+Create Page Rules for advanced caching:
+
+1. Go to **Rules** > **Page Rules**
+2. Create rules for your domain
+
+Example: Cache everything for static assets:
+```
+example.com/static/*
+Cache Level: Cache Everything
+Edge Cache TTL: 1 month
+```
+
+## Comparison with Cloudflare Workers Sites
+
+| Feature | Pages | Workers Sites |
+|---------|-------|---------------|
+| Git integration | Yes | No |
+| Preview deploys | Automatic | Manual |
+| Build system | Built-in | External |
+| Functions | Pages Functions | Workers |
+| Best for | Static sites | Dynamic apps |
+
+Pages is recommended for markata-go sites.
+
+## Next Steps
+
+- [Cloudflare Pages Docs](https://developers.cloudflare.com/pages/) - Official documentation
+- [Configuration Guide](../configuration/) - Customize your markata-go site
+- [Feeds Guide](../feeds/) - Set up RSS and Atom feeds

--- a/docs/guides/deployment/docker.md
+++ b/docs/guides/deployment/docker.md
@@ -1,0 +1,631 @@
+---
+title: "Deploy with Docker"
+description: "Step-by-step guide to deploy markata-go sites using Docker containers"
+date: 2026-01-24
+published: true
+tags:
+  - documentation
+  - deployment
+  - docker
+---
+
+# Deploy with Docker
+
+Docker provides a consistent, reproducible environment for building and serving your markata-go site. It's ideal for self-hosting, local development, and integration with container orchestration platforms.
+
+## Prerequisites
+
+- Docker installed ([Get Docker](https://docs.docker.com/get-docker/))
+- Docker Compose (optional, for multi-container setups)
+- Your markata-go site ready to build
+
+## Cost
+
+| Setup | Cost | Best For |
+|-------|------|----------|
+| Local Docker | Free | Development, testing |
+| Self-hosted server | $5-20/mo (VPS) | Personal sites, full control |
+| Container platforms | Varies | Production, scaling |
+
+## Method 1: Simple Nginx Container
+
+The simplest approach: build locally and serve with nginx.
+
+### Step 1: Build Your Site
+
+```bash
+markata-go build --clean
+```
+
+### Step 2: Create Dockerfile
+
+Create `Dockerfile` in your project root:
+
+```dockerfile
+FROM nginx:alpine
+
+# Copy built site to nginx
+COPY public/ /usr/share/nginx/html/
+
+# Custom nginx config for clean URLs
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]
+```
+
+### Step 3: Create nginx Configuration
+
+Create `nginx.conf`:
+
+```nginx
+server {
+    listen 80;
+    server_name localhost;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Enable gzip compression
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml text/javascript;
+
+    # Clean URLs - serve index.html for directories
+    location / {
+        try_files $uri $uri/ $uri/index.html =404;
+    }
+
+    # Cache static assets
+    location /static/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # Don't cache HTML
+    location ~* \.html$ {
+        expires -1;
+        add_header Cache-Control "no-store, no-cache, must-revalidate";
+    }
+
+    # Security headers
+    add_header X-Frame-Options "DENY" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+}
+```
+
+### Step 4: Build and Run
+
+```bash
+# Build the image
+docker build -t my-site .
+
+# Run the container
+docker run -d -p 8080:80 --name my-site my-site
+
+# View your site at http://localhost:8080
+```
+
+## Method 2: Multi-Stage Build
+
+Build the site inside Docker for fully reproducible builds.
+
+### Dockerfile with Multi-Stage Build
+
+```dockerfile
+# Stage 1: Build the site
+FROM golang:1.22-alpine AS builder
+
+# Install git (needed for go install)
+RUN apk add --no-cache git
+
+# Install markata-go
+RUN go install github.com/WaylonWalker/markata-go/cmd/markata-go@latest
+
+# Set working directory
+WORKDIR /site
+
+# Copy site source
+COPY . .
+
+# Build the site
+ENV MARKATA_GO_URL=https://example.com
+RUN markata-go build --clean
+
+# Stage 2: Serve with nginx
+FROM nginx:alpine
+
+# Copy built site from builder stage
+COPY --from=builder /site/public/ /usr/share/nginx/html/
+
+# Custom nginx configuration
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]
+```
+
+### Build and Run
+
+```bash
+# Build with your production URL
+docker build \
+  --build-arg MARKATA_GO_URL=https://example.com \
+  -t my-site .
+
+# Run
+docker run -d -p 8080:80 --name my-site my-site
+```
+
+## Method 3: Docker Compose
+
+For development with live reload or multi-service setups.
+
+### docker-compose.yml
+
+```yaml
+version: '3.8'
+
+services:
+  site:
+    build: .
+    ports:
+      - "8080:80"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  # Optional: Add Watchtower for automatic updates
+  watchtower:
+    image: containrrr/watchtower
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: --interval 3600 site
+```
+
+### Commands
+
+```bash
+# Start services
+docker compose up -d
+
+# View logs
+docker compose logs -f site
+
+# Rebuild after changes
+docker compose build && docker compose up -d
+
+# Stop services
+docker compose down
+```
+
+## Method 4: Development with Live Reload
+
+For local development with automatic rebuilds.
+
+### docker-compose.dev.yml
+
+```yaml
+version: '3.8'
+
+services:
+  dev:
+    image: golang:1.22-alpine
+    working_dir: /site
+    volumes:
+      - .:/site
+      - go-cache:/go
+    ports:
+      - "8080:8080"
+    command: |
+      sh -c '
+        apk add --no-cache git
+        go install github.com/WaylonWalker/markata-go/cmd/markata-go@latest
+        markata-go serve
+      '
+    environment:
+      - MARKATA_GO_URL=http://localhost:8080
+
+volumes:
+  go-cache:
+```
+
+### Run Development Server
+
+```bash
+docker compose -f docker-compose.dev.yml up
+```
+
+## Production Deployment
+
+### Deploying to a VPS
+
+1. **Build and Push to Registry**
+
+```bash
+# Build image
+docker build -t your-registry/my-site:latest .
+
+# Push to registry (Docker Hub, GitHub Container Registry, etc.)
+docker push your-registry/my-site:latest
+```
+
+2. **Pull and Run on Server**
+
+```bash
+# On your server
+docker pull your-registry/my-site:latest
+docker run -d \
+  --name my-site \
+  -p 80:80 \
+  --restart unless-stopped \
+  your-registry/my-site:latest
+```
+
+### With HTTPS (Traefik)
+
+Use Traefik as a reverse proxy with automatic HTTPS.
+
+#### docker-compose.prod.yml
+
+```yaml
+version: '3.8'
+
+services:
+  traefik:
+    image: traefik:v2.10
+    command:
+      - "--api.insecure=true"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.websecure.address=:443"
+      - "--certificatesresolvers.letsencrypt.acme.httpchallenge=true"
+      - "--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web"
+      - "--certificatesresolvers.letsencrypt.acme.email=you@example.com"
+      - "--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json"
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - letsencrypt:/letsencrypt
+    restart: unless-stopped
+
+  site:
+    build: .
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.site.rule=Host(`example.com`)"
+      - "traefik.http.routers.site.entrypoints=websecure"
+      - "traefik.http.routers.site.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.site-http.rule=Host(`example.com`)"
+      - "traefik.http.routers.site-http.entrypoints=web"
+      - "traefik.http.routers.site-http.middlewares=redirect-to-https"
+      - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
+    restart: unless-stopped
+
+volumes:
+  letsencrypt:
+```
+
+### With HTTPS (Caddy)
+
+Caddy provides automatic HTTPS with simpler configuration.
+
+#### Caddyfile
+
+```
+example.com {
+    root * /srv
+    file_server
+    encode gzip
+
+    header /static/* Cache-Control "public, max-age=31536000, immutable"
+    header *.html Cache-Control "no-cache, must-revalidate"
+
+    try_files {path} {path}/ {path}/index.html
+}
+```
+
+#### docker-compose.caddy.yml
+
+```yaml
+version: '3.8'
+
+services:
+  caddy:
+    image: caddy:alpine
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
+      - ./public:/srv
+      - caddy_data:/data
+      - caddy_config:/config
+    restart: unless-stopped
+
+volumes:
+  caddy_data:
+  caddy_config:
+```
+
+## CI/CD Integration
+
+### GitHub Actions
+
+```yaml
+name: Build and Deploy Docker
+
+on:
+  push:
+    branches: [main]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          build-args: |
+            MARKATA_GO_URL=https://example.com
+
+  deploy:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to server
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          script: |
+            docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            docker stop my-site || true
+            docker rm my-site || true
+            docker run -d \
+              --name my-site \
+              -p 80:80 \
+              --restart unless-stopped \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+```
+
+## Container Orchestration
+
+### Kubernetes Deployment
+
+```yaml
+# deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: markata-site
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: markata-site
+  template:
+    metadata:
+      labels:
+        app: markata-site
+    spec:
+      containers:
+        - name: site
+          image: your-registry/my-site:latest
+          ports:
+            - containerPort: 80
+          resources:
+            limits:
+              memory: "128Mi"
+              cpu: "100m"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: markata-site
+spec:
+  selector:
+    app: markata-site
+  ports:
+    - port: 80
+      targetPort: 80
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: markata-site
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  tls:
+    - hosts:
+        - example.com
+      secretName: markata-site-tls
+  rules:
+    - host: example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: markata-site
+                port:
+                  number: 80
+```
+
+## Troubleshooting
+
+### Container Won't Start
+
+Check logs:
+```bash
+docker logs my-site
+```
+
+Common issues:
+- Port already in use: Change the host port (`-p 8081:80`)
+- Permission denied: Check file permissions in copied directories
+
+### 404 Errors on Subpages
+
+Ensure nginx is configured for clean URLs:
+```nginx
+location / {
+    try_files $uri $uri/ $uri/index.html =404;
+}
+```
+
+### Large Image Size
+
+Optimize your Dockerfile:
+```dockerfile
+# Use alpine-based images
+FROM nginx:alpine
+
+# Use .dockerignore to exclude unnecessary files
+```
+
+Create `.dockerignore`:
+```
+.git
+node_modules
+*.md
+Dockerfile
+docker-compose*.yml
+```
+
+### Build Fails in Multi-Stage
+
+Ensure Go modules are available:
+```dockerfile
+# If using go modules
+COPY go.mod go.sum ./
+RUN go mod download
+```
+
+### CSS/JS Not Loading
+
+Verify MARKATA_GO_URL matches your deployment:
+```bash
+docker build --build-arg MARKATA_GO_URL=https://example.com -t my-site .
+```
+
+## Performance Optimization
+
+### Enable Brotli Compression
+
+```nginx
+# In nginx.conf
+brotli on;
+brotli_types text/plain text/css application/json application/javascript text/xml application/xml text/javascript;
+```
+
+Requires nginx with brotli module:
+```dockerfile
+FROM fholzer/nginx-brotli:latest
+```
+
+### Resource Limits
+
+```yaml
+# In docker-compose.yml
+services:
+  site:
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 128M
+        reservations:
+          cpus: '0.1'
+          memory: 64M
+```
+
+### Health Checks
+
+```dockerfile
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+  CMD wget -q --spider http://localhost/ || exit 1
+```
+
+## Security Best Practices
+
+### Run as Non-Root User
+
+```dockerfile
+FROM nginx:alpine
+
+# Create non-root user
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
+# Copy files
+COPY --chown=appuser:appgroup public/ /usr/share/nginx/html/
+
+# Switch to non-root user (for processes that don't need root)
+# Note: nginx master process needs root for port 80
+```
+
+### Read-Only Filesystem
+
+```yaml
+services:
+  site:
+    read_only: true
+    tmpfs:
+      - /var/cache/nginx
+      - /var/run
+```
+
+### Security Scanning
+
+```bash
+# Scan image for vulnerabilities
+docker scout cve my-site:latest
+
+# Or use Trivy
+trivy image my-site:latest
+```
+
+## Next Steps
+
+- [Self-Hosting Guide](../self-hosting/) - More self-hosting options
+- [Configuration Guide](../configuration/) - Customize your markata-go site
+- [Themes Guide](../themes/) - Change your site's appearance

--- a/docs/guides/deployment/github-pages.md
+++ b/docs/guides/deployment/github-pages.md
@@ -1,0 +1,326 @@
+---
+title: "Deploy to GitHub Pages"
+description: "Step-by-step guide to deploy markata-go sites on GitHub Pages"
+date: 2026-01-24
+published: true
+tags:
+  - documentation
+  - deployment
+  - github-pages
+---
+
+# Deploy to GitHub Pages
+
+GitHub Pages provides free hosting for static sites directly from a GitHub repository. It's the easiest way to deploy if your code is already on GitHub.
+
+## Prerequisites
+
+- A GitHub account
+- Your markata-go site in a GitHub repository
+- Git installed locally
+
+## Cost
+
+| Tier | Storage | Bandwidth | Custom Domain |
+|------|---------|-----------|---------------|
+| Free | 1 GB | 100 GB/mo | Yes (HTTPS) |
+
+GitHub Pages is completely free for public repositories. Private repositories require GitHub Pro ($4/mo) or a paid organization plan.
+
+## Method 1: GitHub Actions (Recommended)
+
+This method automatically builds and deploys your site on every push to `main`.
+
+### Step 1: Create the Workflow
+
+Create `.github/workflows/deploy.yml`:
+
+```yaml
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache: true
+
+      - name: Install markata-go
+        run: go install github.com/WaylonWalker/markata-go/cmd/markata-go@latest
+
+      - name: Build site
+        run: markata-go build --clean
+        env:
+          MARKATA_GO_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./public
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+```
+
+### Step 2: Configure Repository Settings
+
+1. Go to your repository on GitHub
+2. Navigate to **Settings** > **Pages**
+3. Under **Source**, select **GitHub Actions**
+4. Push your changes to trigger the workflow
+
+### Step 3: Access Your Site
+
+After the workflow completes, your site will be available at:
+
+```
+https://<username>.github.io/<repository-name>/
+```
+
+## Method 2: Manual Deployment
+
+For more control or if you can't use GitHub Actions.
+
+### Step 1: Build Locally
+
+```bash
+# Set the URL for your GitHub Pages site
+export MARKATA_GO_URL=https://username.github.io/repo-name
+
+# Build the site
+markata-go build --clean
+```
+
+### Step 2: Deploy to gh-pages Branch
+
+```bash
+# Navigate to output directory
+cd public
+
+# Initialize git and push to gh-pages branch
+git init
+git add -A
+git commit -m "Deploy site"
+git push -f git@github.com:username/repo-name.git main:gh-pages
+```
+
+Or use the `gh-pages` npm package:
+
+```bash
+npm install -g gh-pages
+markata-go build --clean
+gh-pages -d public
+```
+
+### Step 3: Configure Repository
+
+1. Go to **Settings** > **Pages**
+2. Under **Source**, select **Deploy from a branch**
+3. Select the `gh-pages` branch and `/ (root)` folder
+4. Click **Save**
+
+## Custom Domain Setup
+
+### Step 1: Add CNAME File
+
+Create `static/CNAME` (no extension) with your domain:
+
+```
+example.com
+```
+
+This file will be copied to `public/CNAME` during build.
+
+### Step 2: Update Configuration
+
+In your `markata-go.toml`:
+
+```toml
+[markata-go]
+url = "https://example.com"
+```
+
+### Step 3: Configure DNS
+
+**For apex domain (example.com):**
+
+Add these A records pointing to GitHub's servers:
+
+```
+185.199.108.153
+185.199.109.153
+185.199.110.153
+185.199.111.153
+```
+
+**For subdomain (www.example.com or blog.example.com):**
+
+Add a CNAME record:
+
+```
+Type: CNAME
+Name: www (or blog)
+Value: username.github.io
+```
+
+### Step 4: Enable HTTPS
+
+1. Go to **Settings** > **Pages**
+2. Under **Custom domain**, enter your domain
+3. Check **Enforce HTTPS** (may take up to 24 hours)
+
+## Troubleshooting
+
+### Build Fails: "command not found: markata-go"
+
+Ensure Go is set up correctly in your workflow:
+
+```yaml
+- name: Setup Go
+  uses: actions/setup-go@v5
+  with:
+    go-version: '1.22'
+    cache: true
+
+- name: Install markata-go
+  run: |
+    go install github.com/WaylonWalker/markata-go/cmd/markata-go@latest
+    echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+```
+
+### 404 Errors on Subpages
+
+Make sure your site URL matches the GitHub Pages URL:
+
+```bash
+# For project sites (username.github.io/repo-name)
+MARKATA_GO_URL=https://username.github.io/repo-name markata-go build
+
+# For user sites (username.github.io)
+MARKATA_GO_URL=https://username.github.io markata-go build
+```
+
+### CSS/JS Not Loading
+
+Check that asset paths are relative or use the correct base URL. The workflow above sets `MARKATA_GO_URL` automatically.
+
+### Custom Domain Not Working
+
+1. Verify DNS propagation: `dig example.com`
+2. Ensure CNAME file exists in output
+3. Wait up to 24 hours for HTTPS certificate
+
+### Workflow Not Triggering
+
+Ensure the workflow file is in the correct location:
+```
+.github/workflows/deploy.yml
+```
+
+And that you're pushing to the `main` branch (or adjust the workflow trigger).
+
+## Advanced Configuration
+
+### Caching for Faster Builds
+
+Add caching for the markata-go binary:
+
+```yaml
+- name: Cache markata-go
+  uses: actions/cache@v4
+  with:
+    path: ~/go/bin/markata-go
+    key: markata-go-${{ runner.os }}-v1
+
+- name: Install markata-go
+  run: |
+    if [ ! -f ~/go/bin/markata-go ]; then
+      go install github.com/WaylonWalker/markata-go/cmd/markata-go@latest
+    fi
+```
+
+### Preview Deployments for Pull Requests
+
+Deploy preview versions for PRs:
+
+```yaml
+name: Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Build
+        run: |
+          go install github.com/WaylonWalker/markata-go/cmd/markata-go@latest
+          markata-go build --clean
+        env:
+          MARKATA_GO_URL: https://username.github.io/repo/pr-${{ github.event.number }}
+
+      - name: Deploy Preview
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+          destination_dir: pr-${{ github.event.number }}
+
+      - name: Comment PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Preview: https://username.github.io/repo/pr-${{ github.event.number }}/'
+            })
+```
+
+## Next Steps
+
+- [Custom Domain Setup](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site) - GitHub's official docs
+- [Configuration Guide](../configuration/) - Customize your markata-go site
+- [Themes Guide](../themes/) - Change your site's appearance

--- a/docs/guides/deployment/index.md
+++ b/docs/guides/deployment/index.md
@@ -1,0 +1,112 @@
+---
+title: "Deployment Guide"
+description: "Choose the best platform to deploy your markata-go static site"
+date: 2026-01-24
+published: true
+tags:
+  - documentation
+  - deployment
+  - hosting
+---
+
+# Deployment Guide
+
+markata-go generates static sites that can be deployed anywhere that serves HTML files. This guide helps you choose the best platform for your needs.
+
+## Platform Comparison
+
+| Platform | Free Tier | Custom Domain | Build Time | Best For |
+|----------|-----------|---------------|------------|----------|
+| [GitHub Pages](./github-pages/) | Unlimited | Yes (HTTPS) | ~2 min | Open source projects |
+| [Netlify](./netlify/) | 100 GB/mo | Yes (HTTPS) | ~1 min | Teams, forms, functions |
+| [Vercel](./vercel/) | 100 GB/mo | Yes (HTTPS) | ~1 min | Performance, edge |
+| [Cloudflare Pages](./cloudflare-pages/) | Unlimited | Yes (HTTPS) | ~2 min | Global CDN, Workers |
+| [AWS S3](./aws-s3/) | 5 GB (12 mo) | Yes (via CF) | Manual | Enterprise, AWS stack |
+| [Docker](./docker/) | N/A | Self-managed | ~30 sec | Self-hosted, control |
+
+## Quick Decision Guide
+
+**Choose GitHub Pages if:**
+- Your code is on GitHub
+- You want zero configuration
+- You don't need server-side features
+
+**Choose Netlify if:**
+- You need forms, functions, or split testing
+- You want automatic deploy previews
+- You're working with a team
+
+**Choose Vercel if:**
+- Performance is your top priority
+- You want edge functions
+- You need analytics
+
+**Choose Cloudflare Pages if:**
+- You want unlimited bandwidth
+- You need Workers integration
+- Global performance matters
+
+**Choose AWS S3 if:**
+- You're already in the AWS ecosystem
+- You need fine-grained access control
+- Enterprise compliance is required
+
+**Choose Docker if:**
+- You want full control
+- You're self-hosting other services
+- You need offline capabilities
+
+## Building for Production
+
+Before deploying to any platform, build your site:
+
+```bash
+# Standard production build
+markata-go build --clean
+
+# Build with custom URL
+MARKATA_GO_URL=https://example.com markata-go build --clean
+
+# Verbose build for debugging
+markata-go build --clean -v
+```
+
+### Output Structure
+
+After building, your `public/` directory contains:
+
+```
+public/
+├── index.html              # Home page
+├── blog/
+│   ├── index.html          # Blog listing
+│   ├── rss.xml             # RSS feed
+│   └── atom.xml            # Atom feed
+├── posts/
+│   └── my-post/
+│       └── index.html      # Individual post
+├── static/                 # Assets (CSS, JS, images)
+└── sitemap.xml
+```
+
+## Environment Variables
+
+All platforms support these environment variables:
+
+| Variable | Purpose | Example |
+|----------|---------|---------|
+| `MARKATA_GO_URL` | Base URL for links and feeds | `https://example.com` |
+| `MARKATA_GO_OUTPUT` | Output directory | `public` |
+
+## Next Steps
+
+Choose a platform guide to get started:
+
+- [GitHub Pages](./github-pages/) - Free hosting for GitHub repos
+- [Netlify](./netlify/) - Feature-rich with generous free tier
+- [Vercel](./vercel/) - Performance-focused deployment
+- [Cloudflare Pages](./cloudflare-pages/) - Unlimited bandwidth
+- [AWS S3](./aws-s3/) - Enterprise-grade static hosting
+- [Docker](./docker/) - Self-hosted containers
+
+For self-hosting on your own servers, see the [Self-Hosting Guide](../self-hosting/).

--- a/docs/guides/deployment/netlify.md
+++ b/docs/guides/deployment/netlify.md
@@ -1,0 +1,324 @@
+---
+title: "Deploy to Netlify"
+description: "Step-by-step guide to deploy markata-go sites on Netlify"
+date: 2026-01-24
+published: true
+tags:
+  - documentation
+  - deployment
+  - netlify
+---
+
+# Deploy to Netlify
+
+Netlify offers continuous deployment, serverless functions, form handling, and a powerful CDN. It's excellent for teams and sites that need more than just static hosting.
+
+## Prerequisites
+
+- A Netlify account (free tier available)
+- Your markata-go site in a Git repository (GitHub, GitLab, or Bitbucket)
+
+## Cost
+
+| Tier | Bandwidth | Build Minutes | Forms | Price |
+|------|-----------|---------------|-------|-------|
+| Free | 100 GB/mo | 300 min/mo | 100/mo | $0 |
+| Pro | 1 TB/mo | 25,000 min/mo | Unlimited | $19/mo |
+| Business | 1 TB/mo | 25,000 min/mo | Unlimited | $99/mo |
+
+The free tier is generous enough for most personal and small business sites.
+
+## Method 1: Git Integration (Recommended)
+
+### Step 1: Connect Repository
+
+1. Log in to [Netlify](https://app.netlify.com)
+2. Click **Add new site** > **Import an existing project**
+3. Choose your Git provider and authorize Netlify
+4. Select your repository
+
+### Step 2: Configure Build Settings
+
+Enter these settings:
+
+| Setting | Value |
+|---------|-------|
+| Base directory | (leave empty) |
+| Build command | `go install github.com/WaylonWalker/markata-go/cmd/markata-go@latest && markata-go build --clean` |
+| Publish directory | `public` |
+
+### Step 3: Set Environment Variables
+
+Click **Advanced** and add:
+
+| Key | Value |
+|-----|-------|
+| `GO_VERSION` | `1.22` |
+| `MARKATA_GO_URL` | `https://your-site.netlify.app` |
+
+### Step 4: Deploy
+
+Click **Deploy site**. Netlify will build and deploy your site automatically.
+
+## Method 2: netlify.toml Configuration
+
+For more control, create `netlify.toml` in your repository root:
+
+```toml
+[build]
+  command = "go install github.com/WaylonWalker/markata-go/cmd/markata-go@latest && markata-go build --clean"
+  publish = "public"
+
+[build.environment]
+  GO_VERSION = "1.22"
+  MARKATA_GO_URL = "https://your-site.netlify.app"
+
+# Production context
+[context.production]
+  environment = { MARKATA_GO_URL = "https://example.com" }
+
+# Deploy previews (automatic for PRs)
+[context.deploy-preview]
+  command = "go install github.com/WaylonWalker/markata-go/cmd/markata-go@latest && markata-go build"
+
+# Branch deploys
+[context.branch-deploy]
+  command = "go install github.com/WaylonWalker/markata-go/cmd/markata-go@latest && markata-go build"
+
+# Security and caching headers
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+
+[[headers]]
+  for = "/static/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+[[headers]]
+  for = "/*.html"
+  [headers.values]
+    Cache-Control = "public, max-age=0, must-revalidate"
+
+# Redirects
+[[redirects]]
+  from = "/old-path/*"
+  to = "/new-path/:splat"
+  status = 301
+```
+
+## Method 3: CLI Deployment
+
+Deploy manually using the Netlify CLI:
+
+```bash
+# Install CLI
+npm install -g netlify-cli
+
+# Login
+netlify login
+
+# Initialize project (first time)
+netlify init
+
+# Build your site
+markata-go build --clean
+
+# Deploy preview
+netlify deploy --dir=public
+
+# Deploy to production
+netlify deploy --dir=public --prod
+```
+
+## Custom Domain Setup
+
+### Step 1: Add Domain in Netlify
+
+1. Go to **Site settings** > **Domain management**
+2. Click **Add custom domain**
+3. Enter your domain (e.g., `example.com`)
+
+### Step 2: Configure DNS
+
+**Option A: Use Netlify DNS (Recommended)**
+
+1. Click **Set up Netlify DNS** for your domain
+2. Update your domain registrar's nameservers to Netlify's:
+   ```
+   dns1.p01.nsone.net
+   dns2.p01.nsone.net
+   dns3.p01.nsone.net
+   dns4.p01.nsone.net
+   ```
+
+**Option B: External DNS**
+
+Add these records at your DNS provider:
+
+For apex domain:
+```
+Type: A
+Name: @
+Value: 75.2.60.5
+```
+
+For www subdomain:
+```
+Type: CNAME
+Name: www
+Value: your-site.netlify.app
+```
+
+### Step 3: Enable HTTPS
+
+Netlify automatically provisions Let's Encrypt certificates. Go to **Domain management** > **HTTPS** and click **Verify DNS configuration**.
+
+### Step 4: Update Configuration
+
+Update your `markata-go.toml`:
+
+```toml
+[markata-go]
+url = "https://example.com"
+```
+
+And your `netlify.toml`:
+
+```toml
+[context.production.environment]
+  MARKATA_GO_URL = "https://example.com"
+```
+
+## Deploy Previews
+
+Netlify automatically creates preview deployments for pull requests. Each PR gets a unique URL like:
+
+```
+https://deploy-preview-123--your-site.netlify.app
+```
+
+To customize preview behavior, add to `netlify.toml`:
+
+```toml
+[context.deploy-preview]
+  command = "go install github.com/WaylonWalker/markata-go/cmd/markata-go@latest && markata-go build"
+  
+[context.deploy-preview.environment]
+  # Leave MARKATA_GO_URL empty to use Netlify's preview URL
+```
+
+## Forms (No Backend Required)
+
+Netlify can handle form submissions without a backend:
+
+```html
+<form name="contact" method="POST" data-netlify="true">
+  <input type="hidden" name="form-name" value="contact" />
+  <input type="text" name="name" required />
+  <input type="email" name="email" required />
+  <textarea name="message" required></textarea>
+  <button type="submit">Send</button>
+</form>
+```
+
+Form submissions appear in **Site settings** > **Forms**.
+
+## Serverless Functions
+
+Add serverless functions in `netlify/functions/`:
+
+```javascript
+// netlify/functions/hello.js
+exports.handler = async (event, context) => {
+  return {
+    statusCode: 200,
+    body: JSON.stringify({ message: "Hello from Netlify Functions!" })
+  };
+};
+```
+
+Access at `/.netlify/functions/hello`.
+
+## Troubleshooting
+
+### Build Fails: Go Not Found
+
+Ensure `GO_VERSION` is set in environment variables:
+
+```toml
+[build.environment]
+  GO_VERSION = "1.22"
+```
+
+### Build Timeout
+
+Free tier has a 15-minute build limit. Optimize your build:
+
+```toml
+[build]
+  command = """
+    if [ ! -f $HOME/go/bin/markata-go ]; then
+      go install github.com/WaylonWalker/markata-go/cmd/markata-go@latest
+    fi
+    markata-go build --clean
+  """
+```
+
+### Assets Not Loading
+
+Check your site URL configuration:
+
+```bash
+# View current config
+netlify env:list
+
+# Set production URL
+netlify env:set MARKATA_GO_URL https://example.com
+```
+
+### Deploy Preview URL Issues
+
+For deploy previews, let Netlify handle the URL:
+
+```toml
+[context.deploy-preview.environment]
+  # Don't set MARKATA_GO_URL - let Netlify use the preview URL
+```
+
+### Custom Headers Not Applied
+
+Ensure `netlify.toml` is in your repository root (not in a subdirectory).
+
+## Performance Optimization
+
+### Enable Asset Optimization
+
+In **Site settings** > **Build & deploy** > **Post processing**:
+
+- Enable **Pretty URLs**
+- Enable **Asset optimization** (minify CSS/JS)
+- Enable **Prerendering**
+
+### Configure Caching
+
+```toml
+[[headers]]
+  for = "/static/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+[[headers]]
+  for = "/*.xml"
+  [headers.values]
+    Cache-Control = "public, max-age=3600"
+```
+
+## Next Steps
+
+- [Netlify Docs](https://docs.netlify.com/) - Official documentation
+- [Configuration Guide](../configuration/) - Customize your markata-go site
+- [Feeds Guide](../feeds/) - Set up RSS and Atom feeds

--- a/docs/guides/deployment/vercel.md
+++ b/docs/guides/deployment/vercel.md
@@ -1,0 +1,362 @@
+---
+title: "Deploy to Vercel"
+description: "Step-by-step guide to deploy markata-go sites on Vercel"
+date: 2026-01-24
+published: true
+tags:
+  - documentation
+  - deployment
+  - vercel
+---
+
+# Deploy to Vercel
+
+Vercel provides zero-configuration deployments with excellent performance and edge capabilities. It's known for its speed and developer experience.
+
+## Prerequisites
+
+- A Vercel account (free tier available)
+- Your markata-go site in a Git repository (GitHub, GitLab, or Bitbucket)
+
+## Cost
+
+| Tier | Bandwidth | Builds | Edge Functions | Price |
+|------|-----------|--------|----------------|-------|
+| Hobby | 100 GB/mo | 6,000 min/mo | 100,000 exec/mo | $0 |
+| Pro | 1 TB/mo | Unlimited | 1M exec/mo | $20/mo |
+| Enterprise | Custom | Unlimited | Custom | Contact |
+
+The Hobby tier is free but limited to personal, non-commercial use.
+
+## Method 1: Git Integration (Recommended)
+
+### Step 1: Connect Repository
+
+1. Log in to [Vercel](https://vercel.com)
+2. Click **Add New** > **Project**
+3. Import your Git repository
+4. Authorize Vercel to access your repo
+
+### Step 2: Configure Build Settings
+
+Set these options:
+
+| Setting | Value |
+|---------|-------|
+| Framework Preset | Other |
+| Build Command | See below |
+| Output Directory | `public` |
+| Install Command | `echo "No npm dependencies"` |
+
+**Build Command:**
+```bash
+curl -sSL https://go.dev/dl/go1.22.0.linux-amd64.tar.gz | tar -xzf - && ./go/bin/go install github.com/WaylonWalker/markata-go/cmd/markata-go@latest && ~/go/bin/markata-go build --clean
+```
+
+### Step 3: Set Environment Variables
+
+Add these environment variables:
+
+| Key | Value |
+|-----|-------|
+| `MARKATA_GO_URL` | `https://your-project.vercel.app` |
+
+### Step 4: Deploy
+
+Click **Deploy**. Vercel will build and deploy your site.
+
+## Method 2: vercel.json Configuration
+
+Create `vercel.json` in your repository root for more control:
+
+```json
+{
+  "buildCommand": "curl -sSL https://go.dev/dl/go1.22.0.linux-amd64.tar.gz | tar -xzf - && ./go/bin/go install github.com/WaylonWalker/markata-go/cmd/markata-go@latest && ~/go/bin/markata-go build --clean",
+  "outputDirectory": "public",
+  "installCommand": "echo 'No npm dependencies'",
+  "framework": null,
+  "headers": [
+    {
+      "source": "/static/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/(.*).html",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        }
+      ]
+    }
+  ],
+  "redirects": [
+    {
+      "source": "/old-path/:path*",
+      "destination": "/new-path/:path*",
+      "permanent": true
+    }
+  ]
+}
+```
+
+## Method 3: CLI Deployment
+
+Deploy manually using the Vercel CLI:
+
+```bash
+# Install CLI
+npm install -g vercel
+
+# Login
+vercel login
+
+# Build your site locally
+markata-go build --clean
+
+# Deploy preview (from public directory)
+cd public && vercel
+
+# Deploy to production
+cd public && vercel --prod
+```
+
+## Custom Domain Setup
+
+### Step 1: Add Domain
+
+1. Go to your project's **Settings** > **Domains**
+2. Enter your domain (e.g., `example.com`)
+3. Click **Add**
+
+### Step 2: Configure DNS
+
+Vercel provides DNS records to add at your registrar:
+
+**For apex domain:**
+```
+Type: A
+Name: @
+Value: 76.76.21.21
+```
+
+**For www subdomain:**
+```
+Type: CNAME
+Name: www
+Value: cname.vercel-dns.com
+```
+
+### Step 3: Verify and Enable HTTPS
+
+Vercel automatically provisions SSL certificates once DNS is configured. This usually takes a few minutes.
+
+### Step 4: Update Configuration
+
+Update your `markata-go.toml`:
+
+```toml
+[markata-go]
+url = "https://example.com"
+```
+
+Set the production environment variable:
+
+```bash
+vercel env add MARKATA_GO_URL production
+# Enter: https://example.com
+```
+
+## Environment Variables
+
+Manage environment variables per environment:
+
+```bash
+# Add to production
+vercel env add MARKATA_GO_URL production
+# Value: https://example.com
+
+# Add to preview (for PR deployments)
+vercel env add MARKATA_GO_URL preview
+# Value: (leave empty to use Vercel's preview URL)
+
+# Add to development
+vercel env add MARKATA_GO_URL development
+# Value: http://localhost:8080
+
+# List all variables
+vercel env ls
+
+# Pull variables to local .env
+vercel env pull
+```
+
+## Preview Deployments
+
+Vercel automatically creates preview deployments for every push:
+
+- **Production**: `your-project.vercel.app`
+- **Preview**: `your-project-git-branch-username.vercel.app`
+- **PR Preview**: Automatically commented on GitHub PRs
+
+## Edge Functions
+
+Add edge functions for dynamic functionality:
+
+```javascript
+// api/hello.js
+export const config = {
+  runtime: 'edge',
+};
+
+export default function handler(request) {
+  return new Response(JSON.stringify({ message: 'Hello from the Edge!' }), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+```
+
+Access at `/api/hello`.
+
+## Analytics
+
+Enable Vercel Analytics for performance insights:
+
+1. Go to **Project Settings** > **Analytics**
+2. Click **Enable**
+
+Add the analytics script to your template:
+
+```html
+<script defer src="/_vercel/insights/script.js"></script>
+```
+
+## Speed Insights
+
+Enable Speed Insights for Core Web Vitals:
+
+1. Go to **Project Settings** > **Speed Insights**
+2. Click **Enable**
+
+## Troubleshooting
+
+### Build Fails: Go Installation Issues
+
+The build command needs to install Go first. Ensure your build command is correct:
+
+```json
+{
+  "buildCommand": "curl -sSL https://go.dev/dl/go1.22.0.linux-amd64.tar.gz | tar -xzf - && ./go/bin/go install github.com/WaylonWalker/markata-go/cmd/markata-go@latest && ~/go/bin/markata-go build --clean"
+}
+```
+
+### Build Timeout
+
+Hobby tier has a 45-second build limit. Consider:
+
+1. Upgrading to Pro for longer builds
+2. Pre-building locally and deploying the output:
+   ```bash
+   markata-go build --clean
+   cd public && vercel --prod
+   ```
+
+### 404 on Page Refresh
+
+Vercel handles clean URLs automatically for static sites. Ensure your output directory is correct.
+
+### Environment Variables Not Applied
+
+Check that variables are set for the correct environment:
+
+```bash
+vercel env ls
+```
+
+Production, Preview, and Development are separate environments.
+
+### Assets Not Loading
+
+Verify your `MARKATA_GO_URL` matches your deployment URL:
+
+```bash
+# Check current value
+vercel env ls | grep MARKATA_GO_URL
+```
+
+## Performance Optimization
+
+### Enable Compression
+
+Vercel automatically compresses responses with gzip and Brotli.
+
+### Configure Caching
+
+In `vercel.json`:
+
+```json
+{
+  "headers": [
+    {
+      "source": "/static/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/(.*).xml",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Use Edge Network
+
+Vercel's edge network automatically serves your site from the nearest location to each visitor.
+
+## Monorepo Support
+
+For monorepos, configure the root directory:
+
+```json
+{
+  "installCommand": "echo 'Skip install'",
+  "buildCommand": "cd packages/my-site && curl -sSL ... && markata-go build",
+  "outputDirectory": "packages/my-site/public"
+}
+```
+
+Or set the **Root Directory** in project settings.
+
+## Next Steps
+
+- [Vercel Docs](https://vercel.com/docs) - Official documentation
+- [Configuration Guide](../configuration/) - Customize your markata-go site
+- [Themes Guide](../themes/) - Change your site's appearance


### PR DESCRIPTION
## Summary

Restructures deployment documentation into platform-specific guides for easier navigation and discovery.

Fixes #164

## Changes

- **Platform selection guide** (`docs/guides/deployment/index.md`) - Overview with comparison table and quick decision guide
- **GitHub Pages** (`github-pages.md`) - GitHub Actions workflow, manual deployment, custom domains
- **Netlify** (`netlify.md`) - Git integration, netlify.toml config, forms, serverless functions
- **Vercel** (`vercel.md`) - vercel.json config, edge functions, analytics
- **Cloudflare Pages** (`cloudflare-pages.md`) - Wrangler CLI, Workers integration, _headers/_redirects
- **AWS S3** (`aws-s3.md`) - S3 + CloudFront setup, IAM roles, GitHub Actions automation
- **Docker** (`docker.md`) - Multi-stage builds, Docker Compose, Traefik/Caddy HTTPS, Kubernetes

## Guide Structure

Each platform guide follows a consistent structure:
- Prerequisites and cost information
- Multiple deployment methods (GUI + CLI)
- Custom domain and HTTPS setup
- CI/CD integration examples
- Troubleshooting section
- Performance optimization tips

## Checklist

- [x] Platform selection guide with comparison table
- [x] GitHub Pages guide
- [x] Netlify guide
- [x] Vercel guide
- [x] Cloudflare Pages guide
- [x] AWS S3 + CloudFront guide
- [x] Docker guide
- [x] All guides have proper frontmatter
- [x] All guides include CI/CD integration examples