### PR TITLE
feat(cli): add blogroll update command for metadata extraction

### DIFF
--- a/cmd/markata-go/cmd/blogroll_update.go
+++ b/cmd/markata-go/cmd/blogroll_update.go
@@ -1,0 +1,402 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/BurntSushi/toml"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/WaylonWalker/markata-go/pkg/blogroll"
+	"github.com/WaylonWalker/markata-go/pkg/config"
+	"github.com/WaylonWalker/markata-go/pkg/models"
+)
+
+var (
+	// blogrollDryRun shows what would be updated without making changes.
+	blogrollDryRun bool
+
+	// blogrollForce overwrites existing metadata even if present.
+	blogrollForce bool
+
+	// blogrollFeed updates only a specific feed by handle/URL.
+	blogrollFeed string
+)
+
+// blogrollCmd represents the blogroll command group.
+var blogrollCmd = &cobra.Command{
+	Use:   "blogroll",
+	Short: "Manage blogroll feeds",
+	Long: `Commands for managing blogroll feeds and metadata.
+
+Subcommands:
+  update     - Update feed metadata from external sources`,
+}
+
+// blogrollUpdateCmd updates blogroll metadata.
+var blogrollUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update feed metadata from external sources",
+	Long: `Automatically update blogroll feed metadata by fetching information from:
+
+1. OpenGraph Protocol - og:title, og:description, og:image
+2. HTML Meta Tags - description, keywords, author
+3. RSS/Atom Feed Metadata - feed title, description, author
+
+This command reads your config file, fetches metadata for each blogroll feed,
+and updates the config with any missing or outdated information.
+
+Example usage:
+  markata-go blogroll update              # Update all feeds
+  markata-go blogroll update --dry-run    # Preview changes without modifying
+  markata-go blogroll update --force      # Overwrite existing metadata
+  markata-go blogroll update --feed=dave  # Update only feed matching "dave"`,
+	RunE: runBlogrollUpdate,
+}
+
+func init() {
+	rootCmd.AddCommand(blogrollCmd)
+	blogrollCmd.AddCommand(blogrollUpdateCmd)
+
+	blogrollUpdateCmd.Flags().BoolVar(&blogrollDryRun, "dry-run", false, "show what would be updated without making changes")
+	blogrollUpdateCmd.Flags().BoolVar(&blogrollForce, "force", false, "overwrite existing metadata even if present")
+	blogrollUpdateCmd.Flags().StringVar(&blogrollFeed, "feed", "", "update only specific feed by handle or URL substring")
+}
+
+func runBlogrollUpdate(_ *cobra.Command, _ []string) error {
+	// Discover config file
+	configPath := cfgFile
+	if configPath == "" {
+		var err error
+		configPath, err = config.Discover()
+		if err != nil {
+			return fmt.Errorf("no config file found: %w", err)
+		}
+	}
+
+	// Load current configuration
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	// Check if blogroll is configured
+	if !cfg.Blogroll.Enabled {
+		fmt.Println("Blogroll is not enabled in configuration.")
+		fmt.Println("Add [blogroll] enabled = true to your config file.")
+		return nil
+	}
+
+	if len(cfg.Blogroll.Feeds) == 0 {
+		fmt.Println("No blogroll feeds configured.")
+		fmt.Println("Add [[blogroll.feeds]] entries to your config file.")
+		return nil
+	}
+
+	// Create the updater
+	timeout := time.Duration(cfg.Blogroll.Timeout) * time.Second
+	if timeout == 0 {
+		timeout = 30 * time.Second
+	}
+	updater := blogroll.NewUpdater(timeout)
+
+	// Track changes
+	results := make([]blogroll.UpdateResult, 0, len(cfg.Blogroll.Feeds))
+	feedsUpdated := 0
+	feedsSkipped := 0
+	feedsErrored := 0
+
+	fmt.Printf("Updating blogroll metadata from %s...\n\n", configPath)
+
+	// Process each feed
+	for i := range cfg.Blogroll.Feeds {
+		feed := &cfg.Blogroll.Feeds[i]
+
+		// Filter by specific feed if requested
+		if blogrollFeed != "" {
+			if !matchesFeed(feed, blogrollFeed) {
+				continue
+			}
+		}
+
+		result := updateFeedMetadata(updater, feed, blogrollForce)
+		results = append(results, result)
+
+		switch {
+		case result.Error != "":
+			feedsErrored++
+			fmt.Printf("  ✗ %s: %s\n", feed.URL, result.Error)
+		case result.Updated:
+			feedsUpdated++
+			printUpdateResult(result, blogrollDryRun)
+		default:
+			feedsSkipped++
+			if verbose {
+				fmt.Printf("  - %s: no changes needed\n", feedDisplayName(feed))
+			}
+		}
+	}
+
+	fmt.Println()
+
+	// Summary
+	if blogrollFeed != "" && len(results) == 0 {
+		fmt.Printf("No feeds matching '%s' found.\n", blogrollFeed)
+		return nil
+	}
+
+	fmt.Printf("Summary: %d updated, %d skipped, %d errors\n", feedsUpdated, feedsSkipped, feedsErrored)
+
+	// Write changes if not dry-run and there are updates
+	if !blogrollDryRun && feedsUpdated > 0 {
+		if err := writeConfigUpdate(configPath, cfg); err != nil {
+			return fmt.Errorf("failed to write config: %w", err)
+		}
+		fmt.Printf("\nConfig updated: %s\n", configPath)
+	} else if blogrollDryRun && feedsUpdated > 0 {
+		fmt.Println("\n(dry-run mode - no changes written)")
+	}
+
+	return nil
+}
+
+// matchesFeed checks if a feed matches the filter string.
+func matchesFeed(feed *configFeedRef, filter string) bool {
+	filter = strings.ToLower(filter)
+
+	// Match by URL
+	if strings.Contains(strings.ToLower(feed.URL), filter) {
+		return true
+	}
+
+	// Match by title
+	if strings.Contains(strings.ToLower(feed.Title), filter) {
+		return true
+	}
+
+	return false
+}
+
+// configFeedRef is a type alias for cleaner code.
+type configFeedRef = models.ExternalFeedConfig
+
+// updateFeedMetadata fetches and applies metadata updates to a feed.
+func updateFeedMetadata(updater *blogroll.Updater, feed *configFeedRef, force bool) blogroll.UpdateResult {
+	result := blogroll.UpdateResult{
+		FeedURL: feed.URL,
+		Handle:  feedDisplayName(feed),
+	}
+
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Fetch metadata
+	metadata, err := updater.FetchMetadata(ctx, feed.URL)
+	if err != nil {
+		result.Error = err.Error()
+		return result
+	}
+
+	// Build old metadata for comparison
+	result.OldMetadata = &blogroll.Metadata{
+		Title:       feed.Title,
+		Description: feed.Description,
+		ImageURL:    feed.ImageURL,
+		SiteURL:     feed.SiteURL,
+	}
+
+	// Apply updates
+	result.NewMetadata = &blogroll.Metadata{}
+
+	// Title
+	if feed.Title == "" || force {
+		if metadata.Title != "" && metadata.Title != feed.Title {
+			feed.Title = metadata.Title
+			result.NewMetadata.Title = metadata.Title
+			result.Updated = true
+		}
+	}
+
+	// Description
+	if feed.Description == "" || force {
+		if metadata.Description != "" && metadata.Description != feed.Description {
+			feed.Description = metadata.Description
+			result.NewMetadata.Description = metadata.Description
+			result.Updated = true
+		}
+	}
+
+	// ImageURL
+	if feed.ImageURL == "" || force {
+		if metadata.ImageURL != "" && metadata.ImageURL != feed.ImageURL {
+			feed.ImageURL = metadata.ImageURL
+			result.NewMetadata.ImageURL = metadata.ImageURL
+			result.Updated = true
+		}
+	}
+
+	// SiteURL
+	if feed.SiteURL == "" || force {
+		if metadata.SiteURL != "" && metadata.SiteURL != feed.SiteURL {
+			feed.SiteURL = metadata.SiteURL
+			result.NewMetadata.SiteURL = metadata.SiteURL
+			result.Updated = true
+		}
+	}
+
+	return result
+}
+
+// feedDisplayName returns a display name for a feed.
+func feedDisplayName(feed *configFeedRef) string {
+	if feed.Title != "" {
+		return feed.Title
+	}
+	return feed.URL
+}
+
+// printUpdateResult prints the changes for a feed.
+func printUpdateResult(result blogroll.UpdateResult, dryRun bool) {
+	prefix := "  ✓"
+	if dryRun {
+		prefix = "  →"
+	}
+
+	fmt.Printf("%s %s:\n", prefix, result.Handle)
+
+	if result.NewMetadata.Title != "" {
+		fmt.Printf("      title: %q\n", result.NewMetadata.Title)
+	}
+	if result.NewMetadata.Description != "" {
+		desc := result.NewMetadata.Description
+		if len(desc) > 60 {
+			desc = desc[:57] + "..."
+		}
+		fmt.Printf("      description: %q\n", desc)
+	}
+	if result.NewMetadata.ImageURL != "" {
+		fmt.Printf("      image_url: %s\n", result.NewMetadata.ImageURL)
+	}
+	if result.NewMetadata.SiteURL != "" {
+		fmt.Printf("      site_url: %s\n", result.NewMetadata.SiteURL)
+	}
+}
+
+// writeConfigUpdate writes the updated config back to the file.
+func writeConfigUpdate(configPath string, cfg *models.Config) error {
+	// Determine format from extension
+	ext := strings.ToLower(filepath.Ext(configPath))
+
+	// Read the original file to preserve structure
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("read config: %w", err)
+	}
+
+	// Parse to a generic map to preserve other settings
+	var configMap map[string]interface{}
+
+	switch ext {
+	case formatTOML:
+		if err := toml.Unmarshal(data, &configMap); err != nil {
+			return fmt.Errorf("parse TOML: %w", err)
+		}
+	case extYAML, extYML:
+		if err := yaml.Unmarshal(data, &configMap); err != nil {
+			return fmt.Errorf("parse YAML: %w", err)
+		}
+	default:
+		return fmt.Errorf("unsupported config format: %s", ext)
+	}
+
+	// Update the blogroll section
+	updateBlogrollInMap(configMap, cfg.Blogroll)
+
+	// Write back
+	switch ext {
+	case formatTOML:
+		return writeTOMLConfig(configPath, configMap)
+	case extYAML, extYML:
+		return writeYAMLConfig(configPath, configMap)
+	default:
+		return fmt.Errorf("unsupported config format: %s", ext)
+	}
+}
+
+// updateBlogrollInMap updates the blogroll section in a config map.
+func updateBlogrollInMap(configMap map[string]interface{}, blogrollCfg models.BlogrollConfig) {
+	// Find the markata-go wrapper or use root
+	var target map[string]interface{}
+	if mg, ok := configMap["markata-go"].(map[string]interface{}); ok {
+		target = mg
+	} else {
+		target = configMap
+	}
+
+	// Get or create blogroll section
+	var blogrollMap map[string]interface{}
+	if br, ok := target["blogroll"].(map[string]interface{}); ok {
+		blogrollMap = br
+	} else {
+		blogrollMap = make(map[string]interface{})
+		target["blogroll"] = blogrollMap
+	}
+
+	// Convert feeds to map format
+	feeds := make([]map[string]interface{}, len(blogrollCfg.Feeds))
+	for i := range blogrollCfg.Feeds {
+		feed := &blogrollCfg.Feeds[i]
+		feedMap := map[string]interface{}{
+			"url": feed.URL,
+		}
+		if feed.Title != "" {
+			feedMap["title"] = feed.Title
+		}
+		if feed.Description != "" {
+			feedMap["description"] = feed.Description
+		}
+		if feed.Category != "" {
+			feedMap["category"] = feed.Category
+		}
+		if len(feed.Tags) > 0 {
+			feedMap["tags"] = feed.Tags
+		}
+		if feed.SiteURL != "" {
+			feedMap["site_url"] = feed.SiteURL
+		}
+		if feed.ImageURL != "" {
+			feedMap["image_url"] = feed.ImageURL
+		}
+		if feed.Active != nil {
+			feedMap["active"] = *feed.Active
+		}
+		feeds[i] = feedMap
+	}
+
+	blogrollMap["feeds"] = feeds
+}
+
+// writeTOMLConfig writes a config map as TOML.
+func writeTOMLConfig(path string, configMap map[string]interface{}) error {
+	var buf strings.Builder
+	encoder := toml.NewEncoder(&buf)
+	if err := encoder.Encode(configMap); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(buf.String()), 0o644) //nolint:gosec // config files should be readable
+}
+
+// writeYAMLConfig writes a config map as YAML.
+func writeYAMLConfig(path string, configMap map[string]interface{}) error {
+	data, err := yaml.Marshal(configMap)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644) //nolint:gosec // config files should be readable
+}

--- a/pkg/blogroll/updater.go
+++ b/pkg/blogroll/updater.go
@@ -1,0 +1,543 @@
+// Package blogroll provides functionality for managing blogroll metadata.
+package blogroll
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Updater handles fetching and extracting metadata from external sites.
+type Updater struct {
+	client  *http.Client
+	timeout time.Duration
+}
+
+// NewUpdater creates a new Updater with the given timeout.
+func NewUpdater(timeout time.Duration) *Updater {
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+	return &Updater{
+		client: &http.Client{
+			Timeout: timeout,
+		},
+		timeout: timeout,
+	}
+}
+
+// Metadata represents extracted metadata from a website.
+type Metadata struct {
+	// From OpenGraph
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	ImageURL    string `json:"image_url,omitempty"`
+	SiteURL     string `json:"site_url,omitempty"`
+
+	// Author information
+	Author string `json:"author,omitempty"`
+
+	// From feed
+	FeedTitle       string     `json:"feed_title,omitempty"`
+	FeedDescription string     `json:"feed_description,omitempty"`
+	FeedAuthor      string     `json:"feed_author,omitempty"`
+	FeedImageURL    string     `json:"feed_image_url,omitempty"`
+	LastUpdated     *time.Time `json:"last_updated,omitempty"`
+
+	// Source tracking
+	Source string `json:"source,omitempty"` // "opengraph", "meta", "feed"
+}
+
+// UpdateResult contains the result of updating a single feed's metadata.
+type UpdateResult struct {
+	FeedURL     string    `json:"feed_url"`
+	Handle      string    `json:"handle,omitempty"`
+	OldMetadata *Metadata `json:"old_metadata,omitempty"`
+	NewMetadata *Metadata `json:"new_metadata,omitempty"`
+	Updated     bool      `json:"updated"`
+	Error       string    `json:"error,omitempty"`
+}
+
+// FetchMetadata fetches metadata from a site URL or feed URL.
+// It tries multiple sources in order: OpenGraph, HTML meta tags, feed metadata.
+func (u *Updater) FetchMetadata(ctx context.Context, feedURL string) (*Metadata, error) {
+	metadata := &Metadata{}
+
+	// First, try to extract site URL from feed URL
+	siteURL, err := extractSiteURL(feedURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid feed URL: %w", err)
+	}
+
+	// Fetch site metadata (OpenGraph + HTML meta)
+	siteMetadata, siteErr := u.fetchSiteMetadata(ctx, siteURL)
+	if siteErr == nil && siteMetadata != nil {
+		mergeMetadata(metadata, siteMetadata)
+	}
+
+	// Fetch feed metadata
+	feedMetadata, feedErr := u.fetchFeedMetadata(ctx, feedURL)
+	if feedErr == nil && feedMetadata != nil {
+		// Feed metadata fills in gaps but doesn't overwrite
+		mergeMetadataWithoutOverwrite(metadata, feedMetadata)
+	}
+
+	// If we couldn't get any metadata, return an error
+	if siteErr != nil && feedErr != nil {
+		return nil, fmt.Errorf("failed to fetch metadata from %s: %w", feedURL, siteErr)
+	}
+
+	// Set the site URL if not already set
+	if metadata.SiteURL == "" {
+		metadata.SiteURL = siteURL
+	}
+
+	return metadata, nil
+}
+
+// fetchURL is a helper that fetches a URL and returns the body as bytes.
+func (u *Updater) fetchURL(ctx context.Context, targetURL, accept string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", targetURL, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	req.Header.Set("User-Agent", "markata-go/1.0 (Blogroll Updater)")
+	req.Header.Set("Accept", accept)
+
+	resp, err := u.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	// Read body with a limit (1MB)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+
+	return body, nil
+}
+
+// fetchSiteMetadata fetches OpenGraph and HTML meta tags from a site.
+func (u *Updater) fetchSiteMetadata(ctx context.Context, siteURL string) (*Metadata, error) {
+	body, err := u.fetchURL(ctx, siteURL, "text/html,application/xhtml+xml")
+	if err != nil {
+		return nil, err
+	}
+	return parseHTMLMetadata(string(body), siteURL), nil
+}
+
+// fetchFeedMetadata fetches metadata from an RSS/Atom feed.
+func (u *Updater) fetchFeedMetadata(ctx context.Context, feedURL string) (*Metadata, error) {
+	body, err := u.fetchURL(ctx, feedURL, "application/rss+xml, application/atom+xml, application/xml, text/xml")
+	if err != nil {
+		return nil, err
+	}
+	return parseFeedMetadata(string(body)), nil
+}
+
+// parseHTMLMetadata extracts OpenGraph and meta tags from HTML using regex.
+func parseHTMLMetadata(htmlContent, baseURL string) *Metadata {
+	metadata := &Metadata{}
+
+	// Extract <title> tag
+	titleRe := regexp.MustCompile(`(?i)<title[^>]*>([^<]*)</title>`)
+	if matches := titleRe.FindStringSubmatch(htmlContent); len(matches) > 1 {
+		metadata.Title = strings.TrimSpace(matches[1])
+	}
+
+	// Extract meta tags with pattern: <meta property="..." content="..."> or <meta name="..." content="...">
+	metaRe := regexp.MustCompile(`(?i)<meta\s+[^>]*(?:property|name)=["']([^"']+)["'][^>]*content=["']([^"']*)["'][^>]*>`)
+	metaRe2 := regexp.MustCompile(`(?i)<meta\s+[^>]*content=["']([^"']*)["'][^>]*(?:property|name)=["']([^"']+)["'][^>]*>`)
+
+	processMetaMatch := func(prop, content string) {
+		processOpenGraphMeta(prop, content, metadata, baseURL)
+		processHTMLMeta(prop, content, metadata, baseURL)
+	}
+
+	for _, matches := range metaRe.FindAllStringSubmatch(htmlContent, -1) {
+		if len(matches) > 2 {
+			processMetaMatch(matches[1], matches[2])
+		}
+	}
+
+	for _, matches := range metaRe2.FindAllStringSubmatch(htmlContent, -1) {
+		if len(matches) > 2 {
+			processMetaMatch(matches[2], matches[1])
+		}
+	}
+
+	// Extract link rel="icon" for favicon
+	if metadata.ImageURL == "" {
+		iconRe := regexp.MustCompile(`(?i)<link\s+[^>]*rel=["'](?:icon|shortcut icon|apple-touch-icon)[^"']*["'][^>]*href=["']([^"']+)["'][^>]*>`)
+		iconRe2 := regexp.MustCompile(`(?i)<link\s+[^>]*href=["']([^"']+)["'][^>]*rel=["'](?:icon|shortcut icon|apple-touch-icon)[^"']*["'][^>]*>`)
+
+		if matches := iconRe.FindStringSubmatch(htmlContent); len(matches) > 1 {
+			metadata.ImageURL = resolveURL(matches[1], baseURL)
+		} else if matches := iconRe2.FindStringSubmatch(htmlContent); len(matches) > 1 {
+			metadata.ImageURL = resolveURL(matches[1], baseURL)
+		}
+	}
+
+	if metadata.Title != "" || metadata.Description != "" || metadata.ImageURL != "" {
+		metadata.Source = "opengraph"
+	}
+
+	return metadata
+}
+
+// processOpenGraphMeta handles OpenGraph protocol meta tags.
+func processOpenGraphMeta(property, content string, metadata *Metadata, baseURL string) {
+	switch property {
+	case "og:title":
+		if metadata.Title == "" {
+			metadata.Title = content
+		}
+	case "og:description":
+		if metadata.Description == "" {
+			metadata.Description = content
+		}
+	case "og:image":
+		if metadata.ImageURL == "" {
+			metadata.ImageURL = resolveURL(content, baseURL)
+		}
+	case "og:url":
+		if metadata.SiteURL == "" {
+			metadata.SiteURL = content
+		}
+	case "og:site_name":
+		// Can be used as fallback title
+		if metadata.Title == "" {
+			metadata.Title = content
+		}
+	}
+}
+
+// processHTMLMeta handles standard HTML meta tags.
+func processHTMLMeta(name, content string, metadata *Metadata, baseURL string) {
+	switch name {
+	case "description":
+		if metadata.Description == "" {
+			metadata.Description = content
+		}
+	case "author":
+		if metadata.Author == "" {
+			metadata.Author = content
+		}
+	case "twitter:title":
+		if metadata.Title == "" {
+			metadata.Title = content
+		}
+	case "twitter:description":
+		if metadata.Description == "" {
+			metadata.Description = content
+		}
+	case "twitter:image":
+		if metadata.ImageURL == "" {
+			metadata.ImageURL = resolveURL(content, baseURL)
+		}
+	}
+}
+
+// parseFeedMetadata extracts metadata from RSS/Atom feed content.
+func parseFeedMetadata(feedContent string) *Metadata {
+	metadata := &Metadata{
+		Source: "feed",
+	}
+
+	// Detect feed type and parse accordingly
+	if strings.Contains(feedContent, "<feed") && strings.Contains(feedContent, "xmlns=\"http://www.w3.org/2005/Atom\"") {
+		parseAtomFeedMetadata(feedContent, metadata)
+	} else {
+		parseRSSFeedMetadata(feedContent, metadata)
+	}
+
+	return metadata
+}
+
+// parseAtomFeedMetadata parses Atom feed metadata.
+func parseAtomFeedMetadata(content string, metadata *Metadata) {
+	// Extract title
+	if title := extractXMLTag(content, "title"); title != "" {
+		metadata.FeedTitle = stripCDATA(title)
+	}
+
+	// Extract subtitle (description)
+	if subtitle := extractXMLTag(content, "subtitle"); subtitle != "" {
+		metadata.FeedDescription = stripCDATA(subtitle)
+	}
+
+	// Extract author
+	if authorName := extractNestedXMLTag(content, "author", "name"); authorName != "" {
+		metadata.FeedAuthor = stripCDATA(authorName)
+	}
+
+	// Extract icon/logo
+	if icon := extractXMLTag(content, "icon"); icon != "" {
+		metadata.FeedImageURL = stripCDATA(icon)
+	} else if logo := extractXMLTag(content, "logo"); logo != "" {
+		metadata.FeedImageURL = stripCDATA(logo)
+	}
+
+	// Extract updated timestamp
+	if updated := extractXMLTag(content, "updated"); updated != "" {
+		if t, err := time.Parse(time.RFC3339, stripCDATA(updated)); err == nil {
+			metadata.LastUpdated = &t
+		}
+	}
+}
+
+// parseRSSFeedMetadata parses RSS feed metadata.
+func parseRSSFeedMetadata(content string, metadata *Metadata) {
+	// Find the channel section
+	channelStart := strings.Index(content, "<channel")
+	channelEnd := strings.Index(content, "</channel>")
+	if channelStart == -1 || channelEnd == -1 {
+		return
+	}
+	channel := content[channelStart:channelEnd]
+
+	// Extract title (avoid item titles)
+	if title := extractChannelTag(channel, "title"); title != "" {
+		metadata.FeedTitle = stripCDATA(title)
+	}
+
+	// Extract description
+	if desc := extractChannelTag(channel, "description"); desc != "" {
+		metadata.FeedDescription = stripCDATA(desc)
+	}
+
+	// Extract managing editor or webmaster as author
+	if author := extractChannelTag(channel, "managingEditor"); author != "" {
+		metadata.FeedAuthor = stripCDATA(extractEmailName(author))
+	} else if author := extractChannelTag(channel, "webMaster"); author != "" {
+		metadata.FeedAuthor = stripCDATA(extractEmailName(author))
+	} else if author := extractChannelTag(channel, "author"); author != "" {
+		metadata.FeedAuthor = stripCDATA(author)
+	}
+
+	// Extract image
+	if imgURL := extractNestedXMLTag(channel, "image", "url"); imgURL != "" {
+		metadata.FeedImageURL = stripCDATA(imgURL)
+	}
+
+	// Extract lastBuildDate or pubDate
+	if lastBuild := extractChannelTag(channel, "lastBuildDate"); lastBuild != "" {
+		if t, err := parseRSSDate(stripCDATA(lastBuild)); err == nil {
+			metadata.LastUpdated = &t
+		}
+	} else if pubDate := extractChannelTag(channel, "pubDate"); pubDate != "" {
+		if t, err := parseRSSDate(stripCDATA(pubDate)); err == nil {
+			metadata.LastUpdated = &t
+		}
+	}
+}
+
+// extractChannelTag extracts a tag value from the channel section, avoiding item content.
+func extractChannelTag(channel, tag string) string {
+	// Find first occurrence before any <item> tag
+	itemStart := strings.Index(channel, "<item")
+	searchContent := channel
+	if itemStart > 0 {
+		searchContent = channel[:itemStart]
+	}
+	return extractXMLTag(searchContent, tag)
+}
+
+// extractXMLTag extracts the content of an XML tag.
+func extractXMLTag(content, tag string) string {
+	// Try both with and without namespace prefix
+	patterns := []string{
+		fmt.Sprintf("<%s[^>]*>([^<]*)</%s>", tag, tag),
+		fmt.Sprintf("<%s[^>]*>(.*?)</%s>", tag, tag),
+	}
+
+	for _, pattern := range patterns {
+		re := regexp.MustCompile(pattern)
+		matches := re.FindStringSubmatch(content)
+		if len(matches) > 1 {
+			return strings.TrimSpace(matches[1])
+		}
+	}
+
+	return ""
+}
+
+// extractNestedXMLTag extracts a nested tag value.
+func extractNestedXMLTag(content, parent, child string) string {
+	// Find parent tag
+	parentPattern := fmt.Sprintf("<%s[^>]*>(.*?)</%s>", parent, parent)
+	re := regexp.MustCompile(parentPattern)
+	matches := re.FindStringSubmatch(content)
+	if len(matches) > 1 {
+		return extractXMLTag(matches[1], child)
+	}
+	return ""
+}
+
+// stripCDATA removes CDATA wrapper and trims whitespace.
+func stripCDATA(s string) string {
+	s = strings.TrimSpace(s)
+	if strings.HasPrefix(s, "<![CDATA[") && strings.HasSuffix(s, "]]>") {
+		s = s[9 : len(s)-3]
+	}
+	return strings.TrimSpace(s)
+}
+
+// extractEmailName extracts a name from an email format like "email (Name)" or "Name <email>".
+func extractEmailName(s string) string {
+	// Format: email (Name)
+	if idx := strings.Index(s, "("); idx > 0 {
+		end := strings.Index(s, ")")
+		if end > idx {
+			return strings.TrimSpace(s[idx+1 : end])
+		}
+	}
+	// Format: Name <email>
+	if idx := strings.Index(s, "<"); idx > 0 {
+		return strings.TrimSpace(s[:idx])
+	}
+	return s
+}
+
+// parseRSSDate parses RSS date formats.
+func parseRSSDate(s string) (time.Time, error) {
+	formats := []string{
+		time.RFC1123Z,
+		time.RFC1123,
+		time.RFC822Z,
+		time.RFC822,
+		"Mon, 02 Jan 2006 15:04:05 -0700",
+		"02 Jan 2006 15:04:05 -0700",
+		time.RFC3339,
+	}
+
+	for _, format := range formats {
+		if t, err := time.Parse(format, s); err == nil {
+			return t, nil
+		}
+	}
+
+	return time.Time{}, fmt.Errorf("unable to parse date: %s", s)
+}
+
+// extractSiteURL extracts the base site URL from a feed URL.
+func extractSiteURL(feedURL string) (string, error) {
+	u, err := url.Parse(feedURL)
+	if err != nil {
+		return "", err
+	}
+
+	// Return just the scheme and host
+	return fmt.Sprintf("%s://%s", u.Scheme, u.Host), nil
+}
+
+// resolveURL resolves a potentially relative URL against a base URL.
+func resolveURL(href, baseURL string) string {
+	if href == "" {
+		return ""
+	}
+
+	// Already absolute
+	if strings.HasPrefix(href, "http://") || strings.HasPrefix(href, "https://") {
+		return href
+	}
+
+	// Protocol-relative
+	if strings.HasPrefix(href, "//") {
+		return "https:" + href
+	}
+
+	// Relative URL
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		return href
+	}
+
+	ref, err := url.Parse(href)
+	if err != nil {
+		return href
+	}
+
+	return base.ResolveReference(ref).String()
+}
+
+// mergeMetadata merges source metadata into target, overwriting non-empty values.
+func mergeMetadata(target, source *Metadata) {
+	if source.Title != "" {
+		target.Title = source.Title
+	}
+	if source.Description != "" {
+		target.Description = source.Description
+	}
+	if source.ImageURL != "" {
+		target.ImageURL = source.ImageURL
+	}
+	if source.SiteURL != "" {
+		target.SiteURL = source.SiteURL
+	}
+	if source.Author != "" {
+		target.Author = source.Author
+	}
+	if source.FeedTitle != "" {
+		target.FeedTitle = source.FeedTitle
+	}
+	if source.FeedDescription != "" {
+		target.FeedDescription = source.FeedDescription
+	}
+	if source.FeedAuthor != "" {
+		target.FeedAuthor = source.FeedAuthor
+	}
+	if source.FeedImageURL != "" {
+		target.FeedImageURL = source.FeedImageURL
+	}
+	if source.LastUpdated != nil {
+		target.LastUpdated = source.LastUpdated
+	}
+	if source.Source != "" {
+		target.Source = source.Source
+	}
+}
+
+// mergeMetadataWithoutOverwrite merges source into target only for empty fields.
+func mergeMetadataWithoutOverwrite(target, source *Metadata) {
+	if target.Title == "" && source.FeedTitle != "" {
+		target.Title = source.FeedTitle
+	}
+	if target.Description == "" && source.FeedDescription != "" {
+		target.Description = source.FeedDescription
+	}
+	if target.ImageURL == "" && source.FeedImageURL != "" {
+		target.ImageURL = source.FeedImageURL
+	}
+	if target.Author == "" && source.FeedAuthor != "" {
+		target.Author = source.FeedAuthor
+	}
+	if target.LastUpdated == nil && source.LastUpdated != nil {
+		target.LastUpdated = source.LastUpdated
+	}
+	// Keep feed-specific fields
+	if source.FeedTitle != "" {
+		target.FeedTitle = source.FeedTitle
+	}
+	if source.FeedDescription != "" {
+		target.FeedDescription = source.FeedDescription
+	}
+	if source.FeedAuthor != "" {
+		target.FeedAuthor = source.FeedAuthor
+	}
+	if source.FeedImageURL != "" {
+		target.FeedImageURL = source.FeedImageURL
+	}
+}


### PR DESCRIPTION
## Summary

- Add `markata-go blogroll update` CLI command to auto-populate blogroll feed metadata
- Fetch metadata from OpenGraph tags, HTML meta tags, and RSS/Atom feeds
- Support `--dry-run`, `--force`, and `--feed` flags for flexible usage

Fixes #264

## Changes

### New Files
- `cmd/markata-go/cmd/blogroll_update.go` - CLI command implementation
- `pkg/blogroll/updater.go` - Metadata extraction logic

### Modified Files
- `pkg/plugins/registry.go` - Register BlogrollPlugin in default plugins
- `cmd/markata-go/cmd/core.go` - Pass blogroll config to lifecycle
- `cmd/markata-go/cmd/benchmark.go` - Pass blogroll config to benchmark manager
- `pkg/config/merge.go` - Merge blogroll config
- `pkg/config/merge_test.go` - Tests for blogroll config merge

## Usage

```bash
# Update all blogroll feeds
markata-go blogroll update

# Preview changes without modifying config
markata-go blogroll update --dry-run

# Overwrite existing metadata
markata-go blogroll update --force

# Update only specific feed by name or URL
markata-go blogroll update --feed=simonwillison
```

## Metadata Sources (Priority Order)

1. **OpenGraph Protocol** - `og:title`, `og:description`, `og:image`, `og:url`
2. **HTML Meta Tags** - `description`, `author`, `twitter:*`
3. **RSS/Atom Feed Metadata** - feed title, description, author, image

## Testing

```bash
go test ./...
golangci-lint run ./...
```