### PR TITLE
feat(tui): implement feed table view with statistics

### DIFF
--- a/pkg/tui/keys.go
+++ b/pkg/tui/keys.go
@@ -11,6 +11,7 @@ type keyMapType struct {
 	Help    key.Binding
 	Posts   key.Binding
 	Tags    key.Binding
+	Feeds   key.Binding
 	Enter   key.Binding
 	Escape  key.Binding
 }
@@ -47,6 +48,10 @@ var keyMap = keyMapType{
 	Tags: key.NewBinding(
 		key.WithKeys("t"),
 		key.WithHelp("t", "tags"),
+	),
+	Feeds: key.NewBinding(
+		key.WithKeys("f"),
+		key.WithHelp("f", "feeds"),
 	),
 	Enter: key.NewBinding(
 		key.WithKeys("enter"),


### PR DESCRIPTION
## Summary
- Implements feed table view with NAME, POSTS, FILTER, OUTPUT columns
- Adds `f` keybinding and `:feeds` command to access feeds view
- Updates navigation and help text for the new feeds view

Fixes #224

## Changes
- `pkg/tui/model.go`: Add feeds state, loadFeeds command, feedsLoadedMsg handler, renderFeeds function
- `pkg/tui/keys.go`: Add Feeds key binding

## Table Layout
```
Feeds (3)

NAME                  POSTS  FILTER                         OUTPUT
> blog                   45  (none)                         /feeds/blog.json
  til                    12  (none)                         /feeds/til.json
  all                    57  (none)                         /feeds/all.json
```

Note: The FILTER column currently shows "(none)" since `lifecycle.Feed` doesn't expose the filter expression. This can be enhanced later if needed.