### PR TITLE
perf(lifecycle): auto-detect optimal concurrency from CPU cores

### DIFF
--- a/pkg/lifecycle/manager.go
+++ b/pkg/lifecycle/manager.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -149,7 +150,16 @@ type Manager struct {
 }
 
 // NewManager creates a new lifecycle Manager with default settings.
+// Concurrency is auto-detected from CPU cores, capped at 16.
 func NewManager() *Manager {
+	concurrency := runtime.NumCPU()
+	if concurrency > 16 {
+		concurrency = 16 // Cap to avoid excessive goroutine overhead
+	}
+	if concurrency < 1 {
+		concurrency = 1
+	}
+
 	return &Manager{
 		plugins:     make([]Plugin, 0),
 		config:      NewConfig(),
@@ -159,7 +169,7 @@ func NewManager() *Manager {
 		stagesRun:   make(map[Stage]bool),
 		cache:       newMemoryCache(),
 		warnings:    make([]*HookError, 0),
-		concurrency: 4, // Default concurrency
+		concurrency: concurrency,
 	}
 }
 


### PR DESCRIPTION
## Summary
- Auto-detect concurrency using `runtime.NumCPU()` instead of hardcoded 4
- Cap at 16 to avoid excessive goroutine overhead on high-core systems
- Config can still override via `SetConcurrency()` if needed

## Benchmark Data (from issue)
| Concurrency | Time | Speedup |
|-------------|------|---------|
| 1 | 10.7ms | 1.0x |
| 4 (current) | 3.9ms | 2.7x |
| 16 (auto) | 2.8ms | 3.8x |

Fixes #240