### PR TITLE
feat(plugins): enhance title inference with comprehensive fallbacks

### DIFF
--- a/pkg/plugins/auto_title.go
+++ b/pkg/plugins/auto_title.go
@@ -3,7 +3,9 @@ package plugins
 
 import (
 	"path/filepath"
+	"regexp"
 	"strings"
+	"time"
 	"unicode"
 
 	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
@@ -11,9 +13,19 @@ import (
 )
 
 // AutoTitlePlugin auto-generates human-readable titles for posts that don't have one.
-// It derives titles from filenames by replacing hyphens and underscores with spaces
-// and applying title case.
+// It uses a comprehensive fallback strategy to ensure every post has a title:
+//  1. Frontmatter title (explicit, highest priority)
+//  2. First H1 heading from markdown content
+//  3. Filename-based title (with date prefix stripping)
+//  4. Directory name (for index.md files)
+//  5. Generated fallback with timestamp
 type AutoTitlePlugin struct{}
+
+// dateRegex matches common date prefixes in filenames: YYYY-MM-DD with optional separator
+var dateRegex = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}[-_]?`)
+
+// h1Regex matches Markdown H1 headings at the start of a line
+var h1Regex = regexp.MustCompile(`^#\s+(.+)$`)
 
 // NewAutoTitlePlugin creates a new AutoTitlePlugin.
 func NewAutoTitlePlugin() *AutoTitlePlugin {
@@ -35,33 +47,136 @@ func (p *AutoTitlePlugin) Priority(stage lifecycle.Stage) int {
 }
 
 // Transform generates titles for posts that don't have one.
+// Uses a comprehensive fallback strategy to ensure no post has a nil title.
 func (p *AutoTitlePlugin) Transform(m *lifecycle.Manager) error {
 	return m.ProcessPostsConcurrently(func(post *models.Post) error {
 		if post.Skip {
 			return nil
 		}
 
-		// Skip if title is already set
+		// Skip if title is already set (frontmatter takes highest priority)
 		if post.Title != nil && *post.Title != "" {
 			return nil
 		}
 
-		// Generate title from filename
-		title := p.generateTitle(post.Path)
-		if title != "" {
-			post.Title = &title
-		}
+		// Try fallback strategies in order of priority
+		title := p.inferTitle(post)
+		post.Title = &title
 
 		return nil
 	})
 }
 
+// inferTitle attempts to generate a title using multiple fallback strategies.
+// Priority order:
+//  1. First H1 heading from content
+//  2. Date-stripped filename
+//  3. Directory name (for index.md files)
+//  4. Plain filename-based title
+//  5. Generated fallback with path identifier
+func (p *AutoTitlePlugin) inferTitle(post *models.Post) string {
+	// Strategy 1: Extract from first H1 heading in content
+	if title := p.extractFromContent(post.Content); title != "" {
+		return title
+	}
+
+	// Strategy 2: Check for index files and use directory name
+	base := filepath.Base(post.Path)
+	if strings.EqualFold(base, "index.md") || strings.EqualFold(base, "index.markdown") {
+		if title := p.extractFromDirectory(post.Path); title != "" {
+			return title
+		}
+	}
+
+	// Strategy 3: Generate from filename (with date stripping)
+	if title := p.generateTitle(post.Path); title != "" {
+		return title
+	}
+
+	// Strategy 4: Final fallback - never return empty
+	return p.generateFallback(post.Path)
+}
+
+// extractFromContent extracts a title from the first H1 heading in markdown content.
+func (p *AutoTitlePlugin) extractFromContent(content string) string {
+	if content == "" {
+		return ""
+	}
+
+	lines := strings.Split(content, "\n")
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if matches := h1Regex.FindStringSubmatch(trimmed); len(matches) > 1 {
+			// Clean up the title - remove any trailing markup
+			title := strings.TrimSpace(matches[1])
+			// Remove trailing # characters (alternate H1 syntax: # Title #)
+			title = strings.TrimRight(title, "#")
+			title = strings.TrimSpace(title)
+			if title != "" {
+				return title
+			}
+		}
+	}
+	return ""
+}
+
+// extractFromDirectory extracts a title from the parent directory name.
+// Used for index.md files where the directory name is more meaningful.
+func (p *AutoTitlePlugin) extractFromDirectory(path string) string {
+	dir := filepath.Dir(path)
+	if dir == "" || dir == "." || dir == "/" {
+		return ""
+	}
+
+	// Get the immediate parent directory name
+	dirName := filepath.Base(dir)
+	if dirName == "" || dirName == "." || dirName == "/" {
+		return ""
+	}
+
+	// Convert directory name to title case
+	title := strings.ReplaceAll(dirName, "-", " ")
+	title = strings.ReplaceAll(title, "_", " ")
+	return toTitleCase(title)
+}
+
+// stripDatePrefix removes a date prefix (YYYY-MM-DD) from a filename.
+// Returns the cleaned filename and whether a date was found.
+func (p *AutoTitlePlugin) stripDatePrefix(filename string) (string, bool) {
+	if match := dateRegex.FindString(filename); match != "" {
+		return strings.TrimLeft(filename[len(match):], "-_"), true
+	}
+	return filename, false
+}
+
+// generateFallback creates a fallback title when all other strategies fail.
+// Uses a combination of path info and timestamp to ensure uniqueness.
+func (p *AutoTitlePlugin) generateFallback(path string) string {
+	if path != "" {
+		// Try to create something from the path
+		base := filepath.Base(path)
+		stem := strings.TrimSuffix(base, filepath.Ext(base))
+		if stem != "" && stem != "." {
+			return "Untitled " + stem
+		}
+	}
+	// Last resort - use timestamp
+	return "Untitled " + time.Now().Format("2006-01-02-150405")
+}
+
 // generateTitle creates a human-readable title from a file path.
+// Includes date prefix stripping for files like "2024-01-15-my-post.md".
 func (p *AutoTitlePlugin) generateTitle(path string) string {
 	// Extract filename without extension
 	base := filepath.Base(path)
 	stem := strings.TrimSuffix(base, filepath.Ext(base))
 
+	if stem == "" {
+		return ""
+	}
+
+	// Strip date prefix if present
+	stem, _ = p.stripDatePrefix(stem)
 	if stem == "" {
 		return ""
 	}

--- a/pkg/plugins/auto_title_test.go
+++ b/pkg/plugins/auto_title_test.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
@@ -52,9 +53,14 @@ func TestAutoTitlePlugin_generateTitle(t *testing.T) {
 			expected: "Python Tips And Tricks",
 		},
 		{
-			name:     "date prefixed",
+			name:     "date prefixed - strips date",
 			path:     "posts/2024-01-15-new-feature.md",
-			expected: "2024 01 15 New Feature",
+			expected: "New Feature",
+		},
+		{
+			name:     "date prefixed with underscore",
+			path:     "posts/2024-01-15_my-post.md",
+			expected: "My Post",
 		},
 		{
 			name:     "single word",
@@ -84,6 +90,11 @@ func TestAutoTitlePlugin_generateTitle(t *testing.T) {
 		{
 			name:     "empty stem after extension removal",
 			path:     ".md",
+			expected: "",
+		},
+		{
+			name:     "date only filename returns empty",
+			path:     "posts/2024-01-15.md",
 			expected: "",
 		},
 	}
@@ -116,6 +127,15 @@ func TestAutoTitlePlugin_Transform(t *testing.T) {
 			},
 		},
 		{
+			name: "extracts H1 from content",
+			posts: []*models.Post{
+				{Path: "posts/my-post.md", Content: "# Awesome Title\n\nContent here"},
+			},
+			expectedTitle: map[string]string{
+				"posts/my-post.md": "Awesome Title",
+			},
+		},
+		{
 			name: "skips post with existing title",
 			posts: func() []*models.Post {
 				title := "My Custom Title"
@@ -128,7 +148,7 @@ func TestAutoTitlePlugin_Transform(t *testing.T) {
 			},
 		},
 		{
-			name: "skips post marked as skip",
+			name: "skips post marked as skip - title remains nil",
 			posts: []*models.Post{
 				{Path: "posts/skipped-post.md", Skip: true, Content: "Hello"},
 			},
@@ -149,6 +169,24 @@ func TestAutoTitlePlugin_Transform(t *testing.T) {
 			},
 		},
 		{
+			name: "index file uses directory name",
+			posts: []*models.Post{
+				{Path: "docs/index.md", Content: "Content without heading"},
+			},
+			expectedTitle: map[string]string{
+				"docs/index.md": "Docs",
+			},
+		},
+		{
+			name: "date-prefixed filename strips date",
+			posts: []*models.Post{
+				{Path: "posts/2024-01-15-new-feature.md", Content: "No heading"},
+			},
+			expectedTitle: map[string]string{
+				"posts/2024-01-15-new-feature.md": "New Feature",
+			},
+		},
+		{
 			name: "multiple posts mixed",
 			posts: func() []*models.Post {
 				customTitle := "Custom"
@@ -162,6 +200,15 @@ func TestAutoTitlePlugin_Transform(t *testing.T) {
 				"posts/auto-gen.md":     "Auto Gen",
 				"posts/has-title.md":    "Custom",
 				"posts/another-auto.md": "Another Auto",
+			},
+		},
+		{
+			name: "H1 takes priority over filename",
+			posts: []*models.Post{
+				{Path: "posts/wrong-name.md", Content: "# Correct Title\n\nBody"},
+			},
+			expectedTitle: map[string]string{
+				"posts/wrong-name.md": "Correct Title",
 			},
 		},
 	}
@@ -195,6 +242,39 @@ func TestAutoTitlePlugin_Transform(t *testing.T) {
 	}
 }
 
+func TestAutoTitlePlugin_Transform_NoNilTitles(t *testing.T) {
+	// This test specifically verifies that no post ever has a nil title
+	// after the auto_title plugin runs (unless Skip is true)
+	plugin := NewAutoTitlePlugin()
+
+	posts := []*models.Post{
+		{Path: "normal.md", Content: ""},
+		{Path: ".md", Content: ""},                 // Edge case: no filename
+		{Path: "posts/2024-01-01.md", Content: ""}, // Date only
+		{Path: "index.md", Content: ""},            // Root index with no directory
+		{Path: "", Content: ""},                    // Empty path
+	}
+
+	m := lifecycle.NewManager()
+	for _, post := range posts {
+		m.AddPost(post)
+	}
+
+	err := plugin.Transform(m)
+	if err != nil {
+		t.Fatalf("Transform() error = %v", err)
+	}
+
+	for _, post := range m.Posts() {
+		if post.Title == nil {
+			t.Errorf("post %q has nil title - all non-skipped posts should have a title", post.Path)
+		}
+		if post.Title != nil && *post.Title == "" {
+			t.Errorf("post %q has empty title - should have a fallback title", post.Path)
+		}
+	}
+}
+
 func TestToTitleCase(t *testing.T) {
 	tests := []struct {
 		input    string
@@ -215,6 +295,286 @@ func TestToTitleCase(t *testing.T) {
 			got := toTitleCase(tt.input)
 			if got != tt.expected {
 				t.Errorf("toTitleCase(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestAutoTitlePlugin_extractFromContent(t *testing.T) {
+	plugin := NewAutoTitlePlugin()
+
+	tests := []struct {
+		name     string
+		content  string
+		expected string
+	}{
+		{
+			name:     "simple H1",
+			content:  "# My Great Title\n\nSome content here.",
+			expected: "My Great Title",
+		},
+		{
+			name:     "H1 with trailing hashes",
+			content:  "# Title With Hashes #\n\nContent",
+			expected: "Title With Hashes",
+		},
+		{
+			name:     "H1 after blank lines",
+			content:  "\n\n# Title After Blanks\n\nContent",
+			expected: "Title After Blanks",
+		},
+		{
+			name:     "H1 with extra spaces",
+			content:  "#   Spaced Out Title   \n\nContent",
+			expected: "Spaced Out Title",
+		},
+		{
+			name:     "no H1 heading",
+			content:  "## H2 Heading\n\nJust some text",
+			expected: "",
+		},
+		{
+			name:     "empty content",
+			content:  "",
+			expected: "",
+		},
+		{
+			name:     "H1 not at start of line - no match",
+			content:  "text # Not a heading\n",
+			expected: "",
+		},
+		{
+			name:     "multiple H1s - returns first",
+			content:  "# First Title\n\n# Second Title",
+			expected: "First Title",
+		},
+		{
+			name:     "H1 with special characters",
+			content:  "# C++ Programming Guide\n\nContent",
+			expected: "C++ Programming Guide",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := plugin.extractFromContent(tt.content)
+			if got != tt.expected {
+				t.Errorf("extractFromContent() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestAutoTitlePlugin_extractFromDirectory(t *testing.T) {
+	plugin := NewAutoTitlePlugin()
+
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{
+			name:     "simple directory",
+			path:     "docs/index.md",
+			expected: "Docs",
+		},
+		{
+			name:     "hyphenated directory",
+			path:     "getting-started/index.md",
+			expected: "Getting Started",
+		},
+		{
+			name:     "underscored directory",
+			path:     "api_reference/index.md",
+			expected: "Api Reference",
+		},
+		{
+			name:     "nested directory",
+			path:     "guides/advanced/index.md",
+			expected: "Advanced",
+		},
+		{
+			name:     "root index",
+			path:     "index.md",
+			expected: "",
+		},
+		{
+			name:     "current dir index",
+			path:     "./index.md",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := plugin.extractFromDirectory(tt.path)
+			if got != tt.expected {
+				t.Errorf("extractFromDirectory(%q) = %q, want %q", tt.path, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestAutoTitlePlugin_stripDatePrefix(t *testing.T) {
+	plugin := NewAutoTitlePlugin()
+
+	tests := []struct {
+		name         string
+		filename     string
+		expectedName string
+		expectedHas  bool
+	}{
+		{
+			name:         "date with hyphen separator",
+			filename:     "2024-01-15-my-post",
+			expectedName: "my-post",
+			expectedHas:  true,
+		},
+		{
+			name:         "date with underscore separator",
+			filename:     "2024-01-15_my-post",
+			expectedName: "my-post",
+			expectedHas:  true,
+		},
+		{
+			name:         "date without separator",
+			filename:     "2024-01-15my-post",
+			expectedName: "my-post",
+			expectedHas:  true,
+		},
+		{
+			name:         "no date prefix",
+			filename:     "my-post",
+			expectedName: "my-post",
+			expectedHas:  false,
+		},
+		{
+			name:         "date only",
+			filename:     "2024-01-15",
+			expectedName: "",
+			expectedHas:  true,
+		},
+		{
+			name:         "partial date - not stripped",
+			filename:     "2024-01-post",
+			expectedName: "2024-01-post",
+			expectedHas:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotName, gotHas := plugin.stripDatePrefix(tt.filename)
+			if gotName != tt.expectedName || gotHas != tt.expectedHas {
+				t.Errorf("stripDatePrefix(%q) = (%q, %v), want (%q, %v)",
+					tt.filename, gotName, gotHas, tt.expectedName, tt.expectedHas)
+			}
+		})
+	}
+}
+
+func TestAutoTitlePlugin_generateFallback(t *testing.T) {
+	plugin := NewAutoTitlePlugin()
+
+	tests := []struct {
+		name     string
+		path     string
+		contains string // Check contains because timestamp varies
+	}{
+		{
+			name:     "path with filename",
+			path:     "posts/weird.md",
+			contains: "Untitled weird",
+		},
+		{
+			name:     "empty path",
+			path:     "",
+			contains: "Untitled 20", // Will contain timestamp starting with year
+		},
+		{
+			name:     "path with stem",
+			path:     "test.md",
+			contains: "Untitled test",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := plugin.generateFallback(tt.path)
+			if !strings.Contains(got, tt.contains) {
+				t.Errorf("generateFallback(%q) = %q, want to contain %q", tt.path, got, tt.contains)
+			}
+		})
+	}
+}
+
+func TestAutoTitlePlugin_inferTitle(t *testing.T) {
+	plugin := NewAutoTitlePlugin()
+
+	tests := []struct {
+		name     string
+		post     *models.Post
+		expected string
+	}{
+		{
+			name: "H1 takes priority",
+			post: &models.Post{
+				Path:    "posts/some-file.md",
+				Content: "# Title From H1\n\nContent",
+			},
+			expected: "Title From H1",
+		},
+		{
+			name: "index.md uses directory when no H1",
+			post: &models.Post{
+				Path:    "my-docs/index.md",
+				Content: "No heading here",
+			},
+			expected: "My Docs",
+		},
+		{
+			name: "index.md with H1 uses H1",
+			post: &models.Post{
+				Path:    "my-docs/index.md",
+				Content: "# Documentation Home\n\nContent",
+			},
+			expected: "Documentation Home",
+		},
+		{
+			name: "filename fallback when no H1 and not index",
+			post: &models.Post{
+				Path:    "posts/my-great-article.md",
+				Content: "Just some text without heading",
+			},
+			expected: "My Great Article",
+		},
+		{
+			name: "date-prefixed filename",
+			post: &models.Post{
+				Path:    "posts/2024-01-15-new-feature.md",
+				Content: "No heading",
+			},
+			expected: "New Feature",
+		},
+		{
+			name: "fallback for edge case",
+			post: &models.Post{
+				Path:    ".md",
+				Content: "",
+			},
+			expected: "Untitled ", // Will have timestamp, but starts with this
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := plugin.inferTitle(tt.post)
+			if tt.name == "fallback for edge case" {
+				if !strings.HasPrefix(got, tt.expected) {
+					t.Errorf("inferTitle() = %q, want prefix %q", got, tt.expected)
+				}
+			} else if got != tt.expected {
+				t.Errorf("inferTitle() = %q, want %q", got, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Fixes #251

Enhances the `auto_title` plugin with a comprehensive fallback strategy to ensure posts never have nil titles, which caused TUI filter errors (`cannot call method 'lower' on type <nil>`).

## Changes

### New Fallback Priority Order:
1. **Frontmatter title** (explicit, highest priority - unchanged)
2. **First H1 heading** from markdown content (new)
3. **Directory name** for index.md files (new)
4. **Date-stripped filename** - removes YYYY-MM-DD prefix (enhanced)
5. **Plain filename** based title (existing)
6. **Generated fallback** ("Untitled [identifier]") - ensures never nil (new)

### New Functions:
- `extractFromContent()` - extracts title from first H1 heading in markdown
- `extractFromDirectory()` - uses parent directory name for index.md files  
- `stripDatePrefix()` - removes date prefixes like `2024-01-15-`
- `generateFallback()` - creates fallback title when all else fails
- `inferTitle()` - orchestrates the fallback chain

### Test Coverage:
- Added comprehensive unit tests for all new functions
- Added `TestAutoTitlePlugin_Transform_NoNilTitles` to verify no post ever has nil title
- Updated existing tests for date-prefix stripping behavior change

## Examples

| Path | Content | Title |
|------|---------|-------|
| `posts/my-post.md` | `# Hello World` | "Hello World" |
| `docs/index.md` | (no H1) | "Docs" |
| `2024-01-15-feature.md` | (no H1) | "Feature" |
| `weird-edge.md` | (no H1) | "Weird Edge" |
| `.md` | (empty) | "Untitled 2026-01-24-..." |