### PR TITLE
feat(plugins): add site stats plugin for analytics dashboards

### DIFF
--- a/pkg/plugins/stats_test.go
+++ b/pkg/plugins/stats_test.go
@@ -2,7 +2,9 @@ package plugins
 
 import (
 	"testing"
+	"time"
 
+	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
 	"github.com/WaylonWalker/markata-go/pkg/models"
 )
 
@@ -281,4 +283,264 @@ func createTestPostWithStats(words, chars, readingTime, codeLines, codeBlocks in
 	post.Set("code_lines", codeLines)
 	post.Set("code_blocks", codeBlocks)
 	return post
+}
+
+func TestStatsPlugin_calculateFeedStats_withYearAndTags(t *testing.T) {
+	p := NewStatsPlugin()
+
+	// Create test posts with dates and tags
+	date2023 := time.Date(2023, 6, 15, 0, 0, 0, 0, time.UTC)
+	date2024 := time.Date(2024, 3, 10, 0, 0, 0, 0, time.UTC)
+
+	post1 := createTestPostWithStats(100, 500, 5, 10, 2)
+	post1.Date = &date2023
+	post1.Tags = []string{"go", "programming"}
+
+	post2 := createTestPostWithStats(200, 1000, 10, 20, 3)
+	post2.Date = &date2024
+	post2.Tags = []string{"go", "tutorial"}
+
+	post3 := createTestPostWithStats(150, 750, 8, 15, 1)
+	post3.Date = &date2023
+	post3.Tags = []string{"programming"}
+
+	feed := &models.FeedConfig{
+		Slug:  "test",
+		Posts: []*models.Post{post1, post2, post3},
+	}
+
+	stats := p.calculateFeedStats(feed)
+
+	// Test PostsByYear
+	if stats.PostsByYear[2023] != 2 {
+		t.Errorf("PostsByYear[2023] = %d, want 2", stats.PostsByYear[2023])
+	}
+	if stats.PostsByYear[2024] != 1 {
+		t.Errorf("PostsByYear[2024] = %d, want 1", stats.PostsByYear[2024])
+	}
+
+	// Test WordsByYear
+	if stats.WordsByYear[2023] != 250 { // 100 + 150
+		t.Errorf("WordsByYear[2023] = %d, want 250", stats.WordsByYear[2023])
+	}
+	if stats.WordsByYear[2024] != 200 {
+		t.Errorf("WordsByYear[2024] = %d, want 200", stats.WordsByYear[2024])
+	}
+
+	// Test PostsByTag
+	if stats.PostsByTag["go"] != 2 {
+		t.Errorf("PostsByTag[go] = %d, want 2", stats.PostsByTag["go"])
+	}
+	if stats.PostsByTag["programming"] != 2 {
+		t.Errorf("PostsByTag[programming] = %d, want 2", stats.PostsByTag["programming"])
+	}
+	if stats.PostsByTag["tutorial"] != 1 {
+		t.Errorf("PostsByTag[tutorial] = %d, want 1", stats.PostsByTag["tutorial"])
+	}
+}
+
+func TestStatsHelper_methods(t *testing.T) {
+	// Create a test manager and populate with stats
+	m := lifecycle.NewManager()
+
+	// Create site stats
+	siteStats := &SiteStats{
+		TotalPosts:             10,
+		TotalWords:             5000,
+		TotalReadingTime:       25,
+		TotalReadingTimeText:   "25 min",
+		AverageWords:           500,
+		AverageReadingTime:     3,
+		AverageReadingTimeText: "3 min read",
+		TotalCodeLines:         200,
+		TotalCodeBlocks:        20,
+		PostsByYear:            map[int]int{2023: 4, 2024: 6},
+		WordsByYear:            map[int]int{2023: 2000, 2024: 3000},
+		PostsByTag:             map[string]int{"go": 5, "python": 3, "tutorial": 7},
+	}
+	m.Cache().Set("site_stats", siteStats)
+
+	// Create feed stats
+	feedStats := &FeedStats{
+		PostCount:              5,
+		TotalWords:             2500,
+		TotalReadingTime:       12,
+		TotalReadingTimeText:   "12 min",
+		AverageWords:           500,
+		AverageReadingTime:     2,
+		AverageReadingTimeText: "2 min read",
+		TotalCodeLines:         100,
+		TotalCodeBlocks:        10,
+		PostsByYear:            map[int]int{2023: 2, 2024: 3},
+		WordsByYear:            map[int]int{2023: 1000, 2024: 1500},
+		PostsByTag:             map[string]int{"go": 3, "tutorial": 4},
+	}
+	m.Cache().Set("feed_stats.blog", feedStats)
+
+	// Test StatsHelper
+	helper := NewStatsHelper(m)
+
+	// Test site-level methods
+	if helper.TotalPosts() != 10 {
+		t.Errorf("TotalPosts() = %d, want 10", helper.TotalPosts())
+	}
+	if helper.TotalWords() != 5000 {
+		t.Errorf("TotalWords() = %d, want 5000", helper.TotalWords())
+	}
+	if helper.TotalReadingTime() != 25 {
+		t.Errorf("TotalReadingTime() = %d, want 25", helper.TotalReadingTime())
+	}
+	if helper.TotalReadingTimeText() != "25 min" {
+		t.Errorf("TotalReadingTimeText() = %q, want %q", helper.TotalReadingTimeText(), "25 min")
+	}
+	if helper.AverageWords() != 500 {
+		t.Errorf("AverageWords() = %d, want 500", helper.AverageWords())
+	}
+	if helper.TotalCodeLines() != 200 {
+		t.Errorf("TotalCodeLines() = %d, want 200", helper.TotalCodeLines())
+	}
+	if helper.TotalCodeBlocks() != 20 {
+		t.Errorf("TotalCodeBlocks() = %d, want 20", helper.TotalCodeBlocks())
+	}
+
+	// Test PostsByYear
+	postsByYear := helper.PostsByYear()
+	if postsByYear[2023] != 4 {
+		t.Errorf("PostsByYear()[2023] = %d, want 4", postsByYear[2023])
+	}
+	if postsByYear[2024] != 6 {
+		t.Errorf("PostsByYear()[2024] = %d, want 6", postsByYear[2024])
+	}
+
+	// Test WordsByYear
+	wordsByYear := helper.WordsByYear()
+	if wordsByYear[2023] != 2000 {
+		t.Errorf("WordsByYear()[2023] = %d, want 2000", wordsByYear[2023])
+	}
+
+	// Test PostsByTag
+	postsByTag := helper.PostsByTag()
+	if postsByTag["go"] != 5 {
+		t.Errorf("PostsByTag()[go] = %d, want 5", postsByTag["go"])
+	}
+
+	// Test Kpi method
+	if helper.Kpi("total_posts") != 10 {
+		t.Errorf("Kpi(total_posts) = %v, want 10", helper.Kpi("total_posts"))
+	}
+	if helper.Kpi("total_words") != 5000 {
+		t.Errorf("Kpi(total_words) = %v, want 5000", helper.Kpi("total_words"))
+	}
+	if helper.Kpi("unknown") != nil {
+		t.Errorf("Kpi(unknown) = %v, want nil", helper.Kpi("unknown"))
+	}
+}
+
+func TestStatsHelper_ForFeed(t *testing.T) {
+	// Create a test manager and populate with stats
+	m := lifecycle.NewManager()
+
+	// Create site stats
+	siteStats := &SiteStats{
+		TotalPosts:  10,
+		PostsByYear: make(map[int]int),
+		WordsByYear: make(map[int]int),
+		PostsByTag:  make(map[string]int),
+	}
+	m.Cache().Set("site_stats", siteStats)
+
+	// Create feed stats
+	feedStats := &FeedStats{
+		PostCount:              5,
+		TotalWords:             2500,
+		TotalReadingTime:       12,
+		TotalReadingTimeText:   "12 min",
+		AverageWords:           500,
+		AverageReadingTime:     2,
+		AverageReadingTimeText: "2 min read",
+		TotalCodeLines:         100,
+		TotalCodeBlocks:        10,
+		PostsByYear:            map[int]int{2023: 2, 2024: 3},
+		WordsByYear:            map[int]int{2023: 1000, 2024: 1500},
+		PostsByTag:             map[string]int{"go": 3, "tutorial": 4},
+	}
+	m.Cache().Set("feed_stats.blog", feedStats)
+
+	// Test StatsHelper.ForFeed
+	helper := NewStatsHelper(m)
+	feedHelper := helper.ForFeed("blog")
+
+	if feedHelper.PostCount() != 5 {
+		t.Errorf("ForFeed(blog).PostCount() = %d, want 5", feedHelper.PostCount())
+	}
+	if feedHelper.TotalWords() != 2500 {
+		t.Errorf("ForFeed(blog).TotalWords() = %d, want 2500", feedHelper.TotalWords())
+	}
+	if feedHelper.TotalReadingTime() != 12 {
+		t.Errorf("ForFeed(blog).TotalReadingTime() = %d, want 12", feedHelper.TotalReadingTime())
+	}
+	if feedHelper.AverageWords() != 500 {
+		t.Errorf("ForFeed(blog).AverageWords() = %d, want 500", feedHelper.AverageWords())
+	}
+	if feedHelper.TotalCodeLines() != 100 {
+		t.Errorf("ForFeed(blog).TotalCodeLines() = %d, want 100", feedHelper.TotalCodeLines())
+	}
+
+	// Test PostsByYear
+	postsByYear := feedHelper.PostsByYear()
+	if postsByYear[2023] != 2 {
+		t.Errorf("ForFeed(blog).PostsByYear()[2023] = %d, want 2", postsByYear[2023])
+	}
+
+	// Test PostsByTag
+	postsByTag := feedHelper.PostsByTag()
+	if postsByTag["go"] != 3 {
+		t.Errorf("ForFeed(blog).PostsByTag()[go] = %d, want 3", postsByTag["go"])
+	}
+
+	// Test Kpi method
+	if feedHelper.Kpi("post_count") != 5 {
+		t.Errorf("ForFeed(blog).Kpi(post_count) = %v, want 5", feedHelper.Kpi("post_count"))
+	}
+	if feedHelper.Kpi("total_posts") != 5 { // alias
+		t.Errorf("ForFeed(blog).Kpi(total_posts) = %v, want 5", feedHelper.Kpi("total_posts"))
+	}
+
+	// Test non-existent feed
+	nonExistentFeed := helper.ForFeed("nonexistent")
+	if nonExistentFeed.PostCount() != 0 {
+		t.Errorf("ForFeed(nonexistent).PostCount() = %d, want 0", nonExistentFeed.PostCount())
+	}
+}
+
+func TestStatsHelper_nilStats(t *testing.T) {
+	// Create a test manager without any stats
+	m := lifecycle.NewManager()
+
+	helper := NewStatsHelper(m)
+
+	// All methods should return zero/empty values without panicking
+	if helper.TotalPosts() != 0 {
+		t.Errorf("TotalPosts() = %d, want 0", helper.TotalPosts())
+	}
+	if helper.TotalWords() != 0 {
+		t.Errorf("TotalWords() = %d, want 0", helper.TotalWords())
+	}
+	if helper.TotalReadingTimeText() != "0 min" {
+		t.Errorf("TotalReadingTimeText() = %q, want %q", helper.TotalReadingTimeText(), "0 min")
+	}
+
+	postsByYear := helper.PostsByYear()
+	if len(postsByYear) != 0 {
+		t.Errorf("PostsByYear() = %v, want empty map", postsByYear)
+	}
+
+	postsByTag := helper.PostsByTag()
+	if len(postsByTag) != 0 {
+		t.Errorf("PostsByTag() = %v, want empty map", postsByTag)
+	}
+
+	if helper.Kpi("total_posts") != 0 {
+		t.Errorf("Kpi(total_posts) = %v, want 0", helper.Kpi("total_posts"))
+	}
 }


### PR DESCRIPTION
## Summary

- Add enhanced site stats plugin with year-based and tag-based aggregations
- Add StatsHelper for template-friendly access to statistics
- Add per-feed stats filtering support

Fixes #262

## Changes

### Enhanced SiteStats and FeedStats structures
- Added `PostsByYear` map: year → post count
- Added `WordsByYear` map: year → total word count
- Added `PostsByTag` map: tag name → post count

### New StatsHelper for templates
Provides template-friendly access to site statistics with the following API:

```jinja2
{# Site-level stats #}
{{ stats.total_posts }}
{{ stats.total_words }}
{{ stats.total_reading_time }}
{{ stats.posts_by_year }}
{{ stats.words_by_year }}
{{ stats.posts_by_tag }}
{{ stats.kpi("total_posts") }}

{# Feed-specific stats #}
{{ stats.for_feed("blog").post_count }}
{{ stats.for_feed("blog").posts_by_year }}
{{ stats.for_feed("blog").kpi("total_words") }}
```

### Example usage for "Year in Review" posts

```markdown
---
title: "My 2024 Wrapped"
jinja: true
---

# 2024 Writing Stats

- Total Posts: {{ stats.posts_by_year[2024] }}
- Total Words: {{ stats.words_by_year[2024] }}
- Blog Posts: {{ stats.for_feed("blog").posts_by_year[2024] }}
```

## Testing

- Added comprehensive tests for new functionality
- All existing tests pass
- golangci-lint passes with no warnings