### PR TITLE
fix: prevent navigation overflow on mobile

### DIFF
--- a/pkg/themes/default/static/css/components.css
+++ b/pkg/themes/default/static/css/components.css
@@ -57,6 +57,35 @@
 }
 
 /* ==========================================================================
+   Navigation - Mobile Responsive
+   ========================================================================== */
+
+@media (max-width: 768px) {
+  .site-nav--header,
+  .site-nav--horizontal {
+    /* Allow horizontal scrolling within nav only, not whole page */
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    /* Prevent nav from causing page overflow */
+    max-width: 100%;
+    /* Hide scrollbar but keep functionality */
+    scrollbar-width: none; /* Firefox */
+    -ms-overflow-style: none; /* IE/Edge */
+  }
+
+  .site-nav--header::-webkit-scrollbar,
+  .site-nav--horizontal::-webkit-scrollbar {
+    display: none; /* Chrome/Safari/Opera */
+  }
+
+  .nav-link {
+    /* Prevent text wrapping in nav items */
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+}
+
+/* ==========================================================================
    Footer Component
    ========================================================================== */
 

--- a/pkg/themes/default/static/css/main.css
+++ b/pkg/themes/default/static/css/main.css
@@ -897,6 +897,16 @@ a.wikilink.wikilink-missing {
     align-items: flex-start;
   }
 
+  /* Prevent header from causing horizontal page overflow */
+  .site-header {
+    overflow-x: hidden;
+  }
+
+  .site-header .container {
+    max-width: 100%;
+    overflow: hidden;
+  }
+
   .post-nav {
     flex-direction: column;
   }

--- a/themes/default/static/css/components.css
+++ b/themes/default/static/css/components.css
@@ -57,6 +57,35 @@
 }
 
 /* ==========================================================================
+   Navigation - Mobile Responsive
+   ========================================================================== */
+
+@media (max-width: 768px) {
+  .site-nav--header,
+  .site-nav--horizontal {
+    /* Allow horizontal scrolling within nav only, not whole page */
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    /* Prevent nav from causing page overflow */
+    max-width: 100%;
+    /* Hide scrollbar but keep functionality */
+    scrollbar-width: none; /* Firefox */
+    -ms-overflow-style: none; /* IE/Edge */
+  }
+
+  .site-nav--header::-webkit-scrollbar,
+  .site-nav--horizontal::-webkit-scrollbar {
+    display: none; /* Chrome/Safari/Opera */
+  }
+
+  .nav-link {
+    /* Prevent text wrapping in nav items */
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+}
+
+/* ==========================================================================
    Footer Component
    ========================================================================== */
 

--- a/themes/default/static/css/main.css
+++ b/themes/default/static/css/main.css
@@ -897,6 +897,16 @@ a.wikilink.wikilink-missing {
     align-items: flex-start;
   }
 
+  /* Prevent header from causing horizontal page overflow */
+  .site-header {
+    overflow-x: hidden;
+  }
+
+  .site-header .container {
+    max-width: 100%;
+    overflow: hidden;
+  }
+
   .post-nav {
     flex-direction: column;
   }


### PR DESCRIPTION
## Summary

- Fixes navigation menus with many items causing unwanted horizontal page scrolling on mobile devices
- Adds responsive CSS that contains scrolling to the nav element only

## Changes

- Added mobile-responsive styles for navigation at 768px breakpoint
- Nav container gets `overflow-x: auto` to allow horizontal scrolling within nav only
- Hidden scrollbars while maintaining scroll functionality (cross-browser support)
- Nav links use `white-space: nowrap` and `flex-shrink: 0` to prevent wrapping
- Header container uses `overflow: hidden` to prevent page-level horizontal scrolling

## Testing

On mobile (or with browser dev tools at < 768px width):
1. Configure a site with many navigation items
2. Verify horizontal scroll is contained within the nav bar only
3. Verify no horizontal page-level scrolling occurs

Fixes #361