### PR TITLE
feat(feeds): Add guide series support with ordered collections

### DIFF
--- a/pkg/models/feed.go
+++ b/pkg/models/feed.go
@@ -14,6 +14,20 @@ const (
 	PaginationJS PaginationType = "js"
 )
 
+// FeedType represents the type of feed.
+type FeedType string
+
+const (
+	// FeedTypeBlog is a standard blog feed sorted by date.
+	FeedTypeBlog FeedType = "blog"
+
+	// FeedTypeSeries is a series of related posts.
+	FeedTypeSeries FeedType = "series"
+
+	// FeedTypeGuide is a guide series with ordered content and prerequisites.
+	FeedTypeGuide FeedType = "guide"
+)
+
 // FeedConfig represents a feed configuration.
 type FeedConfig struct {
 	// Slug is the URL-safe identifier for the feed
@@ -24,6 +38,9 @@ type FeedConfig struct {
 
 	// Description is the feed description
 	Description string `json:"description" yaml:"description" toml:"description"`
+
+	// Type is the feed type (blog, series, guide)
+	Type FeedType `json:"type" yaml:"type" toml:"type"`
 
 	// Filter is the filter expression for selecting posts
 	Filter string `json:"filter" yaml:"filter" toml:"filter"`

--- a/templates/feed.html
+++ b/templates/feed.html
@@ -9,11 +9,16 @@
 {% endblock %}
 
 {% block content %}
-<div class="feed">
+<div class="feed{% if feed.type == 'guide' %} feed--guide{% elif feed.type == 'series' %} feed--series{% endif %}">
   <header class="feed-header">
     <h1>{{ feed.title | default:"Posts" }}</h1>
     {% if feed.description %}
     <p>{{ feed.description }}</p>
+    {% endif %}
+    {% if feed.type == "guide" or feed.type == "series" %}
+    <div class="feed-meta">
+      <span class="feed-count">{{ feed.posts | length }} parts</span>
+    </div>
     {% endif %}
   </header>
 
@@ -21,12 +26,20 @@
     {% if page.pagination_type == "js" %}
     {# For JS pagination, render ALL posts - JavaScript will handle showing/hiding #}
     {% for post in feed.posts %}
+    {% if feed.type == "guide" %}
+    {% include "partials/guide-card.html" %}
+    {% else %}
     {% include "partials/card.html" %}
+    {% endif %}
     {% endfor %}
     {% else %}
     {# For manual/htmx pagination, render only current page posts #}
     {% for post in page.posts %}
+    {% if feed.type == "guide" %}
+    {% include "partials/guide-card.html" %}
+    {% else %}
     {% include "partials/card.html" %}
+    {% endif %}
     {% endfor %}
     {% endif %}
   </div>

--- a/templates/partials/guide-card.html
+++ b/templates/partials/guide-card.html
@@ -1,0 +1,39 @@
+{# Guide card - displays a single guide post in a series #}
+<article class="card guide-card">
+    <div class="guide-card-header">
+        {% if post.Extra.guide_order %}
+        <span class="guide-order">Part {{ post.Extra.guide_order }}</span>
+        {% endif %}
+        <h2><a href="{{ post.href }}">{{ post.title }}</a></h2>
+    </div>
+
+    {% if post.description %}
+    <p class="guide-description">{{ post.description | truncate:200 }}</p>
+    {% endif %}
+
+    <div class="guide-card-meta">
+        {% if post.Extra.estimated_time %}
+        <span class="guide-time">{{ post.Extra.estimated_time }}</span>
+        {% endif %}
+        {% if post.Extra.difficulty %}
+        <span class="guide-difficulty guide-difficulty--{{ post.Extra.difficulty }}">{{ post.Extra.difficulty }}</span>
+        {% endif %}
+    </div>
+
+    {% if post.Extra.prerequisites %}
+    <div class="guide-prerequisites">
+        <strong>Prerequisites:</strong>
+        {% for prereq in post.Extra.prerequisites %}
+        <a href="/{{ prereq }}/" class="prerequisite-link">{{ prereq }}</a>{% if not forloop.Last %}, {% endif %}
+        {% endfor %}
+    </div>
+    {% endif %}
+
+    {% if post.tags %}
+    <div class="tags">
+        {% for tag in post.tags %}
+        <a href="/tags/{{ tag | slugify }}/" class="tag">{{ tag }}</a>
+        {% endfor %}
+    </div>
+    {% endif %}
+</article>

--- a/templates/partials/guide-navigation.html
+++ b/templates/partials/guide-navigation.html
@@ -1,0 +1,29 @@
+{# Guide navigation - prev/next navigation for guide series #}
+{% if post.Prev or post.Next %}
+<nav class="guide-navigation" aria-label="Guide series navigation">
+    {% if post.Prev %}
+    <a href="{{ post.Prev.href }}" class="guide-nav guide-nav--prev" rel="prev">
+        <span class="guide-nav-label">Previous</span>
+        <span class="guide-nav-title">{{ post.Prev.title }}</span>
+    </a>
+    {% else %}
+    <span class="guide-nav guide-nav--prev guide-nav--disabled"></span>
+    {% endif %}
+
+    {% if post.PrevNextFeed %}
+    <a href="/{{ post.PrevNextFeed }}/" class="guide-nav guide-nav--series">
+        <span class="guide-nav-label">Series</span>
+        <span class="guide-nav-title">View All</span>
+    </a>
+    {% endif %}
+
+    {% if post.Next %}
+    <a href="{{ post.Next.href }}" class="guide-nav guide-nav--next" rel="next">
+        <span class="guide-nav-label">Next</span>
+        <span class="guide-nav-title">{{ post.Next.title }}</span>
+    </a>
+    {% else %}
+    <span class="guide-nav guide-nav--next guide-nav--disabled"></span>
+    {% endif %}
+</nav>
+{% endif %}

--- a/templates/post.html
+++ b/templates/post.html
@@ -28,10 +28,24 @@
                 {% endfor %}
             </div>
             {% endif %}
+            {% if post.Extra.guide_order and post.PrevNextFeed %}
+            <div class="guide-info">
+                <span class="guide-part">Part {{ post.Extra.guide_order }}</span>
+                {% if post.Extra.difficulty %}
+                <span class="guide-difficulty guide-difficulty--{{ post.Extra.difficulty }}">{{ post.Extra.difficulty }}</span>
+                {% endif %}
+                {% if post.Extra.estimated_time %}
+                <span class="guide-time">{{ post.Extra.estimated_time }}</span>
+                {% endif %}
+            </div>
+            {% endif %}
         </header>
         <div class="post-content{% if post.css_class %} {{ post.css_class }}{% endif %}">
             {{ body | safe }}
         </div>
+
+        {# Guide series navigation #}
+        {% include "partials/guide-navigation.html" %}
     </article>
 
     {% include "components/doc_sidebar.html" %}


### PR DESCRIPTION
## Summary

Implements Guide Series as Feed Collections as specified in issue #195.

This PR adds support for guide-type feeds that enable:
- Ordered guide sequences sorted by `guide_order` frontmatter field
- Automatic prev/next navigation within guide series
- Guide-specific templates showing part numbers, difficulty, and time estimates

## Changes

### Core Implementation
- **FeedType enum**: Added `blog`, `series`, `guide` feed types to `pkg/models/feed.go`
- **Guide sorting**: Guide-type feeds default to sorting by `guide_order` (ascending) instead of date
- **Navigation setup**: Series/guide feeds automatically populate `Prev`/`Next` pointers on posts
- **Integer comparison**: Added `toInt()` helper to support numeric sorting for guide_order

### Templates
- **guide-card.html**: New partial showing guide order, difficulty, estimated time, and prerequisites
- **guide-navigation.html**: New partial for prev/next navigation links
- **feed.html**: Updated to use guide-specific cards for guide-type feeds
- **post.html**: Updated to show guide info and navigation for posts in guide series

### Tests
- Added 5 new tests covering guide-type feeds, navigation setup, series feeds, and blog defaults
- Extended `TestCompareFieldValues` to cover integer comparisons

## Usage Example

```toml
[[feeds]]
slug = "getting-started"
title = "Getting Started Guide"
type = "guide"
filter = "tags contains 'getting-started'"
```

Posts in the guide use frontmatter:
```yaml
---
title: "Installation"
guide_order: 1
difficulty: "beginner"
estimated_time: "10 min"
prerequisites: []
---
```

## Fixes

Fixes #195