### PR TITLE
docs: fix config section naming consistency

### DIFF
--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -51,7 +51,7 @@ Configure -> Glob -> Load -> Transform -> Render -> Collect -> Write -> Cleanup
 [markata]
 glob_patterns = ["**/*.md"]  # Patterns to match
 
-[markata.glob]
+[markata-go.glob]
 use_gitignore = true  # Respect .gitignore patterns
 ```
 
@@ -70,7 +70,7 @@ glob_patterns = [
     "docs/**/*.md"
 ]
 
-[markata.glob]
+[markata-go.glob]
 use_gitignore = true
 ```
 
@@ -274,7 +274,7 @@ words_per_minute = 200  # Average reading speed (default: 200)
 
 **Configuration (TOML):**
 ```toml
-[markata.stats]
+[markata-go.stats]
 words_per_minute = 200      # Average reading speed (default: 200)
 include_code_in_count = false  # Include code blocks in word count (default: false)
 track_code_blocks = true    # Count lines of code in code blocks (default: true)
@@ -351,7 +351,7 @@ Same fields as feed statistics, aggregated across all posts.
 
 **Configuration (TOML):**
 ```toml
-[markata.breadcrumbs]
+[markata-go.breadcrumbs]
 enabled = true           # Enable/disable breadcrumbs globally
 show_home = true         # Include "Home" as first breadcrumb
 home_label = "Home"      # Label for home breadcrumb
@@ -360,7 +360,7 @@ max_depth = 0            # Maximum depth (0 = unlimited)
 structured_data = true   # Generate JSON-LD for SEO
 
 # Alternative: under components section
-[markata.components.breadcrumbs]
+[markata-go.components.breadcrumbs]
 enabled = true
 show_home = true
 ```
@@ -913,7 +913,7 @@ templates_dir = "templates"  # Templates directory (default: "templates")
 theme = "default"            # Theme name (default: "default")
 
 # Or with theme options:
-[markata.theme]
+[markata-go.theme]
 name = "default"
 ```
 
@@ -964,7 +964,7 @@ name = "default"
 
 **Configuration (TOML):**
 ```toml
-[markata.heading_anchors]
+[markata-go.heading_anchors]
 enabled = true        # Enable/disable the plugin (default: true)
 min_level = 2         # Minimum heading level to process (default: 2, h2)
 max_level = 4         # Maximum heading level to process (default: 4, h4)
@@ -1017,7 +1017,7 @@ h4:hover .heading-anchor {
 
 **Configuration (TOML):**
 ```toml
-[markata.md_video]
+[markata-go.md_video]
 enabled = true                    # Enable the plugin (default: true)
 video_extensions = [".mp4", ".webm", ".ogg", ".ogv", ".mov", ".m4v"]  # Extensions to treat as video
 video_class = "md-video"          # CSS class for video elements (default)
@@ -1035,7 +1035,7 @@ The default configuration mimics animated GIF behavior because most embedded vid
 
 To use traditional video behavior (click to play with sound):
 ```toml
-[markata.md_video]
+[markata-go.md_video]
 autoplay = false
 loop = false
 muted = false
@@ -1096,7 +1096,7 @@ controls = true
 
 **Configuration (TOML):**
 ```toml
-[markata.youtube]
+[markata-go.youtube]
 enabled = true              # Enable the plugin (default: true)
 privacy_enhanced = true     # Use youtube-nocookie.com (default: true)
 container_class = "youtube-embed"  # CSS class for container (default)
@@ -1141,7 +1141,7 @@ More content below...
 By default, the plugin uses `youtube-nocookie.com` which prevents YouTube from storing cookies on visitors' browsers until they play the video. Disable this for standard embeds:
 
 ```toml
-[markata.youtube]
+[markata-go.youtube]
 privacy_enhanced = false
 ```
 
@@ -1190,7 +1190,7 @@ privacy_enhanced = false
 
 **Configuration (TOML):**
 ```toml
-[markata.link_collector]
+[markata-go.link_collector]
 include_feeds = false  # Include feed pages in inlinks (default: false)
 include_index = false  # Include index page in inlinks (default: false)
 ```
@@ -1269,7 +1269,7 @@ type Link struct {
 
 **Configuration (TOML):**
 ```toml
-[markata.chartjs]
+[markata-go.chartjs]
 enabled = true
 cdn_url = "https://cdn.jsdelivr.net/npm/chart.js"
 container_class = "chartjs-container"
@@ -1503,7 +1503,7 @@ A doughnut chart is useful for showing a primary metric with breakdown:
 
 **Configuration (TOML):**
 ```toml
-[markata.one_line_link]
+[markata-go.one_line_link]
 enabled = true
 card_class = "link-card"
 fallback_title = "Link"
@@ -1573,7 +1573,7 @@ exclude_patterns = ["^https://twitter\\.com", "^https://x\\.com"]
 
 **Configuration (TOML):**
 ```toml
-[markata.wikilink_hover]
+[markata-go.wikilink_hover]
 enabled = true
 preview_length = 200
 include_image = true
@@ -1748,7 +1748,7 @@ Style your wikilinks to indicate they have preview functionality:
 Configure a screenshot service for richer previews:
 
 ```toml
-[markata.wikilink_hover]
+[markata-go.wikilink_hover]
 enabled = true
 preview_length = 200
 include_image = true
@@ -1802,7 +1802,7 @@ slug: "about"
 ```
 ```toml
 # markata-go.toml - conflicts!
-[[markata.feeds]]
+[[markata-go.feeds]]
 slug = "about"
 ```
 
@@ -1844,7 +1844,7 @@ slug: "my-page"  # Conflict!
 
 **Configuration (TOML):**
 ```toml
-[[markata.feeds]]
+[[markata-go.feeds]]
 slug = "blog"
 title = "Blog Posts"
 description = "All blog posts"
@@ -1853,13 +1853,13 @@ sort = "date"
 reverse = true
 items_per_page = 10
 
-[markata.feeds.formats]
+[markata-go.feeds.formats]
 html = true
 rss = true
 atom = false
 json = false
 
-[[markata.feeds]]
+[[markata-go.feeds]]
 slug = "tutorials"
 title = "Tutorials"
 filter = "tags contains 'tutorial'"
@@ -1908,29 +1908,29 @@ See [[feeds-guide|Feeds Guide]] for complete filter syntax.
 
 **Configuration (TOML):**
 ```toml
-[markata.auto_feeds.tags]
+[markata-go.auto_feeds.tags]
 enabled = true
 slug_prefix = "tags"  # Results in /tags/python/, /tags/go/, etc.
 
-[markata.auto_feeds.tags.formats]
+[markata-go.auto_feeds.tags.formats]
 html = true
 rss = true
 
-[markata.auto_feeds.categories]
+[markata-go.auto_feeds.categories]
 enabled = true
 slug_prefix = "categories"
 
-[markata.auto_feeds.categories.formats]
+[markata-go.auto_feeds.categories.formats]
 html = true
 rss = true
 
-[markata.auto_feeds.archives]
+[markata-go.auto_feeds.archives]
 enabled = true
 slug_prefix = "archive"
 yearly_feeds = true   # /archive/2024/
 monthly_feeds = false # /archive/2024/01/
 
-[markata.auto_feeds.archives.formats]
+[markata-go.auto_feeds.archives.formats]
 html = true
 rss = false
 ```
@@ -1958,7 +1958,7 @@ For archives:
 
 **Configuration (TOML):**
 ```toml
-[markata.prevnext]
+[markata-go.prevnext]
 enabled = true           # Enable/disable the plugin (default: true)
 strategy = "first_feed"  # Strategy for determining navigation context
 default_feed = "blog"    # Default feed slug (for "explicit_feed" strategy)
@@ -2037,7 +2037,7 @@ series: "go-tutorial"
 ```
 
 ```toml
-[markata.prevnext]
+[markata-go.prevnext]
 strategy = "series"
 ```
 
@@ -2301,7 +2301,7 @@ mysite/
 
 **Configuration (TOML):**
 ```toml
-[markata.theme]
+[markata-go.theme]
 palette = "nord"  # Palette name (built-in or custom)
 ```
 
@@ -2487,7 +2487,7 @@ Include the generated CSS in your base template:
 
 **Configuration (TOML):**
 ```toml
-[markata.redirects]
+[markata-go.redirects]
 redirects_file = "static/_redirects"  # Path to redirects file (default)
 redirect_template = ""                 # Custom template path (optional)
 ```
@@ -2551,7 +2551,7 @@ Create a custom template with these available variables:
 ```
 
 ```toml
-[markata.redirects]
+[markata-go.redirects]
 redirect_template = "templates/redirect.html"
 ```
 
@@ -2572,7 +2572,7 @@ redirect_template = "templates/redirect.html"
 
 **Configuration (TOML):**
 ```toml
-[markata.qrcode]
+[markata-go.qrcode]
 enabled = true
 format = "svg"              # "svg" or "png"
 size = 200                  # Size in pixels
@@ -2654,7 +2654,7 @@ output/
 
 **Custom colors example:**
 ```toml
-[markata.qrcode]
+[markata-go.qrcode]
 foreground = "#2e3440"  # Nord dark
 background = "#eceff4"  # Nord light
 ```
@@ -2718,7 +2718,7 @@ The following plugins are not enabled by default and must be explicitly configur
 
 **Configuration (TOML):**
 ```toml
-[markata.mermaid]
+[markata-go.mermaid]
 enabled = true                                              # Enable the plugin (default: false)
 cdn_url = "https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.esm.min.mjs"  # Mermaid CDN URL
 theme = "default"                                           # Mermaid theme (default, dark, forest, neutral)
@@ -3013,7 +3013,7 @@ gitGraph
 
 **Configuration (TOML):**
 ```toml
-[markata.glossary]
+[markata-go.glossary]
 enabled = true              # Enable the plugin (default: true when configured)
 link_class = "glossary-term"  # CSS class for glossary links (default)
 case_sensitive = false      # Case-sensitive term matching (default: false)
@@ -3101,7 +3101,7 @@ plugins := append(plugins.DefaultPlugins(), plugins.NewGlossaryPlugin())
 
 **Configuration (TOML):**
 ```toml
-[markata.csv_fence]
+[markata-go.csv_fence]
 enabled = true          # Enable the plugin (default: true when configured)
 table_class = "csv-table"  # CSS class for generated tables (default)
 has_header = true       # Treat first row as header (default: true)

--- a/issues/002-incomplete-spec-file-implementation.md
+++ b/issues/002-incomplete-spec-file-implementation.md
@@ -50,9 +50,9 @@ All spec files listed in the README should be fully implemented:
 - [ ] Theme inheritance (`[theme.extends]`)
 
 ### Configuration
-- [ ] `[name.theme]` config section
-- [ ] `[name.theme.options]` for theme-specific options
-- [ ] `[name.theme.variables]` CSS variable overrides
+- [ ] `[markata-go.theme]` config section
+- [ ] `[markata-go.theme.options]` for theme-specific options
+- [ ] `[markata-go.theme.variables]` CSS variable overrides
 - [ ] `custom_css` option
 
 ### Built-in Themes

--- a/spec/spec/DEFAULT_PLUGINS.md
+++ b/spec/spec/DEFAULT_PLUGINS.md
@@ -62,16 +62,16 @@ content_dir = "."
 assets_dir = "static"
 templates_dir = "templates"
 
-[name.glob]
+[markata-go.glob]
 glob_patterns = ["**/*.md"]
 use_gitignore = true
 exclude_patterns = ["node_modules/**", ".git/**", "output/**"]
 
-[name.feeds]
+[markata-go.feeds]
 default_items_per_page = 10
 default_orphan_threshold = 3
 
-[name.feeds.default_formats]
+[markata-go.feeds.default_formats]
 html = true
 rss = true
 atom = false
@@ -93,7 +93,7 @@ sitemap = false
 
 **Configuration:**
 ```toml
-[name.glob]
+[markata-go.glob]
 glob_patterns = ["posts/**/*.md", "pages/*.md"]
 use_gitignore = true
 exclude_patterns = ["**/draft-*", "**/wip-*"]
@@ -175,7 +175,7 @@ for path in core.files:
 
 **Configuration:**
 ```toml
-[name.auto_description]
+[markata-go.auto_description]
 enabled = true
 max_length = 160               # Characters
 strip_html = true              # Remove HTML tags
@@ -212,7 +212,7 @@ for post in core.filter("description == None or description == ''"):
 
 **Configuration:**
 ```toml
-[name.jinja_md]
+[markata-go.jinja_md]
 enabled = true
 default_enabled = false        # Require explicit jinja: true in frontmatter
 ```
@@ -275,7 +275,7 @@ for post in core.filter(filter_expr):
 
 **Configuration:**
 ```toml
-[name.overwrite_check]
+[markata-go.overwrite_check]
 enabled = true
 warn_only = false              # If true, warn instead of fail
 ```
@@ -359,7 +359,7 @@ The plugin MUST implement:
 
 **Configuration:**
 ```toml
-[name.prevnext]
+[markata-go.prevnext]
 enabled = true
 strategy = "first_feed"        # Resolution strategy (see below)
 default_feed = "blog"          # Feed to use when strategy = "explicit_feed"
@@ -492,18 +492,18 @@ for post in manager.posts():
 
 ```toml
 # Strategy 1: Use first feed (default)
-[name.prevnext]
+[markata-go.prevnext]
 enabled = true
 strategy = "first_feed"
 
 # Strategy 2: Always use specific feed
-[name.prevnext]
+[markata-go.prevnext]
 enabled = true
 strategy = "explicit_feed"
 default_feed = "all-posts"
 
 # Strategy 3: Series-based navigation (uses series frontmatter to find feed)
-[name.prevnext]
+[markata-go.prevnext]
 enabled = true
 strategy = "series"
 ```
@@ -536,10 +536,10 @@ prevnext_feed: announcements
 
 **Configuration:**
 ```toml
-[name.markdown]
+[markata-go.markdown]
 backend = "auto"               # "markdown-it", "commonmark", etc.
 
-[name.markdown.extensions]
+[markata-go.markdown.extensions]
 tables = true
 admonitions = true
 footnotes = true
@@ -547,7 +547,7 @@ strikethrough = true
 task_lists = true
 heading_ids = true
 
-[name.markdown.highlight]
+[markata-go.markdown.highlight]
 enabled = true
 theme = "github-dark"
 line_numbers = false
@@ -584,7 +584,7 @@ for post in core.filter("not skip"):
 
 **Configuration:**
 ```toml
-[name.wikilinks]
+[markata-go.wikilinks]
 enabled = true
 warn_broken = true             # Warn about broken links
 broken_class = "broken-link"   # CSS class for broken links
@@ -633,7 +633,7 @@ for post in core.filter("not skip"):
 
 **Configuration:**
 ```toml
-[name.heading_anchors]
+[markata-go.heading_anchors]
 enabled = true
 min_level = 2                  # Start at h2
 max_level = 4                  # End at h4
@@ -677,7 +677,7 @@ for post in core.filter("not skip"):
 
 **Configuration:**
 ```toml
-[name.md_video]
+[markata-go.md_video]
 enabled = true
 video_extensions = [".mp4", ".webm", ".ogg", ".ogv", ".mov", ".m4v"]
 video_class = "md-video"
@@ -753,7 +753,7 @@ The plugin MUST implement:
 
 **Configuration:**
 ```toml
-[name.toc]
+[markata-go.toc]
 enabled = true
 min_level = 2
 max_level = 4
@@ -809,7 +809,7 @@ min_headings = 3               # Only generate if >= 3 headings
 
 **Configuration:**
 ```toml
-[name.link_collector]
+[markata-go.link_collector]
 enabled = true
 include_feeds = false          # Exclude feed pages from inlinks by default
 include_index = false          # Exclude index page from inlinks by default
@@ -1151,13 +1151,13 @@ for post in core.filter("not skip"):
 
 **Configuration:**
 ```toml
-[name.assets]
+[markata-go.assets]
 dir = "static"
 output_subdir = ""             # "" = root, "assets" = /assets/
 exclude = ["*.psd", "*.ai"]
 fingerprint = false
 
-[name.assets.fingerprint]
+[markata-go.assets.fingerprint]
 enabled = false
 algorithm = "sha256"
 length = 8
@@ -1205,7 +1205,7 @@ for src in assets_dir.recursive_glob("*"):
 
 **Configuration:**
 ```toml
-[name.redirects]
+[markata-go.redirects]
 redirects_file = "static/_redirects"    # Path to redirects file (default)
 redirect_template = ""                   # Optional custom template path
 ```
@@ -1298,15 +1298,15 @@ for redirect in parse_redirects(content):
 
 ```toml
 # Basic usage (default settings)
-[name.redirects]
+[markata-go.redirects]
 # Uses static/_redirects by default
 
 # Custom redirects file location
-[name.redirects]
+[markata-go.redirects]
 redirects_file = "_redirects"
 
 # With custom template
-[name.redirects]
+[markata-go.redirects]
 redirects_file = "config/_redirects"
 redirect_template = "templates/redirect.html"
 ```

--- a/spec/spec/FEEDS.md
+++ b/spec/spec/FEEDS.md
@@ -36,7 +36,7 @@ Feeds are the core differentiator of this static site generator. A feed is a **f
 ### Basic Feed
 
 ```toml
-[[name.feeds]]
+[[markata-go.feeds]]
 slug = "blog"
 title = "Blog"
 filter = "published == True"
@@ -47,7 +47,7 @@ reverse = true
 ### Full Configuration
 
 ```toml
-[[name.feeds]]
+[[markata-go.feeds]]
 # Identity
 slug = "blog"                      # URL path: /blog/
 title = "All Posts"                # Display title
@@ -63,7 +63,7 @@ items_per_page = 10                # 0 = no pagination (all on one page)
 orphan_threshold = 3               # If last page has ≤3 items, merge with previous
 
 # Output Formats (all optional, defaults shown)
-[name.feeds.formats]
+[markata-go.feeds.formats]
 html = true                        # /blog/index.html, /blog/page/2/index.html
 rss = true                         # /blog/rss.xml
 atom = true                        # /blog/atom.xml
@@ -73,7 +73,7 @@ text = false                       # /blog/index.txt
 sitemap = false                    # /blog/sitemap.xml
 
 # Templates (can override per-format)
-[name.feeds.templates]
+[markata-go.feeds.templates]
 html = "feed.html"                 # Template for HTML pages
 card = "partials/card.html"        # Template for post cards in list
 rss = "rss.xml"                    # Template for RSS (usually default)
@@ -126,7 +126,7 @@ Feeds support multiple pagination strategies for different use cases and user ex
 ### Configuration
 
 ```toml
-[[name.feeds]]
+[[markata-go.feeds]]
 slug = "blog"
 title = "Blog"
 filter = "published == True"
@@ -170,7 +170,7 @@ HTMX pagination provides a seamless user experience by loading new pages without
 htmx_version = "2.0.8"             # HTMX version to use
 skip_htmx_integrity_check = false  # Skip SHA-256 verification (not recommended)
 
-[[name.feeds]]
+[[markata-go.feeds]]
 slug = "blog"
 enabled = true
 pagination_type = "htmx"
@@ -320,7 +320,7 @@ Traditional pagination with full page reloads. Best for SEO and accessibility.
 ### Configuration
 
 ```toml
-[[name.feeds]]
+[[markata-go.feeds]]
 slug = "blog"
 enabled = true
 pagination_type = "manual"
@@ -357,7 +357,7 @@ For custom pagination behavior, a JavaScript configuration file is generated.
 ### Configuration
 
 ```toml
-[[name.feeds]]
+[[markata-go.feeds]]
 slug = "blog"
 enabled = true
 pagination_type = "js"
@@ -612,7 +612,7 @@ XML sitemap for search engines (follows sitemaps.org protocol).
 
 **Configuration options:**
 ```toml
-[name.feeds.sitemap]
+[markata-go.feeds.sitemap]
 include_feeds = true              # Include feed index pages in sitemap
 default_changefreq = "weekly"     # daily, weekly, monthly, yearly, never
 default_priority = 0.5            # 0.0 to 1.0
@@ -632,7 +632,7 @@ priority: 0.8
 To generate a site-wide sitemap with all posts (not just feed posts), create a feed with no filter:
 
 ```toml
-[[name.feeds]]
+[[markata-go.feeds]]
 slug = "sitemap"
 title = "Sitemap"
 filter = "published == True"      # All published posts
@@ -644,7 +644,7 @@ formats = { sitemap = true }      # Only sitemap output
 This generates `/sitemap.xml` at the root when `slug = ""`:
 
 ```toml
-[[name.feeds]]
+[[markata-go.feeds]]
 slug = ""                         # Root sitemap
 title = "Sitemap"
 filter = "published == True"
@@ -660,7 +660,7 @@ formats = { html = false, sitemap = true }
 The root index is just a feed with `slug = ""`:
 
 ```toml
-[[name.feeds]]
+[[markata-go.feeds]]
 slug = ""                          # Outputs to /index.html
 title = "Home"
 filter = "published == True"
@@ -673,7 +673,7 @@ formats = { html = true, rss = false }
 ### Archive (All Posts)
 
 ```toml
-[[name.feeds]]
+[[markata-go.feeds]]
 slug = "archive"
 title = "Archive"
 filter = "published == True"
@@ -688,7 +688,7 @@ formats = { html = true }
 Generate a feed per tag dynamically:
 
 ```toml
-[name.feeds.auto_tags]
+[markata-go.feeds.auto_tags]
 enabled = true
 slug_prefix = "tags"               # /tags/python/, /tags/rust/
 title_template = "Posts tagged '{{ tag }}'"
@@ -701,7 +701,7 @@ This auto-generates feeds for each unique tag found in posts.
 ### Category Pages
 
 ```toml
-[name.feeds.auto_categories]
+[markata-go.feeds.auto_categories]
 enabled = true
 slug_prefix = "category"
 source_field = "category"          # Frontmatter field to use
@@ -712,7 +712,7 @@ filter_template = "published == True and category == '{{ category }}'"
 ### Year/Month Archives
 
 ```toml
-[name.feeds.auto_date]
+[markata-go.feeds.auto_date]
 enabled = true
 slug_template = "{{ date.year }}/{{ date.month }}"
 title_template = "Posts from {{ date | date('%B %Y') }}"
@@ -725,7 +725,7 @@ formats = { html = true }
 JSON-only feed for JavaScript consumption:
 
 ```toml
-[[name.feeds]]
+[[markata-go.feeds]]
 slug = "api/posts"
 title = "Posts API"
 filter = "published == True"
@@ -740,7 +740,7 @@ formats = { json = true }          # Only JSON output
 Generate a JSON index for client-side search:
 
 ```toml
-[[name.feeds]]
+[[markata-go.feeds]]
 slug = "search"
 title = "Search Index"
 filter = "published == True"
@@ -851,8 +851,8 @@ Feed configuration follows a **defaults → override** pattern. Global defaults 
 │                    CONFIGURATION RESOLUTION                          │
 ├─────────────────────────────────────────────────────────────────────┤
 │  1. Start with built-in defaults                                     │
-│  2. Apply [name.feeds.defaults.*] settings                          │
-│  3. Apply [[name.feeds]] individual feed settings                   │
+│  2. Apply [markata-go.feeds.defaults.*] settings                          │
+│  3. Apply [[markata-go.feeds]] individual feed settings                   │
 │  4. Individual feed values WIN over defaults                         │
 └─────────────────────────────────────────────────────────────────────┘
 ```
@@ -882,11 +882,11 @@ Feed configuration follows a **defaults → override** pattern. Global defaults 
 # =============================================================================
 # GLOBAL FEED DEFAULTS
 # =============================================================================
-[name.feeds.defaults]
+[markata-go.feeds.defaults]
 items_per_page = 10
 orphan_threshold = 3
 
-[name.feeds.defaults.formats]
+[markata-go.feeds.defaults.formats]
 html = true
 rss = true
 atom = false                       # Atom OFF by default
@@ -895,12 +895,12 @@ markdown = false
 text = false
 sitemap = false                    # Sitemap OFF by default
 
-[name.feeds.defaults.templates]
+[markata-go.feeds.defaults.templates]
 html = "feed.html"
 card = "partials/card.html"
 rss = "rss.xml"
 
-[name.feeds.syndication]
+[markata-go.feeds.syndication]
 max_items = 20
 include_content = false
 
@@ -909,7 +909,7 @@ include_content = false
 # =============================================================================
 
 # Home page - uses most defaults, but fewer items and no RSS
-[[name.feeds]]
+[[markata-go.feeds]]
 slug = ""
 title = "Home"
 filter = "published == True"
@@ -919,7 +919,7 @@ items_per_page = 5                 # Override: fewer items on home
 formats = { rss = false }          # Override: no RSS for home page
 
 # Blog - uses all defaults
-[[name.feeds]]
+[[markata-go.feeds]]
 slug = "blog"
 title = "Blog"
 filter = "published == True"
@@ -929,7 +929,7 @@ reverse = true
 # formats: inherits html=true, rss=true from defaults
 
 # API endpoint - completely different format set
-[[name.feeds]]
+[[markata-go.feeds]]
 slug = "api/posts"
 title = "Posts API"
 filter = "published == True"
@@ -939,7 +939,7 @@ items_per_page = 0                 # Override: no pagination
 formats = { html = false, rss = false, json = true }  # Override: JSON only
 
 # Archive - different pagination
-[[name.feeds]]
+[[markata-go.feeds]]
 slug = "archive"
 title = "All Posts"
 filter = "published == True"
@@ -949,7 +949,7 @@ items_per_page = 0                 # Override: all posts on one page
 formats = { rss = false }          # Override: no RSS for archive
 
 # Tutorials - wants Atom too
-[[name.feeds]]
+[[markata-go.feeds]]
 slug = "tutorials"
 title = "Tutorials"
 filter = "published == True and 'tutorial' in tags"
@@ -988,12 +988,12 @@ Templates follow the same pattern:
 
 ```toml
 # Global default
-[name.feeds.defaults.templates]
+[markata-go.feeds.defaults.templates]
 html = "feed.html"
 card = "partials/card.html"
 
 # Individual feed override
-[[name.feeds]]
+[[markata-go.feeds]]
 slug = "featured"
 templates = { html = "featured-feed.html" }
 # Result: html="featured-feed.html", card="partials/card.html" (inherited)
@@ -1006,13 +1006,13 @@ templates = { html = "featured-feed.html" }
 ### Global Feed Defaults
 
 ```toml
-[name.feeds.defaults]
+[markata-go.feeds.defaults]
 # Pagination
 items_per_page = 10
 orphan_threshold = 3
 
 # Formats enabled by default
-[name.feeds.defaults.formats]
+[markata-go.feeds.defaults.formats]
 html = true
 rss = true
 atom = false
@@ -1022,7 +1022,7 @@ text = false
 sitemap = false
 
 # Templates used by default
-[name.feeds.defaults.templates]
+[markata-go.feeds.defaults.templates]
 html = "feed.html"
 card = "partials/card.html"
 rss = "rss.xml"
@@ -1033,14 +1033,14 @@ text = "feed.txt"
 sitemap = "sitemap.xml"
 
 # Syndication settings (RSS/Atom/JSON)
-[name.feeds.syndication]
+[markata-go.feeds.syndication]
 max_items = 20                     # Max items in RSS/Atom feeds
 include_content = false            # Include full content or just summary
 ```
 
 ### Built-in Defaults
 
-If no `[name.feeds.defaults]` is specified, these built-in values apply:
+If no `[markata-go.feeds.defaults]` is specified, these built-in values apply:
 
 | Setting | Built-in Default |
 |---------|------------------|
@@ -1082,21 +1082,21 @@ author = "Jane Doe"
 # =============================================================================
 # GLOBAL FEED DEFAULTS
 # =============================================================================
-[name.feeds.defaults]
+[markata-go.feeds.defaults]
 items_per_page = 10
 orphan_threshold = 3
 
-[name.feeds.defaults.formats]
+[markata-go.feeds.defaults.formats]
 html = true
 rss = true
 atom = true
 json = true
 
-[name.feeds.defaults.templates]
+[markata-go.feeds.defaults.templates]
 html = "feed.html"
 card = "partials/card.html"
 
-[name.feeds.syndication]
+[markata-go.feeds.syndication]
 max_items = 20
 include_content = false
 
@@ -1105,7 +1105,7 @@ include_content = false
 # =============================================================================
 
 # Home page - fewer items, no syndication feeds
-[[name.feeds]]
+[[markata-go.feeds]]
 slug = ""
 title = "Recent Posts"
 filter = "published == True"
@@ -1115,7 +1115,7 @@ items_per_page = 5                 # Override default
 formats = { rss = false, atom = false, json = false }  # Override: HTML only
 
 # Main blog feed - uses all defaults
-[[name.feeds]]
+[[markata-go.feeds]]
 slug = "blog"
 title = "Blog"
 description = "All blog posts"
@@ -1125,7 +1125,7 @@ reverse = true
 # Inherits: items_per_page=10, all formats enabled
 
 # Tutorials section - uses defaults
-[[name.feeds]]
+[[markata-go.feeds]]
 slug = "tutorials"
 title = "Tutorials"
 filter = "published == True and 'tutorial' in tags"
@@ -1133,7 +1133,7 @@ sort = "date"
 reverse = true
 
 # Archive - all posts, no pagination, HTML only
-[[name.feeds]]
+[[markata-go.feeds]]
 slug = "archive"
 title = "Archive"
 filter = "published == True"
@@ -1143,7 +1143,7 @@ items_per_page = 0                 # Override: no pagination
 formats = { rss = false, atom = false, json = false }  # Override: HTML only
 
 # API endpoint - JSON only, no pagination
-[[name.feeds]]
+[[markata-go.feeds]]
 slug = "api/posts"
 filter = "published == True"
 sort = "date"
@@ -1156,7 +1156,7 @@ formats = { html = false, rss = false, atom = false, json = true }
 # =============================================================================
 
 # Tag pages - inherit some defaults, override formats
-[name.feeds.auto_tags]
+[markata-go.feeds.auto_tags]
 enabled = true
 slug_prefix = "tags"
 formats = { atom = false, json = false }  # Override: HTML + RSS only

--- a/spec/spec/HEAD_STYLE.md
+++ b/spec/spec/HEAD_STYLE.md
@@ -14,9 +14,9 @@ This system works alongside the [THEMES.md](./THEMES.md) theming system:
 │     └─ themes/default/static/css/main.css                           │
 │                                                                      │
 │  2. Theme CSS Variables (from theme.toml options)                   │
-│     └─ [name.theme.variables] overrides                             │
+│     └─ [markata-go.theme.variables] overrides                             │
 │                                                                      │
-│  3. Global head/style config ([name.head], [name.style])            │
+│  3. Global head/style config ([markata-go.head], [markata-go.style])            │
 │     └─ Site-wide meta tags, scripts, color overrides                │
 │                                                                      │
 │  4. Per-post config_overrides (frontmatter)                         │
@@ -27,9 +27,9 @@ This system works alongside the [THEMES.md](./THEMES.md) theming system:
 ```
 
 **When to use each:**
-- **Theme** (`[name.theme]`): Visual identity, fonts, layout, component styles
-- **Theme Variables** (`[name.theme.variables]`): Quick color/spacing tweaks
-- **Head/Style** (`[name.head]`, `[name.style]`): Meta tags, scripts, analytics, color overrides
+- **Theme** (`[markata-go.theme]`): Visual identity, fonts, layout, component styles
+- **Theme Variables** (`[markata-go.theme.variables]`): Quick color/spacing tweaks
+- **Head/Style** (`[markata-go.head]`, `[markata-go.style]`): Meta tags, scripts, analytics, color overrides
 - **Post Overrides** (`config_overrides`): Per-post customizations
 
 ## Overview
@@ -43,7 +43,7 @@ This system works alongside the [THEMES.md](./THEMES.md) theming system:
 │  1. Post frontmatter config_overrides                               │
 │     └─ Highest priority, applies to single post                     │
 │                                                                      │
-│  2. Global config [name.head] and [name.style]                      │
+│  2. Global config [markata-go.head] and [markata-go.style]                      │
 │     └─ Applies to all posts                                          │
 │                                                                      │
 │  3. Theme defaults                                                   │
@@ -65,20 +65,20 @@ This system works alongside the [THEMES.md](./THEMES.md) theming system:
 Add meta tags to every page:
 
 ```toml
-[[name.head.meta]]
+[[markata-go.head.meta]]
 name = "author"
 content = "Jane Doe"
 
-[[name.head.meta]]
+[[markata-go.head.meta]]
 name = "robots"
 content = "index, follow"
 
 # Open Graph tags use 'property' instead of 'name'
-[[name.head.meta]]
+[[markata-go.head.meta]]
 property = "og:type"
 content = "article"
 
-[[name.head.meta]]
+[[markata-go.head.meta]]
 property = "og:site_name"
 content = "My Blog"
 ```
@@ -96,15 +96,15 @@ content = "My Blog"
 Add link elements (stylesheets, canonical URLs, favicons):
 
 ```toml
-[[name.head.link]]
+[[markata-go.head.link]]
 rel = "stylesheet"
 href = "/css/custom.css"
 
-[[name.head.link]]
+[[markata-go.head.link]]
 rel = "icon"
 href = "/favicon.ico"
 
-[[name.head.link]]
+[[markata-go.head.link]]
 rel = "preconnect"
 href = "https://fonts.googleapis.com"
 ```
@@ -121,10 +121,10 @@ href = "https://fonts.googleapis.com"
 Add scripts to the head:
 
 ```toml
-[[name.head.script]]
+[[markata-go.head.script]]
 src = "https://cdn.tailwindcss.com"
 
-[[name.head.script]]
+[[markata-go.head.script]]
 src = "/js/analytics.js"
 ```
 
@@ -139,7 +139,7 @@ src = "/js/analytics.js"
 For complex head content, use raw text:
 
 ```toml
-[name.head]
+[markata-go.head]
 text = '''
 <style>
   :root {
@@ -155,14 +155,14 @@ text = '''
 Or as a list of text blocks:
 
 ```toml
-[[name.head.text]]
+[[markata-go.head.text]]
 value = '''
 <style>
   .custom-class { color: red; }
 </style>
 '''
 
-[[name.head.text]]
+[[markata-go.head.text]]
 value = '''
 <script type="application/ld+json">
   {"@context": "https://schema.org", "@type": "WebSite"}
@@ -177,7 +177,7 @@ value = '''
 ### Color Scheme
 
 ```toml
-[name.style]
+[markata-go.style]
 # Dark mode colors (default)
 color_bg = "#1f2022"
 color_bg_code = "#1f2022"
@@ -472,19 +472,19 @@ Access style configuration in templates:
 Use Jinja expressions in head configuration:
 
 ```toml
-[[name.head.link]]
+[[markata-go.head.link]]
 rel = "canonical"
 href = "{{ config.url }}/{{ post.slug }}/"
 
-[[name.head.meta]]
+[[markata-go.head.meta]]
 property = "og:url"
 content = "{{ config.url }}/{{ post.slug }}/"
 
-[[name.head.meta]]
+[[markata-go.head.meta]]
 property = "og:title"
 content = "{{ post.title }}"
 
-[[name.head.meta]]
+[[markata-go.head.meta]]
 property = "og:description"
 content = "{{ post.description }}"
 ```
@@ -666,10 +666,10 @@ def get_merged_config(core, post):
 ### Analytics Integration
 
 ```toml
-[[name.head.script]]
+[[markata-go.head.script]]
 src = "https://www.googletagmanager.com/gtag/js?id=GA_MEASUREMENT_ID"
 
-[name.head]
+[markata-go.head]
 text = '''
 <script>
   window.dataLayer = window.dataLayer || [];
@@ -683,16 +683,16 @@ text = '''
 ### Font Loading
 
 ```toml
-[[name.head.link]]
+[[markata-go.head.link]]
 rel = "preconnect"
 href = "https://fonts.googleapis.com"
 
-[[name.head.link]]
+[[markata-go.head.link]]
 rel = "preconnect"
 href = "https://fonts.gstatic.com"
 crossorigin = true
 
-[[name.head.link]]
+[[markata-go.head.link]]
 rel = "stylesheet"
 href = "https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
 ```
@@ -700,19 +700,19 @@ href = "https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=
 ### Social Media Cards
 
 ```toml
-[[name.head.meta]]
+[[markata-go.head.meta]]
 property = "og:type"
 content = "website"
 
-[[name.head.meta]]
+[[markata-go.head.meta]]
 property = "og:image"
 content = "{{ config.url }}/og-image.png"
 
-[[name.head.meta]]
+[[markata-go.head.meta]]
 name = "twitter:card"
 content = "summary_large_image"
 
-[[name.head.meta]]
+[[markata-go.head.meta]]
 name = "twitter:site"
 content = "@myhandle"
 ```
@@ -720,7 +720,7 @@ content = "@myhandle"
 ### Structured Data
 
 ```toml
-[name.head]
+[markata-go.head]
 text = '''
 <script type="application/ld+json">
 {

--- a/spec/spec/IMPLEMENTATION.md
+++ b/spec/spec/IMPLEMENTATION.md
@@ -360,10 +360,10 @@ def slugify(text: str) -> str:
 **Configuration:**
 
 ```toml
-[name.markdown]
+[markata-go.markdown]
 extensions = ["tables", "admonitions", "footnotes"]
 
-[name.markdown.highlight]
+[markata-go.markdown.highlight]
 enabled = true
 theme = "github-dark"
 ```
@@ -475,7 +475,7 @@ def write(core):
 **Feed Configuration:**
 
 ```toml
-[[name.feeds]]
+[[markata-go.feeds]]
 slug = "blog"
 title = "Blog"
 filter = "published == True"
@@ -484,7 +484,7 @@ reverse = true
 items_per_page = 10
 template = "feed.html"
 
-[name.feeds.blog.formats]
+[markata-go.feeds.blog.formats]
 html = true
 rss = true
 atom = false

--- a/spec/spec/INSTALL.md
+++ b/spec/spec/INSTALL.md
@@ -5,7 +5,7 @@
 ## Your Choices
 
 ```
-Name:     [name]
+Name:     [markata-go]
 Language: [language]
 ```
 
@@ -109,17 +109,17 @@ jinja: true
 {% endfor %}
 ```
 
-**Configuration** (`[name].toml`):
+**Configuration** (`[markata-go].toml`):
 ```toml
-[name]
+[markata-go]
 output_dir = "public"
 url = "https://example.com"
 
-[name.glob]
+[markata-go.glob]
 glob_patterns = ["posts/**/*.md"]
 
 # Feeds - the core feature
-[[name.feeds]]
+[[markata-go.feeds]]
 slug = "blog"
 title = "Blog"
 filter = "published == True"
@@ -127,14 +127,14 @@ sort = "date"
 reverse = true
 items_per_page = 10
 
-[name.feeds.formats]
+[markata-go.feeds.formats]
 html = true
 rss = true
 atom = true
 json = true
 
 # Auto-generate tag pages
-[name.feeds.auto_tags]
+[markata-go.feeds.auto_tags]
 enabled = true
 slug_prefix = "tags"
 ```
@@ -192,16 +192,16 @@ The implementation is complete when `tests.yaml` test cases pass.
 
 ```bash
 # Install
-pip install ./[name]  # or npm install, go install, cargo install
+pip install ./[markata-go]  # or npm install, go install, cargo install
 
 # Create a post
-[name] new "Hello World"
+[markata-go] new "Hello World"
 
 # Build
-[name] build
+[markata-go] build
 
 # Serve locally
-[name] serve
+[markata-go] serve
 ```
 
 ---

--- a/spec/spec/REDIRECTS.md
+++ b/spec/spec/REDIRECTS.md
@@ -35,14 +35,14 @@ Static redirects enable URL migrations and content reorganization without losing
 ### Basic Configuration
 
 ```toml
-[name.redirects]
+[markata-go.redirects]
 redirects_file = "static/_redirects"
 ```
 
 ### Full Configuration
 
 ```toml
-[name.redirects]
+[markata-go.redirects]
 # Path to redirects file (relative to project root)
 redirects_file = "static/_redirects"
 

--- a/spec/spec/SPEC.md
+++ b/spec/spec/SPEC.md
@@ -248,19 +248,19 @@ Configuration is namespaced under the tool name and supports multiple file forma
 ### Example Configuration
 
 ```toml
-[name]
+[markata-go]
 output_dir = "public"
 url = "https://example.com"
 title = "My Site"
 hooks = ["default"]
 
-[name.glob]
+[markata-go.glob]
 patterns = ["posts/**/*.md", "pages/*.md"]
 
-[name.markdown]
+[markata-go.markdown]
 extensions = ["tables", "admonitions"]
 
-[[name.feeds]]
+[[markata-go.feeds]]
 slug = "blog"
 title = "Blog"
 filter = "published == True"
@@ -334,7 +334,7 @@ template:{path}:mtime → template modification time
 
 ### Location
 
-`.[name].cache/` in project root
+`.[markata-go].cache/` in project root
 
 ---
 
@@ -383,7 +383,7 @@ For cache busting, assets can be fingerprinted with content hashes:
 
 **Configuration:**
 ```toml
-[name.assets]
+[markata-go.assets]
 dir = "static"
 fingerprint = true                    # Enable fingerprinting
 fingerprint_algorithm = "sha256"      # or "md5"
@@ -578,7 +578,7 @@ Flags:
 ### Configuration
 
 ```toml
-[name.serve]
+[markata-go.serve]
 port = 3000
 host = "localhost"
 livereload = true
@@ -586,7 +586,7 @@ open_browser = false
 debounce_ms = 100  # wait before rebuilding after file change
 
 # Watch patterns (defaults shown)
-[name.serve.watch]
+[markata-go.serve.watch]
 content = ["**/*.md"]                    # Post files
 config = ["[name].toml", "pyproject.toml", "*.yaml", "*.json"]
 templates = ["templates/**/*.html", "templates/**/*.jinja2"]

--- a/spec/spec/tests.yaml
+++ b/spec/spec/tests.yaml
@@ -1211,7 +1211,7 @@ feed_config_inheritance:
         card: "card.html"
 
   - name: "built-in defaults when no config"
-    description: "Use built-in defaults when no [name.feeds.defaults] specified"
+    description: "Use built-in defaults when no [markata-go.feeds.defaults] specified"
     input:
       config: {}
       feed_config:


### PR DESCRIPTION
## Summary

- Fix incorrect config section names in documentation where `[markata.xxx]` (Python markata style) was used instead of `[markata-go.xxx]`
- Replace `[name.xxx]` placeholders in spec files with actual `[markata-go.xxx]` names
- Ensure documentation matches the actual implementation (which uses `[markata-go.xxx]` or top-level `[xxx]`)

## Changes

| File | Description |
|------|-------------|
| `docs/reference/plugins.md` | 36 occurrences of `[markata.xxx]` → `[markata-go.xxx]` |
| `spec/spec/DEFAULT_PLUGINS.md` | 25 placeholder replacements |
| `spec/spec/FEEDS.md` | 46 placeholder replacements |
| `spec/spec/HEAD_STYLE.md` | 33 placeholder replacements |
| `spec/spec/IMPLEMENTATION.md` | 4 placeholder replacements |
| `spec/spec/INSTALL.md` | 11 placeholder replacements |
| `spec/spec/REDIRECTS.md` | 2 placeholder replacements |
| `spec/spec/SPEC.md` | 8 placeholder replacements |
| `spec/spec/tests.yaml` | 1 placeholder replacement |
| `issues/002-incomplete-spec-file-implementation.md` | 3 placeholder replacements |

Fixes #233