### PR TITLE
fix(reader): display entry images when available

### DIFF
--- a/templates/reader.html
+++ b/templates/reader.html
@@ -28,6 +28,9 @@
     {% for entry in entries %}
     <li class="reader-entry">
       <article>
+        {% if entry.image_url %}
+        <img src="{{ entry.image_url }}" alt="" class="entry-image" loading="lazy">
+        {% endif %}
         <h2 class="reader-entry-title">
           <a href="{{ entry.url }}" target="_blank" rel="noopener">{{ entry.title }}</a>
         </h2>


### PR DESCRIPTION
## Summary
- Adds image rendering to the reader template when `entry.image_url` is available
- Images are lazy-loaded for better performance

Fixes #325