### PR TITLE
fix(templates): correct card.html include path in feed template

### DIFF
--- a/pkg/themes/default/templates/feed.html
+++ b/pkg/themes/default/templates/feed.html
@@ -23,12 +23,12 @@
     {% if page.pagination_type == "js" %}
     {# For JS pagination, render ALL posts - JavaScript will handle showing/hiding #}
     {% for post in feed.posts %}
-    {% include "partials/card.html" %}
+    {% include "card.html" %}
     {% endfor %}
     {% else %}
     {# For manual/htmx pagination, render only current page posts #}
     {% for post in page.posts %}
-    {% include "partials/card.html" %}
+    {% include "card.html" %}
     {% endfor %}
     {% endif %}
   </div>


### PR DESCRIPTION
## Summary

- Fix incorrect template include path in `feed.html` that was causing feed pages to use fallback template

## Problem

The `feed.html` embedded template was referencing `partials/card.html`, but the card template is actually located at `card.html` (not in a partials subdirectory). This caused:

1. Template rendering to fail silently when loading `feed.html`
2. Feed pages to fall back to the hardcoded Go template
3. Missing nav items and footer components on feed pages (archive, blog, tags, etc.)

## Fix

Changed the include paths from `partials/card.html` to `card.html` to match the actual template location.

## Testing

Verified fix by building the waylonwalker.com-markata-go-migration site - feed pages now correctly display:
- All 5 nav items from config (Home, Start Here, Archive, About, RSS)
- Proper CSS classes (`site-nav site-nav--header site-nav--horizontal`)
- Footer with copyright and markata-go link