### PR TITLE
feat(tui): add 'e' key to edit post in $EDITOR

### DIFF
--- a/pkg/tui/keys.go
+++ b/pkg/tui/keys.go
@@ -13,6 +13,7 @@ type keyMapType struct {
 	Tags    key.Binding
 	Enter   key.Binding
 	Escape  key.Binding
+	Edit    key.Binding
 }
 
 var keyMap = keyMapType{
@@ -55,5 +56,9 @@ var keyMap = keyMapType{
 	Escape: key.NewBinding(
 		key.WithKeys("esc"),
 		key.WithHelp("esc", "cancel"),
+	),
+	Edit: key.NewBinding(
+		key.WithKeys("e"),
+		key.WithHelp("e", "edit"),
 	),
 }


### PR DESCRIPTION
## Summary

- Adds 'e' key to edit the selected post directly in the user's editor
- Editor selection follows priority: `$EDITOR` > `$VISUAL` > `vim` > `nano`
- TUI suspends during editing and reloads posts when editor closes

Fixes #221

## Changes

- `pkg/tui/keys.go`: Add `Edit` keybinding for 'e' key
- `pkg/tui/model.go`:
  - Add `editorFinishedMsg` type for editor completion
  - Add `getSelectedPost()` helper to safely get currently selected post
  - Add `getEditor()` to detect editor from environment or fallback
  - Add `openInEditor()` using `tea.ExecProcess` to properly suspend TUI
  - Handle editor finished message to reload posts
  - Update help text and status bar to show 'e' key