### PR TITLE
fix(css): hide skip-to-content link completely on mobile

### DIFF
--- a/pkg/themes/default/static/css/layouts.css
+++ b/pkg/themes/default/static/css/layouts.css
@@ -586,7 +586,7 @@
 
 .skip-link {
   position: absolute;
-  top: -40px;
+  top: -60px;
   left: var(--space-4);
   padding: var(--space-2) var(--space-4);
   background: var(--color-primary);

--- a/themes/default/static/css/layouts.css
+++ b/themes/default/static/css/layouts.css
@@ -588,7 +588,7 @@
 
 .skip-link {
   position: absolute;
-  top: -40px;
+  top: -60px;
   left: var(--space-4);
   padding: var(--space-2) var(--space-4);
   background: var(--color-primary);


### PR DESCRIPTION
## Summary

Fixes the skip-to-content accessibility link showing a few pixels on mobile devices.

## Problem

The skip link was positioned at `top: -40px` but the element itself is ~40px tall, causing pixels to peek through on mobile viewports.

## Changes

- Updated `.skip-link` CSS in both files:
  - `themes/default/static/css/layouts.css`
  - `pkg/themes/default/static/css/layouts.css`
- Changed `top: -40px;` to `top: -60px;`
- Provides 20px safety margin for complete hiding

## Testing

- [x] Skip link completely hidden when not focused
- [x] Link still appears smoothly on focus
- [x] No visual regression on desktop/mobile

Fixes #318