### PR TITLE
feat(lint): show fixable issues count and suggest fix command

### DIFF
--- a/cmd/markata-go/cmd/lint.go
+++ b/cmd/markata-go/cmd/lint.go
@@ -68,6 +68,7 @@ func init() {
 type lintStats struct {
 	totalFiles      int
 	totalIssues     int
+	fixableIssues   int
 	totalFixed      int
 	filesWithIssues int
 	hasErrors       bool
@@ -327,6 +328,13 @@ func processFile(file string, stats *lintStats) {
 	stats.filesWithIssues++
 	stats.totalIssues += len(result.Issues)
 
+	// Count fixable issues
+	for _, issue := range result.Issues {
+		if issue.Fixable {
+			stats.fixableIssues++
+		}
+	}
+
 	fmt.Printf("\n%s:\n", file)
 	for _, issue := range result.Issues {
 		printIssue(issue)
@@ -386,8 +394,19 @@ func printSummary(stats *lintStats) {
 	} else {
 		fmt.Printf("✗ %d file(s) linted, %d issue(s) in %d file(s)\n",
 			stats.totalFiles, stats.totalIssues, stats.filesWithIssues)
+
 		if lintFix {
 			fmt.Printf("  → Fixed %d file(s)\n", stats.totalFixed)
+		} else if stats.fixableIssues > 0 {
+			// Show fixable count and suggest fix command
+			nonFixable := stats.totalIssues - stats.fixableIssues
+			fmt.Printf("ℹ  %d issue(s) can be automatically fixed", stats.fixableIssues)
+			if nonFixable > 0 {
+				fmt.Printf(", %d cannot", nonFixable)
+			}
+			fmt.Println()
+			fmt.Println()
+			fmt.Println("Run 'markata-go lint --fix' to automatically fix fixable issues")
 		}
 	}
 }

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -28,6 +28,7 @@ type Issue struct {
 	Type       string   // Issue type (e.g., "duplicate-key", "invalid-date")
 	Severity   Severity // Severity level
 	Message    string   // Human-readable message
+	Fixable    bool     // Whether this issue can be automatically fixed
 	FixApplied bool     // Whether fix was applied
 }
 
@@ -69,6 +70,17 @@ func (r *Result) HasErrors() bool {
 		}
 	}
 	return false
+}
+
+// FixableCount returns the number of fixable issues.
+func (r *Result) FixableCount() int {
+	count := 0
+	for _, issue := range r.Issues {
+		if issue.Fixable {
+			count++
+		}
+	}
+	return count
 }
 
 // Lint analyzes content and returns any issues found.
@@ -157,6 +169,7 @@ func checkDuplicateKeys(filePath, frontmatter string) []Issue {
 					Type:     "duplicate-key",
 					Severity: SeverityError,
 					Message:  fmt.Sprintf("duplicate key '%s' (first occurrence at line %d)", key, firstLine),
+					Fixable:  true,
 				})
 			} else {
 				seen[key] = lineNum
@@ -209,6 +222,7 @@ func checkDateFormats(filePath, frontmatter string) []Issue {
 								Type:     "invalid-date",
 								Severity: SeverityWarning,
 								Message:  fmt.Sprintf("invalid date format for '%s': %s (%s)", key, value, p.desc),
+								Fixable:  true,
 							})
 							break
 						}
@@ -250,6 +264,7 @@ func checkImageLinks(filePath, body string, hasFrontmatter bool, frontmatter str
 					Type:     "missing-alt-text",
 					Severity: SeverityWarning,
 					Message:  "image link missing alt text",
+					Fixable:  true,
 				})
 			}
 		}
@@ -281,6 +296,7 @@ func checkProtocollessURLs(filePath, content string) []Issue {
 					Type:     "protocol-less-url",
 					Severity: SeverityWarning,
 					Message:  "protocol-less URL found (should use https://)",
+					Fixable:  true,
 				})
 			}
 		}


### PR DESCRIPTION
## Summary

Enhances the lint command output to show how many issues are automatically fixable and suggests the `--fix` command when appropriate.

## Changes

- Added `Fixable` field to `Issue` struct in `pkg/lint/linter.go`
- Updated lint output to show count of fixable issues
- Added suggestion to run `markata-go lint --fix` when fixable issues exist

## Example Output

```
Found 12 issues (8 fixable)
Run 'markata-go lint --fix' to automatically fix 8 issues
```

Fixes #205