### PR TITLE
feat(plugins): Add blogroll and RSS reader plugin

### DIFF
--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -82,6 +82,7 @@ type tomlConfig struct {
 	Sidebar       tomlSidebarConfig      `toml:"sidebar"`
 	Toc           tomlTocConfig          `toml:"toc"`
 	Header        tomlHeaderLayoutConfig `toml:"header"`
+	Blogroll      tomlBlogrollConfig     `toml:"blogroll"`
 	UnknownFields map[string]any         `toml:"-"`
 }
 
@@ -518,6 +519,66 @@ func (h *tomlHeaderLayoutConfig) toHeaderLayoutConfig() models.HeaderLayoutConfi
 	}
 }
 
+// Blogroll-related TOML structs
+
+type tomlBlogrollConfig struct {
+	Enabled            bool                     `toml:"enabled"`
+	CacheDir           string                   `toml:"cache_dir"`
+	CacheDuration      string                   `toml:"cache_duration"`
+	Timeout            int                      `toml:"timeout"`
+	ConcurrentRequests int                      `toml:"concurrent_requests"`
+	MaxEntriesPerFeed  int                      `toml:"max_entries_per_feed"`
+	Feeds              []tomlExternalFeedConfig `toml:"feeds"`
+	Templates          tomlBlogrollTemplates    `toml:"templates"`
+}
+
+type tomlExternalFeedConfig struct {
+	URL         string   `toml:"url"`
+	Title       string   `toml:"title"`
+	Description string   `toml:"description"`
+	Category    string   `toml:"category"`
+	Tags        []string `toml:"tags"`
+	Active      *bool    `toml:"active"`
+	SiteURL     string   `toml:"site_url"`
+	ImageURL    string   `toml:"image_url"`
+}
+
+type tomlBlogrollTemplates struct {
+	Blogroll string `toml:"blogroll"`
+	Reader   string `toml:"reader"`
+}
+
+func (b *tomlBlogrollConfig) toBlogrollConfig() models.BlogrollConfig {
+	config := models.BlogrollConfig{
+		Enabled:            b.Enabled,
+		CacheDir:           b.CacheDir,
+		CacheDuration:      b.CacheDuration,
+		Timeout:            b.Timeout,
+		ConcurrentRequests: b.ConcurrentRequests,
+		MaxEntriesPerFeed:  b.MaxEntriesPerFeed,
+		Templates: models.BlogrollTemplates{
+			Blogroll: b.Templates.Blogroll,
+			Reader:   b.Templates.Reader,
+		},
+	}
+
+	for i := range b.Feeds {
+		fc := &b.Feeds[i]
+		config.Feeds = append(config.Feeds, models.ExternalFeedConfig{
+			URL:         fc.URL,
+			Title:       fc.Title,
+			Description: fc.Description,
+			Category:    fc.Category,
+			Tags:        fc.Tags,
+			Active:      fc.Active,
+			SiteURL:     fc.SiteURL,
+			ImageURL:    fc.ImageURL,
+		})
+	}
+
+	return config
+}
+
 //nolint:dupl // Intentional duplication - each format has its own conversion method
 func (c *tomlComponentsConfig) toComponentsConfig() models.ComponentsConfig {
 	config := models.ComponentsConfig{
@@ -638,6 +699,9 @@ func (c *tomlConfig) toConfig() *models.Config {
 	// Convert Header config
 	config.Header = c.Header.toHeaderLayoutConfig()
 
+	// Convert Blogroll config
+	config.Blogroll = c.Blogroll.toBlogrollConfig()
+
 	return config
 }
 
@@ -751,6 +815,7 @@ type yamlConfig struct {
 	Sidebar       yamlSidebarConfig      `yaml:"sidebar"`
 	Toc           yamlTocConfig          `yaml:"toc"`
 	Header        yamlHeaderLayoutConfig `yaml:"header"`
+	Blogroll      yamlBlogrollConfig     `yaml:"blogroll"`
 }
 
 type yamlNavItem struct {
@@ -1179,6 +1244,66 @@ func (h *yamlHeaderLayoutConfig) toHeaderLayoutConfig() models.HeaderLayoutConfi
 	}
 }
 
+// Blogroll-related YAML structs
+
+type yamlBlogrollConfig struct {
+	Enabled            bool                     `yaml:"enabled"`
+	CacheDir           string                   `yaml:"cache_dir"`
+	CacheDuration      string                   `yaml:"cache_duration"`
+	Timeout            int                      `yaml:"timeout"`
+	ConcurrentRequests int                      `yaml:"concurrent_requests"`
+	MaxEntriesPerFeed  int                      `yaml:"max_entries_per_feed"`
+	Feeds              []yamlExternalFeedConfig `yaml:"feeds"`
+	Templates          yamlBlogrollTemplates    `yaml:"templates"`
+}
+
+type yamlExternalFeedConfig struct {
+	URL         string   `yaml:"url"`
+	Title       string   `yaml:"title"`
+	Description string   `yaml:"description"`
+	Category    string   `yaml:"category"`
+	Tags        []string `yaml:"tags"`
+	Active      *bool    `yaml:"active"`
+	SiteURL     string   `yaml:"site_url"`
+	ImageURL    string   `yaml:"image_url"`
+}
+
+type yamlBlogrollTemplates struct {
+	Blogroll string `yaml:"blogroll"`
+	Reader   string `yaml:"reader"`
+}
+
+func (b *yamlBlogrollConfig) toBlogrollConfig() models.BlogrollConfig {
+	config := models.BlogrollConfig{
+		Enabled:            b.Enabled,
+		CacheDir:           b.CacheDir,
+		CacheDuration:      b.CacheDuration,
+		Timeout:            b.Timeout,
+		ConcurrentRequests: b.ConcurrentRequests,
+		MaxEntriesPerFeed:  b.MaxEntriesPerFeed,
+		Templates: models.BlogrollTemplates{
+			Blogroll: b.Templates.Blogroll,
+			Reader:   b.Templates.Reader,
+		},
+	}
+
+	for i := range b.Feeds {
+		fc := &b.Feeds[i]
+		config.Feeds = append(config.Feeds, models.ExternalFeedConfig{
+			URL:         fc.URL,
+			Title:       fc.Title,
+			Description: fc.Description,
+			Category:    fc.Category,
+			Tags:        fc.Tags,
+			Active:      fc.Active,
+			SiteURL:     fc.SiteURL,
+			ImageURL:    fc.ImageURL,
+		})
+	}
+
+	return config
+}
+
 //nolint:dupl // Intentional duplication - each format has its own conversion method
 func (c *yamlComponentsConfig) toComponentsConfig() models.ComponentsConfig {
 	config := models.ComponentsConfig{
@@ -1299,6 +1424,9 @@ func (c *yamlConfig) toConfig() *models.Config {
 	// Convert Header config
 	config.Header = c.Header.toHeaderLayoutConfig()
 
+	// Convert Blogroll config
+	config.Blogroll = c.Blogroll.toBlogrollConfig()
+
 	return config
 }
 
@@ -1399,6 +1527,7 @@ type jsonConfig struct {
 	Sidebar       jsonSidebarConfig      `json:"sidebar"`
 	Toc           jsonTocConfig          `json:"toc"`
 	Header        jsonHeaderLayoutConfig `json:"header"`
+	Blogroll      jsonBlogrollConfig     `json:"blogroll"`
 }
 
 type jsonNavItem struct {
@@ -1827,6 +1956,66 @@ func (h *jsonHeaderLayoutConfig) toHeaderLayoutConfig() models.HeaderLayoutConfi
 	}
 }
 
+// Blogroll-related JSON structs
+
+type jsonBlogrollConfig struct {
+	Enabled            bool                     `json:"enabled"`
+	CacheDir           string                   `json:"cache_dir"`
+	CacheDuration      string                   `json:"cache_duration"`
+	Timeout            int                      `json:"timeout"`
+	ConcurrentRequests int                      `json:"concurrent_requests"`
+	MaxEntriesPerFeed  int                      `json:"max_entries_per_feed"`
+	Feeds              []jsonExternalFeedConfig `json:"feeds"`
+	Templates          jsonBlogrollTemplates    `json:"templates"`
+}
+
+type jsonExternalFeedConfig struct {
+	URL         string   `json:"url"`
+	Title       string   `json:"title"`
+	Description string   `json:"description"`
+	Category    string   `json:"category"`
+	Tags        []string `json:"tags"`
+	Active      *bool    `json:"active"`
+	SiteURL     string   `json:"site_url"`
+	ImageURL    string   `json:"image_url"`
+}
+
+type jsonBlogrollTemplates struct {
+	Blogroll string `json:"blogroll"`
+	Reader   string `json:"reader"`
+}
+
+func (b *jsonBlogrollConfig) toBlogrollConfig() models.BlogrollConfig {
+	config := models.BlogrollConfig{
+		Enabled:            b.Enabled,
+		CacheDir:           b.CacheDir,
+		CacheDuration:      b.CacheDuration,
+		Timeout:            b.Timeout,
+		ConcurrentRequests: b.ConcurrentRequests,
+		MaxEntriesPerFeed:  b.MaxEntriesPerFeed,
+		Templates: models.BlogrollTemplates{
+			Blogroll: b.Templates.Blogroll,
+			Reader:   b.Templates.Reader,
+		},
+	}
+
+	for i := range b.Feeds {
+		fc := &b.Feeds[i]
+		config.Feeds = append(config.Feeds, models.ExternalFeedConfig{
+			URL:         fc.URL,
+			Title:       fc.Title,
+			Description: fc.Description,
+			Category:    fc.Category,
+			Tags:        fc.Tags,
+			Active:      fc.Active,
+			SiteURL:     fc.SiteURL,
+			ImageURL:    fc.ImageURL,
+		})
+	}
+
+	return config
+}
+
 //nolint:dupl // Intentional duplication - each format has its own conversion method
 func (c *jsonComponentsConfig) toComponentsConfig() models.ComponentsConfig {
 	config := models.ComponentsConfig{
@@ -1946,6 +2135,9 @@ func (c *jsonConfig) toConfig() *models.Config {
 
 	// Convert Header config
 	config.Header = c.Header.toHeaderLayoutConfig()
+
+	// Convert Blogroll config
+	config.Blogroll = c.Blogroll.toBlogrollConfig()
 
 	return config
 }

--- a/pkg/models/blogroll.go
+++ b/pkg/models/blogroll.go
@@ -1,0 +1,187 @@
+package models
+
+import "time"
+
+// BlogrollConfig configures the blogroll and RSS reader functionality.
+type BlogrollConfig struct {
+	// Enabled controls whether blogroll functionality is active (default: false)
+	Enabled bool `json:"enabled" yaml:"enabled" toml:"enabled"`
+
+	// CacheDir is the directory for caching fetched feeds (default: "cache/blogroll")
+	CacheDir string `json:"cache_dir" yaml:"cache_dir" toml:"cache_dir"`
+
+	// CacheDuration is how long to cache fetched feeds (default: "1h")
+	CacheDuration string `json:"cache_duration" yaml:"cache_duration" toml:"cache_duration"`
+
+	// Timeout is the HTTP request timeout in seconds (default: 30)
+	Timeout int `json:"timeout" yaml:"timeout" toml:"timeout"`
+
+	// ConcurrentRequests is the max concurrent feed fetches (default: 5)
+	ConcurrentRequests int `json:"concurrent_requests" yaml:"concurrent_requests" toml:"concurrent_requests"`
+
+	// MaxEntriesPerFeed limits entries fetched per feed (default: 50)
+	MaxEntriesPerFeed int `json:"max_entries_per_feed" yaml:"max_entries_per_feed" toml:"max_entries_per_feed"`
+
+	// Feeds is the list of RSS/Atom feeds to fetch
+	Feeds []ExternalFeedConfig `json:"feeds" yaml:"feeds" toml:"feeds"`
+
+	// Templates configures custom templates for blogroll pages
+	Templates BlogrollTemplates `json:"templates" yaml:"templates" toml:"templates"`
+}
+
+// NewBlogrollConfig creates a new BlogrollConfig with default values.
+func NewBlogrollConfig() BlogrollConfig {
+	return BlogrollConfig{
+		Enabled:            false,
+		CacheDir:           "cache/blogroll",
+		CacheDuration:      "1h",
+		Timeout:            30,
+		ConcurrentRequests: 5,
+		MaxEntriesPerFeed:  50,
+		Feeds:              []ExternalFeedConfig{},
+		Templates: BlogrollTemplates{
+			Blogroll: "blogroll.html",
+			Reader:   "reader.html",
+		},
+	}
+}
+
+// BlogrollTemplates specifies custom templates for blogroll pages.
+type BlogrollTemplates struct {
+	// Blogroll is the template for the /blogroll page
+	Blogroll string `json:"blogroll" yaml:"blogroll" toml:"blogroll"`
+
+	// Reader is the template for the /reader page
+	Reader string `json:"reader" yaml:"reader" toml:"reader"`
+}
+
+// ExternalFeedConfig represents a configured external RSS/Atom feed.
+type ExternalFeedConfig struct {
+	// URL is the feed URL (required)
+	URL string `json:"url" yaml:"url" toml:"url"`
+
+	// Title is the human-readable feed title (optional, fetched if not set)
+	Title string `json:"title" yaml:"title" toml:"title"`
+
+	// Description is a short description of the feed
+	Description string `json:"description" yaml:"description" toml:"description"`
+
+	// Category groups feeds together (e.g., "technology", "design")
+	Category string `json:"category" yaml:"category" toml:"category"`
+
+	// Tags are additional labels for filtering
+	Tags []string `json:"tags" yaml:"tags" toml:"tags"`
+
+	// Active controls whether this feed is fetched (default: true)
+	Active *bool `json:"active,omitempty" yaml:"active,omitempty" toml:"active,omitempty"`
+
+	// SiteURL is the main website URL (fetched from feed if not set)
+	SiteURL string `json:"site_url" yaml:"site_url" toml:"site_url"`
+
+	// ImageURL is a logo or icon for the feed
+	ImageURL string `json:"image_url" yaml:"image_url" toml:"image_url"`
+}
+
+// IsActive returns whether the feed is active (defaults to true).
+func (f *ExternalFeedConfig) IsActive() bool {
+	if f.Active == nil {
+		return true
+	}
+	return *f.Active
+}
+
+// ExternalFeed represents a fetched and parsed external RSS/Atom feed.
+type ExternalFeed struct {
+	// Config is the original configuration for this feed
+	Config ExternalFeedConfig `json:"config"`
+
+	// Title is the feed title (from config or fetched)
+	Title string `json:"title"`
+
+	// Description is the feed description
+	Description string `json:"description"`
+
+	// SiteURL is the main website URL
+	SiteURL string `json:"site_url"`
+
+	// FeedURL is the RSS/Atom feed URL
+	FeedURL string `json:"feed_url"`
+
+	// ImageURL is the feed's logo/icon
+	ImageURL string `json:"image_url"`
+
+	// Category is the feed category
+	Category string `json:"category"`
+
+	// Tags are the feed tags
+	Tags []string `json:"tags"`
+
+	// LastFetched is when the feed was last fetched
+	LastFetched *time.Time `json:"last_fetched,omitempty"`
+
+	// LastUpdated is the feed's last build/update date
+	LastUpdated *time.Time `json:"last_updated,omitempty"`
+
+	// EntryCount is the number of entries in the feed
+	EntryCount int `json:"entry_count"`
+
+	// Entries are the feed entries/items
+	Entries []*ExternalEntry `json:"entries"`
+
+	// Error holds any error that occurred during fetching
+	Error string `json:"error,omitempty"`
+}
+
+// ExternalEntry represents a single entry/item from an external feed.
+type ExternalEntry struct {
+	// FeedURL is the source feed URL
+	FeedURL string `json:"feed_url"`
+
+	// FeedTitle is the source feed title
+	FeedTitle string `json:"feed_title"`
+
+	// ID is the unique identifier (GUID) for the entry
+	ID string `json:"id"`
+
+	// URL is the link to the full article
+	URL string `json:"url"`
+
+	// Title is the entry title
+	Title string `json:"title"`
+
+	// Description is a short summary or excerpt
+	Description string `json:"description"`
+
+	// Content is the full entry content (HTML)
+	Content string `json:"content"`
+
+	// Author is the entry author
+	Author string `json:"author,omitempty"`
+
+	// Published is the publication date
+	Published *time.Time `json:"published,omitempty"`
+
+	// Updated is the last update date
+	Updated *time.Time `json:"updated,omitempty"`
+
+	// Categories are the entry categories/tags
+	Categories []string `json:"categories,omitempty"`
+
+	// ImageURL is the entry's featured image
+	ImageURL string `json:"image_url,omitempty"`
+
+	// ReadingTime is estimated reading time in minutes
+	ReadingTime int `json:"reading_time"`
+}
+
+// BlogrollCategory groups feeds by category for display.
+type BlogrollCategory struct {
+	// Name is the category name
+	Name string `json:"name"`
+
+	// Slug is the URL-safe category identifier
+	Slug string `json:"slug"`
+
+	// Feeds are the feeds in this category
+	Feeds []*ExternalFeed `json:"feeds"`
+}

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -259,6 +259,9 @@ type Config struct {
 
 	// ContentTemplates configures the content template system for the new command
 	ContentTemplates ContentTemplatesConfig `json:"content_templates" yaml:"content_templates" toml:"content_templates"`
+
+	// Blogroll configures the blogroll and RSS reader functionality
+	Blogroll BlogrollConfig `json:"blogroll" yaml:"blogroll" toml:"blogroll"`
 }
 
 // HeadConfig configures elements added to the HTML <head> section.
@@ -1034,6 +1037,7 @@ func NewConfig() *Config {
 		Header:           NewHeaderLayoutConfig(),
 		FooterLayout:     NewFooterLayoutConfig(),
 		ContentTemplates: NewContentTemplatesConfig(),
+		Blogroll:         NewBlogrollConfig(),
 	}
 }
 

--- a/pkg/plugins/blogroll.go
+++ b/pkg/plugins/blogroll.go
@@ -1,0 +1,849 @@
+// Package plugins provides lifecycle plugins for markata-go.
+package plugins
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"html"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+
+	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
+	"github.com/WaylonWalker/markata-go/pkg/models"
+)
+
+// categoryUncategorized is the default category name for feeds without a category.
+const categoryUncategorized = "Uncategorized"
+
+// BlogrollPlugin fetches and processes external RSS/Atom feeds.
+// It runs in the Collect stage to gather external feed entries
+// and in the Write stage to generate blogroll and reader pages.
+type BlogrollPlugin struct {
+	feeds   []*models.ExternalFeed
+	entries []*models.ExternalEntry
+	mu      sync.RWMutex
+}
+
+// NewBlogrollPlugin creates a new BlogrollPlugin.
+func NewBlogrollPlugin() *BlogrollPlugin {
+	return &BlogrollPlugin{
+		feeds:   make([]*models.ExternalFeed, 0),
+		entries: make([]*models.ExternalEntry, 0),
+	}
+}
+
+// Name returns the unique name of the plugin.
+func (p *BlogrollPlugin) Name() string {
+	return "blogroll"
+}
+
+// Priority returns the plugin's priority for a given stage.
+func (p *BlogrollPlugin) Priority(stage lifecycle.Stage) int {
+	switch stage {
+	case lifecycle.StageCollect:
+		// Run after feeds plugin to not interfere
+		return lifecycle.PriorityLate + 10
+	case lifecycle.StageWrite:
+		// Run after publish_feeds to write blogroll pages
+		return lifecycle.PriorityLate + 20
+	default:
+		return lifecycle.PriorityDefault
+	}
+}
+
+// Collect fetches and parses configured external feeds.
+func (p *BlogrollPlugin) Collect(m *lifecycle.Manager) error {
+	config := m.Config()
+	blogrollConfig := getBlogrollConfig(config)
+
+	if !blogrollConfig.Enabled {
+		return nil
+	}
+
+	// Fetch all feeds concurrently
+	feeds, entries, err := p.fetchFeeds(blogrollConfig)
+	if err != nil {
+		return fmt.Errorf("blogroll: %w", err)
+	}
+
+	p.mu.Lock()
+	p.feeds = feeds
+	p.entries = entries
+	p.mu.Unlock()
+
+	// Store in cache for templates
+	m.Cache().Set("blogroll_feeds", feeds)
+	m.Cache().Set("blogroll_entries", entries)
+	m.Cache().Set("blogroll_categories", p.groupByCategory(feeds))
+
+	return nil
+}
+
+// Write generates the blogroll and reader pages.
+func (p *BlogrollPlugin) Write(m *lifecycle.Manager) error {
+	config := m.Config()
+	blogrollConfig := getBlogrollConfig(config)
+
+	if !blogrollConfig.Enabled {
+		return nil
+	}
+
+	p.mu.RLock()
+	feeds := p.feeds
+	entries := p.entries
+	p.mu.RUnlock()
+
+	if len(feeds) == 0 {
+		return nil
+	}
+
+	outputDir := config.OutputDir
+	if outputDir == "" {
+		outputDir = "output"
+	}
+
+	// Generate blogroll page
+	if err := p.writeBlogrollPage(m, outputDir, feeds, blogrollConfig); err != nil {
+		return fmt.Errorf("blogroll page: %w", err)
+	}
+
+	// Generate reader page
+	if err := p.writeReaderPage(m, outputDir, entries, blogrollConfig); err != nil {
+		return fmt.Errorf("reader page: %w", err)
+	}
+
+	return nil
+}
+
+// fetchFeeds fetches all configured feeds concurrently.
+func (p *BlogrollPlugin) fetchFeeds(config models.BlogrollConfig) ([]*models.ExternalFeed, []*models.ExternalEntry, error) {
+	var activeFeeds []models.ExternalFeedConfig
+	for i := range config.Feeds {
+		if config.Feeds[i].IsActive() {
+			activeFeeds = append(activeFeeds, config.Feeds[i])
+		}
+	}
+
+	if len(activeFeeds) == 0 {
+		return nil, nil, nil
+	}
+
+	// Parse cache duration
+	cacheDuration, err := time.ParseDuration(config.CacheDuration)
+	if err != nil {
+		cacheDuration = time.Hour
+	}
+
+	// Create cache directory
+	if config.CacheDir != "" {
+		if err := os.MkdirAll(config.CacheDir, 0o755); err != nil {
+			return nil, nil, fmt.Errorf("create cache dir: %w", err)
+		}
+	}
+
+	// Fetch feeds concurrently
+	concurrency := config.ConcurrentRequests
+	if concurrency <= 0 {
+		concurrency = 5
+	}
+
+	timeout := config.Timeout
+	if timeout <= 0 {
+		timeout = 30
+	}
+
+	maxEntries := config.MaxEntriesPerFeed
+	if maxEntries <= 0 {
+		maxEntries = 50
+	}
+
+	semaphore := make(chan struct{}, concurrency)
+	resultsCh := make(chan *models.ExternalFeed, len(activeFeeds))
+	var wg sync.WaitGroup
+
+	for i := range activeFeeds {
+		wg.Add(1)
+		go func(feedConfig models.ExternalFeedConfig) {
+			defer wg.Done()
+			semaphore <- struct{}{}
+			defer func() { <-semaphore }()
+
+			feed := p.fetchFeed(feedConfig, config.CacheDir, cacheDuration, timeout, maxEntries)
+			resultsCh <- feed
+		}(activeFeeds[i])
+	}
+
+	wg.Wait()
+	close(resultsCh)
+
+	// Collect results
+	feeds := make([]*models.ExternalFeed, 0, len(activeFeeds))
+	var allEntries []*models.ExternalEntry
+	for feed := range resultsCh {
+		feeds = append(feeds, feed)
+		allEntries = append(allEntries, feed.Entries...)
+	}
+
+	// Sort feeds by title
+	sort.Slice(feeds, func(i, j int) bool {
+		return strings.ToLower(feeds[i].Title) < strings.ToLower(feeds[j].Title)
+	})
+
+	// Sort entries by published date (newest first)
+	sort.Slice(allEntries, func(i, j int) bool {
+		ti := allEntries[i].Published
+		tj := allEntries[j].Published
+		if ti == nil && tj == nil {
+			return false
+		}
+		if ti == nil {
+			return false
+		}
+		if tj == nil {
+			return true
+		}
+		return ti.After(*tj)
+	})
+
+	return feeds, allEntries, nil
+}
+
+// initFeedFromConfig creates a new ExternalFeed initialized from configuration.
+func initFeedFromConfig(config models.ExternalFeedConfig) *models.ExternalFeed {
+	feed := &models.ExternalFeed{
+		Config:   config,
+		FeedURL:  config.URL,
+		Category: config.Category,
+		Tags:     config.Tags,
+		Entries:  make([]*models.ExternalEntry, 0),
+	}
+
+	// Use config values if set
+	if config.Title != "" {
+		feed.Title = config.Title
+	}
+	if config.Description != "" {
+		feed.Description = config.Description
+	}
+	if config.SiteURL != "" {
+		feed.SiteURL = config.SiteURL
+	}
+	if config.ImageURL != "" {
+		feed.ImageURL = config.ImageURL
+	}
+
+	return feed
+}
+
+// mergeCachedFeed merges config values into a cached feed.
+func mergeCachedFeed(cached *models.ExternalFeed, config models.ExternalFeedConfig) *models.ExternalFeed {
+	if config.Title != "" {
+		cached.Title = config.Title
+	}
+	if config.Category != "" {
+		cached.Category = config.Category
+	}
+	cached.Tags = config.Tags
+	return cached
+}
+
+// updateFeedFromParsed updates feed metadata from parsed feed data.
+func updateFeedFromParsed(feed *models.ExternalFeed, parsed *parsedFeed) {
+	if feed.Title == "" {
+		feed.Title = parsed.Title
+	}
+	if feed.Description == "" {
+		feed.Description = parsed.Description
+	}
+	if feed.SiteURL == "" {
+		feed.SiteURL = parsed.SiteURL
+	}
+	if feed.ImageURL == "" {
+		feed.ImageURL = parsed.ImageURL
+	}
+
+	now := time.Now()
+	feed.LastFetched = &now
+	if parsed.LastUpdated != nil {
+		feed.LastUpdated = parsed.LastUpdated
+	}
+}
+
+// fetchFeed fetches a single feed with caching.
+func (p *BlogrollPlugin) fetchFeed(config models.ExternalFeedConfig, cacheDir string, cacheDuration time.Duration, timeout, maxEntries int) *models.ExternalFeed {
+	feed := initFeedFromConfig(config)
+
+	// Check cache
+	if cacheDir != "" {
+		if cached := p.loadFromCache(config.URL, cacheDir, cacheDuration); cached != nil {
+			return mergeCachedFeed(cached, config)
+		}
+	}
+
+	// Fetch the feed
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", config.URL, http.NoBody)
+	if err != nil {
+		feed.Error = fmt.Sprintf("create request: %v", err)
+		return feed
+	}
+
+	req.Header.Set("User-Agent", "markata-go/1.0 (RSS Reader)")
+	req.Header.Set("Accept", "application/rss+xml, application/atom+xml, application/xml, text/xml")
+
+	client := &http.Client{
+		Timeout: time.Duration(timeout) * time.Second,
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		feed.Error = fmt.Sprintf("fetch: %v", err)
+		return feed
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		feed.Error = fmt.Sprintf("HTTP %d", resp.StatusCode)
+		return feed
+	}
+
+	// Parse the feed using simple XML parsing
+	parsedFeed, entries, err := parseFeedResponse(resp)
+	if err != nil {
+		feed.Error = fmt.Sprintf("parse: %v", err)
+		return feed
+	}
+
+	// Update feed with parsed values
+	updateFeedFromParsed(feed, parsedFeed)
+
+	// Limit entries
+	if len(entries) > maxEntries {
+		entries = entries[:maxEntries]
+	}
+
+	// Add feed info to entries
+	for _, entry := range entries {
+		entry.FeedURL = config.URL
+		entry.FeedTitle = feed.Title
+	}
+
+	feed.Entries = entries
+	feed.EntryCount = len(entries)
+
+	// Save to cache
+	if cacheDir != "" {
+		p.saveToCache(feed, cacheDir)
+	}
+
+	return feed
+}
+
+// loadFromCache loads a feed from cache if valid.
+func (p *BlogrollPlugin) loadFromCache(url, cacheDir string, maxAge time.Duration) *models.ExternalFeed {
+	cacheFile := filepath.Join(cacheDir, p.cacheKey(url)+".json")
+
+	info, err := os.Stat(cacheFile)
+	if err != nil {
+		return nil
+	}
+
+	// Check if cache is still valid
+	if time.Since(info.ModTime()) > maxAge {
+		return nil
+	}
+
+	data, err := os.ReadFile(cacheFile)
+	if err != nil {
+		return nil
+	}
+
+	var feed models.ExternalFeed
+	if err := json.Unmarshal(data, &feed); err != nil {
+		return nil
+	}
+
+	return &feed
+}
+
+// saveToCache saves a feed to cache.
+// Cache writes are best-effort; errors are silently ignored.
+func (p *BlogrollPlugin) saveToCache(feed *models.ExternalFeed, cacheDir string) {
+	cacheFile := filepath.Join(cacheDir, p.cacheKey(feed.FeedURL)+".json")
+
+	data, err := json.MarshalIndent(feed, "", "  ")
+	if err != nil {
+		return
+	}
+
+	//nolint:errcheck // Cache writes are best-effort
+	os.WriteFile(cacheFile, data, 0o600)
+}
+
+// cacheKey generates a cache key from a URL.
+func (p *BlogrollPlugin) cacheKey(url string) string {
+	hash := sha256.Sum256([]byte(url))
+	return hex.EncodeToString(hash[:8])
+}
+
+// groupByCategory groups feeds by their category.
+func (p *BlogrollPlugin) groupByCategory(feeds []*models.ExternalFeed) []*models.BlogrollCategory {
+	categoryMap := make(map[string]*models.BlogrollCategory)
+
+	for _, feed := range feeds {
+		category := feed.Category
+		if category == "" {
+			category = categoryUncategorized
+		}
+
+		cat, ok := categoryMap[category]
+		if !ok {
+			cat = &models.BlogrollCategory{
+				Name: category,
+				Slug: blogrollSlugify(category),
+			}
+			categoryMap[category] = cat
+		}
+		cat.Feeds = append(cat.Feeds, feed)
+	}
+
+	// Convert to slice and sort
+	categories := make([]*models.BlogrollCategory, 0, len(categoryMap))
+	for _, cat := range categoryMap {
+		categories = append(categories, cat)
+	}
+
+	sort.Slice(categories, func(i, j int) bool {
+		// Put "Uncategorized" last
+		if categories[i].Name == categoryUncategorized {
+			return false
+		}
+		if categories[j].Name == categoryUncategorized {
+			return true
+		}
+		return categories[i].Name < categories[j].Name
+	})
+
+	return categories
+}
+
+// writeBlogrollPage generates the /blogroll page.
+func (p *BlogrollPlugin) writeBlogrollPage(m *lifecycle.Manager, outputDir string, feeds []*models.ExternalFeed, config models.BlogrollConfig) error {
+	// Create output directory
+	blogrollDir := filepath.Join(outputDir, "blogroll")
+	if err := os.MkdirAll(blogrollDir, 0o755); err != nil {
+		return err
+	}
+
+	// Group feeds by category
+	categories := p.groupByCategory(feeds)
+
+	// Build template context
+	ctx := map[string]interface{}{
+		"title":       "Blogroll",
+		"description": "Blogs and feeds I follow",
+		"feeds":       feeds,
+		"categories":  categories,
+		"feed_count":  len(feeds),
+	}
+
+	// Try to render with template engine
+	content, err := p.renderTemplate(m, config.Templates.Blogroll, ctx)
+	if err != nil {
+		// Fall back to built-in template
+		content = p.renderBlogrollFallback(feeds, categories)
+	}
+
+	// Write the file
+	outputFile := filepath.Join(blogrollDir, "index.html")
+	return os.WriteFile(outputFile, []byte(content), 0o600)
+}
+
+// writeReaderPage generates the /reader page.
+func (p *BlogrollPlugin) writeReaderPage(m *lifecycle.Manager, outputDir string, entries []*models.ExternalEntry, config models.BlogrollConfig) error {
+	// Create output directory
+	readerDir := filepath.Join(outputDir, "reader")
+	if err := os.MkdirAll(readerDir, 0o755); err != nil {
+		return err
+	}
+
+	// Build template context
+	ctx := map[string]interface{}{
+		"title":       "Reader",
+		"description": "Latest posts from blogs I follow",
+		"entries":     entries,
+		"entry_count": len(entries),
+	}
+
+	// Try to render with template engine
+	content, err := p.renderTemplate(m, config.Templates.Reader, ctx)
+	if err != nil {
+		// Fall back to built-in template
+		content = p.renderReaderFallback(entries)
+	}
+
+	// Write the file
+	outputFile := filepath.Join(readerDir, "index.html")
+	return os.WriteFile(outputFile, []byte(content), 0o600)
+}
+
+// renderTemplate attempts to render using the template engine.
+func (p *BlogrollPlugin) renderTemplate(m *lifecycle.Manager, templateName string, ctx map[string]interface{}) (string, error) {
+	// Check if template engine is available
+	engine, ok := m.Cache().Get("template_engine")
+	if !ok {
+		return "", fmt.Errorf("template engine not available")
+	}
+
+	// Try to use the engine
+	if eng, ok := engine.(interface {
+		RenderToString(string, map[string]interface{}) (string, error)
+	}); ok {
+		return eng.RenderToString(templateName, ctx)
+	}
+
+	return "", fmt.Errorf("template engine does not support RenderToString")
+}
+
+// renderBlogrollFallback generates a basic blogroll page.
+func (p *BlogrollPlugin) renderBlogrollFallback(feeds []*models.ExternalFeed, categories []*models.BlogrollCategory) string {
+	var sb strings.Builder
+
+	sb.WriteString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Blogroll</title>
+  <style>
+    :root {
+      --bg: #ffffff;
+      --text: #1a1a1a;
+      --muted: #666666;
+      --border: #e0e0e0;
+      --card-bg: #f8f9fa;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #1a1a1a;
+        --text: #f0f0f0;
+        --muted: #999999;
+        --border: #333333;
+        --card-bg: #2a2a2a;
+      }
+    }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 2rem;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.6;
+    }
+    h1 { margin-bottom: 0.5rem; }
+    .subtitle { color: var(--muted); margin-bottom: 2rem; }
+    .category { margin-bottom: 2rem; }
+    .category h2 { border-bottom: 1px solid var(--border); padding-bottom: 0.5rem; }
+    .feed-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+      gap: 1rem;
+    }
+    .feed-card {
+      background: var(--card-bg);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 1rem;
+    }
+    .feed-card h3 {
+      margin: 0 0 0.5rem 0;
+      font-size: 1rem;
+    }
+    .feed-card h3 a {
+      color: var(--text);
+      text-decoration: none;
+    }
+    .feed-card h3 a:hover { text-decoration: underline; }
+    .feed-card p {
+      margin: 0;
+      font-size: 0.875rem;
+      color: var(--muted);
+    }
+    .feed-meta {
+      margin-top: 0.5rem;
+      font-size: 0.75rem;
+      color: var(--muted);
+    }
+    .nav-links {
+      margin-bottom: 1rem;
+    }
+    .nav-links a {
+      color: var(--text);
+      margin-right: 1rem;
+    }
+  </style>
+</head>
+<body>
+  <nav class="nav-links">
+    <a href="/">Home</a>
+    <a href="/blogroll/">Blogroll</a>
+    <a href="/reader/">Reader</a>
+  </nav>
+  <h1>Blogroll</h1>
+  <p class="subtitle">`)
+	sb.WriteString(fmt.Sprintf("%d blogs and feeds I follow", len(feeds)))
+	sb.WriteString(`</p>
+`)
+
+	for _, cat := range categories {
+		sb.WriteString(fmt.Sprintf(`  <section class="category">
+    <h2>%s</h2>
+    <div class="feed-grid">
+`, html.EscapeString(cat.Name)))
+
+		for _, feed := range cat.Feeds {
+			sb.WriteString(`      <div class="feed-card">
+        <h3>`)
+			if feed.SiteURL != "" {
+				sb.WriteString(fmt.Sprintf(`<a href=%q target="_blank" rel="noopener">%s</a>`,
+					feed.SiteURL,
+					html.EscapeString(feed.Title)))
+			} else {
+				sb.WriteString(html.EscapeString(feed.Title))
+			}
+			sb.WriteString(`</h3>
+`)
+			if feed.Description != "" {
+				sb.WriteString(fmt.Sprintf(`        <p>%s</p>
+`, html.EscapeString(blogrollTruncateString(feed.Description, 150))))
+			}
+			sb.WriteString(fmt.Sprintf(`        <div class="feed-meta">%d posts</div>
+      </div>
+`, feed.EntryCount))
+		}
+
+		sb.WriteString(`    </div>
+  </section>
+`)
+	}
+
+	sb.WriteString(`</body>
+</html>`)
+
+	return sb.String()
+}
+
+// renderReaderFallback generates a basic reader page.
+func (p *BlogrollPlugin) renderReaderFallback(entries []*models.ExternalEntry) string {
+	var sb strings.Builder
+
+	sb.WriteString(`<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Reader</title>
+  <style>
+    :root {
+      --bg: #ffffff;
+      --text: #1a1a1a;
+      --muted: #666666;
+      --border: #e0e0e0;
+      --card-bg: #f8f9fa;
+      --link: #0066cc;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #1a1a1a;
+        --text: #f0f0f0;
+        --muted: #999999;
+        --border: #333333;
+        --card-bg: #2a2a2a;
+        --link: #66b3ff;
+      }
+    }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 2rem;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.6;
+    }
+    h1 { margin-bottom: 0.5rem; }
+    .subtitle { color: var(--muted); margin-bottom: 2rem; }
+    .entry-list { list-style: none; padding: 0; margin: 0; }
+    .entry {
+      border-bottom: 1px solid var(--border);
+      padding: 1.5rem 0;
+    }
+    .entry:last-child { border-bottom: none; }
+    .entry h2 {
+      margin: 0 0 0.5rem 0;
+      font-size: 1.25rem;
+    }
+    .entry h2 a {
+      color: var(--text);
+      text-decoration: none;
+    }
+    .entry h2 a:hover { text-decoration: underline; }
+    .entry-meta {
+      font-size: 0.875rem;
+      color: var(--muted);
+      margin-bottom: 0.5rem;
+    }
+    .entry-meta a { color: var(--link); }
+    .entry-description {
+      color: var(--text);
+      font-size: 0.9375rem;
+    }
+    .nav-links {
+      margin-bottom: 1rem;
+    }
+    .nav-links a {
+      color: var(--text);
+      margin-right: 1rem;
+    }
+  </style>
+</head>
+<body>
+  <nav class="nav-links">
+    <a href="/">Home</a>
+    <a href="/blogroll/">Blogroll</a>
+    <a href="/reader/">Reader</a>
+  </nav>
+  <h1>Reader</h1>
+  <p class="subtitle">Latest posts from blogs I follow</p>
+  <ul class="entry-list">
+`)
+
+	// Limit to 50 entries for the page
+	displayEntries := entries
+	if len(displayEntries) > 50 {
+		displayEntries = displayEntries[:50]
+	}
+
+	for _, entry := range displayEntries {
+		sb.WriteString(`    <li class="entry">
+      <h2><a href="`)
+		sb.WriteString(html.EscapeString(entry.URL))
+		sb.WriteString(`" target="_blank" rel="noopener">`)
+		sb.WriteString(html.EscapeString(entry.Title))
+		sb.WriteString(`</a></h2>
+      <div class="entry-meta">
+        <span class="source">`)
+		sb.WriteString(html.EscapeString(entry.FeedTitle))
+		sb.WriteString(`</span>`)
+
+		if entry.Published != nil {
+			sb.WriteString(` &middot; <time>`)
+			sb.WriteString(entry.Published.Format("Jan 2, 2006"))
+			sb.WriteString(`</time>`)
+		}
+
+		sb.WriteString(`
+      </div>
+`)
+		if entry.Description != "" {
+			sb.WriteString(`      <p class="entry-description">`)
+			sb.WriteString(html.EscapeString(blogrollTruncateString(blogrollStripHTML(entry.Description), 200)))
+			sb.WriteString(`</p>
+`)
+		}
+		sb.WriteString(`    </li>
+`)
+	}
+
+	sb.WriteString(`  </ul>
+</body>
+</html>`)
+
+	return sb.String()
+}
+
+// getBlogrollConfig retrieves blogroll configuration from the manager config.
+func getBlogrollConfig(config *lifecycle.Config) models.BlogrollConfig {
+	if config.Extra == nil {
+		return models.NewBlogrollConfig()
+	}
+
+	if blogroll, ok := config.Extra["blogroll"]; ok {
+		if bc, ok := blogroll.(models.BlogrollConfig); ok {
+			return bc
+		}
+	}
+
+	return models.NewBlogrollConfig()
+}
+
+// blogrollSlugify converts a string to a URL-safe slug.
+func blogrollSlugify(s string) string {
+	// Convert to lowercase
+	s = strings.ToLower(s)
+
+	// Replace spaces and underscores with hyphens
+	s = strings.ReplaceAll(s, " ", "-")
+	s = strings.ReplaceAll(s, "_", "-")
+
+	// Remove non-alphanumeric characters except hyphens
+	var result strings.Builder
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '-' {
+			result.WriteRune(r)
+		}
+	}
+
+	// Remove multiple consecutive hyphens
+	slug := result.String()
+	for strings.Contains(slug, "--") {
+		slug = strings.ReplaceAll(slug, "--", "-")
+	}
+
+	// Trim leading/trailing hyphens
+	return strings.Trim(slug, "-")
+}
+
+// blogrollTruncateString truncates a string to the specified length.
+func blogrollTruncateString(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}
+
+// blogrollStripHTML removes HTML tags from a string.
+func blogrollStripHTML(s string) string {
+	// Simple regex-based HTML stripping
+	re := regexp.MustCompile(`<[^>]*>`)
+	s = re.ReplaceAllString(s, "")
+
+	// Decode common HTML entities
+	s = html.UnescapeString(s)
+
+	// Normalize whitespace
+	s = strings.Join(strings.Fields(s), " ")
+
+	return s
+}
+
+// Ensure BlogrollPlugin implements the required interfaces.
+var (
+	_ lifecycle.Plugin         = (*BlogrollPlugin)(nil)
+	_ lifecycle.CollectPlugin  = (*BlogrollPlugin)(nil)
+	_ lifecycle.WritePlugin    = (*BlogrollPlugin)(nil)
+	_ lifecycle.PriorityPlugin = (*BlogrollPlugin)(nil)
+)

--- a/pkg/plugins/feed_parser.go
+++ b/pkg/plugins/feed_parser.go
@@ -1,0 +1,356 @@
+package plugins
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/WaylonWalker/markata-go/pkg/models"
+)
+
+// parsedFeed holds parsed feed metadata.
+type parsedFeed struct {
+	Title       string
+	Description string
+	SiteURL     string
+	ImageURL    string
+	LastUpdated *time.Time
+}
+
+// parseFeedResponse parses an RSS or Atom feed from an HTTP response.
+func parseFeedResponse(resp *http.Response) (*parsedFeed, []*models.ExternalEntry, error) {
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read body: %w", err)
+	}
+
+	// Try to detect feed type and parse
+	content := string(body)
+	if strings.Contains(content, "<feed") && strings.Contains(content, "xmlns=\"http://www.w3.org/2005/Atom\"") {
+		return parseAtomFeed(body)
+	}
+	// Default to RSS
+	return parseRSSFeed(body)
+}
+
+// rssChannel represents an RSS channel.
+type rssChannel struct {
+	XMLName     xml.Name  `xml:"channel"`
+	Title       string    `xml:"title"`
+	Link        string    `xml:"link"`
+	Description string    `xml:"description"`
+	PubDate     string    `xml:"pubDate"`
+	LastBuild   string    `xml:"lastBuildDate"`
+	Image       *rssImage `xml:"image"`
+	Items       []rssItem `xml:"item"`
+}
+
+// rssImage represents an RSS image.
+type rssImage struct {
+	URL   string `xml:"url"`
+	Title string `xml:"title"`
+	Link  string `xml:"link"`
+}
+
+// rssItem represents an RSS item.
+type rssItem struct {
+	Title       string   `xml:"title"`
+	Link        string   `xml:"link"`
+	Description string   `xml:"description"`
+	Content     string   `xml:"encoded"` // content:encoded
+	PubDate     string   `xml:"pubDate"`
+	GUID        string   `xml:"guid"`
+	Author      string   `xml:"author"`
+	Creator     string   `xml:"creator"` // dc:creator
+	Categories  []string `xml:"category"`
+	Enclosure   *rssEnclosure
+}
+
+// rssEnclosure represents an RSS enclosure (media).
+type rssEnclosure struct {
+	URL  string `xml:"url,attr"`
+	Type string `xml:"type,attr"`
+}
+
+// rssWrapper wraps the RSS document.
+type rssWrapper struct {
+	XMLName xml.Name   `xml:"rss"`
+	Channel rssChannel `xml:"channel"`
+}
+
+// parseRSSFeed parses an RSS 2.0 feed.
+func parseRSSFeed(data []byte) (*parsedFeed, []*models.ExternalEntry, error) {
+	var rss rssWrapper
+	if err := xml.Unmarshal(data, &rss); err != nil {
+		return nil, nil, fmt.Errorf("unmarshal RSS: %w", err)
+	}
+
+	channel := rss.Channel
+
+	feed := &parsedFeed{
+		Title:       cleanString(channel.Title),
+		Description: cleanString(channel.Description),
+		SiteURL:     channel.Link,
+	}
+
+	if channel.Image != nil {
+		feed.ImageURL = channel.Image.URL
+	}
+
+	// Parse last updated
+	if channel.LastBuild != "" {
+		if t := feedParseDate(channel.LastBuild); t != nil {
+			feed.LastUpdated = t
+		}
+	} else if channel.PubDate != "" {
+		if t := feedParseDate(channel.PubDate); t != nil {
+			feed.LastUpdated = t
+		}
+	}
+
+	// Parse items
+	entries := make([]*models.ExternalEntry, 0, len(channel.Items))
+	for i := range channel.Items {
+		item := &channel.Items[i]
+		entry := &models.ExternalEntry{
+			Title:       cleanString(item.Title),
+			URL:         item.Link,
+			Description: cleanString(item.Description),
+			Content:     item.Content,
+			Categories:  item.Categories,
+		}
+
+		// Use GUID or link as ID
+		if item.GUID != "" {
+			entry.ID = item.GUID
+		} else {
+			entry.ID = item.Link
+		}
+
+		// Author (prefer dc:creator over author)
+		if item.Creator != "" {
+			entry.Author = item.Creator
+		} else if item.Author != "" {
+			entry.Author = item.Author
+		}
+
+		// Parse date
+		if item.PubDate != "" {
+			entry.Published = feedParseDate(item.PubDate)
+		}
+
+		// Estimate reading time
+		content := item.Content
+		if content == "" {
+			content = item.Description
+		}
+		entry.ReadingTime = estimateReadingTime(content)
+
+		entries = append(entries, entry)
+	}
+
+	return feed, entries, nil
+}
+
+// atomFeed represents an Atom feed.
+type atomFeed struct {
+	XMLName  xml.Name    `xml:"feed"`
+	Title    string      `xml:"title"`
+	Subtitle string      `xml:"subtitle"`
+	ID       string      `xml:"id"`
+	Updated  string      `xml:"updated"`
+	Links    []atomLink  `xml:"link"`
+	Icon     string      `xml:"icon"`
+	Logo     string      `xml:"logo"`
+	Entries  []atomEntry `xml:"entry"`
+}
+
+// atomLink represents an Atom link.
+type atomLink struct {
+	Rel  string `xml:"rel,attr"`
+	Type string `xml:"type,attr"`
+	Href string `xml:"href,attr"`
+}
+
+// atomEntry represents an Atom entry.
+type atomEntry struct {
+	ID        string         `xml:"id"`
+	Title     string         `xml:"title"`
+	Links     []atomLink     `xml:"link"`
+	Published string         `xml:"published"`
+	Updated   string         `xml:"updated"`
+	Summary   string         `xml:"summary"`
+	Content   atomContent    `xml:"content"`
+	Author    *atomAuthor    `xml:"author"`
+	Category  []atomCategory `xml:"category"`
+}
+
+// atomContent represents Atom content.
+type atomContent struct {
+	Type  string `xml:"type,attr"`
+	Value string `xml:",chardata"`
+}
+
+// atomAuthor represents an Atom author.
+type atomAuthor struct {
+	Name  string `xml:"name"`
+	Email string `xml:"email"`
+	URI   string `xml:"uri"`
+}
+
+// atomCategory represents an Atom category.
+type atomCategory struct {
+	Term  string `xml:"term,attr"`
+	Label string `xml:"label,attr"`
+}
+
+// parseAtomFeed parses an Atom 1.0 feed.
+func parseAtomFeed(data []byte) (*parsedFeed, []*models.ExternalEntry, error) {
+	var atom atomFeed
+	if err := xml.Unmarshal(data, &atom); err != nil {
+		return nil, nil, fmt.Errorf("unmarshal Atom: %w", err)
+	}
+
+	feed := &parsedFeed{
+		Title:       cleanString(atom.Title),
+		Description: cleanString(atom.Subtitle),
+	}
+
+	// Find site URL (alternate link)
+	for _, link := range atom.Links {
+		if link.Rel == "alternate" || link.Rel == "" {
+			feed.SiteURL = link.Href
+			break
+		}
+	}
+
+	// Use logo or icon
+	if atom.Logo != "" {
+		feed.ImageURL = atom.Logo
+	} else if atom.Icon != "" {
+		feed.ImageURL = atom.Icon
+	}
+
+	// Parse updated
+	if atom.Updated != "" {
+		feed.LastUpdated = feedParseDate(atom.Updated)
+	}
+
+	// Parse entries
+	entries := make([]*models.ExternalEntry, 0, len(atom.Entries))
+	for i := range atom.Entries {
+		item := &atom.Entries[i]
+		entry := &models.ExternalEntry{
+			ID:          item.ID,
+			Title:       cleanString(item.Title),
+			Description: cleanString(item.Summary),
+			Content:     item.Content.Value,
+		}
+
+		// Find entry URL (alternate link)
+		for _, link := range item.Links {
+			if link.Rel == "alternate" || link.Rel == "" {
+				entry.URL = link.Href
+				break
+			}
+		}
+
+		// Author
+		if item.Author != nil {
+			entry.Author = item.Author.Name
+		}
+
+		// Published/Updated dates
+		if item.Published != "" {
+			entry.Published = feedParseDate(item.Published)
+		}
+		if item.Updated != "" {
+			entry.Updated = feedParseDate(item.Updated)
+		}
+		// If no published date, use updated
+		if entry.Published == nil && entry.Updated != nil {
+			entry.Published = entry.Updated
+		}
+
+		// Categories
+		for _, cat := range item.Category {
+			if cat.Label != "" {
+				entry.Categories = append(entry.Categories, cat.Label)
+			} else if cat.Term != "" {
+				entry.Categories = append(entry.Categories, cat.Term)
+			}
+		}
+
+		// Estimate reading time
+		entry.ReadingTime = estimateReadingTimeForAtomEntry(item)
+
+		entries = append(entries, entry)
+	}
+
+	return feed, entries, nil
+}
+
+// estimateReadingTimeForAtomEntry calculates the reading time for an Atom entry.
+func estimateReadingTimeForAtomEntry(item *atomEntry) int {
+	content := item.Content.Value
+	if content == "" {
+		content = item.Summary
+	}
+	return estimateReadingTime(content)
+}
+
+// feedParseDate tries to parse a date string in various formats.
+func feedParseDate(s string) *time.Time {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+
+	formats := []string{
+		time.RFC1123Z,
+		time.RFC1123,
+		time.RFC3339,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05-07:00",
+		"2006-01-02T15:04:05Z",
+		"2006-01-02T15:04:05",
+		"2006-01-02 15:04:05",
+		"2006-01-02",
+		"Mon, 02 Jan 2006 15:04:05 -0700",
+		"Mon, 02 Jan 2006 15:04:05 MST",
+		"Mon, 2 Jan 2006 15:04:05 -0700",
+		"Mon, 2 Jan 2006 15:04:05 MST",
+		"02 Jan 2006 15:04:05 -0700",
+		"02 Jan 2006 15:04:05 MST",
+	}
+
+	for _, format := range formats {
+		if t, err := time.Parse(format, s); err == nil {
+			return &t
+		}
+	}
+
+	return nil
+}
+
+// cleanString removes leading/trailing whitespace and normalizes spaces.
+func cleanString(s string) string {
+	return strings.TrimSpace(s)
+}
+
+// estimateReadingTime estimates reading time in minutes.
+func estimateReadingTime(content string) int {
+	// Strip HTML and count words
+	text := blogrollStripHTML(content)
+	words := len(strings.Fields(text))
+
+	// Average reading speed: 200 words per minute
+	minutes := words / 200
+	if minutes < 1 {
+		minutes = 1
+	}
+	return minutes
+}

--- a/pkg/plugins/registry.go
+++ b/pkg/plugins/registry.go
@@ -68,6 +68,7 @@ func registerBuiltinPluginsLocked() {
 	pluginRegistry.constructors["stats"] = func() lifecycle.Plugin { return NewStatsPlugin() }
 	pluginRegistry.constructors["breadcrumbs"] = func() lifecycle.Plugin { return NewBreadcrumbsPlugin() }
 	pluginRegistry.constructors["embeds"] = func() lifecycle.Plugin { return NewEmbedsPlugin() }
+	pluginRegistry.constructors["blogroll"] = func() lifecycle.Plugin { return NewBlogrollPlugin() }
 }
 
 // RegisterPluginConstructor registers a plugin constructor with the given name.


### PR DESCRIPTION
## Summary

- Adds a new `blogroll` plugin that fetches, caches, and displays external RSS/Atom feeds
- Generates a `/blogroll` page listing followed blogs organized by category
- Generates a `/reader` page showing aggregated recent entries from all feeds
- Supports feed caching with configurable duration
- Parses both RSS 2.0 and Atom 1.0 feed formats

## Configuration

```toml
[markata-go.blogroll]
enabled = true
cache_dir = ".cache/blogroll"
cache_duration = "1h"
timeout = 30
concurrent_requests = 5
max_entries_per_feed = 50

[[markata-go.blogroll.feeds]]
url = "https://example.com/feed.xml"
title = "Example Blog"
category = "Tech"
```

Fixes #183