### PR TITLE
feat(tui): add manual data refresh with R key

### DIFF
--- a/pkg/tui/keys.go
+++ b/pkg/tui/keys.go
@@ -16,6 +16,7 @@ type keyMapType struct {
 	Escape  key.Binding
 	Edit    key.Binding
 	Sort    key.Binding
+	Refresh key.Binding
 }
 
 var keyMap = keyMapType{
@@ -70,5 +71,9 @@ var keyMap = keyMapType{
 	Sort: key.NewBinding(
 		key.WithKeys("s"),
 		key.WithHelp("s", "sort"),
+	),
+	Refresh: key.NewBinding(
+		key.WithKeys("r"),
+		key.WithHelp("r", "refresh"),
 	),
 }


### PR DESCRIPTION
## Summary

This PR adds manual data refresh functionality to the TUI, allowing users to press 'R' to reload posts, tags, and feeds data.

**Key Features:**
- Press `R` to manually refresh all data
- Visual feedback during refresh operation
- Reloads posts, tags, and feeds from disk
- Updates all views with fresh data
- Maintains current view and selection

**Changes:**
- Added 'R' key binding for refresh
- Implemented refresh operation with loading indicator
- Added data reload from filesystem
- Updated help text with refresh shortcut
- Proper state management during refresh

Fixes #347