### PR TITLE
feat(tui): add sort menu with multiple sort options

### DIFF
--- a/pkg/services/post_service.go
+++ b/pkg/services/post_service.go
@@ -180,6 +180,8 @@ func sortPosts(posts []*models.Post, field string, order SortOrder) {
 			cmp = compareTitles(posts[i].Title, posts[j].Title)
 		case "path":
 			cmp = strings.Compare(posts[i].Path, posts[j].Path)
+		case "words":
+			cmp = compareWordCounts(posts[i], posts[j])
 		default:
 			return false
 		}
@@ -218,6 +220,28 @@ func compareTitles(a, b *string) int {
 		bs = *b
 	}
 	return strings.Compare(strings.ToLower(as), strings.ToLower(bs))
+}
+
+func compareWordCounts(a, b *models.Post) int {
+	wcA := getWordCount(a)
+	wcB := getWordCount(b)
+	if wcA < wcB {
+		return -1
+	}
+	if wcA > wcB {
+		return 1
+	}
+	return 0
+}
+
+func getWordCount(p *models.Post) int {
+	if p.Extra == nil {
+		return 0
+	}
+	if wc, ok := p.Extra["word_count"].(int); ok {
+		return wc
+	}
+	return 0
 }
 
 func matchesSearch(p *models.Post, query string, _ SearchOptions) bool {

--- a/pkg/tui/keys.go
+++ b/pkg/tui/keys.go
@@ -13,6 +13,7 @@ type keyMapType struct {
 	Tags    key.Binding
 	Enter   key.Binding
 	Escape  key.Binding
+	Sort    key.Binding
 }
 
 var keyMap = keyMapType{
@@ -55,5 +56,9 @@ var keyMap = keyMapType{
 	Escape: key.NewBinding(
 		key.WithKeys("esc"),
 		key.WithHelp("esc", "cancel"),
+	),
+	Sort: key.NewBinding(
+		key.WithKeys("s"),
+		key.WithHelp("s", "sort"),
 	),
 }


### PR DESCRIPTION
## Summary

- Add sort functionality to TUI with 's' keybinding to open sort menu overlay
- Support sorting by date, title, word count, and path fields
- Display current sort indicator in header (e.g. `[↓date]` or `[↑title]`)

Fixes #223

## Changes

### Sort Menu Overlay
- Press `s` in posts view to open sort menu
- Navigate options with `j`/`k` or arrow keys
- Set ascending order with `a`, descending with `d`
- Apply with `Enter`, cancel with `Esc`

### Sort Options
| Display | Field | Description |
|---------|-------|-------------|
| Date | `date` | Post date (default) |
| Title | `title` | Alphabetical |
| Word Count | `words` | Word count |
| Path | `path` | File path |

### Files Changed
- `pkg/tui/keys.go` - Add Sort keybinding
- `pkg/tui/model.go` - Add sort state, menu handling, and overlay rendering
- `pkg/services/post_service.go` - Add word count sorting support