### PR TITLE
feat(plugins): add image zoom/lightbox with GLightbox

### DIFF
--- a/docs/guides/markdown.md
+++ b/docs/guides/markdown.md
@@ -1502,3 +1502,151 @@ Here's an inline footnote.^[This is the footnote content inline.]
 - [[dynamic-content|Dynamic Content]] - Using Jinja in Markdown
 - [[frontmatter-guide|Frontmatter]] - Frontmatter fields and metadata
 - [[configuration-guide|Configuration]] - Markdown configuration options
+
+---
+
+## Image Zoom / Lightbox
+
+markata-go supports optional image zoom functionality using GLightbox. When enabled, users can click/tap images to view them in a full-screen lightbox with support for mobile gestures, keyboard navigation, and gallery mode.
+
+### Enabling Image Zoom
+
+Image zoom is disabled by default. Enable it in your `markata-go.toml`:
+
+```toml
+[markata-go.image_zoom]
+enabled = true
+```
+
+### Marking Individual Images
+
+Use the `{data-zoomable}` attribute marker to make specific images zoomable:
+
+**Input:**
+
+```markdown
+![Beautiful sunset {data-zoomable}](/images/sunset.jpg)
+
+![Regular image without zoom](/images/icon.png)
+```
+
+**Output:**
+
+```html
+<a href="/images/sunset.jpg" class="glightbox-link">
+  <img src="/images/sunset.jpg" alt="Beautiful sunset" class="glightbox" data-glightbox="description: Beautiful sunset">
+</a>
+
+<img src="/images/icon.png" alt="Regular image without zoom">
+```
+
+The first image will open in a lightbox when clicked. The second remains a regular image.
+
+### Alternative: Class Marker
+
+You can also use the `{.zoomable}` class marker:
+
+```markdown
+![Photo {.zoomable}](/images/photo.jpg)
+```
+
+### Enable for All Images in a Post
+
+Add `image_zoom: true` to your frontmatter to enable zoom for all images in that post:
+
+```yaml
+---
+title: "Photo Gallery"
+image_zoom: true
+---
+
+![First photo](/images/photo1.jpg)
+![Second photo](/images/photo2.jpg)
+![Third photo](/images/photo3.jpg)
+```
+
+All three images will be zoomable without needing individual markers.
+
+### Enable for All Images Site-Wide
+
+To make all images zoomable by default across your entire site:
+
+```toml
+[markata-go.image_zoom]
+enabled = true
+auto_all_images = true
+```
+
+### Configuration Options
+
+```toml
+[markata-go.image_zoom]
+enabled = false           # Enable the plugin (default: false)
+library = "glightbox"     # Lightbox library (currently only glightbox supported)
+selector = ".glightbox"   # CSS selector for zoomable images
+cdn = true                # Use CDN for library files (default: true)
+auto_all_images = false   # Make all images zoomable (default: false)
+
+# GLightbox-specific options
+open_effect = "zoom"      # Effect when opening: "zoom", "fade", "none"
+close_effect = "zoom"     # Effect when closing: "zoom", "fade", "none"
+slide_effect = "slide"    # Effect when sliding: "slide", "fade", "zoom", "none"
+touch_navigation = true   # Enable touch/swipe gestures
+loop = false              # Loop through images in gallery
+draggable = true          # Enable dragging images to navigate
+```
+
+### Keyboard Navigation
+
+When the lightbox is open:
+
+| Key | Action |
+|-----|--------|
+| `Escape` | Close the lightbox |
+| `→` / `Right Arrow` | Next image (in gallery) |
+| `←` / `Left Arrow` | Previous image (in gallery) |
+
+### Mobile Gestures
+
+On touch devices:
+
+| Gesture | Action |
+|---------|--------|
+| Swipe left/right | Navigate between images |
+| Pinch | Zoom in/out |
+| Drag | Pan zoomed image |
+| Tap outside | Close lightbox |
+
+### Image Galleries
+
+Images marked as zoomable within the same post automatically form a gallery. Users can navigate between them using arrow keys or swipe gestures.
+
+### CSS Customization
+
+Style the lightbox links with CSS:
+
+```css
+/* Style the zoomable image wrapper */
+.glightbox-link {
+  display: inline-block;
+  cursor: zoom-in;
+}
+
+/* Add hover effect */
+.glightbox-link:hover img {
+  opacity: 0.9;
+  transform: scale(1.02);
+  transition: all 0.2s ease;
+}
+
+/* Style for zoomable images */
+img.glightbox {
+  cursor: zoom-in;
+}
+```
+
+### Performance Notes
+
+- JavaScript and CSS for GLightbox are only loaded on pages that have zoomable images
+- When using CDN (default), files are loaded from jsDelivr
+- The library is ~11KB gzipped, loaded asynchronously

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -1062,6 +1062,63 @@ func NewYouTubeConfig() YouTubeConfig {
 	}
 }
 
+// ImageZoomConfig configures the image_zoom plugin for lightbox functionality.
+type ImageZoomConfig struct {
+	// Enabled controls whether image zoom is active (default: false)
+	Enabled bool `json:"enabled" yaml:"enabled" toml:"enabled"`
+
+	// Library is the lightbox library to use (default: "glightbox")
+	// Supported: "glightbox"
+	Library string `json:"library" yaml:"library" toml:"library"`
+
+	// Selector is the CSS selector for images to make zoomable (default: ".glightbox")
+	Selector string `json:"selector" yaml:"selector" toml:"selector"`
+
+	// CDN uses CDN for library files instead of local (default: true)
+	CDN bool `json:"cdn" yaml:"cdn" toml:"cdn"`
+
+	// AutoAllImages enables zoom on all images without explicit marking (default: false)
+	AutoAllImages bool `json:"auto_all_images" yaml:"auto_all_images" toml:"auto_all_images"`
+
+	// OpenEffect is the effect when opening the lightbox (default: "zoom")
+	// Options: "zoom", "fade", "none"
+	OpenEffect string `json:"open_effect" yaml:"open_effect" toml:"open_effect"`
+
+	// CloseEffect is the effect when closing the lightbox (default: "zoom")
+	// Options: "zoom", "fade", "none"
+	CloseEffect string `json:"close_effect" yaml:"close_effect" toml:"close_effect"`
+
+	// SlideEffect is the effect when sliding between images (default: "slide")
+	// Options: "slide", "fade", "zoom", "none"
+	SlideEffect string `json:"slide_effect" yaml:"slide_effect" toml:"slide_effect"`
+
+	// TouchNavigation enables touch/swipe navigation (default: true)
+	TouchNavigation bool `json:"touch_navigation" yaml:"touch_navigation" toml:"touch_navigation"`
+
+	// Loop enables looping through images in a gallery (default: false)
+	Loop bool `json:"loop" yaml:"loop" toml:"loop"`
+
+	// Draggable enables dragging images to navigate (default: true)
+	Draggable bool `json:"draggable" yaml:"draggable" toml:"draggable"`
+}
+
+// NewImageZoomConfig creates a new ImageZoomConfig with default values.
+func NewImageZoomConfig() ImageZoomConfig {
+	return ImageZoomConfig{
+		Enabled:         false, // Disabled by default
+		Library:         "glightbox",
+		Selector:        ".glightbox",
+		CDN:             true,
+		AutoAllImages:   false,
+		OpenEffect:      "zoom",
+		CloseEffect:     "zoom",
+		SlideEffect:     "slide",
+		TouchNavigation: true,
+		Loop:            false,
+		Draggable:       true,
+	}
+}
+
 // EmbedsConfig configures the embeds plugin for embedding internal and external content.
 type EmbedsConfig struct {
 	// Enabled controls whether embed processing is active (default: true)

--- a/pkg/plugins/image_zoom.go
+++ b/pkg/plugins/image_zoom.go
@@ -1,0 +1,277 @@
+// Package plugins provides lifecycle plugins for markata-go.
+package plugins
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
+	"github.com/WaylonWalker/markata-go/pkg/models"
+)
+
+// ImageZoomPlugin adds optional image zoom/lightbox functionality using GLightbox.
+// It runs at the render stage (post_render, after markdown conversion) to add
+// data-zoomable attributes to images, and at the write stage to inject the
+// required JavaScript and CSS.
+type ImageZoomPlugin struct {
+	config models.ImageZoomConfig
+}
+
+// NewImageZoomPlugin creates a new ImageZoomPlugin with default settings.
+func NewImageZoomPlugin() *ImageZoomPlugin {
+	return &ImageZoomPlugin{
+		config: models.NewImageZoomConfig(),
+	}
+}
+
+// Name returns the unique name of the plugin.
+func (p *ImageZoomPlugin) Name() string {
+	return "image_zoom"
+}
+
+// Priority returns the plugin's priority for a given stage.
+// This plugin runs after render_markdown (which has default priority 0).
+func (p *ImageZoomPlugin) Priority(stage lifecycle.Stage) int {
+	if stage == lifecycle.StageRender {
+		return lifecycle.PriorityLate // Run after render_markdown
+	}
+	return lifecycle.PriorityDefault
+}
+
+// Configure reads configuration options for the plugin from config.Extra.
+// Configuration is expected under the "image_zoom" key.
+func (p *ImageZoomPlugin) Configure(m *lifecycle.Manager) error {
+	config := m.Config()
+	if config.Extra == nil {
+		return nil
+	}
+
+	// Check for image_zoom config in Extra
+	imageZoomConfig, ok := config.Extra["image_zoom"]
+	if !ok {
+		return nil
+	}
+
+	// Handle map configuration
+	if cfgMap, ok := imageZoomConfig.(map[string]interface{}); ok {
+		if enabled, ok := cfgMap["enabled"].(bool); ok {
+			p.config.Enabled = enabled
+		}
+		if library, ok := cfgMap["library"].(string); ok && library != "" {
+			p.config.Library = library
+		}
+		if selector, ok := cfgMap["selector"].(string); ok && selector != "" {
+			p.config.Selector = selector
+		}
+		if cdn, ok := cfgMap["cdn"].(bool); ok {
+			p.config.CDN = cdn
+		}
+		if autoAllImages, ok := cfgMap["auto_all_images"].(bool); ok {
+			p.config.AutoAllImages = autoAllImages
+		}
+		if openEffect, ok := cfgMap["open_effect"].(string); ok && openEffect != "" {
+			p.config.OpenEffect = openEffect
+		}
+		if closeEffect, ok := cfgMap["close_effect"].(string); ok && closeEffect != "" {
+			p.config.CloseEffect = closeEffect
+		}
+		if slideEffect, ok := cfgMap["slide_effect"].(string); ok && slideEffect != "" {
+			p.config.SlideEffect = slideEffect
+		}
+		if touchNavigation, ok := cfgMap["touch_navigation"].(bool); ok {
+			p.config.TouchNavigation = touchNavigation
+		}
+		if loop, ok := cfgMap["loop"].(bool); ok {
+			p.config.Loop = loop
+		}
+		if draggable, ok := cfgMap["draggable"].(bool); ok {
+			p.config.Draggable = draggable
+		}
+	}
+
+	return nil
+}
+
+// Render processes images in the rendered HTML for all posts.
+// It adds data-glightbox attributes to images that should be zoomable.
+func (p *ImageZoomPlugin) Render(m *lifecycle.Manager) error {
+	if !p.config.Enabled {
+		return nil
+	}
+
+	return m.ProcessPostsConcurrently(p.processPost)
+}
+
+// imageZoomImgTagRegex matches <img> tags and captures their attributes.
+var imageZoomImgTagRegex = regexp.MustCompile(`<img\s+([^>]*)>`)
+
+// dataZoomableRegex matches the {data-zoomable} attribute marker in alt text or title.
+var dataZoomableRegex = regexp.MustCompile(`\{data-zoomable\}`)
+
+// zoomableClassRegex matches the {.zoomable} class marker in alt text or title.
+var zoomableClassRegex = regexp.MustCompile(`\{\.zoomable\}`)
+
+// processPost processes a single post's HTML for images that should be zoomable.
+func (p *ImageZoomPlugin) processPost(post *models.Post) error {
+	// Skip posts marked as skip or with no HTML content
+	if post.Skip || post.ArticleHTML == "" {
+		return nil
+	}
+
+	// Check frontmatter for image_zoom setting
+	postZoomEnabled := p.config.AutoAllImages
+	if post.Extra != nil {
+		if imgZoom, ok := post.Extra["image_zoom"]; ok {
+			if enabled, ok := imgZoom.(bool); ok {
+				postZoomEnabled = enabled
+			}
+		}
+	}
+
+	// Track if we found any zoomable images
+	foundZoomable := false
+
+	// Process all img tags
+	result := imageZoomImgTagRegex.ReplaceAllStringFunc(post.ArticleHTML, func(match string) string {
+		// Extract the attributes
+		submatches := imageZoomImgTagRegex.FindStringSubmatch(match)
+		if len(submatches) < 2 {
+			return match
+		}
+		attrs := submatches[1]
+
+		// Check if already has glightbox attribute
+		if strings.Contains(attrs, "data-glightbox") {
+			foundZoomable = true
+			return match
+		}
+
+		// Check for {data-zoomable} or {.zoomable} markers in alt text
+		hasZoomableMarker := dataZoomableRegex.MatchString(attrs) || zoomableClassRegex.MatchString(attrs)
+
+		// Determine if this image should be zoomable
+		shouldZoom := hasZoomableMarker || postZoomEnabled
+
+		if !shouldZoom {
+			return match
+		}
+
+		foundZoomable = true
+
+		// Clean up the markers from alt text if present
+		cleanedAttrs := dataZoomableRegex.ReplaceAllString(attrs, "")
+		cleanedAttrs = zoomableClassRegex.ReplaceAllString(cleanedAttrs, "")
+		cleanedAttrs = strings.TrimSpace(cleanedAttrs)
+
+		// Extract src and alt for the glightbox data attribute
+		srcMatch := regexp.MustCompile(`src="([^"]+)"`).FindStringSubmatch(cleanedAttrs)
+		altMatch := regexp.MustCompile(`alt="([^"]*)"`).FindStringSubmatch(cleanedAttrs)
+
+		src := ""
+		alt := ""
+		if len(srcMatch) > 1 {
+			src = srcMatch[1]
+		}
+		if len(altMatch) > 1 {
+			alt = strings.TrimSpace(altMatch[1])
+		}
+
+		// Build the glightbox data attribute
+		glightboxAttr := fmt.Sprintf(`data-glightbox="description: %s"`, alt)
+
+		// Add the gallery class and data attribute
+		if strings.Contains(cleanedAttrs, `class="`) {
+			// Append to existing class
+			cleanedAttrs = regexp.MustCompile(`class="([^"]*)"`).ReplaceAllString(
+				cleanedAttrs,
+				`class="$1 glightbox"`,
+			)
+		} else {
+			// Add new class attribute
+			cleanedAttrs = `class="glightbox" ` + cleanedAttrs
+		}
+
+		// Add the data-glightbox attribute
+		cleanedAttrs = cleanedAttrs + " " + glightboxAttr
+
+		// Wrap image in anchor for lightbox functionality
+		return `<a href="` + src + `" class="glightbox-link"><img ` + cleanedAttrs + `></a>`
+	})
+
+	// Store whether this post needs the glightbox library
+	if foundZoomable {
+		if post.Extra == nil {
+			post.Extra = make(map[string]interface{})
+		}
+		post.Extra["needs_image_zoom"] = true
+	}
+
+	post.ArticleHTML = result
+	return nil
+}
+
+// Write injects GLightbox CSS and JS into posts that need it.
+func (p *ImageZoomPlugin) Write(m *lifecycle.Manager) error {
+	if !p.config.Enabled {
+		return nil
+	}
+
+	// Check if any posts need image zoom
+	needsZoom := false
+	for _, post := range m.Posts() {
+		if post.Extra != nil {
+			if needs, ok := post.Extra["needs_image_zoom"].(bool); ok && needs {
+				needsZoom = true
+				break
+			}
+		}
+	}
+
+	if !needsZoom {
+		return nil
+	}
+
+	// Store the GLightbox configuration for templates to use
+	config := m.Config()
+	if config.Extra == nil {
+		config.Extra = make(map[string]interface{})
+	}
+
+	// Build the GLightbox initialization options
+	glightboxOptions := map[string]interface{}{
+		"selector":        p.config.Selector,
+		"openEffect":      p.config.OpenEffect,
+		"closeEffect":     p.config.CloseEffect,
+		"slideEffect":     p.config.SlideEffect,
+		"touchNavigation": p.config.TouchNavigation,
+		"loop":            p.config.Loop,
+		"draggable":       p.config.Draggable,
+	}
+
+	config.Extra["glightbox_options"] = glightboxOptions
+	config.Extra["glightbox_enabled"] = true
+	config.Extra["glightbox_cdn"] = p.config.CDN
+
+	return nil
+}
+
+// SetConfig sets the image zoom configuration directly.
+// This is useful for testing or programmatic configuration.
+func (p *ImageZoomPlugin) SetConfig(config models.ImageZoomConfig) {
+	p.config = config
+}
+
+// Config returns the current image zoom configuration.
+func (p *ImageZoomPlugin) Config() models.ImageZoomConfig {
+	return p.config
+}
+
+// Ensure ImageZoomPlugin implements the required interfaces.
+var (
+	_ lifecycle.Plugin          = (*ImageZoomPlugin)(nil)
+	_ lifecycle.ConfigurePlugin = (*ImageZoomPlugin)(nil)
+	_ lifecycle.RenderPlugin    = (*ImageZoomPlugin)(nil)
+	_ lifecycle.WritePlugin     = (*ImageZoomPlugin)(nil)
+	_ lifecycle.PriorityPlugin  = (*ImageZoomPlugin)(nil)
+)

--- a/pkg/plugins/image_zoom_test.go
+++ b/pkg/plugins/image_zoom_test.go
@@ -1,0 +1,277 @@
+package plugins
+
+import (
+	"testing"
+
+	"github.com/WaylonWalker/markata-go/pkg/models"
+)
+
+func TestImageZoomPlugin_Name(t *testing.T) {
+	p := NewImageZoomPlugin()
+	if got := p.Name(); got != "image_zoom" {
+		t.Errorf("Name() = %q, want %q", got, "image_zoom")
+	}
+}
+
+func TestImageZoomPlugin_DefaultConfig(t *testing.T) {
+	p := NewImageZoomPlugin()
+	cfg := p.Config()
+
+	if cfg.Enabled != false {
+		t.Errorf("default Enabled = %v, want false", cfg.Enabled)
+	}
+	if cfg.Library != "glightbox" {
+		t.Errorf("default Library = %q, want %q", cfg.Library, "glightbox")
+	}
+	if cfg.Selector != ".glightbox" {
+		t.Errorf("default Selector = %q, want %q", cfg.Selector, ".glightbox")
+	}
+	if cfg.CDN != true {
+		t.Errorf("default CDN = %v, want true", cfg.CDN)
+	}
+	if cfg.AutoAllImages != false {
+		t.Errorf("default AutoAllImages = %v, want false", cfg.AutoAllImages)
+	}
+	if cfg.OpenEffect != "zoom" {
+		t.Errorf("default OpenEffect = %q, want %q", cfg.OpenEffect, "zoom")
+	}
+}
+
+func TestImageZoomPlugin_ProcessPostDisabled(t *testing.T) {
+	p := NewImageZoomPlugin()
+	// Plugin is disabled by default
+
+	post := &models.Post{
+		ArticleHTML: `<p><img src="test.jpg" alt="Test image"></p>`,
+	}
+
+	// Process should be a no-op when disabled
+	err := p.processPost(post)
+	if err != nil {
+		t.Errorf("processPost() error = %v", err)
+	}
+
+	// HTML should be unchanged
+	expected := `<p><img src="test.jpg" alt="Test image"></p>`
+	if post.ArticleHTML != expected {
+		t.Errorf("ArticleHTML = %q, want %q", post.ArticleHTML, expected)
+	}
+}
+
+func TestImageZoomPlugin_ProcessPostWithDataZoomable(t *testing.T) {
+	p := NewImageZoomPlugin()
+	p.SetConfig(models.ImageZoomConfig{
+		Enabled:  true,
+		Library:  "glightbox",
+		Selector: ".glightbox",
+	})
+
+	post := &models.Post{
+		ArticleHTML: `<p><img src="test.jpg" alt="Test image {data-zoomable}"></p>`,
+	}
+
+	err := p.processPost(post)
+	if err != nil {
+		t.Errorf("processPost() error = %v", err)
+	}
+
+	// Check that the image was wrapped in an anchor
+	if !containsSubstring(post.ArticleHTML, `<a href="test.jpg" class="glightbox-link">`) {
+		t.Errorf("ArticleHTML should contain glightbox anchor, got: %s", post.ArticleHTML)
+	}
+
+	// Check that data-glightbox attribute was added
+	if !containsSubstring(post.ArticleHTML, `data-glightbox=`) {
+		t.Errorf("ArticleHTML should contain data-glightbox attribute, got: %s", post.ArticleHTML)
+	}
+
+	// Check that the marker was removed from alt text
+	if containsSubstring(post.ArticleHTML, `{data-zoomable}`) {
+		t.Errorf("ArticleHTML should not contain {data-zoomable} marker, got: %s", post.ArticleHTML)
+	}
+
+	// Check that needs_image_zoom flag was set
+	if post.Extra == nil || post.Extra["needs_image_zoom"] != true {
+		t.Errorf("post.Extra[needs_image_zoom] should be true")
+	}
+}
+
+func TestImageZoomPlugin_ProcessPostWithZoomableClass(t *testing.T) {
+	p := NewImageZoomPlugin()
+	p.SetConfig(models.ImageZoomConfig{
+		Enabled:  true,
+		Library:  "glightbox",
+		Selector: ".glightbox",
+	})
+
+	post := &models.Post{
+		ArticleHTML: `<p><img src="photo.png" alt="Photo {.zoomable}"></p>`,
+	}
+
+	err := p.processPost(post)
+	if err != nil {
+		t.Errorf("processPost() error = %v", err)
+	}
+
+	// Check that the image was processed
+	if !containsSubstring(post.ArticleHTML, `<a href="photo.png" class="glightbox-link">`) {
+		t.Errorf("ArticleHTML should contain glightbox anchor, got: %s", post.ArticleHTML)
+	}
+
+	// Check that the marker was removed
+	if containsSubstring(post.ArticleHTML, `{.zoomable}`) {
+		t.Errorf("ArticleHTML should not contain {.zoomable} marker, got: %s", post.ArticleHTML)
+	}
+}
+
+func TestImageZoomPlugin_ProcessPostAutoAllImages(t *testing.T) {
+	p := NewImageZoomPlugin()
+	p.SetConfig(models.ImageZoomConfig{
+		Enabled:       true,
+		Library:       "glightbox",
+		Selector:      ".glightbox",
+		AutoAllImages: true,
+	})
+
+	post := &models.Post{
+		ArticleHTML: `<p><img src="test.jpg" alt="Regular image"></p>`,
+	}
+
+	err := p.processPost(post)
+	if err != nil {
+		t.Errorf("processPost() error = %v", err)
+	}
+
+	// All images should be zoomable when AutoAllImages is true
+	if !containsSubstring(post.ArticleHTML, `<a href="test.jpg" class="glightbox-link">`) {
+		t.Errorf("ArticleHTML should contain glightbox anchor with AutoAllImages, got: %s", post.ArticleHTML)
+	}
+}
+
+func TestImageZoomPlugin_ProcessPostFrontmatterOverride(t *testing.T) {
+	p := NewImageZoomPlugin()
+	p.SetConfig(models.ImageZoomConfig{
+		Enabled:       true,
+		Library:       "glightbox",
+		Selector:      ".glightbox",
+		AutoAllImages: false, // Default off
+	})
+
+	post := &models.Post{
+		ArticleHTML: `<p><img src="test.jpg" alt="Regular image"></p>`,
+		Extra: map[string]interface{}{
+			"image_zoom": true, // Frontmatter enables for this post
+		},
+	}
+
+	err := p.processPost(post)
+	if err != nil {
+		t.Errorf("processPost() error = %v", err)
+	}
+
+	// Image should be zoomable due to frontmatter override
+	if !containsSubstring(post.ArticleHTML, `<a href="test.jpg" class="glightbox-link">`) {
+		t.Errorf("ArticleHTML should contain glightbox anchor with frontmatter override, got: %s", post.ArticleHTML)
+	}
+}
+
+func TestImageZoomPlugin_ProcessPostSkipsSkippedPosts(t *testing.T) {
+	p := NewImageZoomPlugin()
+	p.SetConfig(models.ImageZoomConfig{
+		Enabled:       true,
+		AutoAllImages: true,
+	})
+
+	post := &models.Post{
+		Skip:        true,
+		ArticleHTML: `<p><img src="test.jpg" alt="Test"></p>`,
+	}
+
+	originalHTML := post.ArticleHTML
+
+	err := p.processPost(post)
+	if err != nil {
+		t.Errorf("processPost() error = %v", err)
+	}
+
+	// HTML should be unchanged for skipped posts
+	if post.ArticleHTML != originalHTML {
+		t.Errorf("ArticleHTML should be unchanged for skipped posts")
+	}
+}
+
+func TestImageZoomPlugin_ProcessPostPreservesExistingGlightbox(t *testing.T) {
+	p := NewImageZoomPlugin()
+	p.SetConfig(models.ImageZoomConfig{
+		Enabled:       true,
+		AutoAllImages: true,
+	})
+
+	// Image already has data-glightbox
+	post := &models.Post{
+		ArticleHTML: `<p><img src="test.jpg" alt="Test" data-glightbox="gallery1"></p>`,
+	}
+
+	err := p.processPost(post)
+	if err != nil {
+		t.Errorf("processPost() error = %v", err)
+	}
+
+	// Should not double-wrap
+	if containsSubstring(post.ArticleHTML, `<a href="test.jpg" class="glightbox-link">`) {
+		t.Errorf("ArticleHTML should not wrap already-glightbox images")
+	}
+
+	// But should still mark as needs_image_zoom
+	if post.Extra == nil || post.Extra["needs_image_zoom"] != true {
+		t.Errorf("post.Extra[needs_image_zoom] should be true even for existing glightbox")
+	}
+}
+
+func TestImageZoomPlugin_MultipleImages(t *testing.T) {
+	p := NewImageZoomPlugin()
+	p.SetConfig(models.ImageZoomConfig{
+		Enabled:  true,
+		Library:  "glightbox",
+		Selector: ".glightbox",
+	})
+
+	post := &models.Post{
+		ArticleHTML: `<p><img src="a.jpg" alt="Image A {data-zoomable}"></p>
+<p><img src="b.jpg" alt="Image B"></p>
+<p><img src="c.jpg" alt="Image C {data-zoomable}"></p>`,
+	}
+
+	err := p.processPost(post)
+	if err != nil {
+		t.Errorf("processPost() error = %v", err)
+	}
+
+	// First and third images should be zoomable
+	if !containsSubstring(post.ArticleHTML, `<a href="a.jpg" class="glightbox-link">`) {
+		t.Errorf("First image should be zoomable")
+	}
+	if !containsSubstring(post.ArticleHTML, `<a href="c.jpg" class="glightbox-link">`) {
+		t.Errorf("Third image should be zoomable")
+	}
+
+	// Second image should NOT be zoomable (no marker, AutoAllImages is false)
+	// It should still be a plain img tag
+	if containsSubstring(post.ArticleHTML, `<a href="b.jpg"`) {
+		t.Errorf("Second image should not be zoomable without marker")
+	}
+}
+
+// containsSubstring is a helper to check if a string contains a substring.
+func containsSubstring(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || s != "" && containsSubstringHelper(s, substr))
+}
+
+func containsSubstringHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/plugins/registry.go
+++ b/pkg/plugins/registry.go
@@ -72,6 +72,7 @@ func registerBuiltinPluginsLocked() {
 	pluginRegistry.constructors["mentions"] = func() lifecycle.Plugin { return NewMentionsPlugin() }
 	pluginRegistry.constructors["webmentions"] = func() lifecycle.Plugin { return NewWebMentionsPlugin() }
 	pluginRegistry.constructors["background"] = func() lifecycle.Plugin { return NewBackgroundPlugin() }
+	pluginRegistry.constructors["image_zoom"] = func() lifecycle.Plugin { return NewImageZoomPlugin() }
 }
 
 // RegisterPluginConstructor registers a plugin constructor with the given name.
@@ -139,6 +140,7 @@ func DefaultPlugins() []lifecycle.Plugin {
 		// Render stage plugins
 		NewRenderMarkdownPlugin(),
 		NewHeadingAnchorsPlugin(), // Add anchors after markdown rendering
+		NewImageZoomPlugin(),      // Process image zoom attributes
 		NewMDVideoPlugin(),        // Convert video images to video tags
 		NewYouTubePlugin(),        // Convert YouTube URLs to embeds
 		NewLinkCollectorPlugin(),  // Collect links after markdown rendering

--- a/templates/base.html
+++ b/templates/base.html
@@ -76,6 +76,15 @@
     <link href="/_pagefind/pagefind-ui.css" rel="stylesheet">
     {% endif %}
 
+    <!-- GLightbox CSS for image zoom -->
+    {% if config.Extra.glightbox_enabled %}
+    {% if config.Extra.glightbox_cdn %}
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/glightbox@3.3.0/dist/css/glightbox.min.css">
+    {% else %}
+    <link rel="stylesheet" href="/css/glightbox.min.css">
+    {% endif %}
+    {% endif %}
+
     <!-- Theme CSS -->
     <link rel="stylesheet" href="{{ 'css/variables.css' | theme_asset }}">
     <link rel="stylesheet" href="{{ 'css/main.css' | theme_asset }}">
@@ -228,6 +237,28 @@
     {% for script in config.theme.background.scripts %}
     <script src="{{ script }}"></script>
     {% endfor %}
+    {% endif %}
+
+    <!-- GLightbox JS for image zoom -->
+    {% if config.Extra.glightbox_enabled %}
+    {% if config.Extra.glightbox_cdn %}
+    <script src="https://cdn.jsdelivr.net/npm/glightbox@3.3.0/dist/js/glightbox.min.js"></script>
+    {% else %}
+    <script src="/js/glightbox.min.js"></script>
+    {% endif %}
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const lightbox = GLightbox({
+                selector: '{{ config.Extra.glightbox_options.selector | default:".glightbox" }}',
+                openEffect: '{{ config.Extra.glightbox_options.openEffect | default:"zoom" }}',
+                closeEffect: '{{ config.Extra.glightbox_options.closeEffect | default:"zoom" }}',
+                slideEffect: '{{ config.Extra.glightbox_options.slideEffect | default:"slide" }}',
+                touchNavigation: {{ config.Extra.glightbox_options.touchNavigation | default:true | yesno:"true,false" }},
+                loop: {{ config.Extra.glightbox_options.loop | default:false | yesno:"true,false" }},
+                draggable: {{ config.Extra.glightbox_options.draggable | default:true | yesno:"true,false" }}
+            });
+        });
+    </script>
     {% endif %}
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Add `image_zoom` plugin for optional lightbox functionality using GLightbox
- Support `{data-zoomable}` and `{.zoomable}` Markdown attribute markers
- Enable per-post (`image_zoom: true` frontmatter) or site-wide (`auto_all_images: true` config) zoom

## Changes

### New Files
- `pkg/plugins/image_zoom.go` - Plugin implementation (ConfigurePlugin, RenderPlugin, WritePlugin)
- `pkg/plugins/image_zoom_test.go` - Comprehensive tests

### Modified Files
- `pkg/models/config.go` - Add `ImageZoomConfig` struct with GLightbox options
- `pkg/plugins/registry.go` - Register plugin in registry and DefaultPlugins()
- `templates/base.html` - Add conditional GLightbox CSS/JS injection
- `docs/guides/markdown.md` - User documentation with examples
- `docs/reference/plugins.md` - Plugin reference documentation

## Configuration

```toml
[markata-go.image_zoom]
enabled = true
library = "glightbox"
selector = ".glightbox"
cdn = true
auto_all_images = false
open_effect = "zoom"
close_effect = "zoom"
slide_effect = "slide"
touch_navigation = true
loop = false
draggable = true
```

## Markdown Syntax

```markdown
![Photo with zoom {data-zoomable}](/images/photo.jpg)
![Alternative syntax {.zoomable}](/images/sunset.jpg)
```

Or enable for all images in a post:

```yaml
---
title: "Photo Gallery"
image_zoom: true
---
```

## Testing

- 10 unit tests covering all functionality
- Tests for disabled state, markers, auto_all_images, frontmatter override, skipped posts, existing glightbox preservation, multiple images

Fixes #320