### PR TITLE
feat(theme): add configurable multi-layered background decorations

### DIFF
--- a/docs/guides/themes.md
+++ b/docs/guides/themes.md
@@ -598,6 +598,121 @@ Test your gradient choices in both light and dark mode.
 
 ---
 
+## Background Decorations
+
+Add multi-layered background decorations to your site for visual effects like snow, particles, stars, or animated elements.
+
+### Basic Configuration
+
+```toml
+[markata-go.theme.background]
+enabled = true
+
+backgrounds = [
+  { html = '<snow-fall count="200"></snow-fall>' },
+]
+
+scripts = ["/static/js/snow-fall.js"]
+```
+
+This adds a snow effect using a custom web component with its supporting JavaScript.
+
+### Multiple Layers
+
+Stack multiple background layers with different z-index values:
+
+```toml
+[markata-go.theme.background]
+enabled = true
+
+backgrounds = [
+  { html = '<div class="stars"></div>', z_index = -20 },
+  { html = '<div class="clouds"></div>', z_index = -10 },
+  { html = '<snow-fall count="100"></snow-fall>', z_index = -5 },
+]
+
+scripts = ["/static/js/background-effects.js"]
+
+css = '''
+.stars {
+  position: absolute;
+  inset: 0;
+  background: url("/images/stars.png") repeat;
+  opacity: 0.3;
+}
+
+.clouds {
+  position: absolute;
+  inset: 0;
+  background: url("/images/clouds.png") repeat-x;
+  animation: drift 60s linear infinite;
+}
+
+@keyframes drift {
+  from { background-position: 0 0; }
+  to { background-position: 100% 0; }
+}
+'''
+```
+
+### Configuration Reference
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `enabled` | boolean | Enable/disable background decorations (default: false) |
+| `backgrounds` | array | List of background elements |
+| `backgrounds[].html` | string | HTML content for this layer |
+| `backgrounds[].z_index` | integer | Stacking order (-1 is default, behind content) |
+| `scripts` | array | Script URLs to load for background functionality |
+| `css` | string | Custom CSS for styling background elements |
+
+### Tips for Background Decorations
+
+1. **Performance**: Complex animations can impact performance. Test on lower-powered devices.
+
+2. **Accessibility**: Ensure backgrounds don't interfere with content readability. Use `pointer-events: none` (applied automatically).
+
+3. **Z-Index**: Use negative values to place backgrounds behind content. Positive values overlay content.
+
+4. **Web Components**: Custom elements like `<snow-fall>` provide encapsulated, reusable effects.
+
+5. **Reduced Motion**: Consider respecting `prefers-reduced-motion` in your CSS:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .background-layer * {
+    animation: none !important;
+  }
+}
+```
+
+### Example: Particle Background
+
+Using [particles.js](https://vincentgarreau.com/particles.js/):
+
+```toml
+[markata-go.theme.background]
+enabled = true
+
+backgrounds = [
+  { html = '<div id="particles-js"></div>' },
+]
+
+scripts = [
+  "https://cdn.jsdelivr.net/particles.js/2.0.0/particles.min.js",
+  "/static/js/particles-config.js",
+]
+
+css = '''
+#particles-js {
+  position: absolute;
+  inset: 0;
+}
+'''
+```
+
+---
+
 ## Best Practices
 
 ### 1. Start with a Palette

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -474,6 +474,57 @@ type ThemeConfig struct {
 
 	// CustomCSS is a path to a custom CSS file to include
 	CustomCSS string `json:"custom_css" yaml:"custom_css" toml:"custom_css"`
+
+	// Background configures multi-layered background decorations
+	Background BackgroundConfig `json:"background,omitempty" yaml:"background,omitempty" toml:"background,omitempty"`
+}
+
+// BackgroundConfig configures multi-layered background decorations for pages.
+// Background elements are rendered as fixed-position layers behind the main content.
+type BackgroundConfig struct {
+	// Enabled controls whether background decorations are active (default: false)
+	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty" toml:"enabled,omitempty"`
+
+	// Backgrounds is the list of background elements to render
+	Backgrounds []BackgroundElement `json:"backgrounds,omitempty" yaml:"backgrounds,omitempty" toml:"backgrounds,omitempty"`
+
+	// Scripts is a list of script URLs to include for background functionality
+	// Example: ["/static/js/snow-fall.js"]
+	Scripts []string `json:"scripts,omitempty" yaml:"scripts,omitempty" toml:"scripts,omitempty"`
+
+	// CSS is custom CSS for styling background elements
+	CSS string `json:"css,omitempty" yaml:"css,omitempty" toml:"css,omitempty"`
+}
+
+// BackgroundElement represents a single background decoration layer.
+type BackgroundElement struct {
+	// HTML is the HTML content for this background layer
+	// Example: '<snow-fall count="200"></snow-fall>'
+	HTML string `json:"html" yaml:"html" toml:"html"`
+
+	// ZIndex controls the stacking order of this layer (default: -1)
+	// Negative values place the layer behind content, positive values in front
+	ZIndex int `json:"z_index,omitempty" yaml:"z_index,omitempty" toml:"z_index,omitempty"`
+}
+
+// NewBackgroundConfig creates a new BackgroundConfig with default values.
+func NewBackgroundConfig() BackgroundConfig {
+	enabled := false
+	return BackgroundConfig{
+		Enabled:     &enabled,
+		Backgrounds: []BackgroundElement{},
+		Scripts:     []string{},
+		CSS:         "",
+	}
+}
+
+// IsEnabled returns whether background decorations are enabled.
+// Defaults to false if not explicitly set.
+func (b *BackgroundConfig) IsEnabled() bool {
+	if b.Enabled == nil {
+		return false
+	}
+	return *b.Enabled
 }
 
 // GlobConfig configures file globbing behavior.

--- a/pkg/plugins/background.go
+++ b/pkg/plugins/background.go
@@ -1,0 +1,191 @@
+// Package plugins provides lifecycle plugins for markata-go.
+package plugins
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
+	"github.com/WaylonWalker/markata-go/pkg/models"
+)
+
+// BackgroundPlugin adds configurable multi-layered background decorations to pages.
+// It runs at the configure stage to validate configuration.
+type BackgroundPlugin struct {
+	config models.BackgroundConfig
+}
+
+// NewBackgroundPlugin creates a new BackgroundPlugin with default settings.
+func NewBackgroundPlugin() *BackgroundPlugin {
+	return &BackgroundPlugin{
+		config: models.NewBackgroundConfig(),
+	}
+}
+
+// Name returns the unique name of the plugin.
+func (p *BackgroundPlugin) Name() string {
+	return "background"
+}
+
+// Configure reads configuration options for the plugin from config.Extra.
+// Configuration is expected under the "theme.background" key.
+func (p *BackgroundPlugin) Configure(m *lifecycle.Manager) error {
+	config := m.Config()
+	if config.Extra == nil {
+		return nil
+	}
+
+	// Check for theme config first
+	themeConfig, ok := config.Extra["theme"]
+	if !ok {
+		return nil
+	}
+
+	themeMap, ok := themeConfig.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	// Check for background config within theme
+	bgConfig, ok := themeMap["background"]
+	if !ok {
+		return nil
+	}
+
+	// Handle map configuration
+	if cfgMap, ok := bgConfig.(map[string]interface{}); ok {
+		if enabled, ok := cfgMap["enabled"].(bool); ok {
+			p.config.Enabled = &enabled
+		}
+
+		if css, ok := cfgMap["css"].(string); ok {
+			p.config.CSS = css
+		}
+
+		// Parse scripts array
+		if scripts, ok := cfgMap["scripts"].([]interface{}); ok {
+			p.config.Scripts = make([]string, 0, len(scripts))
+			for _, s := range scripts {
+				if str, ok := s.(string); ok {
+					p.config.Scripts = append(p.config.Scripts, str)
+				}
+			}
+		}
+
+		// Parse backgrounds array
+		if backgrounds, ok := cfgMap["backgrounds"].([]interface{}); ok {
+			p.config.Backgrounds = make([]models.BackgroundElement, 0, len(backgrounds))
+			for _, bg := range backgrounds {
+				if bgMap, ok := bg.(map[string]interface{}); ok {
+					element := models.BackgroundElement{}
+					if html, ok := bgMap["html"].(string); ok {
+						element.HTML = html
+					}
+					switch v := bgMap["z_index"].(type) {
+					case int64:
+						element.ZIndex = int(v)
+					case int:
+						element.ZIndex = v
+					}
+					p.config.Backgrounds = append(p.config.Backgrounds, element)
+				}
+			}
+		}
+	}
+
+	return p.validate()
+}
+
+// validate checks that the configuration is valid.
+func (p *BackgroundPlugin) validate() error {
+	if !p.config.IsEnabled() {
+		return nil
+	}
+
+	// Validate that HTML in background elements doesn't contain dangerous content
+	for i, bg := range p.config.Backgrounds {
+		if bg.HTML == "" {
+			return fmt.Errorf("background element %d has empty HTML", i)
+		}
+		// Basic validation - warn if script tags are embedded directly
+		if strings.Contains(strings.ToLower(bg.HTML), "<script") {
+			return fmt.Errorf("background element %d contains <script> tag; use the scripts array instead", i)
+		}
+	}
+
+	return nil
+}
+
+// IsEnabled returns whether the background plugin is enabled.
+func (p *BackgroundPlugin) IsEnabled() bool {
+	return p.config.IsEnabled()
+}
+
+// Config returns the current background configuration.
+func (p *BackgroundPlugin) Config() models.BackgroundConfig {
+	return p.config
+}
+
+// SetConfig sets the background configuration directly.
+// This is useful for testing or programmatic configuration.
+func (p *BackgroundPlugin) SetConfig(config models.BackgroundConfig) {
+	p.config = config
+}
+
+// GenerateBackgroundHTML generates the HTML for background elements.
+// This is called by templates to inject background decorations.
+func (p *BackgroundPlugin) GenerateBackgroundHTML() string {
+	if !p.config.IsEnabled() || len(p.config.Backgrounds) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.WriteString("<!-- Background Decorations -->\n")
+
+	for _, bg := range p.config.Backgrounds {
+		if bg.ZIndex != 0 {
+			sb.WriteString(fmt.Sprintf(`<div class="background-layer" style="z-index: %d; position: fixed; inset: 0; pointer-events: none;">`, bg.ZIndex))
+		} else {
+			sb.WriteString(`<div class="background-layer" style="position: fixed; inset: 0; pointer-events: none; z-index: -1;">`)
+		}
+		sb.WriteString("\n  ")
+		sb.WriteString(bg.HTML)
+		sb.WriteString("\n</div>\n")
+	}
+
+	return sb.String()
+}
+
+// GenerateBackgroundCSS generates the CSS for background elements.
+// This is called by templates to inject custom CSS.
+func (p *BackgroundPlugin) GenerateBackgroundCSS() string {
+	if !p.config.IsEnabled() || p.config.CSS == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("<style>\n%s\n</style>", p.config.CSS)
+}
+
+// GenerateBackgroundScripts generates the script tags for background elements.
+// This is called by templates to inject scripts.
+func (p *BackgroundPlugin) GenerateBackgroundScripts() string {
+	if !p.config.IsEnabled() || len(p.config.Scripts) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.WriteString("<!-- Background Scripts -->\n")
+
+	for _, script := range p.config.Scripts {
+		sb.WriteString(fmt.Sprintf(`<script src=%q></script>`, script))
+		sb.WriteString("\n")
+	}
+
+	return sb.String()
+}
+
+// Ensure BackgroundPlugin implements the required interfaces.
+var (
+	_ lifecycle.Plugin          = (*BackgroundPlugin)(nil)
+	_ lifecycle.ConfigurePlugin = (*BackgroundPlugin)(nil)
+)

--- a/pkg/plugins/background_test.go
+++ b/pkg/plugins/background_test.go
@@ -1,0 +1,404 @@
+package plugins
+
+import (
+	"testing"
+
+	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
+	"github.com/WaylonWalker/markata-go/pkg/models"
+)
+
+func TestBackgroundPlugin_Name(t *testing.T) {
+	p := NewBackgroundPlugin()
+	if p.Name() != "background" {
+		t.Errorf("expected name 'background', got %q", p.Name())
+	}
+}
+
+func TestBackgroundPlugin_Interfaces(t *testing.T) {
+	_ = t // suppress unused parameter warning
+	p := NewBackgroundPlugin()
+
+	// Verify plugin implements required interfaces
+	var _ lifecycle.Plugin = p
+	var _ lifecycle.ConfigurePlugin = p
+}
+
+func TestBackgroundPlugin_DefaultDisabled(t *testing.T) {
+	p := NewBackgroundPlugin()
+	if p.IsEnabled() {
+		t.Error("expected background to be disabled by default")
+	}
+}
+
+func TestBackgroundPlugin_Configure(t *testing.T) {
+	tests := []struct {
+		name        string
+		extra       map[string]interface{}
+		wantEnabled bool
+		wantCSS     string
+		wantScripts []string
+		wantBgs     int
+		wantErr     bool
+	}{
+		{
+			name:        "empty config",
+			extra:       nil,
+			wantEnabled: false,
+		},
+		{
+			name: "enabled with backgrounds",
+			extra: map[string]interface{}{
+				"theme": map[string]interface{}{
+					"background": map[string]interface{}{
+						"enabled": true,
+						"backgrounds": []interface{}{
+							map[string]interface{}{
+								"html":    `<snow-fall count="200"></snow-fall>`,
+								"z_index": int64(-10),
+							},
+						},
+						"scripts": []interface{}{"/static/js/snow-fall.js"},
+						"css":     ".snow { color: white; }",
+					},
+				},
+			},
+			wantEnabled: true,
+			wantCSS:     ".snow { color: white; }",
+			wantScripts: []string{"/static/js/snow-fall.js"},
+			wantBgs:     1,
+		},
+		{
+			name: "multiple backgrounds",
+			extra: map[string]interface{}{
+				"theme": map[string]interface{}{
+					"background": map[string]interface{}{
+						"enabled": true,
+						"backgrounds": []interface{}{
+							map[string]interface{}{
+								"html": `<div class="stars"></div>`,
+							},
+							map[string]interface{}{
+								"html":    `<div class="clouds"></div>`,
+								"z_index": int64(-5),
+							},
+						},
+					},
+				},
+			},
+			wantEnabled: true,
+			wantBgs:     2,
+		},
+		{
+			name: "empty html in background",
+			extra: map[string]interface{}{
+				"theme": map[string]interface{}{
+					"background": map[string]interface{}{
+						"enabled": true,
+						"backgrounds": []interface{}{
+							map[string]interface{}{
+								"html": "",
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "script tag in html",
+			extra: map[string]interface{}{
+				"theme": map[string]interface{}{
+					"background": map[string]interface{}{
+						"enabled": true,
+						"backgrounds": []interface{}{
+							map[string]interface{}{
+								"html": `<script>alert("bad")</script>`,
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewBackgroundPlugin()
+			m := lifecycle.NewManager()
+
+			config := lifecycle.NewConfig()
+			config.Extra = tt.extra
+			m.SetConfig(config)
+
+			err := p.Configure(m)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Configure() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr {
+				return
+			}
+
+			if p.IsEnabled() != tt.wantEnabled {
+				t.Errorf("IsEnabled() = %v, want %v", p.IsEnabled(), tt.wantEnabled)
+			}
+
+			cfg := p.Config()
+			if cfg.CSS != tt.wantCSS {
+				t.Errorf("CSS = %q, want %q", cfg.CSS, tt.wantCSS)
+			}
+
+			if len(cfg.Scripts) != len(tt.wantScripts) {
+				t.Errorf("Scripts length = %d, want %d", len(cfg.Scripts), len(tt.wantScripts))
+			}
+
+			if len(cfg.Backgrounds) != tt.wantBgs {
+				t.Errorf("Backgrounds length = %d, want %d", len(cfg.Backgrounds), tt.wantBgs)
+			}
+		})
+	}
+}
+
+func TestBackgroundPlugin_GenerateBackgroundHTML(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   models.BackgroundConfig
+		contains []string
+		empty    bool
+	}{
+		{
+			name: "disabled",
+			config: models.BackgroundConfig{
+				Enabled:     bgBoolPtr(false),
+				Backgrounds: []models.BackgroundElement{{HTML: "<div></div>"}},
+			},
+			empty: true,
+		},
+		{
+			name: "no backgrounds",
+			config: models.BackgroundConfig{
+				Enabled:     bgBoolPtr(true),
+				Backgrounds: []models.BackgroundElement{},
+			},
+			empty: true,
+		},
+		{
+			name: "single background",
+			config: models.BackgroundConfig{
+				Enabled: bgBoolPtr(true),
+				Backgrounds: []models.BackgroundElement{
+					{HTML: `<snow-fall count="200"></snow-fall>`},
+				},
+			},
+			contains: []string{
+				"background-layer",
+				`<snow-fall count="200"></snow-fall>`,
+				"z-index: -1",
+			},
+		},
+		{
+			name: "background with z-index",
+			config: models.BackgroundConfig{
+				Enabled: bgBoolPtr(true),
+				Backgrounds: []models.BackgroundElement{
+					{HTML: `<div class="stars"></div>`, ZIndex: -10},
+				},
+			},
+			contains: []string{
+				"z-index: -10",
+				`<div class="stars"></div>`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewBackgroundPlugin()
+			p.SetConfig(tt.config)
+
+			result := p.GenerateBackgroundHTML()
+
+			if tt.empty {
+				if result != "" {
+					t.Errorf("expected empty result, got %q", result)
+				}
+				return
+			}
+
+			for _, want := range tt.contains {
+				if !bgContainsString(result, want) {
+					t.Errorf("result missing %q:\n%s", want, result)
+				}
+			}
+		})
+	}
+}
+
+func TestBackgroundPlugin_GenerateBackgroundCSS(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   models.BackgroundConfig
+		contains string
+		empty    bool
+	}{
+		{
+			name: "disabled",
+			config: models.BackgroundConfig{
+				Enabled: bgBoolPtr(false),
+				CSS:     ".test { color: red; }",
+			},
+			empty: true,
+		},
+		{
+			name: "no css",
+			config: models.BackgroundConfig{
+				Enabled: bgBoolPtr(true),
+				CSS:     "",
+			},
+			empty: true,
+		},
+		{
+			name: "with css",
+			config: models.BackgroundConfig{
+				Enabled: bgBoolPtr(true),
+				CSS:     ".snow { opacity: 0.8; }",
+			},
+			contains: ".snow { opacity: 0.8; }",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewBackgroundPlugin()
+			p.SetConfig(tt.config)
+
+			result := p.GenerateBackgroundCSS()
+
+			if tt.empty {
+				if result != "" {
+					t.Errorf("expected empty result, got %q", result)
+				}
+				return
+			}
+
+			if !bgContainsString(result, tt.contains) {
+				t.Errorf("result missing %q:\n%s", tt.contains, result)
+			}
+
+			if !bgContainsString(result, "<style>") {
+				t.Error("result missing <style> tag")
+			}
+		})
+	}
+}
+
+func TestBackgroundPlugin_GenerateBackgroundScripts(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   models.BackgroundConfig
+		contains []string
+		empty    bool
+	}{
+		{
+			name: "disabled",
+			config: models.BackgroundConfig{
+				Enabled: bgBoolPtr(false),
+				Scripts: []string{"/js/test.js"},
+			},
+			empty: true,
+		},
+		{
+			name: "no scripts",
+			config: models.BackgroundConfig{
+				Enabled: bgBoolPtr(true),
+				Scripts: []string{},
+			},
+			empty: true,
+		},
+		{
+			name: "single script",
+			config: models.BackgroundConfig{
+				Enabled: bgBoolPtr(true),
+				Scripts: []string{"/static/js/snow-fall.js"},
+			},
+			contains: []string{
+				`<script src="/static/js/snow-fall.js"></script>`,
+			},
+		},
+		{
+			name: "multiple scripts",
+			config: models.BackgroundConfig{
+				Enabled: bgBoolPtr(true),
+				Scripts: []string{"/js/particles.js", "/js/snow.js"},
+			},
+			contains: []string{
+				`<script src="/js/particles.js"></script>`,
+				`<script src="/js/snow.js"></script>`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewBackgroundPlugin()
+			p.SetConfig(tt.config)
+
+			result := p.GenerateBackgroundScripts()
+
+			if tt.empty {
+				if result != "" {
+					t.Errorf("expected empty result, got %q", result)
+				}
+				return
+			}
+
+			for _, want := range tt.contains {
+				if !bgContainsString(result, want) {
+					t.Errorf("result missing %q:\n%s", want, result)
+				}
+			}
+		})
+	}
+}
+
+func TestBackgroundConfig_IsEnabled(t *testing.T) {
+	tests := []struct {
+		name    string
+		enabled *bool
+		want    bool
+	}{
+		{"nil defaults to false", nil, false},
+		{"explicit true", bgBoolPtr(true), true},
+		{"explicit false", bgBoolPtr(false), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := models.BackgroundConfig{Enabled: tt.enabled}
+			if got := cfg.IsEnabled(); got != tt.want {
+				t.Errorf("IsEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// Helper function
+func bgContainsString(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || s != "" && bgContainsSubstring(s, substr))
+}
+
+func bgContainsSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+// bgBoolPtr returns a pointer to the given bool value
+func bgBoolPtr(b bool) *bool {
+	return &b
+}

--- a/pkg/plugins/registry.go
+++ b/pkg/plugins/registry.go
@@ -71,6 +71,7 @@ func registerBuiltinPluginsLocked() {
 	pluginRegistry.constructors["blogroll"] = func() lifecycle.Plugin { return NewBlogrollPlugin() }
 	pluginRegistry.constructors["mentions"] = func() lifecycle.Plugin { return NewMentionsPlugin() }
 	pluginRegistry.constructors["webmentions"] = func() lifecycle.Plugin { return NewWebMentionsPlugin() }
+	pluginRegistry.constructors["background"] = func() lifecycle.Plugin { return NewBackgroundPlugin() }
 }
 
 // RegisterPluginConstructor registers a plugin constructor with the given name.
@@ -117,6 +118,7 @@ func DefaultPlugins() []lifecycle.Plugin {
 	return []lifecycle.Plugin{
 		// Configure/Glob stage plugins
 		NewGlobPlugin(),
+		NewBackgroundPlugin(), // Configure background decorations early
 
 		// Load stage plugins
 		NewLoadPlugin(),

--- a/templates/base.html
+++ b/templates/base.html
@@ -102,6 +102,15 @@
     {% if config.webmention.enabled %}
     {% if config.webmention.endpoint %}<link rel="webmention" href="{{ config.webmention.endpoint }}">{% endif %}
     {% endif %}
+
+    <!-- Background Decoration CSS -->
+    {% if config.theme.background.enabled %}
+    {% if config.theme.background.css %}
+    <style>
+{{ config.theme.background.css }}
+    </style>
+    {% endif %}
+    {% endif %}
     {% endblock %}
 
     <!-- Structured Data: JSON-LD -->
@@ -155,6 +164,15 @@
     {% endif %}
 </head>
 <body class="{% block body_class %}{% endblock %}">
+    <!-- Background Decorations -->
+    {% if config.theme.background.enabled %}
+    {% for bg in config.theme.background.backgrounds %}
+    <div class="background-layer" style="position: fixed; inset: 0; pointer-events: none; z-index: {% if bg.z_index %}{{ bg.z_index }}{% else %}-1{% endif %};">
+      {{ bg.html | safe }}
+    </div>
+    {% endfor %}
+    {% endif %}
+
     {% block header %}
     <header class="site-header" data-pagefind-ignore>
         <div class="container">
@@ -203,6 +221,13 @@
             }
         });
     </script>
+    {% endif %}
+
+    <!-- Background Decoration Scripts -->
+    {% if config.theme.background.enabled %}
+    {% for script in config.theme.background.scripts %}
+    <script src="{{ script }}"></script>
+    {% endfor %}
     {% endif %}
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Add `BackgroundConfig` and `BackgroundElement` types to models for configuring multi-layered background decorations
- Add `background` plugin with configuration validation (prevents script injection, validates HTML)
- Update `base.html` template to render background elements, CSS, and scripts
- Add comprehensive tests for the background plugin
- Update themes documentation with background decorations guide

Fixes #326

## Configuration Example

```toml
[markata-go.theme.background]
enabled = true

backgrounds = [
  { html = '<snow-fall count="200"></snow-fall>' },
]

scripts = ["/static/js/snow-fall.js"]

css = '''
.dubs {
  position: fixed;
  pointer-events: none;
}
'''
```

## Changes

- `pkg/models/config.go`: Add `BackgroundConfig` and `BackgroundElement` types with serialization tags
- `pkg/plugins/background.go`: New plugin implementing `lifecycle.ConfigurePlugin`
- `pkg/plugins/background_test.go`: Comprehensive tests for the plugin
- `pkg/plugins/registry.go`: Register the background plugin
- `templates/base.html`: Add background elements, CSS, and scripts injection
- `docs/guides/themes.md`: Add documentation for background decorations

Also includes a bug fix for a typo in `pkg/tui/model.go` (feedCursor -> cursor).