### PR TITLE
fix(config): add missing blogroll fields to merge function

### DIFF
--- a/pkg/config/merge.go
+++ b/pkg/config/merge.go
@@ -640,6 +640,12 @@ func mergeBlogrollConfig(base, override models.BlogrollConfig) models.BlogrollCo
 	if override.CacheDuration != "" {
 		result.CacheDuration = override.CacheDuration
 	}
+	if override.FallbackImageService != "" {
+		result.FallbackImageService = override.FallbackImageService
+	}
+	if override.PaginationType != "" {
+		result.PaginationType = override.PaginationType
+	}
 
 	// Int fields - override if non-zero
 	if override.Timeout != 0 {
@@ -650,6 +656,12 @@ func mergeBlogrollConfig(base, override models.BlogrollConfig) models.BlogrollCo
 	}
 	if override.MaxEntriesPerFeed != 0 {
 		result.MaxEntriesPerFeed = override.MaxEntriesPerFeed
+	}
+	if override.ItemsPerPage != 0 {
+		result.ItemsPerPage = override.ItemsPerPage
+	}
+	if override.OrphanThreshold != 0 {
+		result.OrphanThreshold = override.OrphanThreshold
 	}
 
 	// Feeds - replace if non-empty

--- a/pkg/config/merge_test.go
+++ b/pkg/config/merge_test.go
@@ -626,3 +626,59 @@ func TestMergeConfigs_Blogroll(t *testing.T) {
 		t.Errorf("Blogroll.Feeds[0].Title = %q, want Example", result.Blogroll.Feeds[0].Title)
 	}
 }
+
+func TestMergeBlogrollConfig_FallbackImageService(t *testing.T) {
+	base := models.BlogrollConfig{
+		Enabled:              true,
+		FallbackImageService: "https://default.shots.com/{url}",
+	}
+	override := models.BlogrollConfig{
+		FallbackImageService: "https://custom.shots.com/{url}",
+	}
+
+	result := mergeBlogrollConfig(base, override)
+
+	if result.FallbackImageService != "https://custom.shots.com/{url}" {
+		t.Errorf("FallbackImageService = %q, want custom URL", result.FallbackImageService)
+	}
+}
+
+func TestMergeBlogrollConfig_FallbackImageServicePreservesBase(t *testing.T) {
+	base := models.BlogrollConfig{
+		Enabled:              true,
+		FallbackImageService: "https://base.shots.com/{url}",
+	}
+	override := models.BlogrollConfig{
+		// FallbackImageService not set
+	}
+
+	result := mergeBlogrollConfig(base, override)
+
+	if result.FallbackImageService != "https://base.shots.com/{url}" {
+		t.Errorf("FallbackImageService = %q, want base URL", result.FallbackImageService)
+	}
+}
+
+func TestMergeBlogrollConfig_PaginationFields(t *testing.T) {
+	base := models.BlogrollConfig{
+		ItemsPerPage:    50,
+		OrphanThreshold: 3,
+		PaginationType:  models.PaginationManual,
+	}
+	override := models.BlogrollConfig{
+		ItemsPerPage:   100,
+		PaginationType: models.PaginationHTMX,
+	}
+
+	result := mergeBlogrollConfig(base, override)
+
+	if result.ItemsPerPage != 100 {
+		t.Errorf("ItemsPerPage = %d, want 100", result.ItemsPerPage)
+	}
+	if result.OrphanThreshold != 3 {
+		t.Errorf("OrphanThreshold = %d, want 3 (from base)", result.OrphanThreshold)
+	}
+	if result.PaginationType != models.PaginationHTMX {
+		t.Errorf("PaginationType = %q, want htmx", result.PaginationType)
+	}
+}


### PR DESCRIPTION
## Summary

The `mergeBlogrollConfig` function was missing handling for several `BlogrollConfig` fields, causing them to be lost when merging user config with defaults.

### Fixed fields
- `FallbackImageService` - URL template for generating fallback screenshots
- `ItemsPerPage` - Number of entries per page on the reader page
- `OrphanThreshold` - Minimum entries for a separate page
- `PaginationType` - Pagination strategy (manual, htmx, js)

### Impact
This bug prevented users from using the `fallback_image_service` option in their blogroll config - the value would be silently discarded during config loading.

### Testing
- Added 3 new test cases for the merge behavior
- All existing tests pass