### PR TITLE
fix(tui): run through Collect stage for full data population

### DIFF
--- a/cmd/markata-go/cmd/tui.go
+++ b/cmd/markata-go/cmd/tui.go
@@ -45,8 +45,9 @@ func runTUI(cmd *cobra.Command, _ []string) error {
 	// Create services app
 	app := services.NewApp(manager)
 
-	// Load posts (run through Load stage)
-	if err := app.Build.LoadOnly(cmd.Context()); err != nil {
+	// Load posts through Collect stage for full TUI functionality
+	// This runs Transform (for stats, auto-titles) and Collect (for feeds)
+	if err := app.Build.LoadForTUI(cmd.Context()); err != nil {
 		return fmt.Errorf("failed to load posts: %w", err)
 	}
 

--- a/pkg/services/build_service.go
+++ b/pkg/services/build_service.go
@@ -72,6 +72,12 @@ func (s *buildService) LoadOnly(_ context.Context) error {
 	return s.manager.RunTo(lifecycle.StageLoad)
 }
 
+// LoadForTUI runs through Collect stage for TUI browsing.
+// This includes Transform (for stats, auto-titles) and Collect (for feeds).
+func (s *buildService) LoadForTUI(_ context.Context) error {
+	return s.manager.RunTo(lifecycle.StageCollect)
+}
+
 // Subscribe returns a channel for build progress events.
 func (s *buildService) Subscribe() <-chan BuildEvent {
 	s.mu.Lock()

--- a/pkg/services/interfaces.go
+++ b/pkg/services/interfaces.go
@@ -53,6 +53,10 @@ type BuildService interface {
 	// LoadOnly runs only the load stage (for TUI browsing without full build).
 	LoadOnly(ctx context.Context) error
 
+	// LoadForTUI runs through Collect stage for TUI browsing.
+	// This includes Transform (for stats, titles) and Collect (for feeds).
+	LoadForTUI(ctx context.Context) error
+
 	// Subscribe returns a channel for build progress events.
 	Subscribe() <-chan BuildEvent
 }


### PR DESCRIPTION
## Summary

Fixes #289, #290, #292

The TUI was only running through the Load stage, which meant several plugins never ran:
- **Stats plugin** (word count, reading time) - runs in Transform stage
- **AutoTitle plugin** (generated titles) - runs in Transform stage
- **Feeds plugin** - runs in Collect stage

## Changes

- Add `LoadForTUI()` method to `BuildService` interface
- Implement `LoadForTUI()` in `build_service.go` to run through `StageCollect`
- Update `tui.go` to use `LoadForTUI()` instead of `LoadOnly()`

## Testing

- All tests pass
- golangci-lint passes
- Verified TUI now properly displays:
  - Word counts and reading times in Posts view
  - Generated titles for posts without frontmatter titles
  - Configured feeds in Feeds view