### PR TITLE
fix(blogroll): ensure blogroll plugin loads and config merges correctly

### DIFF
--- a/cmd/markata-go/cmd/benchmark.go
+++ b/cmd/markata-go/cmd/benchmark.go
@@ -410,6 +410,9 @@ func createBenchmarkManager(cfgPath, workDir string) (*lifecycle.Manager, error)
 	// Pass layout configuration for automatic layout selection
 	lcConfig.Extra["layout"] = &cfg.Layout
 
+	// Pass blogroll configuration
+	lcConfig.Extra["blogroll"] = cfg.Blogroll
+
 	m.SetConfig(lcConfig)
 
 	if cfg.Concurrency > 0 {

--- a/cmd/markata-go/cmd/core.go
+++ b/cmd/markata-go/cmd/core.go
@@ -80,6 +80,9 @@ func createManager(cfgPath string) (*lifecycle.Manager, error) {
 	// Pass layout configuration for automatic layout selection
 	lcConfig.Extra["layout"] = &cfg.Layout
 
+	// Pass blogroll configuration
+	lcConfig.Extra["blogroll"] = cfg.Blogroll
+
 	// Pass sidebar, toc, and header configurations
 	lcConfig.Extra["sidebar"] = cfg.Sidebar
 	lcConfig.Extra["toc"] = cfg.Toc

--- a/pkg/config/merge.go
+++ b/pkg/config/merge.go
@@ -93,6 +93,9 @@ func MergeConfigs(base, override *models.Config) *models.Config {
 	// Header - merge
 	result.Header = mergeHeaderLayoutConfig(base.Header, override.Header)
 
+	// Blogroll - merge
+	result.Blogroll = mergeBlogrollConfig(base.Blogroll, override.Blogroll)
+
 	return result
 }
 
@@ -610,6 +613,50 @@ func mergeHeaderLayoutConfig(base, override models.HeaderLayoutConfig) models.He
 	}
 	if override.ShowThemeToggle != nil {
 		result.ShowThemeToggle = override.ShowThemeToggle
+	}
+
+	return result
+}
+
+// mergeBlogrollConfig merges BlogrollConfig values.
+func mergeBlogrollConfig(base, override models.BlogrollConfig) models.BlogrollConfig {
+	result := base
+
+	// Enabled - use override if true (since default is false)
+	if override.Enabled {
+		result.Enabled = true
+	}
+
+	// String fields - override if non-empty
+	if override.CacheDir != "" {
+		result.CacheDir = override.CacheDir
+	}
+	if override.CacheDuration != "" {
+		result.CacheDuration = override.CacheDuration
+	}
+
+	// Int fields - override if non-zero
+	if override.Timeout != 0 {
+		result.Timeout = override.Timeout
+	}
+	if override.ConcurrentRequests != 0 {
+		result.ConcurrentRequests = override.ConcurrentRequests
+	}
+	if override.MaxEntriesPerFeed != 0 {
+		result.MaxEntriesPerFeed = override.MaxEntriesPerFeed
+	}
+
+	// Feeds - replace if non-empty
+	if len(override.Feeds) > 0 {
+		result.Feeds = override.Feeds
+	}
+
+	// Templates - merge
+	if override.Templates.Blogroll != "" {
+		result.Templates.Blogroll = override.Templates.Blogroll
+	}
+	if override.Templates.Reader != "" {
+		result.Templates.Reader = override.Templates.Reader
 	}
 
 	return result

--- a/pkg/plugins/registry.go
+++ b/pkg/plugins/registry.go
@@ -142,6 +142,7 @@ func DefaultPlugins() []lifecycle.Plugin {
 		// Collect stage plugins
 		NewFeedsPlugin(),
 		NewAutoFeedsPlugin(),
+		NewBlogrollPlugin(),       // Fetch external feeds for blogroll
 		NewStatsPlugin(),          // Aggregate stats after feeds are built (runs Collect)
 		NewPrevNextPlugin(),       // Calculate prev/next after feeds are built
 		NewOverwriteCheckPlugin(), // Detect conflicting output paths


### PR DESCRIPTION
## Summary

Fixes #249 - Blogroll config not being passed to plugin

Three issues prevented the blogroll plugin from working:

1. **BlogrollPlugin not in DefaultPlugins()** - The plugin was registered in the constructor map but never instantiated during normal builds
2. **Config not passed to Extra** - Blogroll config was not passed to `lcConfig.Extra["blogroll"]` in `core.go` and `benchmark.go`
3. **MergeConfigs() missing blogroll** - User config was being overwritten by empty defaults because `MergeConfigs()` didn't merge blogroll config

## Changes

- `pkg/plugins/registry.go` - Added `NewBlogrollPlugin()` to `DefaultPlugins()`
- `cmd/markata-go/cmd/core.go` - Pass `cfg.Blogroll` to `lcConfig.Extra["blogroll"]`
- `cmd/markata-go/cmd/benchmark.go` - Same fix for benchmark command
- `pkg/config/merge.go` - Added `mergeBlogrollConfig()` function
- `pkg/config/merge_test.go` - Added tests for blogroll config merging

## Testing

- All existing tests pass
- Added new tests for blogroll config merging
- Manually verified blogroll and reader pages generate correctly with a real site migration