### PR TITLE
fix(blogroll): fix HTML entity decoding and add fallback image service

### DIFF
--- a/pkg/models/blogroll.go
+++ b/pkg/models/blogroll.go
@@ -39,6 +39,12 @@ type BlogrollConfig struct {
 	// PaginationType specifies the pagination strategy (manual, htmx, js)
 	PaginationType PaginationType `json:"pagination_type" yaml:"pagination_type" toml:"pagination_type"`
 
+	// FallbackImageService is an optional URL template for generating fallback images
+	// for entries without images. Use {url} as placeholder for the entry URL.
+	// Example: "https://shots.example.com/shot/?url={url}&width=1200"
+	// If empty, no fallback images are generated (default: "")
+	FallbackImageService string `json:"fallback_image_service" yaml:"fallback_image_service" toml:"fallback_image_service"`
+
 	// Feeds is the list of RSS/Atom feeds to fetch
 	Feeds []ExternalFeedConfig `json:"feeds" yaml:"feeds" toml:"feeds"`
 
@@ -49,18 +55,19 @@ type BlogrollConfig struct {
 // NewBlogrollConfig creates a new BlogrollConfig with default values.
 func NewBlogrollConfig() BlogrollConfig {
 	return BlogrollConfig{
-		Enabled:            false,
-		BlogrollSlug:       "blogroll",
-		ReaderSlug:         "reader",
-		CacheDir:           "cache/blogroll",
-		CacheDuration:      "1h",
-		Timeout:            30,
-		ConcurrentRequests: 5,
-		MaxEntriesPerFeed:  50,
-		ItemsPerPage:       50,
-		OrphanThreshold:    3,
-		PaginationType:     PaginationManual,
-		Feeds:              []ExternalFeedConfig{},
+		Enabled:              false,
+		BlogrollSlug:         "blogroll",
+		ReaderSlug:           "reader",
+		CacheDir:             "cache/blogroll",
+		CacheDuration:        "1h",
+		Timeout:              30,
+		ConcurrentRequests:   5,
+		MaxEntriesPerFeed:    50,
+		ItemsPerPage:         50,
+		OrphanThreshold:      3,
+		PaginationType:       PaginationManual,
+		FallbackImageService: "",
+		Feeds:                []ExternalFeedConfig{},
 		Templates: BlogrollTemplates{
 			Blogroll: "blogroll.html",
 			Reader:   "reader.html",

--- a/pkg/plugins/blogroll_test.go
+++ b/pkg/plugins/blogroll_test.go
@@ -1,0 +1,115 @@
+package plugins
+
+import (
+	"testing"
+)
+
+// =============================================================================
+// extractFirstImageFromHTML Tests
+// =============================================================================
+
+func TestExtractFirstImageFromHTML_BasicImage(t *testing.T) {
+	html := `<p>Some text</p><img src="https://example.com/image.jpg" alt="test">`
+	result := extractFirstImageFromHTML(html)
+	if result != "https://example.com/image.jpg" {
+		t.Errorf("extractFirstImageFromHTML() = %q, want %q", result, "https://example.com/image.jpg")
+	}
+}
+
+func TestExtractFirstImageFromHTML_SingleQuotes(t *testing.T) {
+	html := `<img src='https://example.com/image.png'>`
+	result := extractFirstImageFromHTML(html)
+	if result != "https://example.com/image.png" {
+		t.Errorf("extractFirstImageFromHTML() = %q, want %q", result, "https://example.com/image.png")
+	}
+}
+
+func TestExtractFirstImageFromHTML_NoImage(t *testing.T) {
+	html := `<p>No images here</p>`
+	result := extractFirstImageFromHTML(html)
+	if result != "" {
+		t.Errorf("extractFirstImageFromHTML() = %q, want empty string", result)
+	}
+}
+
+func TestExtractFirstImageFromHTML_HTMLEntities(t *testing.T) {
+	// This tests the bug fix for Atom feeds that encode content as HTML entities
+	html := `&lt;p&gt;Some text&lt;/p&gt;&lt;img src="https://example.com/atom-image.jpg" alt="test"&gt;`
+	result := extractFirstImageFromHTML(html)
+	if result != "https://example.com/atom-image.jpg" {
+		t.Errorf("extractFirstImageFromHTML() with HTML entities = %q, want %q", result, "https://example.com/atom-image.jpg")
+	}
+}
+
+func TestExtractFirstImageFromHTML_NestedHTMLEntities(t *testing.T) {
+	// Test deeply encoded content (edge case)
+	html := `&lt;img src=&quot;https://example.com/deeply-encoded.jpg&quot;&gt;`
+	result := extractFirstImageFromHTML(html)
+	if result != "https://example.com/deeply-encoded.jpg" {
+		t.Errorf("extractFirstImageFromHTML() with nested entities = %q, want %q", result, "https://example.com/deeply-encoded.jpg")
+	}
+}
+
+func TestExtractFirstImageFromHTML_MultipleImages(t *testing.T) {
+	// Should return the first image only
+	html := `<img src="first.jpg"><img src="second.jpg">`
+	result := extractFirstImageFromHTML(html)
+	if result != "first.jpg" {
+		t.Errorf("extractFirstImageFromHTML() = %q, want %q", result, "first.jpg")
+	}
+}
+
+// =============================================================================
+// generateFallbackImageURL Tests
+// =============================================================================
+
+func TestGenerateFallbackImageURL_Basic(t *testing.T) {
+	template := "https://shots.example.com/shot/?url={url}&width=1200"
+	entryURL := "https://blog.example.com/my-post"
+	result := generateFallbackImageURL(template, entryURL)
+	expected := "https://shots.example.com/shot/?url=https%3A%2F%2Fblog.example.com%2Fmy-post&width=1200"
+	if result != expected {
+		t.Errorf("generateFallbackImageURL() = %q, want %q", result, expected)
+	}
+}
+
+func TestGenerateFallbackImageURL_WithSpecialChars(t *testing.T) {
+	template := "https://screenshot.service/{url}"
+	entryURL := "https://example.com/post?foo=bar&baz=qux"
+	result := generateFallbackImageURL(template, entryURL)
+	expected := "https://screenshot.service/https%3A%2F%2Fexample.com%2Fpost%3Ffoo%3Dbar%26baz%3Dqux"
+	if result != expected {
+		t.Errorf("generateFallbackImageURL() = %q, want %q", result, expected)
+	}
+}
+
+func TestGenerateFallbackImageURL_NoPlaceholder(t *testing.T) {
+	// If template has no {url} placeholder, return as-is
+	template := "https://default-image.com/fallback.png"
+	entryURL := "https://blog.example.com/post"
+	result := generateFallbackImageURL(template, entryURL)
+	if result != template {
+		t.Errorf("generateFallbackImageURL() = %q, want %q", result, template)
+	}
+}
+
+func TestGenerateFallbackImageURL_EmptyEntryURL(t *testing.T) {
+	template := "https://shots.example.com/?url={url}"
+	entryURL := ""
+	result := generateFallbackImageURL(template, entryURL)
+	expected := "https://shots.example.com/?url="
+	if result != expected {
+		t.Errorf("generateFallbackImageURL() = %q, want %q", result, expected)
+	}
+}
+
+func TestGenerateFallbackImageURL_URLWithUnicode(t *testing.T) {
+	template := "https://shots.example.com/?url={url}"
+	entryURL := "https://example.com/post/日本語"
+	result := generateFallbackImageURL(template, entryURL)
+	// Unicode characters should be percent-encoded
+	expected := "https://shots.example.com/?url=https%3A%2F%2Fexample.com%2Fpost%2F%E6%97%A5%E6%9C%AC%E8%AA%9E"
+	if result != expected {
+		t.Errorf("generateFallbackImageURL() = %q, want %q", result, expected)
+	}
+}

--- a/pkg/plugins/feed_parser.go
+++ b/pkg/plugins/feed_parser.go
@@ -3,6 +3,7 @@ package plugins
 import (
 	"encoding/xml"
 	"fmt"
+	"html"
 	"io"
 	"net/http"
 	"regexp"
@@ -471,7 +472,9 @@ var imgSrcPattern = regexp.MustCompile(`<img[^>]+src=["']([^"']+)["']`)
 
 // extractFirstImageFromHTML extracts the first image URL from HTML content.
 func extractFirstImageFromHTML(htmlContent string) string {
-	matches := imgSrcPattern.FindStringSubmatch(htmlContent)
+	// Unescape HTML entities (Atom feeds encode content as &lt;img&gt;)
+	unescaped := html.UnescapeString(htmlContent)
+	matches := imgSrcPattern.FindStringSubmatch(unescaped)
 	if len(matches) >= 2 {
 		return matches[1]
 	}


### PR DESCRIPTION
## Summary

Fixes #296

Two improvements to the blogroll/reader feature:

### 1. Bug Fix: HTML Entity Decoding

Atom feeds encode their HTML content as entities (`&lt;img` instead of `<img`). The `extractFirstImageFromHTML` function now unescapes HTML entities before applying the regex.

### 2. Feature: Fallback Image Service

Added `FallbackImageService` config option for generating preview images for entries without images:

```toml
[blogroll]
fallback_image_service = "https://shots.example.com/shot/?url={url}&width=1200"
```

The `{url}` placeholder is replaced with the URL-encoded entry URL.

## Changes

- `pkg/plugins/feed_parser.go` - Added HTML unescaping in `extractFirstImageFromHTML`
- `pkg/models/blogroll.go` - Added `FallbackImageService` field to config
- `pkg/plugins/blogroll.go` - Implemented fallback image URL generation
- `pkg/plugins/blogroll_test.go` - Added 11 new tests

## Tests

- 6 tests for `extractFirstImageFromHTML` (including HTML entity handling)
- 5 tests for `generateFallbackImageURL` (URL encoding, special characters, etc.)

All tests pass.