### PR TITLE
feat(tui): improve filter help and placeholder text

### DIFF
--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -104,7 +104,7 @@ var sortOptions = []sortOption{
 // NewModel creates a new TUI model
 func NewModel(app *services.App) Model {
 	filterInput := textinput.New()
-	filterInput.Placeholder = "Filter posts..."
+	filterInput.Placeholder = "e.g., published == True, 'python' in tags"
 	filterInput.CharLimit = 100
 
 	cmdInput := textinput.New()
@@ -838,8 +838,25 @@ Actions:
   s          Sort menu (Date, Title, Word Count, Path)
 
 Modes:
-  /          Filter mode
+  /          Filter mode (filter posts with expressions)
   :          Command mode
+
+Filter Syntax:
+  Press / to enter filter mode. Filter expressions support:
+
+  Comparison:    published == True, date >= '2024-01-01'
+  Membership:    'python' in tags, 'draft' not in tags
+  Boolean:       published == True and featured == True
+                 published == False or 'wip' in tags
+  Strings:       title == 'My Post', slug != 'about'
+
+  Fields: title, slug, date, published, tags, description
+
+  Examples:
+    published == True
+    'python' in tags
+    date >= '2024-01-01' and published == True
+    'tutorial' in tags and published == True
 
 Sort Menu:
   j/k/↑/↓    Navigate sort options


### PR DESCRIPTION
## Summary

- Update filter placeholder from "Filter posts..." to example syntax: `e.g., published == True, 'python' in tags`
- Add comprehensive filter syntax guide to the help screen (`?`)
- Include common operators, fields, and practical examples

Fixes #245

## Changes

### Filter Placeholder
The placeholder now shows example filter expressions to help users understand the syntax immediately.

### Help Screen Filter Section
Added a new "Filter Syntax" section with:
- Comparison operators: `==`, `!=`, `>=`, `<=`, `>`, `<`
- Membership operators: `in`, `not in` (for tags)
- Boolean operators: `and`, `or`
- Available fields: title, slug, date, published, tags, description
- Practical examples for common use cases

## Testing
- `go test ./pkg/tui/... -v` - All tests pass
- `go fmt ./... && go vet ./...` - No issues
- `go build ./cmd/markata-go` - Builds successfully