### PR TITLE
feat(blogroll): add duplicate detection and primary/secondary feed support

### DIFF
--- a/pkg/lint/blogroll.go
+++ b/pkg/lint/blogroll.go
@@ -1,0 +1,179 @@
+// Package lint provides linting functionality for markata-go.
+// This file contains blogroll-specific lint checks.
+package lint
+
+import (
+	"fmt"
+
+	"github.com/WaylonWalker/markata-go/pkg/models"
+)
+
+// BlogrollIssue represents a linting issue found in blogroll configuration.
+type BlogrollIssue struct {
+	Code     string   // Issue code (e.g., "LBL001")
+	Severity Severity // Severity level
+	Message  string   // Human-readable message
+	FeedURL  string   // Feed URL where issue was found (if applicable)
+	Handle   string   // Handle involved (if applicable)
+}
+
+// BlogrollResult contains the linting results for blogroll configuration.
+type BlogrollResult struct {
+	Issues []BlogrollIssue
+}
+
+// HasErrors returns true if any issues are errors.
+func (r *BlogrollResult) HasErrors() bool {
+	for _, issue := range r.Issues {
+		if issue.Severity == SeverityError {
+			return true
+		}
+	}
+	return false
+}
+
+// ErrorCount returns the number of error-severity issues.
+func (r *BlogrollResult) ErrorCount() int {
+	count := 0
+	for _, issue := range r.Issues {
+		if issue.Severity == SeverityError {
+			count++
+		}
+	}
+	return count
+}
+
+// WarningCount returns the number of warning-severity issues.
+func (r *BlogrollResult) WarningCount() int {
+	count := 0
+	for _, issue := range r.Issues {
+		if issue.Severity == SeverityWarning {
+			count++
+		}
+	}
+	return count
+}
+
+// Blogroll checks blogroll configuration for common issues.
+// Returns a BlogrollResult containing all issues found.
+//
+// Supported checks:
+//   - LBL001: Duplicate Handle Detection - errors if same handle appears multiple times
+//   - LBL002: Duplicate URL Detection - errors if same feed URL appears multiple times
+//   - LBL003: Primary Person Validation - errors if primary_person references non-existent handle
+func Blogroll(config *models.BlogrollConfig) *BlogrollResult {
+	result := &BlogrollResult{}
+
+	if config == nil || len(config.Feeds) == 0 {
+		return result
+	}
+
+	// LBL001: Check for duplicate handles
+	result.Issues = append(result.Issues, checkDuplicateHandles(config.Feeds)...)
+
+	// LBL002: Check for duplicate URLs
+	result.Issues = append(result.Issues, checkDuplicateURLs(config.Feeds)...)
+
+	// LBL003: Check primary_person references
+	result.Issues = append(result.Issues, checkPrimaryPersonRefs(config.Feeds)...)
+
+	return result
+}
+
+// checkDuplicateHandles detects duplicate handles in feed configurations.
+// LBL001: Duplicate Handle Detection
+func checkDuplicateHandles(feeds []models.ExternalFeedConfig) []BlogrollIssue {
+	var issues []BlogrollIssue
+	handleSeen := make(map[string]string) // handle -> first feed URL
+
+	for i := range feeds {
+		feed := &feeds[i]
+		if feed.Handle == "" {
+			continue
+		}
+
+		if firstURL, exists := handleSeen[feed.Handle]; exists {
+			issues = append(issues, BlogrollIssue{
+				Code:     "LBL001",
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("duplicate handle '%s' (first used by %s)", feed.Handle, firstURL),
+				FeedURL:  feed.URL,
+				Handle:   feed.Handle,
+			})
+		} else {
+			handleSeen[feed.Handle] = feed.URL
+		}
+	}
+
+	return issues
+}
+
+// checkDuplicateURLs detects duplicate feed URLs in configuration.
+// LBL002: Duplicate URL Detection
+func checkDuplicateURLs(feeds []models.ExternalFeedConfig) []BlogrollIssue {
+	var issues []BlogrollIssue
+	urlSeen := make(map[string]string) // URL -> handle (or title if no handle)
+
+	for i := range feeds {
+		feed := &feeds[i]
+		if feed.URL == "" {
+			continue
+		}
+
+		identifier := feed.Handle
+		if identifier == "" {
+			identifier = feed.Title
+		}
+		if identifier == "" {
+			identifier = feed.URL
+		}
+
+		if firstIdentifier, exists := urlSeen[feed.URL]; exists {
+			issues = append(issues, BlogrollIssue{
+				Code:     "LBL002",
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("duplicate feed URL '%s' (first used by %s)", feed.URL, firstIdentifier),
+				FeedURL:  feed.URL,
+				Handle:   feed.Handle,
+			})
+		} else {
+			urlSeen[feed.URL] = identifier
+		}
+	}
+
+	return issues
+}
+
+// checkPrimaryPersonRefs validates that primary_person references exist.
+// LBL003: Primary Person Validation
+func checkPrimaryPersonRefs(feeds []models.ExternalFeedConfig) []BlogrollIssue {
+	var issues []BlogrollIssue
+
+	// Build set of valid handles
+	validHandles := make(map[string]bool)
+	for i := range feeds {
+		if feeds[i].Handle != "" {
+			validHandles[feeds[i].Handle] = true
+		}
+	}
+
+	// Check primary_person references
+	for i := range feeds {
+		feed := &feeds[i]
+		if feed.PrimaryPerson == "" {
+			continue
+		}
+
+		if !validHandles[feed.PrimaryPerson] {
+			issues = append(issues, BlogrollIssue{
+				Code:     "LBL003",
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("primary_person '%s' references non-existent handle", feed.PrimaryPerson),
+				FeedURL:  feed.URL,
+				Handle:   feed.Handle,
+			})
+		}
+	}
+
+	return issues
+}

--- a/pkg/lint/blogroll_test.go
+++ b/pkg/lint/blogroll_test.go
@@ -1,0 +1,326 @@
+package lint
+
+import (
+	"testing"
+
+	"github.com/WaylonWalker/markata-go/pkg/models"
+)
+
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+func TestBlogroll_DuplicateHandles(t *testing.T) {
+	tests := []struct {
+		name     string
+		feeds    []models.ExternalFeedConfig
+		wantLen  int
+		wantCode string
+	}{
+		{
+			name: "no duplicates",
+			feeds: []models.ExternalFeedConfig{
+				{URL: "https://example.com/feed.xml", Handle: "example"},
+				{URL: "https://other.com/feed.xml", Handle: "other"},
+			},
+			wantLen: 0,
+		},
+		{
+			name: "duplicate handle",
+			feeds: []models.ExternalFeedConfig{
+				{URL: "https://example.com/feed.xml", Handle: "example"},
+				{URL: "https://other.com/feed.xml", Handle: "example"},
+			},
+			wantLen:  1,
+			wantCode: "LBL001",
+		},
+		{
+			name: "multiple duplicate handles",
+			feeds: []models.ExternalFeedConfig{
+				{URL: "https://a.com/feed.xml", Handle: "example"},
+				{URL: "https://b.com/feed.xml", Handle: "example"},
+				{URL: "https://c.com/feed.xml", Handle: "example"},
+			},
+			wantLen:  2, // 2 duplicates of first
+			wantCode: "LBL001",
+		},
+		{
+			name: "empty handles not considered duplicates",
+			feeds: []models.ExternalFeedConfig{
+				{URL: "https://a.com/feed.xml", Handle: ""},
+				{URL: "https://b.com/feed.xml", Handle: ""},
+			},
+			wantLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &models.BlogrollConfig{Feeds: tt.feeds}
+			result := Blogroll(config)
+
+			var handleIssues []BlogrollIssue
+			for _, issue := range result.Issues {
+				if issue.Code == "LBL001" {
+					handleIssues = append(handleIssues, issue)
+				}
+			}
+
+			if len(handleIssues) != tt.wantLen {
+				t.Errorf("got %d LBL001 issues, want %d", len(handleIssues), tt.wantLen)
+			}
+
+			if tt.wantLen > 0 && handleIssues[0].Code != tt.wantCode {
+				t.Errorf("got code %q, want %q", handleIssues[0].Code, tt.wantCode)
+			}
+		})
+	}
+}
+
+func TestBlogroll_DuplicateURLs(t *testing.T) {
+	tests := []struct {
+		name     string
+		feeds    []models.ExternalFeedConfig
+		wantLen  int
+		wantCode string
+	}{
+		{
+			name: "no duplicates",
+			feeds: []models.ExternalFeedConfig{
+				{URL: "https://example.com/feed.xml"},
+				{URL: "https://other.com/feed.xml"},
+			},
+			wantLen: 0,
+		},
+		{
+			name: "duplicate URL",
+			feeds: []models.ExternalFeedConfig{
+				{URL: "https://example.com/feed.xml", Handle: "first"},
+				{URL: "https://example.com/feed.xml", Handle: "second"},
+			},
+			wantLen:  1,
+			wantCode: "LBL002",
+		},
+		{
+			name: "empty URLs not considered duplicates",
+			feeds: []models.ExternalFeedConfig{
+				{URL: "", Handle: "first"},
+				{URL: "", Handle: "second"},
+			},
+			wantLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &models.BlogrollConfig{Feeds: tt.feeds}
+			result := Blogroll(config)
+
+			var urlIssues []BlogrollIssue
+			for _, issue := range result.Issues {
+				if issue.Code == "LBL002" {
+					urlIssues = append(urlIssues, issue)
+				}
+			}
+
+			if len(urlIssues) != tt.wantLen {
+				t.Errorf("got %d LBL002 issues, want %d", len(urlIssues), tt.wantLen)
+			}
+
+			if tt.wantLen > 0 && urlIssues[0].Code != tt.wantCode {
+				t.Errorf("got code %q, want %q", urlIssues[0].Code, tt.wantCode)
+			}
+		})
+	}
+}
+
+func TestBlogroll_PrimaryPersonValidation(t *testing.T) {
+	tests := []struct {
+		name     string
+		feeds    []models.ExternalFeedConfig
+		wantLen  int
+		wantCode string
+	}{
+		{
+			name: "valid primary_person reference",
+			feeds: []models.ExternalFeedConfig{
+				{URL: "https://dave.com/feed.xml", Handle: "daverupert", Primary: boolPtr(true)},
+				{URL: "https://dave.social/feed.xml", Handle: "davesocial", PrimaryPerson: "daverupert"},
+			},
+			wantLen: 0,
+		},
+		{
+			name: "invalid primary_person reference",
+			feeds: []models.ExternalFeedConfig{
+				{URL: "https://dave.social/feed.xml", Handle: "davesocial", PrimaryPerson: "nonexistent"},
+			},
+			wantLen:  1,
+			wantCode: "LBL003",
+		},
+		{
+			name: "empty primary_person is valid",
+			feeds: []models.ExternalFeedConfig{
+				{URL: "https://example.com/feed.xml", Handle: "example", PrimaryPerson: ""},
+			},
+			wantLen: 0,
+		},
+		{
+			name: "multiple invalid references",
+			feeds: []models.ExternalFeedConfig{
+				{URL: "https://a.com/feed.xml", Handle: "a", PrimaryPerson: "missing1"},
+				{URL: "https://b.com/feed.xml", Handle: "b", PrimaryPerson: "missing2"},
+			},
+			wantLen:  2,
+			wantCode: "LBL003",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &models.BlogrollConfig{Feeds: tt.feeds}
+			result := Blogroll(config)
+
+			var primaryIssues []BlogrollIssue
+			for _, issue := range result.Issues {
+				if issue.Code == "LBL003" {
+					primaryIssues = append(primaryIssues, issue)
+				}
+			}
+
+			if len(primaryIssues) != tt.wantLen {
+				t.Errorf("got %d LBL003 issues, want %d", len(primaryIssues), tt.wantLen)
+			}
+
+			if tt.wantLen > 0 && primaryIssues[0].Code != tt.wantCode {
+				t.Errorf("got code %q, want %q", primaryIssues[0].Code, tt.wantCode)
+			}
+		})
+	}
+}
+
+func TestBlogroll_NilConfig(t *testing.T) {
+	result := Blogroll(nil)
+	if len(result.Issues) != 0 {
+		t.Errorf("expected no issues for nil config, got %d", len(result.Issues))
+	}
+}
+
+func TestBlogroll_EmptyFeeds(t *testing.T) {
+	config := &models.BlogrollConfig{Feeds: []models.ExternalFeedConfig{}}
+	result := Blogroll(config)
+	if len(result.Issues) != 0 {
+		t.Errorf("expected no issues for empty feeds, got %d", len(result.Issues))
+	}
+}
+
+func TestBlogrollResult_HasErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		issues []BlogrollIssue
+		want   bool
+	}{
+		{
+			name:   "no issues",
+			issues: nil,
+			want:   false,
+		},
+		{
+			name:   "only warnings",
+			issues: []BlogrollIssue{{Code: "LBL001", Severity: SeverityWarning}},
+			want:   false,
+		},
+		{
+			name:   "has error",
+			issues: []BlogrollIssue{{Code: "LBL001", Severity: SeverityError}},
+			want:   true,
+		},
+		{
+			name: "mixed",
+			issues: []BlogrollIssue{
+				{Code: "LBL001", Severity: SeverityWarning},
+				{Code: "LBL002", Severity: SeverityError},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &BlogrollResult{Issues: tt.issues}
+			if got := r.HasErrors(); got != tt.want {
+				t.Errorf("HasErrors() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBlogrollResult_ErrorCount(t *testing.T) {
+	result := &BlogrollResult{
+		Issues: []BlogrollIssue{
+			{Code: "LBL001", Severity: SeverityError},
+			{Code: "LBL002", Severity: SeverityWarning},
+			{Code: "LBL003", Severity: SeverityError},
+		},
+	}
+
+	if got := result.ErrorCount(); got != 2 {
+		t.Errorf("ErrorCount() = %d, want 2", got)
+	}
+}
+
+func TestBlogrollResult_WarningCount(t *testing.T) {
+	result := &BlogrollResult{
+		Issues: []BlogrollIssue{
+			{Code: "LBL001", Severity: SeverityError},
+			{Code: "LBL002", Severity: SeverityWarning},
+			{Code: "LBL003", Severity: SeverityWarning},
+		},
+	}
+
+	if got := result.WarningCount(); got != 2 {
+		t.Errorf("WarningCount() = %d, want 2", got)
+	}
+}
+
+func TestExternalFeedConfig_IsPrimary(t *testing.T) {
+	tests := []struct {
+		name string
+		feed models.ExternalFeedConfig
+		want bool
+	}{
+		{
+			name: "default is primary",
+			feed: models.ExternalFeedConfig{URL: "https://example.com/feed.xml"},
+			want: true,
+		},
+		{
+			name: "explicit primary true",
+			feed: models.ExternalFeedConfig{URL: "https://example.com/feed.xml", Primary: boolPtr(true)},
+			want: true,
+		},
+		{
+			name: "explicit primary false",
+			feed: models.ExternalFeedConfig{URL: "https://example.com/feed.xml", Primary: boolPtr(false)},
+			want: false,
+		},
+		{
+			name: "has primary_person without explicit primary",
+			feed: models.ExternalFeedConfig{URL: "https://example.com/feed.xml", PrimaryPerson: "someone"},
+			want: false,
+		},
+		{
+			name: "has primary_person with explicit primary true",
+			feed: models.ExternalFeedConfig{URL: "https://example.com/feed.xml", PrimaryPerson: "someone", Primary: boolPtr(true)},
+			want: true, // Explicit value wins
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.feed.IsPrimary()
+			if got != tt.want {
+				t.Errorf("IsPrimary() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/models/blogroll.go
+++ b/pkg/models/blogroll.go
@@ -116,6 +116,15 @@ type ExternalFeedConfig struct {
 
 	// MaxEntries overrides the global max_entries_per_feed for this feed
 	MaxEntries *int `json:"max_entries,omitempty" yaml:"max_entries,omitempty" toml:"max_entries,omitempty"`
+
+	// Primary marks this as the canonical/primary feed for a person (default: true for entries without PrimaryPerson)
+	// When a person has multiple feeds, mark the main one as primary=true
+	Primary *bool `json:"primary,omitempty" yaml:"primary,omitempty" toml:"primary,omitempty"`
+
+	// PrimaryPerson links this feed to a primary person's handle
+	// Use this to associate secondary feeds (e.g., social accounts) with a primary person
+	// Example: If "daverupert" is the primary handle, set primary_person="daverupert" on secondary feeds
+	PrimaryPerson string `json:"primary_person" yaml:"primary_person" toml:"primary_person"`
 }
 
 // IsActive returns whether the feed is active (defaults to true).
@@ -132,6 +141,20 @@ func (f *ExternalFeedConfig) GetMaxEntries(globalDefault int) int {
 		return *f.MaxEntries
 	}
 	return globalDefault
+}
+
+// IsPrimary returns whether this is a primary feed (defaults to true if PrimaryPerson is not set).
+func (f *ExternalFeedConfig) IsPrimary() bool {
+	// If explicit primary value is set, use it
+	if f.Primary != nil {
+		return *f.Primary
+	}
+	// If linked to a primary person, this is secondary (not primary)
+	if f.PrimaryPerson != "" {
+		return false
+	}
+	// Default to primary
+	return true
 }
 
 // ExternalFeed represents a fetched and parsed external RSS/Atom feed.


### PR DESCRIPTION
## Summary

Fixes #301

Adds comprehensive duplicate detection and primary/secondary feed system to blogroll configuration and linting.

## Example Configuration

```toml
[[blogroll.feeds]]
url = "https://daverupert.com/feed.xml"
title = "Dave Rupert"
handle = "daverupert"
primary = true  # Mark as primary feed

[[blogroll.feeds]]
url = "https://dave.social/feed.xml"
title = "Dave Rupert (Social)"
handle = "davesocial"
primary_person = "daverupert"  # Link to primary person
```

## Lint Checks Added

| Code | Name | Severity |
|------|------|----------|
| LBL001 | Duplicate Handle Detection | Error |
| LBL002 | Duplicate URL Detection | Error |
| LBL003 | Primary Person Validation | Error |

## Changes

- `pkg/models/blogroll.go` - Added `Primary` and `PrimaryPerson` fields
- `pkg/lint/blogroll.go` - New blogroll-specific lint checks
- `pkg/lint/blogroll_test.go` - Comprehensive tests

## Features

- Detect duplicate handles across feeds
- Detect duplicate feed URLs
- Validate primary_person references exist
- Smart defaulting: entries without primary_person default to primary=true