### PR TITLE
fix(tui): Wire filter input to post service

### DIFF
--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -242,6 +242,7 @@ func (m Model) loadPosts() tea.Cmd {
 		opts := services.ListOptions{
 			SortBy:    "date",
 			SortOrder: services.SortDesc,
+			Filter:    m.filter,
 		}
 		posts, err := m.app.Posts.List(context.Background(), opts)
 		if err != nil {


### PR DESCRIPTION
## Summary
- Wire the `m.filter` value to `services.ListOptions` when loading posts in the TUI
- Previously, the filter input UI worked but the filter was never applied to the service query

Fixes #222