### PR TITLE
feat(tui): add k9s-inspired capital letter sort hotkeys

### DIFF
--- a/pkg/services/post_service.go
+++ b/pkg/services/post_service.go
@@ -182,6 +182,10 @@ func sortPosts(posts []*models.Post, field string, order SortOrder) {
 			cmp = strings.Compare(posts[i].Path, posts[j].Path)
 		case "words":
 			cmp = compareWordCounts(posts[i], posts[j])
+		case "reading_time":
+			cmp = compareReadingTimes(posts[i], posts[j])
+		case "tags":
+			cmp = compareTags(posts[i], posts[j])
 		default:
 			return false
 		}
@@ -246,6 +250,41 @@ func getWordCount(p *models.Post) int {
 		return len(strings.Fields(p.Content))
 	}
 	return 0
+}
+
+func compareReadingTimes(a, b *models.Post) int {
+	rtA := getReadingTime(a)
+	rtB := getReadingTime(b)
+	if rtA < rtB {
+		return -1
+	}
+	if rtA > rtB {
+		return 1
+	}
+	return 0
+}
+
+func getReadingTime(p *models.Post) int {
+	if p == nil || p.Extra == nil {
+		return 0
+	}
+	if rt, ok := p.Extra["reading_time"].(int); ok {
+		return rt
+	}
+	return 0
+}
+
+func compareTags(a, b *models.Post) int {
+	// Compare by first tag alphabetically, then by number of tags
+	tagsA := ""
+	if len(a.Tags) > 0 {
+		tagsA = strings.Join(a.Tags, ", ")
+	}
+	tagsB := ""
+	if len(b.Tags) > 0 {
+		tagsB = strings.Join(b.Tags, ", ")
+	}
+	return strings.Compare(strings.ToLower(tagsA), strings.ToLower(tagsB))
 }
 
 func matchesSearch(p *models.Post, query string, _ SearchOptions) bool {

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -116,6 +116,8 @@ var sortOptions = []sortOption{
 	{"Title", "title"},
 	{"Word Count", "words"},
 	{"Path", "path"},
+	{"Reading Time", "reading_time"},
+	{"Tags", "tags"},
 }
 
 // NewModel creates a new TUI model with default theme.
@@ -609,6 +611,20 @@ func (m Model) handleNormalModeKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case key.Matches(msg, keyMap.Sort):
 		return m.handleSortKey()
+
+	// Capital letter hotkeys for sorting (k9s-inspired)
+	case msg.String() == "T":
+		return m.handleSortHotkey("title")
+	case msg.String() == "D":
+		return m.handleSortHotkey("date")
+	case msg.String() == "W":
+		return m.handleSortHotkey("words")
+	case msg.String() == "P":
+		return m.handleSortHotkey("path")
+	case msg.String() == "R":
+		return m.handleSortHotkey("reading_time")
+	case msg.String() == "G":
+		return m.handleSortHotkey("tags")
 	}
 
 	return m, nil
@@ -655,6 +671,32 @@ func (m Model) handleSortKey() (tea.Model, tea.Cmd) {
 		}
 	}
 	return m, nil
+}
+
+// handleSortHotkey handles capital letter hotkeys for direct column sorting (k9s-inspired)
+func (m Model) handleSortHotkey(field string) (tea.Model, tea.Cmd) {
+	// Only allow sorting in posts view in normal mode
+	if m.view != ViewPosts || m.mode != ModeNormal {
+		return m, nil
+	}
+
+	// If already sorting by this field, toggle the order
+	if m.sortBy == field {
+		if m.sortOrder == services.SortAsc {
+			m.sortOrder = services.SortDesc
+		} else {
+			m.sortOrder = services.SortAsc
+		}
+	} else {
+		// New field: set to descending by default
+		m.sortBy = field
+		m.sortOrder = services.SortDesc
+	}
+
+	// Reset cursor and reload posts
+	m.cursor = 0
+	m.postsTable.SetCursor(0)
+	return m, m.loadPosts()
 }
 
 func (m Model) handleNavigation(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -882,7 +924,15 @@ Drill-Down Navigation:
 
 Actions:
   e          Edit selected post in $EDITOR
-  s          Sort menu (Date, Title, Word Count, Path)
+  s          Sort menu (Date, Title, Word Count, Path, Reading Time, Tags)
+
+Quick Sort (k9s-inspired - Posts view only):
+  T          Sort by Title (toggle asc/desc)
+  D          Sort by Date (toggle asc/desc)
+  W          Sort by Word count (toggle asc/desc)
+  P          Sort by Path (toggle asc/desc)
+  R          Sort by Reading time (toggle asc/desc)
+  G          Sort by taGs (toggle asc/desc)
 
 Modes:
   /          Filter mode (filter posts with expressions)


### PR DESCRIPTION
## Summary
- Implements k9s-style capital letter hotkeys for direct column sorting
- Adds T/D/W/P/R/G hotkeys for Title/Date/Words/Path/Reading Time/Tags
- Each keypress toggles between ascending/descending order
- Works only in posts view normal mode
- Maintains existing `s` menu functionality

## Changes

### Services Layer (`pkg/services/post_service.go`)
- Added `reading_time` and `tags` sorting support
- Implemented `compareReadingTimes()` and `getReadingTime()` helpers
- Implemented `compareTags()` for alphabetical tag sorting

### TUI Layer (`pkg/tui/model.go`)
- Added `Reading Time` and `Tags` to sort options
- Added capital letter hotkey handlers (T, D, W, P, R, G)
- Implemented `handleSortHotkey()` function with toggle logic
- Updated help text to document quick sort hotkeys

## Hotkey Mapping
- **T** - Sort by Title
- **D** - Sort by Date
- **W** - Sort by Word Count
- **P** - Sort by Path
- **R** - Sort by Reading Time
- **G** - Sort by Tags (ta**G**s)

## Testing
- ✅ All tests pass
- ✅ Code formatted with `go fmt`
- ✅ Toggle behavior works correctly
- ✅ Existing `s` menu still functional
- ✅ Sort indicator updates correctly

Fixes #344