### PR TITLE
feat(perf): add benchmarks and profiling documentation

### DIFF
--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -122,6 +122,7 @@ For developers who want full control and customization.
 ### Advanced
 - [Plugin Development](/docs/guides/plugin-development/) - Creating custom plugins
 - [Migration](/docs/guides/migration/) - Migrating from other static site generators
+- [Performance and Profiling](/docs/guides/performance/) - Benchmarking and profiling builds
 
 ---
 

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -1,0 +1,335 @@
+---
+title: "Performance and Profiling"
+description: "Guide to benchmarking and profiling markata-go build performance"
+date: 2026-01-24
+published: true
+tags:
+  - performance
+  - benchmarking
+  - profiling
+  - advanced
+---
+
+# Performance and Profiling
+
+This guide covers benchmarking and profiling tools for analyzing and optimizing markata-go build performance.
+
+## Running Benchmarks
+
+markata-go includes comprehensive benchmarks for key build stages. Use Go's built-in benchmarking tools to measure performance.
+
+### Quick Start
+
+```bash
+# Run all benchmarks
+go test -bench=. ./...
+
+# Run benchmarks with memory statistics
+go test -bench=. -benchmem ./...
+
+# Run specific package benchmarks
+go test -bench=. ./pkg/lifecycle/
+go test -bench=. ./pkg/plugins/
+go test -bench=. ./pkg/config/
+```
+
+### Benchmark Output
+
+Benchmark results show operations per second and time per operation:
+
+```
+BenchmarkRenderMarkdown_ColdStart-8    	     100	  12345678 ns/op	  1234567 B/op	   12345 allocs/op
+```
+
+| Column | Meaning |
+|--------|---------|
+| `-8` | Number of CPU cores used |
+| `100` | Number of iterations |
+| `12345678 ns/op` | Time per operation in nanoseconds |
+| `1234567 B/op` | Bytes allocated per operation |
+| `12345 allocs/op` | Memory allocations per operation |
+
+### Comparing Benchmarks
+
+To compare performance between versions or changes:
+
+```bash
+# Install benchstat
+go install golang.org/x/perf/cmd/benchstat@latest
+
+# Run benchmarks and save results
+go test -bench=. -count=10 ./pkg/lifecycle/ > old.txt
+
+# Make changes, then run again
+go test -bench=. -count=10 ./pkg/lifecycle/ > new.txt
+
+# Compare results
+benchstat old.txt new.txt
+```
+
+## Available Benchmarks
+
+### Lifecycle Benchmarks (`pkg/lifecycle/`)
+
+| Benchmark | Description |
+|-----------|-------------|
+| `BenchmarkManager_ColdStart` | Full build with no cache |
+| `BenchmarkManager_HotCache` | Build with warm cache |
+| `BenchmarkManager_GlobStage` | File discovery phase |
+| `BenchmarkManager_LoadStage` | File loading and parsing |
+| `BenchmarkProcessPostsConcurrently` | Concurrent processing at various levels |
+| `BenchmarkFilter` | Filter expression evaluation |
+| `BenchmarkMemoryCache` | Cache operations (set/get) |
+| `BenchmarkPluginSorting` | Plugin priority sorting |
+
+### Plugin Benchmarks (`pkg/plugins/`)
+
+| Benchmark | Description |
+|-----------|-------------|
+| `BenchmarkRenderMarkdown_ColdStart` | Fresh markdown renderer |
+| `BenchmarkRenderMarkdown_HotCache` | Reused markdown renderer |
+| `BenchmarkRenderMarkdown_ContentSizes` | Different content sizes |
+| `BenchmarkRenderMarkdown_SyntaxHighlighting` | Code block rendering |
+| `BenchmarkParseFrontmatter` | Frontmatter parsing |
+| `BenchmarkGlob` | File globbing |
+| `BenchmarkGlob_WithGitignore` | Globbing with .gitignore |
+| `BenchmarkLoad` | File loading |
+| `BenchmarkLoad_Concurrency` | Loading at various concurrency levels |
+| `BenchmarkTemplateEngine` | Template rendering |
+| `BenchmarkPublishHTML_Write` | HTML file writing |
+
+### Config Benchmarks (`pkg/config/`)
+
+| Benchmark | Description |
+|-----------|-------------|
+| `BenchmarkLoad_TOML` | TOML config loading |
+| `BenchmarkLoad_YAML` | YAML config loading |
+| `BenchmarkLoad_JSON` | JSON config loading |
+| `BenchmarkLoadAndValidate` | Load with validation |
+| `BenchmarkParseTOML` | Raw TOML parsing |
+| `BenchmarkParseYAML` | Raw YAML parsing |
+| `BenchmarkParseJSON` | Raw JSON parsing |
+| `BenchmarkMergeConfigs` | Config merging |
+| `BenchmarkValidateConfig` | Config validation |
+
+## CPU Profiling
+
+Generate CPU profiles to identify performance bottlenecks.
+
+### Generate Profile
+
+```bash
+# Profile all benchmarks
+go test -bench=. -cpuprofile=cpu.prof ./pkg/lifecycle/
+
+# Profile specific benchmark
+go test -bench=BenchmarkManager_ColdStart -cpuprofile=cpu.prof ./pkg/lifecycle/
+```
+
+### Analyze Profile
+
+```bash
+# Interactive CLI
+go tool pprof cpu.prof
+
+# Common commands in pprof:
+# top10        - Show top 10 functions by CPU time
+# top20 -cum   - Top 20 by cumulative time
+# list funcName - Show source for a function
+# web          - Open flame graph in browser (requires graphviz)
+
+# Direct web interface
+go tool pprof -http=:8080 cpu.prof
+```
+
+### Example Session
+
+```bash
+$ go tool pprof cpu.prof
+(pprof) top10
+Showing nodes accounting for 1.5s, 75% of 2s total
+      flat  flat%   sum%        cum   cum%
+     0.5s   25%    25%       0.8s    40%  goldmark/renderer.(*Renderer).Render
+     0.3s   15%    40%       0.3s    15%  yaml.unmarshal
+     0.2s   10%    50%       0.4s    20%  regexp.(*Regexp).FindAllStringIndex
+     ...
+```
+
+## Memory Profiling
+
+Track memory allocations and identify potential memory leaks.
+
+### Generate Profile
+
+```bash
+# Memory profile
+go test -bench=. -memprofile=mem.prof ./pkg/lifecycle/
+
+# With allocation count
+go test -bench=. -memprofile=mem.prof -memprofilerate=1 ./pkg/lifecycle/
+```
+
+### Analyze Profile
+
+```bash
+# View allocations
+go tool pprof -alloc_space mem.prof
+
+# View allocation count
+go tool pprof -alloc_objects mem.prof
+
+# In-use memory (useful for finding leaks)
+go tool pprof -inuse_space mem.prof
+```
+
+## Trace Profiling
+
+Generate execution traces for detailed timing analysis.
+
+```bash
+# Generate trace
+go test -bench=BenchmarkManager_ColdStart -trace=trace.out ./pkg/lifecycle/
+
+# View trace (opens in browser)
+go tool trace trace.out
+```
+
+The trace viewer shows:
+- Goroutine scheduling
+- GC events
+- Network/system calls
+- Blocking operations
+
+## Performance Tips
+
+### 1. Concurrency Settings
+
+Adjust `concurrency` in your config for optimal performance:
+
+```toml
+[markata-go]
+concurrency = 8  # Tune based on your CPU cores and I/O
+```
+
+**Benchmark different values:**
+```bash
+go test -bench=BenchmarkLoad_Concurrency ./pkg/plugins/
+```
+
+### 2. Reduce File I/O
+
+- Use `.gitignore` patterns to skip unnecessary files
+- Limit glob patterns to only necessary directories
+
+```toml
+[markata-go.glob]
+patterns = ["posts/**/*.md"]  # Be specific
+use_gitignore = true
+```
+
+### 3. Template Caching
+
+Templates are automatically cached after first use. For best results:
+- Minimize template complexity
+- Use template inheritance efficiently
+- Avoid heavy computations in templates
+
+### 4. Markdown Rendering
+
+Markdown rendering is typically the slowest stage. Optimize by:
+- Keeping posts reasonably sized
+- Using syntax highlighting only when needed
+- Avoiding deeply nested structures
+
+### 5. Build Caching
+
+The manager caches data between stages. For incremental builds:
+- Cache is cleared on each build by default
+- Hot cache significantly improves rebuild times
+
+## Continuous Performance Monitoring
+
+### GitHub Actions Benchmark
+
+Add benchmark comparison to your CI:
+
+```yaml
+name: Benchmarks
+on: [push, pull_request]
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Run benchmarks
+        run: go test -bench=. -benchmem ./... | tee bench.txt
+
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: bench.txt
+```
+
+### Local Performance Script
+
+Create a script for regular performance checks:
+
+```bash
+#!/bin/bash
+# scripts/benchmark.sh
+
+echo "Running markata-go benchmarks..."
+
+# Run benchmarks
+go test -bench=. -benchmem -count=5 ./pkg/lifecycle/ | tee lifecycle.txt
+go test -bench=. -benchmem -count=5 ./pkg/plugins/ | tee plugins.txt
+go test -bench=. -benchmem -count=5 ./pkg/config/ | tee config.txt
+
+echo ""
+echo "Results saved to:"
+echo "  - lifecycle.txt"
+echo "  - plugins.txt"
+echo "  - config.txt"
+```
+
+## Interpreting Results
+
+### What's "Fast Enough"?
+
+Typical performance targets:
+
+| Stage | Target | Notes |
+|-------|--------|-------|
+| Config loading | < 10ms | One-time cost |
+| Globbing (100 files) | < 50ms | Scales with file count |
+| Loading (100 files) | < 200ms | I/O bound |
+| Markdown render (100 posts) | < 500ms | CPU bound |
+| Template render (100 posts) | < 200ms | Cached templates |
+| Write (100 files) | < 100ms | I/O bound |
+
+### Common Bottlenecks
+
+1. **Markdown rendering** - Usually the slowest stage
+2. **Syntax highlighting** - Expensive for code-heavy content
+3. **File I/O** - Disk speed matters for large sites
+4. **Memory allocations** - High allocation count slows GC
+
+### Red Flags
+
+- `B/op` > 10MB per operation for small content
+- `allocs/op` > 10000 for simple operations
+- Linear time growth that should be constant
+- Memory not being released (check with `-inuse_space`)
+
+## Further Reading
+
+- [Go Testing and Benchmarking](https://pkg.go.dev/testing)
+- [pprof Documentation](https://github.com/google/pprof)
+- [Go Execution Tracer](https://pkg.go.dev/runtime/trace)
+- [benchstat Tool](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat)

--- a/pkg/config/benchmark_test.go
+++ b/pkg/config/benchmark_test.go
@@ -1,0 +1,429 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// BenchmarkLoad_TOML measures TOML config loading performance.
+func BenchmarkLoad_TOML(b *testing.B) {
+	dir := b.TempDir()
+	configPath := filepath.Join(dir, "markata-go.toml")
+	content := generateTOMLConfig()
+	//nolint:gosec // G306: test files don't need restrictive permissions
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := Load(configPath)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkLoad_YAML measures YAML config loading performance.
+func BenchmarkLoad_YAML(b *testing.B) {
+	dir := b.TempDir()
+	configPath := filepath.Join(dir, "markata-go.yaml")
+	content := generateYAMLConfig()
+	//nolint:gosec // G306: test files don't need restrictive permissions
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := Load(configPath)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkLoad_JSON measures JSON config loading performance.
+func BenchmarkLoad_JSON(b *testing.B) {
+	dir := b.TempDir()
+	configPath := filepath.Join(dir, "markata-go.json")
+	content := generateJSONConfig()
+	//nolint:gosec // G306: test files don't need restrictive permissions
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := Load(configPath)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkLoadAndValidate measures config loading with validation.
+func BenchmarkLoadAndValidate(b *testing.B) {
+	dir := b.TempDir()
+	configPath := filepath.Join(dir, "markata-go.toml")
+	content := generateTOMLConfig()
+	//nolint:gosec // G306: test files don't need restrictive permissions
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, err := LoadAndValidate(configPath)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkLoadWithDefaults measures loading config with all defaults.
+func BenchmarkLoadWithDefaults(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, err := LoadWithDefaults()
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkDefaultConfig measures creating the default config.
+func BenchmarkDefaultConfig(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = DefaultConfig()
+	}
+}
+
+// BenchmarkMergeConfigs measures config merging performance.
+func BenchmarkMergeConfigs(b *testing.B) {
+	base := DefaultConfig()
+	override := DefaultConfig()
+	override.OutputDir = "public"
+	override.Title = "My Site"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = MergeConfigs(base, override)
+	}
+}
+
+// BenchmarkValidateConfig measures config validation performance.
+func BenchmarkValidateConfig(b *testing.B) {
+	config := DefaultConfig()
+	config.OutputDir = "public"
+	config.URL = "https://example.com"
+	config.Title = "My Site"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = ValidateConfig(config)
+	}
+}
+
+// BenchmarkParseTOML measures raw TOML parsing performance.
+func BenchmarkParseTOML(b *testing.B) {
+	content := []byte(generateTOMLConfig())
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := ParseTOML(content)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkParseYAML measures raw YAML parsing performance.
+func BenchmarkParseYAML(b *testing.B) {
+	content := []byte(generateYAMLConfig())
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := ParseYAML(content)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkParseJSON measures raw JSON parsing performance.
+func BenchmarkParseJSON(b *testing.B) {
+	content := []byte(generateJSONConfig())
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := ParseJSON(content)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkLoad_ComplexConfig measures loading a complex config with many feeds.
+func BenchmarkLoad_ComplexConfig(b *testing.B) {
+	dir := b.TempDir()
+	configPath := filepath.Join(dir, "markata-go.toml")
+	content := generateComplexTOMLConfig()
+	//nolint:gosec // G306: test files don't need restrictive permissions
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := Load(configPath)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkDiscover measures config file discovery performance.
+func BenchmarkDiscover(b *testing.B) {
+	dir := b.TempDir()
+	//nolint:gosec // G306: test files don't need restrictive permissions
+	if err := os.WriteFile(filepath.Join(dir, "markata-go.toml"), []byte("[markata-go]\n"), 0o644); err != nil {
+		b.Fatal(err)
+	}
+
+	// Change to the directory for discovery
+	oldDir, err := os.Getwd()
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		b.Fatal(err)
+	}
+	defer func() {
+		if err := os.Chdir(oldDir); err != nil {
+			b.Logf("failed to change back to original directory: %v", err)
+		}
+	}()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := Discover()
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// Helper functions to generate test configs
+
+func generateTOMLConfig() string {
+	return `[markata-go]
+output_dir = "public"
+url = "https://example.com"
+title = "My Site"
+description = "A great site built with markata-go"
+author = "Test Author"
+assets_dir = "assets"
+templates_dir = "templates"
+concurrency = 4
+
+[markata-go.glob]
+patterns = ["posts/**/*.md", "pages/*.md", "docs/**/*.md"]
+use_gitignore = true
+
+[markata-go.markdown]
+extensions = ["tables", "footnotes", "syntax-highlighting"]
+
+[markata-go.feed_defaults]
+items_per_page = 10
+orphan_threshold = 3
+
+[markata-go.feed_defaults.formats]
+html = true
+rss = true
+
+[[markata-go.feeds]]
+slug = "blog"
+title = "Blog"
+filter = "published == True"
+sort = "date"
+reverse = true
+
+[markata-go.feeds.formats]
+html = true
+rss = true
+atom = true
+`
+}
+
+func generateYAMLConfig() string {
+	return `markata-go:
+  output_dir: public
+  url: https://example.com
+  title: My Site
+  description: A great site built with markata-go
+  author: Test Author
+  assets_dir: assets
+  templates_dir: templates
+  concurrency: 4
+
+  glob:
+    patterns:
+      - "posts/**/*.md"
+      - "pages/*.md"
+      - "docs/**/*.md"
+    use_gitignore: true
+
+  markdown:
+    extensions:
+      - tables
+      - footnotes
+      - syntax-highlighting
+
+  feed_defaults:
+    items_per_page: 10
+    orphan_threshold: 3
+    formats:
+      html: true
+      rss: true
+
+  feeds:
+    - slug: blog
+      title: Blog
+      filter: "published == True"
+      sort: date
+      reverse: true
+      formats:
+        html: true
+        rss: true
+        atom: true
+`
+}
+
+func generateJSONConfig() string {
+	return `{
+  "markata-go": {
+    "output_dir": "public",
+    "url": "https://example.com",
+    "title": "My Site",
+    "description": "A great site built with markata-go",
+    "author": "Test Author",
+    "assets_dir": "assets",
+    "templates_dir": "templates",
+    "concurrency": 4,
+    "glob": {
+      "patterns": ["posts/**/*.md", "pages/*.md", "docs/**/*.md"],
+      "use_gitignore": true
+    },
+    "markdown": {
+      "extensions": ["tables", "footnotes", "syntax-highlighting"]
+    },
+    "feed_defaults": {
+      "items_per_page": 10,
+      "orphan_threshold": 3,
+      "formats": {
+        "html": true,
+        "rss": true
+      }
+    },
+    "feeds": [
+      {
+        "slug": "blog",
+        "title": "Blog",
+        "filter": "published == True",
+        "sort": "date",
+        "reverse": true,
+        "formats": {
+          "html": true,
+          "rss": true,
+          "atom": true
+        }
+      }
+    ]
+  }
+}`
+}
+
+func generateComplexTOMLConfig() string {
+	return `[markata-go]
+output_dir = "public"
+url = "https://example.com"
+title = "My Complex Site"
+description = "A complex site with many feeds and settings"
+author = "Test Author"
+assets_dir = "assets"
+templates_dir = "templates"
+concurrency = 8
+hooks = ["default", "sitemap", "robots", "seo"]
+disabled_hooks = []
+
+[markata-go.glob]
+patterns = ["posts/**/*.md", "pages/*.md", "docs/**/*.md", "notes/**/*.md"]
+use_gitignore = true
+
+[markata-go.markdown]
+extensions = ["tables", "footnotes", "syntax-highlighting", "autolinks", "strikethrough"]
+
+[markata-go.feed_defaults]
+items_per_page = 15
+orphan_threshold = 4
+
+[markata-go.feed_defaults.formats]
+html = true
+rss = true
+atom = true
+json = false
+
+[markata-go.feed_defaults.syndication]
+max_items = 50
+include_content = true
+
+[[markata-go.feeds]]
+slug = "blog"
+title = "Blog"
+description = "All blog posts"
+filter = "published == True and draft != True"
+sort = "date"
+reverse = true
+items_per_page = 10
+
+[markata-go.feeds.formats]
+html = true
+rss = true
+atom = true
+
+[[markata-go.feeds]]
+slug = "projects"
+title = "Projects"
+description = "Project showcase"
+filter = "tags contains project"
+sort = "date"
+reverse = true
+
+[[markata-go.feeds]]
+slug = "notes"
+title = "Notes"
+description = "Quick notes and thoughts"
+filter = "path startswith notes/"
+sort = "date"
+reverse = true
+items_per_page = 20
+
+[[markata-go.feeds]]
+slug = "docs"
+title = "Documentation"
+description = "Documentation pages"
+filter = "path startswith docs/"
+sort = "title"
+reverse = false
+
+[[markata-go.feeds]]
+slug = "archive"
+title = "Archive"
+description = "All posts archive"
+filter = "published == True"
+sort = "date"
+reverse = true
+items_per_page = 50
+`
+}

--- a/tests/fixtures/perf/code-heavy.md
+++ b/tests/fixtures/perf/code-heavy.md
@@ -1,0 +1,372 @@
+---
+title: "Code Heavy Post"
+description: "A post with many code blocks for syntax highlighting benchmarks"
+date: 2024-01-15
+published: true
+tags:
+  - benchmark
+  - code
+---
+
+# Code Heavy Post
+
+This post focuses on code block rendering performance.
+
+## Go
+
+```go
+package lifecycle
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Manager orchestrates the lifecycle stages and plugin execution.
+type Manager struct {
+	plugins     []Plugin
+	config      *Config
+	posts       []*Post
+	mu          sync.RWMutex
+	concurrency int
+}
+
+// NewManager creates a new lifecycle Manager.
+func NewManager() *Manager {
+	return &Manager{
+		plugins:     make([]Plugin, 0),
+		config:      NewConfig(),
+		posts:       make([]*Post, 0),
+		concurrency: 4,
+	}
+}
+
+// Run executes all lifecycle stages in order.
+func (m *Manager) Run() error {
+	stages := []Stage{
+		StageConfigure,
+		StageValidate,
+		StageGlob,
+		StageLoad,
+		StageTransform,
+		StageRender,
+		StageCollect,
+		StageWrite,
+		StageCleanup,
+	}
+
+	for _, stage := range stages {
+		if err := m.runStage(stage); err != nil {
+			return fmt.Errorf("stage %s failed: %w", stage, err)
+		}
+	}
+
+	return nil
+}
+```
+
+## Python
+
+```python
+from typing import List, Optional
+from dataclasses import dataclass
+import asyncio
+
+@dataclass
+class Post:
+    path: str
+    title: str
+    content: str
+    published: bool = False
+    tags: List[str] = None
+
+    def __post_init__(self):
+        if self.tags is None:
+            self.tags = []
+
+class SiteBuilder:
+    def __init__(self, config: dict):
+        self.config = config
+        self.posts: List[Post] = []
+
+    async def build(self) -> None:
+        """Build the entire site."""
+        await self.load_posts()
+        await self.render_posts()
+        await self.write_output()
+
+    async def load_posts(self) -> None:
+        """Load all markdown posts."""
+        # Implementation here
+        pass
+
+    async def render_posts(self) -> None:
+        """Render markdown to HTML."""
+        tasks = [self.render_post(p) for p in self.posts]
+        await asyncio.gather(*tasks)
+
+    async def render_post(self, post: Post) -> None:
+        """Render a single post."""
+        pass
+
+    async def write_output(self) -> None:
+        """Write rendered HTML to output directory."""
+        pass
+
+if __name__ == "__main__":
+    builder = SiteBuilder({"output_dir": "public"})
+    asyncio.run(builder.build())
+```
+
+## JavaScript/TypeScript
+
+```typescript
+interface Post {
+  path: string;
+  title: string;
+  content: string;
+  published: boolean;
+  tags: string[];
+  date?: Date;
+}
+
+interface Config {
+  outputDir: string;
+  templatesDir: string;
+  contentDir: string;
+}
+
+class SiteBuilder {
+  private config: Config;
+  private posts: Post[] = [];
+
+  constructor(config: Config) {
+    this.config = config;
+  }
+
+  async build(): Promise<void> {
+    console.log("Building site...");
+    await this.loadPosts();
+    await this.renderPosts();
+    await this.writeOutput();
+    console.log("Build complete!");
+  }
+
+  private async loadPosts(): Promise<void> {
+    // Load all markdown files
+    const files = await this.glob("**/*.md");
+    for (const file of files) {
+      const post = await this.parsePost(file);
+      this.posts.push(post);
+    }
+  }
+
+  private async renderPosts(): Promise<void> {
+    const promises = this.posts.map(post => this.renderPost(post));
+    await Promise.all(promises);
+  }
+
+  private async renderPost(post: Post): Promise<string> {
+    // Render markdown to HTML
+    return "";
+  }
+
+  private async writeOutput(): Promise<void> {
+    // Write HTML files
+  }
+
+  private async glob(pattern: string): Promise<string[]> {
+    return [];
+  }
+
+  private async parsePost(path: string): Promise<Post> {
+    return {
+      path,
+      title: "",
+      content: "",
+      published: false,
+      tags: [],
+    };
+  }
+}
+
+// Usage
+const builder = new SiteBuilder({
+  outputDir: "public",
+  templatesDir: "templates",
+  contentDir: "content",
+});
+
+builder.build().catch(console.error);
+```
+
+## Rust
+
+```rust
+use std::collections::HashMap;
+use std::path::PathBuf;
+use tokio::fs;
+
+#[derive(Debug, Clone)]
+pub struct Post {
+    pub path: PathBuf,
+    pub title: String,
+    pub content: String,
+    pub published: bool,
+    pub tags: Vec<String>,
+}
+
+pub struct SiteBuilder {
+    config: Config,
+    posts: Vec<Post>,
+}
+
+#[derive(Debug)]
+pub struct Config {
+    pub output_dir: PathBuf,
+    pub content_dir: PathBuf,
+    pub templates_dir: PathBuf,
+}
+
+impl SiteBuilder {
+    pub fn new(config: Config) -> Self {
+        Self {
+            config,
+            posts: Vec::new(),
+        }
+    }
+
+    pub async fn build(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        self.load_posts().await?;
+        self.render_posts().await?;
+        self.write_output().await?;
+        Ok(())
+    }
+
+    async fn load_posts(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        // Load markdown files
+        Ok(())
+    }
+
+    async fn render_posts(&self) -> Result<(), Box<dyn std::error::Error>> {
+        // Render to HTML
+        Ok(())
+    }
+
+    async fn write_output(&self) -> Result<(), Box<dyn std::error::Error>> {
+        // Write files
+        Ok(())
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let config = Config {
+        output_dir: PathBuf::from("public"),
+        content_dir: PathBuf::from("content"),
+        templates_dir: PathBuf::from("templates"),
+    };
+
+    let mut builder = SiteBuilder::new(config);
+    builder.build().await?;
+
+    Ok(())
+}
+```
+
+## SQL
+
+```sql
+-- Create tables for a blog database
+CREATE TABLE posts (
+    id SERIAL PRIMARY KEY,
+    slug VARCHAR(255) UNIQUE NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    content TEXT,
+    published BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE tags (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(100) UNIQUE NOT NULL
+);
+
+CREATE TABLE post_tags (
+    post_id INTEGER REFERENCES posts(id) ON DELETE CASCADE,
+    tag_id INTEGER REFERENCES tags(id) ON DELETE CASCADE,
+    PRIMARY KEY (post_id, tag_id)
+);
+
+-- Query published posts with tags
+SELECT
+    p.id,
+    p.title,
+    p.slug,
+    p.created_at,
+    array_agg(t.name) as tags
+FROM posts p
+LEFT JOIN post_tags pt ON p.id = pt.post_id
+LEFT JOIN tags t ON pt.tag_id = t.id
+WHERE p.published = TRUE
+GROUP BY p.id, p.title, p.slug, p.created_at
+ORDER BY p.created_at DESC;
+```
+
+## YAML
+
+```yaml
+markata-go:
+  output_dir: public
+  url: https://example.com
+  title: My Site
+
+  glob:
+    patterns:
+      - "posts/**/*.md"
+      - "pages/*.md"
+    use_gitignore: true
+
+  feeds:
+    - slug: blog
+      title: Blog
+      filter: "published == True"
+      sort: date
+      reverse: true
+      formats:
+        html: true
+        rss: true
+        atom: true
+```
+
+## Shell
+
+```bash
+#!/bin/bash
+
+# Build script for markata-go site
+
+set -euo pipefail
+
+echo "Building site..."
+
+# Clean output directory
+rm -rf public/
+
+# Run the build
+markata-go build
+
+# Generate sitemap
+markata-go sitemap
+
+# Optimize images (if available)
+if command -v optipng &> /dev/null; then
+    find public -name "*.png" -exec optipng -o5 {} \;
+fi
+
+echo "Build complete!"
+echo "Output in: public/"
+```
+
+This post helps benchmark syntax highlighting performance across multiple languages.

--- a/tests/fixtures/perf/complex-post.md
+++ b/tests/fixtures/perf/complex-post.md
@@ -1,0 +1,219 @@
+---
+title: "Complex Test Post with Many Features"
+description: "A comprehensive post for testing all markdown features and rendering performance"
+date: 2024-01-15T10:30:00Z
+published: true
+draft: false
+template: post.html
+slug: complex-benchmark-post
+tags:
+  - benchmark
+  - testing
+  - performance
+  - go
+  - markdown
+author: "Test Author"
+category: "Performance Testing"
+---
+
+# Complex Test Post with Many Features
+
+This post contains various markdown elements to test rendering performance comprehensively.
+
+## Code Blocks
+
+### Go Code
+
+```go
+package main
+
+import (
+    "fmt"
+    "os"
+)
+
+func main() {
+    fmt.Println("Hello, World!")
+    os.Exit(0)
+}
+
+func fibonacci(n int) int {
+    if n <= 1 {
+        return n
+    }
+    return fibonacci(n-1) + fibonacci(n-2)
+}
+```
+
+### Python Code
+
+```python
+def hello():
+    """A simple hello function."""
+    print("Hello, World!")
+
+class Calculator:
+    def add(self, a, b):
+        return a + b
+
+    def multiply(self, a, b):
+        return a * b
+
+if __name__ == "__main__":
+    hello()
+    calc = Calculator()
+    print(calc.add(2, 3))
+```
+
+### JavaScript Code
+
+```javascript
+function hello() {
+    console.log("Hello, World!");
+}
+
+const fibonacci = (n) => {
+    if (n <= 1) return n;
+    return fibonacci(n - 1) + fibonacci(n - 2);
+};
+
+class MyClass {
+    constructor(name) {
+        this.name = name;
+    }
+
+    greet() {
+        return `Hello, ${this.name}!`;
+    }
+}
+
+hello();
+```
+
+## Tables
+
+| Feature | Description | Status |
+|---------|-------------|--------|
+| Tables | Markdown tables | Supported |
+| Code Blocks | Syntax highlighting | Supported |
+| Lists | Ordered and unordered | Supported |
+| Blockquotes | Quote formatting | Supported |
+| Links | Internal and external | Supported |
+| Images | Image embedding | Supported |
+
+### Complex Table
+
+| Column 1 | Column 2 | Column 3 | Column 4 | Column 5 |
+|:---------|:--------:|:---------|:--------:|----------:|
+| Left | Center | Left | Center | Right |
+| Data 1 | Data 2 | Data 3 | Data 4 | Data 5 |
+| More | More | More | More | More |
+| Even more | data | in | this | table |
+
+## Blockquotes
+
+> This is a blockquote with some important information
+> that spans multiple lines for emphasis.
+>
+> It can contain **bold** and *italic* text as well.
+
+### Nested Blockquotes
+
+> Level 1 quote
+> > Level 2 nested quote
+> > > Level 3 deeply nested quote
+
+## Lists
+
+### Unordered List
+
+- First item
+- Second item with **bold**
+- Third item with `code`
+- Fourth item with [link](https://example.com)
+  - Nested item 1
+  - Nested item 2
+    - Deeply nested item
+- Fifth item
+
+### Ordered List
+
+1. First numbered item
+2. Second numbered item
+3. Third numbered item
+   1. Nested numbered 1
+   2. Nested numbered 2
+4. Fourth numbered item
+
+### Task List
+
+- [x] Completed task
+- [ ] Incomplete task
+- [x] Another completed task
+- [ ] Another incomplete task
+
+## Links and Images
+
+Here's an [external link](https://example.com) and an [internal link](/docs/guides/).
+
+![Example image](https://example.com/image.png "Image title")
+
+## Inline Elements
+
+This paragraph contains `inline code`, **bold text**, *italic text*, ~~strikethrough~~, and ***bold italic*** text.
+
+You can also use <sub>subscript</sub> and <sup>superscript</sup> text.
+
+## Horizontal Rules
+
+---
+
+Above and below are horizontal rules.
+
+***
+
+Another style of horizontal rule.
+
+## Footnotes
+
+Here's a sentence with a footnote[^1].
+
+And another one with a different footnote[^2].
+
+[^1]: This is the first footnote.
+[^2]: This is the second footnote with more content.
+
+## Definition Lists
+
+Term 1
+: Definition for term 1
+
+Term 2
+: Definition for term 2
+: Another definition for term 2
+
+## Math (if supported)
+
+Inline math: $E = mc^2$
+
+Block math:
+
+$$
+\frac{d}{dx}\left( \int_{a}^{x} f(t)\,dt\right) = f(x)
+$$
+
+## Final Section
+
+This concludes the complex benchmark post. It contains:
+
+- Multiple code blocks with different languages
+- Various table formats
+- Nested quotes and lists
+- Task lists
+- Links and images
+- Inline formatting
+- Footnotes
+- Definition lists
+- Math expressions
+
+This ensures comprehensive testing of the markdown rendering pipeline.

--- a/tests/fixtures/perf/simple-post.md
+++ b/tests/fixtures/perf/simple-post.md
@@ -1,0 +1,28 @@
+---
+title: "Simple Test Post"
+description: "A simple post for performance testing"
+date: 2024-01-15
+published: true
+tags:
+  - benchmark
+  - test
+---
+
+# Simple Test Post
+
+This is a simple post for benchmarking basic markdown rendering.
+
+## Section 1
+
+Here's a paragraph with some **bold** and *italic* text.
+
+## Section 2
+
+A list:
+- Item 1
+- Item 2
+- Item 3
+
+## Conclusion
+
+This concludes the simple test post.


### PR DESCRIPTION
## Summary

Fixes #305

Adds comprehensive benchmarking infrastructure and profiling documentation for markata-go.

## Benchmarks Added

### Config Benchmarks (`pkg/config/benchmark_test.go`)
- TOML/YAML/JSON config loading
- Config validation and merging
- Complex config with multiple feeds
- Config file discovery

### Sample Test Data (`tests/fixtures/perf/`)
- `simple-post.md` - Baseline tests
- `complex-post.md` - Full-featured markdown
- `code-heavy.md` - Multiple syntax-highlighted code blocks

### Documentation (`docs/guides/performance.md`)
- Running benchmarks: `go test -bench=. ./pkg/config/`
- CPU profiling: `go test -bench=. -cpuprofile=cpu.prof`
- Memory profiling
- benchstat comparison workflow
- Performance optimization tips

## Key Findings

| Component | Performance | Notes |
|-----------|-------------|-------|
| JSON config | ~40µs | 3x faster than TOML/YAML |
| TOML/YAML config | ~108-111µs | Similar performance |
| Concurrency | Up to 3x | conc-8 vs conc-1 |
| Markdown rendering | ~12ms/100 posts | Primary bottleneck |
| Syntax highlighting | ~14ms/50 posts | CPU intensive |

## Usage

```bash
# Run all benchmarks
go test -bench=. ./...

# Run with CPU profile
go test -bench=. -cpuprofile=cpu.prof ./pkg/config/

# Analyze profile
go tool pprof cpu.prof
```