### PR TITLE
fix(templates): strip HTML tags from search result descriptions

### DIFF
--- a/pkg/templates/filters_test.go
+++ b/pkg/templates/filters_test.go
@@ -395,6 +395,51 @@ func TestFilterStripTags(t *testing.T) {
 			input:    "Plain text",
 			expected: "Plain text",
 		},
+		{
+			name:     "html entities nbsp",
+			input:    "Hello&nbsp;World",
+			expected: "Hello World",
+		},
+		{
+			name:     "html entities amp - re-escaped for html safety",
+			input:    "Tom &amp; Jerry",
+			expected: "Tom &amp; Jerry", // pongo2 re-escapes & for HTML safety
+		},
+		{
+			name:     "html entities lt gt - re-escaped for html safety",
+			input:    "&lt;code&gt;",
+			expected: "&lt;code&gt;", // pongo2 re-escapes < > for HTML safety
+		},
+		{
+			name:     "html entities quot - re-escaped for html safety",
+			input:    "He said &quot;hello&quot;",
+			expected: "He said &quot;hello&quot;", // pongo2 re-escapes quotes
+		},
+		{
+			name:     "html entities apos",
+			input:    "It&#39;s a test",
+			expected: "It&#39;s a test", // pongo2 re-escapes apostrophes
+		},
+		{
+			name:     "multiple whitespace collapse",
+			input:    "Hello    World",
+			expected: "Hello World",
+		},
+		{
+			name:     "whitespace with newlines",
+			input:    "Hello\n\n  World",
+			expected: "Hello World",
+		},
+		{
+			name:     "leading trailing whitespace",
+			input:    "  Hello World  ",
+			expected: "Hello World",
+		},
+		{
+			name:     "combined scenario - tags removed, nbsp decoded, whitespace collapsed",
+			input:    "<p>Hello&nbsp;&nbsp;World</p>  <br/>  <span>Test</span>",
+			expected: "Hello World Test",
+		},
 	}
 
 	for _, tt := range tests {

--- a/templates/partials/card.html
+++ b/templates/partials/card.html
@@ -4,7 +4,7 @@
     <time datetime="{{ post.date | atom_date }}">{{ post.date | date:"Jan 2, 2006" }}</time>
     {% endif %}
     {% if post.description %}
-    <p>{{ post.description | truncate:200 }}</p>
+    <p>{{ post.description | striptags | truncate:200 }}</p>
     {% endif %}
     {% if post.tags %}
     <div class="tags">

--- a/templates/post.html
+++ b/templates/post.html
@@ -6,7 +6,7 @@
         <header>
             <h1 data-pagefind-meta="title">{{ post.title }}</h1>
             {% if post.description %}
-            <p class="visually-hidden" data-pagefind-meta="excerpt">{{ post.description }}</p>
+            <p class="visually-hidden" data-pagefind-meta="excerpt">{{ post.description | striptags }}</p>
             {% endif %}
             {# Pagefind image metadata for search thumbnails #}
             {% if post.cover_image %}


### PR DESCRIPTION
## Summary
Fixes #201 - Search result cards now display clean plain text instead of raw HTML tags.

## Changes
- Add `striptags` filter to `card.html` description
- Add `striptags` filter to `post.html` pagefind excerpt metadata
- Enhance `striptags` filter to decode HTML entities and normalize whitespace
- Add comprehensive tests for the enhanced filter

## Testing
- All existing tests pass
- New tests added for HTML entity decoding, whitespace handling, and combined scenarios