### PR TITLE
feat(cli): add build summary with active features status

### DIFF
--- a/cmd/markata-go/cmd/build.go
+++ b/cmd/markata-go/cmd/build.go
@@ -187,6 +187,38 @@ func runDryBuild(m *lifecycle.Manager) error {
 func printBuildResult(result *BuildResult) {
 	fmt.Println("\nBuild completed successfully!")
 	fmt.Printf("  Posts processed: %d\n", result.PostsProcessed)
-	fmt.Printf("  Feeds generated: %d\n", result.FeedsGenerated)
+
+	// Only show feeds if any were generated
+	if result.FeedsGenerated > 0 {
+		fmt.Printf("  Feeds generated: %d\n", result.FeedsGenerated)
+	}
+
+	// Show blogroll status if configured
+	printBlogrollStatus(result.BlogrollStatus)
+
 	fmt.Printf("  Duration: %.2fs\n", result.Duration)
+}
+
+// printBlogrollStatus prints the blogroll feature status.
+func printBlogrollStatus(status BlogrollStatus) {
+	if !status.Configured {
+		return
+	}
+
+	if status.Enabled {
+		// Active blogroll - show pages and feed count
+		fmt.Printf("  Blogroll: /blogroll, /reader (%d %s)\n",
+			status.FeedsFetched, pluralize(status.FeedsFetched, "feed", "feeds"))
+	} else if status.FeedsConfigured > 0 {
+		// Configured but disabled - show warning
+		fmt.Printf("  \u26a0 Blogroll: feeds configured but enabled=false\n")
+	}
+}
+
+// pluralize returns singular or plural form based on count.
+func pluralize(count int, singular, plural string) string {
+	if count == 1 {
+		return singular
+	}
+	return plural
 }


### PR DESCRIPTION
## Summary

Fixes #255

- Adds a build summary showing posts processed, feeds generated, blogroll status, and build duration
- Shows warnings when features like blogroll are configured but disabled
- Only displays relevant features (e.g., feeds line only shows if feeds > 0)

### Example output:

**Normal build:**
```
Build completed successfully!
  Posts processed: 2121
  Feeds generated: 197
  Duration: 12.16s
```

**With blogroll enabled:**
```
Build completed successfully!
  Posts processed: 42
  Feeds generated: 5
  Blogroll: /blogroll, /reader (3 feeds)
  Duration: 2.34s
```

**With blogroll configured but disabled:**
```
Build completed successfully!
  Posts processed: 42
  Feeds generated: 5
  ⚠ Blogroll: feeds configured but enabled=false
  Duration: 2.34s
```

## Changes

- `cmd/markata-go/cmd/core.go`: Added `BlogrollStatus` struct and `getBlogrollStatus()` function to extract blogroll feature status from the lifecycle manager
- `cmd/markata-go/cmd/build.go`: Updated `printBuildResult()` to show the enhanced summary with blogroll status and added helper functions

## Testing

- All existing tests pass
- Code passes `go fmt`, `go vet`, and `golangci-lint`