### PR TITLE
feat(cli): add migration comparison tool

### DIFF
--- a/pkg/migrate/compare.go
+++ b/pkg/migrate/compare.go
@@ -1,0 +1,281 @@
+package migrate
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
+)
+
+// CompareResult contains the results of comparing two site directories.
+type CompareResult struct {
+	// OldDir is the path to the old site directory
+	OldDir string
+
+	// NewDir is the path to the new site directory
+	NewDir string
+
+	// OldFiles is the list of files in the old directory
+	OldFiles []string
+
+	// NewFiles is the list of files in the new directory
+	NewFiles []string
+
+	// MissingInNew is the list of files in old but not in new
+	MissingInNew []string
+
+	// NewOnly is the list of files in new but not in old
+	NewOnly []string
+
+	// Common is the list of files present in both directories
+	Common []string
+}
+
+// CompareOptions configures the directory comparison.
+type CompareOptions struct {
+	// Extensions to compare (e.g., []string{".html"})
+	// If empty, all files are compared
+	Extensions []string
+
+	// IgnorePatterns are glob patterns to ignore
+	IgnorePatterns []string
+}
+
+// DefaultCompareOptions returns sensible defaults for comparing SSG output.
+func DefaultCompareOptions() CompareOptions {
+	return CompareOptions{
+		Extensions: []string{".html"},
+		IgnorePatterns: []string{
+			"**/assets/**",
+			"**/_pagefind/**",
+			"**/static/**",
+		},
+	}
+}
+
+// Compare compares two directories and returns the differences.
+func Compare(oldDir, newDir string, opts CompareOptions) (*CompareResult, error) {
+	result := &CompareResult{
+		OldDir: oldDir,
+		NewDir: newDir,
+	}
+
+	// Validate directories exist
+	if err := validateDirectory(oldDir); err != nil {
+		return nil, fmt.Errorf("old directory: %w", err)
+	}
+	if err := validateDirectory(newDir); err != nil {
+		return nil, fmt.Errorf("new directory: %w", err)
+	}
+
+	// List files in both directories
+	oldFiles, err := listFiles(oldDir, opts)
+	if err != nil {
+		return nil, fmt.Errorf("listing old directory: %w", err)
+	}
+	result.OldFiles = oldFiles
+
+	newFiles, err := listFiles(newDir, opts)
+	if err != nil {
+		return nil, fmt.Errorf("listing new directory: %w", err)
+	}
+	result.NewFiles = newFiles
+
+	// Create sets for comparison
+	oldSet := make(map[string]struct{}, len(oldFiles))
+	for _, f := range oldFiles {
+		oldSet[f] = struct{}{}
+	}
+
+	newSet := make(map[string]struct{}, len(newFiles))
+	for _, f := range newFiles {
+		newSet[f] = struct{}{}
+	}
+
+	// Find missing in new (present in old, not in new)
+	for _, f := range oldFiles {
+		if _, found := newSet[f]; !found {
+			result.MissingInNew = append(result.MissingInNew, f)
+		} else {
+			result.Common = append(result.Common, f)
+		}
+	}
+
+	// Find new only (present in new, not in old)
+	for _, f := range newFiles {
+		if _, found := oldSet[f]; !found {
+			result.NewOnly = append(result.NewOnly, f)
+		}
+	}
+
+	// Sort results for consistent output
+	sort.Strings(result.MissingInNew)
+	sort.Strings(result.NewOnly)
+	sort.Strings(result.Common)
+
+	return result, nil
+}
+
+// validateDirectory checks if a path exists and is a directory.
+func validateDirectory(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("directory not found: %s", path)
+		}
+		return fmt.Errorf("cannot access: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("not a directory: %s", path)
+	}
+	return nil
+}
+
+// listFiles returns all files in a directory matching the options.
+// Paths are returned relative to the directory root, with forward slashes.
+func listFiles(dir string, opts CompareOptions) ([]string, error) {
+	var files []string
+
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	err = filepath.Walk(absDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Skip directories
+		if info.IsDir() {
+			return nil
+		}
+
+		// Get relative path
+		relPath, err := filepath.Rel(absDir, path)
+		if err != nil {
+			return err
+		}
+
+		// Normalize to forward slashes for consistency
+		relPath = filepath.ToSlash(relPath)
+
+		// Add leading slash for URL-like paths
+		relPath = "/" + relPath
+
+		// Check extension filter
+		if len(opts.Extensions) > 0 {
+			ext := strings.ToLower(filepath.Ext(path))
+			matched := false
+			for _, allowedExt := range opts.Extensions {
+				if strings.EqualFold(ext, allowedExt) {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				return nil
+			}
+		}
+
+		// Check ignore patterns
+		for _, pattern := range opts.IgnorePatterns {
+			// Match against the relative path without leading slash
+			pathToMatch := strings.TrimPrefix(relPath, "/")
+			matched, err := doublestar.Match(pattern, pathToMatch)
+			if err != nil {
+				continue // Skip invalid patterns
+			}
+			if matched {
+				return nil
+			}
+		}
+
+		files = append(files, relPath)
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Strings(files)
+	return files, nil
+}
+
+// HasDifferences returns true if there are any differences between directories.
+func (r *CompareResult) HasDifferences() bool {
+	return len(r.MissingInNew) > 0 || len(r.NewOnly) > 0
+}
+
+// ExitCode returns the appropriate exit code for the comparison result.
+// 0 = directories match, 1 = differences found.
+func (r *CompareResult) ExitCode() int {
+	if r.HasDifferences() {
+		return 1
+	}
+	return 0
+}
+
+// Report generates a human-readable comparison report.
+func (r *CompareResult) Report() string {
+	var sb strings.Builder
+
+	sb.WriteString("Migration Comparison Report\n")
+	sb.WriteString("===========================\n\n")
+
+	fmt.Fprintf(&sb, "Old site: %s/ (%d files)\n", r.OldDir, len(r.OldFiles))
+	fmt.Fprintf(&sb, "New site: %s/ (%d files)\n\n", r.NewDir, len(r.NewFiles))
+
+	if !r.HasDifferences() {
+		sb.WriteString("No differences found - sites match!\n")
+		return sb.String()
+	}
+
+	// Missing in new
+	if len(r.MissingInNew) > 0 {
+		fmt.Fprintf(&sb, "Missing in new site (%d files):\n", len(r.MissingInNew))
+		for _, f := range r.MissingInNew {
+			fmt.Fprintf(&sb, "  - %s\n", f)
+		}
+		sb.WriteString("\n")
+	}
+
+	// New files
+	if len(r.NewOnly) > 0 {
+		fmt.Fprintf(&sb, "New files not in old (%d files):\n", len(r.NewOnly))
+		for _, f := range r.NewOnly {
+			fmt.Fprintf(&sb, "  + %s\n", f)
+		}
+		sb.WriteString("\n")
+	}
+
+	// Summary
+	sb.WriteString("Summary:\n")
+	fmt.Fprintf(&sb, "  Common files:     %d\n", len(r.Common))
+	fmt.Fprintf(&sb, "  Missing in new:   %d\n", len(r.MissingInNew))
+	fmt.Fprintf(&sb, "  New files:        %d\n", len(r.NewOnly))
+
+	return sb.String()
+}
+
+// JSONReport returns a JSON-friendly structure for programmatic use.
+func (r *CompareResult) JSONReport() map[string]interface{} {
+	return map[string]interface{}{
+		"old_dir":         r.OldDir,
+		"new_dir":         r.NewDir,
+		"old_file_count":  len(r.OldFiles),
+		"new_file_count":  len(r.NewFiles),
+		"common_count":    len(r.Common),
+		"missing_count":   len(r.MissingInNew),
+		"new_count":       len(r.NewOnly),
+		"has_differences": r.HasDifferences(),
+		"missing_in_new":  r.MissingInNew,
+		"new_only":        r.NewOnly,
+		"common":          r.Common,
+		"exit_code":       r.ExitCode(),
+	}
+}

--- a/pkg/migrate/compare_test.go
+++ b/pkg/migrate/compare_test.go
@@ -1,0 +1,396 @@
+package migrate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCompare(t *testing.T) {
+	// Create temp directories for testing
+	oldDir := t.TempDir()
+	newDir := t.TempDir()
+
+	// Create some test files in old dir
+	createTestFile(t, oldDir, "index.html", "<html>index</html>")
+	createTestFile(t, oldDir, "about.html", "<html>about</html>")
+	createTestFile(t, oldDir, "blog/post1.html", "<html>post1</html>")
+	createTestFile(t, oldDir, "blog/post2.html", "<html>post2</html>")
+	createTestFile(t, oldDir, "feed.xml", "<rss>feed</rss>")
+
+	// Create some test files in new dir (with differences)
+	createTestFile(t, newDir, "index.html", "<html>index</html>")
+	createTestFile(t, newDir, "about.html", "<html>about</html>")
+	createTestFile(t, newDir, "blog/post1.html", "<html>post1</html>")
+	// post2.html and feed.xml are intentionally not created in newDir
+	createTestFile(t, newDir, "sitemap.xml", "<sitemap>sitemap</sitemap>")
+	createTestFile(t, newDir, "robots.txt", "User-agent: *")
+
+	// Compare with default options (HTML only)
+	opts := CompareOptions{
+		Extensions: []string{".html"},
+	}
+
+	result, err := Compare(oldDir, newDir, opts)
+	if err != nil {
+		t.Fatalf("Compare() error = %v", err)
+	}
+
+	// Check old file count (HTML only)
+	if len(result.OldFiles) != 4 {
+		t.Errorf("OldFiles count = %d, want 4", len(result.OldFiles))
+	}
+
+	// Check new file count (HTML only)
+	if len(result.NewFiles) != 3 {
+		t.Errorf("NewFiles count = %d, want 3", len(result.NewFiles))
+	}
+
+	// Check missing in new
+	if len(result.MissingInNew) != 1 {
+		t.Errorf("MissingInNew count = %d, want 1", len(result.MissingInNew))
+	} else if result.MissingInNew[0] != "/blog/post2.html" {
+		t.Errorf("MissingInNew[0] = %s, want /blog/post2.html", result.MissingInNew[0])
+	}
+
+	// Check new only (none for HTML since sitemap.xml and robots.txt are not HTML)
+	if len(result.NewOnly) != 0 {
+		t.Errorf("NewOnly count = %d, want 0 (HTML only)", len(result.NewOnly))
+	}
+
+	// Check common files
+	if len(result.Common) != 3 {
+		t.Errorf("Common count = %d, want 3", len(result.Common))
+	}
+}
+
+func TestCompare_AllFiles(t *testing.T) {
+	oldDir := t.TempDir()
+	newDir := t.TempDir()
+
+	createTestFile(t, oldDir, "index.html", "<html>index</html>")
+	createTestFile(t, oldDir, "feed.xml", "<rss>feed</rss>")
+
+	createTestFile(t, newDir, "index.html", "<html>index</html>")
+	createTestFile(t, newDir, "sitemap.xml", "<sitemap>sitemap</sitemap>")
+
+	// Compare all files (empty extensions)
+	opts := CompareOptions{
+		Extensions: []string{},
+	}
+
+	result, err := Compare(oldDir, newDir, opts)
+	if err != nil {
+		t.Fatalf("Compare() error = %v", err)
+	}
+
+	// Should include all files
+	if len(result.OldFiles) != 2 {
+		t.Errorf("OldFiles count = %d, want 2", len(result.OldFiles))
+	}
+
+	if len(result.NewFiles) != 2 {
+		t.Errorf("NewFiles count = %d, want 2", len(result.NewFiles))
+	}
+
+	// feed.xml is missing in new
+	if len(result.MissingInNew) != 1 {
+		t.Errorf("MissingInNew count = %d, want 1", len(result.MissingInNew))
+	}
+
+	// sitemap.xml is new only
+	if len(result.NewOnly) != 1 {
+		t.Errorf("NewOnly count = %d, want 1", len(result.NewOnly))
+	}
+}
+
+func TestCompare_WithIgnorePatterns(t *testing.T) {
+	oldDir := t.TempDir()
+	newDir := t.TempDir()
+
+	createTestFile(t, oldDir, "index.html", "<html>index</html>")
+	createTestFile(t, oldDir, "assets/style.css", "body { }")
+	createTestFile(t, oldDir, "assets/script.js", "console.log('test')")
+
+	createTestFile(t, newDir, "index.html", "<html>index</html>")
+	// Assets are different in new dir
+	createTestFile(t, newDir, "assets/app.css", "body { }")
+
+	// Compare with ignore pattern for assets
+	opts := CompareOptions{
+		Extensions:     []string{},
+		IgnorePatterns: []string{"assets/**"},
+	}
+
+	result, err := Compare(oldDir, newDir, opts)
+	if err != nil {
+		t.Fatalf("Compare() error = %v", err)
+	}
+
+	// Should only have HTML files (assets ignored)
+	if len(result.OldFiles) != 1 {
+		t.Errorf("OldFiles count = %d, want 1 (assets ignored)", len(result.OldFiles))
+	}
+
+	if len(result.NewFiles) != 1 {
+		t.Errorf("NewFiles count = %d, want 1 (assets ignored)", len(result.NewFiles))
+	}
+
+	// No differences when assets are ignored
+	if result.HasDifferences() {
+		t.Error("HasDifferences() = true, want false (assets ignored)")
+	}
+}
+
+func TestCompare_InvalidDirectories(t *testing.T) {
+	validDir := t.TempDir()
+
+	// Test with non-existent old directory
+	_, err := Compare("/nonexistent/path", validDir, CompareOptions{})
+	if err == nil {
+		t.Error("expected error for non-existent old directory")
+	}
+
+	// Test with non-existent new directory
+	_, err = Compare(validDir, "/nonexistent/path", CompareOptions{})
+	if err == nil {
+		t.Error("expected error for non-existent new directory")
+	}
+
+	// Test with file instead of directory
+	tempFile := filepath.Join(validDir, "file.txt")
+	if err := os.WriteFile(tempFile, []byte("test"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = Compare(tempFile, validDir, CompareOptions{})
+	if err == nil {
+		t.Error("expected error for file instead of directory")
+	}
+}
+
+func TestCompare_EmptyDirectories(t *testing.T) {
+	oldDir := t.TempDir()
+	newDir := t.TempDir()
+
+	result, err := Compare(oldDir, newDir, CompareOptions{})
+	if err != nil {
+		t.Fatalf("Compare() error = %v", err)
+	}
+
+	if len(result.OldFiles) != 0 {
+		t.Errorf("OldFiles count = %d, want 0", len(result.OldFiles))
+	}
+
+	if len(result.NewFiles) != 0 {
+		t.Errorf("NewFiles count = %d, want 0", len(result.NewFiles))
+	}
+
+	if result.HasDifferences() {
+		t.Error("HasDifferences() = true, want false for empty directories")
+	}
+}
+
+func TestCompareResult_Report(t *testing.T) {
+	result := &CompareResult{
+		OldDir:       "markout",
+		NewDir:       "public",
+		OldFiles:     []string{"/index.html", "/about.html", "/old-post.html"},
+		NewFiles:     []string{"/index.html", "/about.html", "/sitemap.xml"},
+		MissingInNew: []string{"/old-post.html"},
+		NewOnly:      []string{"/sitemap.xml"},
+		Common:       []string{"/index.html", "/about.html"},
+	}
+
+	report := result.Report()
+
+	// Check report contains expected content
+	expectedContent := []string{
+		"Migration Comparison Report",
+		"markout/",
+		"public/",
+		"3 files",
+		"Missing in new site",
+		"/old-post.html",
+		"New files not in old",
+		"/sitemap.xml",
+		"Summary",
+	}
+
+	for _, expected := range expectedContent {
+		if !containsString(report, expected) {
+			t.Errorf("report missing expected content: %q", expected)
+		}
+	}
+}
+
+func TestCompareResult_Report_NoChanges(t *testing.T) {
+	result := &CompareResult{
+		OldDir:   "old",
+		NewDir:   "new",
+		OldFiles: []string{"/index.html"},
+		NewFiles: []string{"/index.html"},
+		Common:   []string{"/index.html"},
+	}
+
+	report := result.Report()
+
+	if !containsString(report, "No differences found") {
+		t.Error("report should indicate no differences")
+	}
+}
+
+func TestCompareResult_ExitCode(t *testing.T) {
+	tests := []struct {
+		name     string
+		result   CompareResult
+		expected int
+	}{
+		{
+			name: "no differences",
+			result: CompareResult{
+				OldFiles: []string{"/index.html"},
+				NewFiles: []string{"/index.html"},
+				Common:   []string{"/index.html"},
+			},
+			expected: 0,
+		},
+		{
+			name: "missing files",
+			result: CompareResult{
+				MissingInNew: []string{"/old.html"},
+			},
+			expected: 1,
+		},
+		{
+			name: "new files only",
+			result: CompareResult{
+				NewOnly: []string{"/new.html"},
+			},
+			expected: 1,
+		},
+		{
+			name: "both missing and new",
+			result: CompareResult{
+				MissingInNew: []string{"/old.html"},
+				NewOnly:      []string{"/new.html"},
+			},
+			expected: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.result.ExitCode(); got != tt.expected {
+				t.Errorf("ExitCode() = %d, want %d", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCompareResult_JSONReport(t *testing.T) {
+	result := &CompareResult{
+		OldDir:       "old",
+		NewDir:       "new",
+		OldFiles:     []string{"/index.html", "/about.html"},
+		NewFiles:     []string{"/index.html"},
+		MissingInNew: []string{"/about.html"},
+		NewOnly:      []string{},
+		Common:       []string{"/index.html"},
+	}
+
+	report := result.JSONReport()
+
+	// Check required fields
+	if report["old_dir"] != "old" {
+		t.Errorf("old_dir = %v, want 'old'", report["old_dir"])
+	}
+	if report["new_dir"] != "new" {
+		t.Errorf("new_dir = %v, want 'new'", report["new_dir"])
+	}
+	if report["old_file_count"] != 2 {
+		t.Errorf("old_file_count = %v, want 2", report["old_file_count"])
+	}
+	if report["new_file_count"] != 1 {
+		t.Errorf("new_file_count = %v, want 1", report["new_file_count"])
+	}
+	if report["missing_count"] != 1 {
+		t.Errorf("missing_count = %v, want 1", report["missing_count"])
+	}
+	if report["has_differences"] != true {
+		t.Errorf("has_differences = %v, want true", report["has_differences"])
+	}
+	if report["exit_code"] != 1 {
+		t.Errorf("exit_code = %v, want 1", report["exit_code"])
+	}
+}
+
+func TestDefaultCompareOptions(t *testing.T) {
+	opts := DefaultCompareOptions()
+
+	if len(opts.Extensions) == 0 {
+		t.Error("default extensions should not be empty")
+	}
+
+	// Should default to HTML
+	foundHTML := false
+	for _, ext := range opts.Extensions {
+		if ext == ".html" {
+			foundHTML = true
+			break
+		}
+	}
+	if !foundHTML {
+		t.Error("default extensions should include .html")
+	}
+
+	// Should have some default ignore patterns
+	if len(opts.IgnorePatterns) == 0 {
+		t.Error("default ignore patterns should not be empty")
+	}
+}
+
+func TestCompare_MultipleExtensions(t *testing.T) {
+	oldDir := t.TempDir()
+	newDir := t.TempDir()
+
+	createTestFile(t, oldDir, "index.html", "<html>index</html>")
+	createTestFile(t, oldDir, "feed.xml", "<rss>feed</rss>")
+	createTestFile(t, oldDir, "style.css", "body { }")
+
+	createTestFile(t, newDir, "index.html", "<html>index</html>")
+	createTestFile(t, newDir, "feed.xml", "<rss>feed</rss>")
+	createTestFile(t, newDir, "style.css", "body { }")
+
+	// Compare HTML and XML files
+	opts := CompareOptions{
+		Extensions: []string{".html", ".xml"},
+	}
+
+	result, err := Compare(oldDir, newDir, opts)
+	if err != nil {
+		t.Fatalf("Compare() error = %v", err)
+	}
+
+	// Should include HTML and XML, but not CSS
+	if len(result.OldFiles) != 2 {
+		t.Errorf("OldFiles count = %d, want 2 (HTML and XML only)", len(result.OldFiles))
+	}
+
+	if result.HasDifferences() {
+		t.Error("HasDifferences() = true, want false")
+	}
+}
+
+// Helper function to create test files
+func createTestFile(t *testing.T, baseDir, path, content string) {
+	t.Helper()
+	fullPath := filepath.Join(baseDir, path)
+	dir := filepath.Dir(fullPath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("failed to create directory %s: %v", dir, err)
+	}
+	if err := os.WriteFile(fullPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to create file %s: %v", fullPath, err)
+	}
+}


### PR DESCRIPTION
## Summary

Add a new `markata-go migrate compare` command to help users verify their migration from Python markata (or other SSGs) is complete by comparing old and new site output directories.

Fixes #259

## Changes

- Add `pkg/migrate/compare.go` with directory comparison logic
- Add `pkg/migrate/compare_test.go` with comprehensive tests
- Update `cmd/markata-go/cmd/migrate.go` to add the `compare` subcommand

## Features

- Compare two directories and report:
  - Files missing in the new site
  - New files not present in the old site  
  - Common files present in both
- Configurable file extension filtering (default: `.html`)
- Support for ignore patterns (e.g., `assets/**`)
- JSON output option for scripting
- Exit code indicates comparison result (0 = match, 1 = differences)

## Example Usage

```bash
# Basic comparison
markata-go migrate compare --old markout --new public

# With extension filtering
markata-go migrate compare --old _site --new public --ext .html,.xml

# With ignore patterns
markata-go migrate compare --old dist --new public --ignore "assets/**"

# JSON output for scripting
markata-go migrate compare --old markout --new public --json
```

## Example Output

```
Migration Comparison Report
===========================

Old site: markout/ (142 files)
New site: public/ (145 files)

Missing in new site (3 files):
  - /blog/old-draft-post.html
  - /archive/2019/index.html  
  - /feed.xml

New files not in old (6 files):
  + /sitemap.xml
  + /robots.txt
  ...

Summary:
  Common files:     139
  Missing in new:   3
  New files:        6
```