### PR TITLE
fix(stats): correct includeCodeInCount option behavior

### DIFF
--- a/pkg/plugins/stats.go
+++ b/pkg/plugins/stats.go
@@ -285,10 +285,21 @@ func (p *StatsPlugin) calculatePostStats(content string) *PostStats {
 	if !p.includeCodeInCount {
 		// Remove code blocks from word counting
 		text = statsCodeBlockPattern.ReplaceAllString(text, " ")
+		// Remove inline code
+		text = statsInlineCodePattern.ReplaceAllString(text, " ")
+	} else {
+		// When including code in count, preserve code content but remove fence markers
+		// Replace fenced code blocks with just their content (no fence markers)
+		text = statsCodeBlockPattern.ReplaceAllStringFunc(text, func(block string) string {
+			// Remove opening fence line and closing fence line
+			lines := strings.Split(block, "\n")
+			if len(lines) <= 2 {
+				return " "
+			}
+			// Join all lines except first (opening fence) and last (closing fence)
+			return strings.Join(lines[1:len(lines)-1], " ")
+		})
 	}
-
-	// Remove inline code
-	text = statsInlineCodePattern.ReplaceAllString(text, " ")
 
 	// Remove images
 	text = statsImagePattern.ReplaceAllString(text, " ")

--- a/pkg/plugins/stats_test.go
+++ b/pkg/plugins/stats_test.go
@@ -242,14 +242,25 @@ More text.
 	p2.includeCodeInCount = true
 	stats2 := p2.calculatePostStats(content)
 
-	// Code included should have more words (fmt, Println, Hello, world add 4+ words)
-	// Note: The code block regex replacement affects word counting
-	// When code is included, the fenced code block content is preserved
+	// Expected: "Some text here" (3) + "More text" (2) = 5 words without code
+	// Expected: "Some text here" (3) + "func main fmt Println Hello world" (6) + "More text" (2) = 11 words with code
 	t.Logf("Without code: %d words, With code: %d words", stats1.WordCount, stats2.WordCount)
 
-	// Just verify the plugin runs without error for both modes
 	if stats1.WordCount == 0 {
 		t.Error("Expected non-zero word count without code")
+	}
+
+	// Verify that including code results in MORE words, not fewer
+	if stats2.WordCount <= stats1.WordCount {
+		t.Errorf("includeCodeInCount=true should increase word count: got %d words (with code) vs %d words (without code)", stats2.WordCount, stats1.WordCount)
+	}
+
+	// Both should detect the same number of code blocks
+	if stats1.CodeBlocks != stats2.CodeBlocks {
+		t.Errorf("CodeBlocks mismatch: %d (without) vs %d (with code in count)", stats1.CodeBlocks, stats2.CodeBlocks)
+	}
+	if stats1.CodeBlocks != 1 {
+		t.Errorf("Expected 1 code block, got %d", stats1.CodeBlocks)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the inverted behavior of the `includeCodeInCount` configuration option in the stats plugin.

## Problem

When `includeCodeInCount = true`, word counts were paradoxically LOWER than with the default `false` setting:
- Default (excludes code): 27 words ✓
- With `includeCodeInCount=true`: 19 words ✗ (should be ~47 words)

## Root Cause

In `pkg/plugins/stats.go` lines 285-294, inline code pattern removal was applied unconditionally. When code blocks were preserved (`includeCodeInCount = true`), the inline code regex would match from opening ``` to closing ```, stripping the code content.

## Changes

- Made inline code removal conditional (only when `!includeCodeInCount`)
- When `includeCodeInCount = true`, fence markers are removed but code content is preserved for counting
- Added test coverage for `includeCodeInCount = true` behavior

## Testing

- [x] All existing tests pass
- [x] New test verifies correct behavior (with code > without code)
- [x] Pre-commit hooks pass

Fixes #322