### PR TITLE
fix: restyle view-as buttons as minimal hyperlinks

### DIFF
--- a/pkg/themes/default/static/css/components.css
+++ b/pkg/themes/default/static/css/components.css
@@ -598,114 +598,56 @@
 
 /* ==========================================================================
    Format Links Component
+   Minimal link-style appearance (not button-like)
    ========================================================================== */
 
 .format-links {
-  display: flex;
+  display: inline-flex;
   flex-wrap: wrap;
-  align-items: center;
-  gap: 0.5rem;
-  margin: 1rem 0;
-  padding: 0.75rem 1rem;
-  background-color: var(--color-surface);
-  border-radius: 8px;
-  border: 1px solid var(--color-border);
-  font-size: 0.875rem;
+  align-items: baseline;
+  gap: 0.125rem;
+  margin: 0.5rem 0;
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
 }
 
 .format-links-label {
   color: var(--color-text-muted);
-  font-weight: 500;
+  font-weight: 400;
   margin-right: 0.25rem;
 }
 
 .format-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.375rem;
-  padding: 0.25rem 0.625rem;
-  color: var(--color-text);
+  color: var(--color-text-muted);
   text-decoration: none;
-  background-color: var(--color-background);
-  border: 1px solid var(--color-border);
-  border-radius: 4px;
-  transition: all 0.2s ease;
+  transition: color 0.15s ease;
 }
 
-.format-link:hover {
+.format-link:hover,
+.format-link:focus {
   color: var(--color-primary);
-  border-color: var(--color-primary);
-  background-color: var(--color-surface);
+  text-decoration: underline;
 }
 
-/* Format-specific icons using CSS pseudo-elements */
-.format-link--markdown::before {
-  content: "M";
-  font-weight: 700;
-  font-size: 0.75rem;
-  padding: 0.125rem 0.25rem;
-  background-color: var(--color-text-muted);
-  color: var(--color-background);
+.format-link:focus {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
   border-radius: 2px;
 }
 
-.format-link--markdown:hover::before {
-  background-color: var(--color-primary);
+/* Separator between links */
+.format-link:not(:last-child)::after {
+  content: "|";
+  margin: 0 0.375rem;
+  color: var(--color-border);
+  text-decoration: none;
+  display: inline-block;
 }
 
-.format-link--text::before {
-  content: "TXT";
-  font-weight: 600;
-  font-size: 0.625rem;
-  letter-spacing: 0.025em;
-  color: var(--color-text-muted);
-}
-
-.format-link--text:hover::before {
-  color: var(--color-primary);
-}
-
-.format-link--og::before {
-  content: "\1F5BC"; /* frame/picture emoji */
-  font-size: 0.875rem;
-}
-
-.format-link--rss::before {
-  content: "\25CF"; /* filled circle */
-  font-size: 0.5rem;
-  color: #f26522; /* RSS orange */
-}
-
-.format-link--atom::before {
-  content: "\26A1"; /* lightning bolt */
-  font-size: 0.75rem;
-}
-
-.format-link--json::before {
-  content: "{ }";
-  font-size: 0.625rem;
-  font-weight: 600;
-  color: var(--color-text-muted);
-}
-
-.format-link--json:hover::before {
-  color: var(--color-primary);
-}
-
-/* Responsive: Stack on small screens */
+/* Responsive: wrap naturally on small screens */
 @media (max-width: 480px) {
   .format-links {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .format-links-label {
-    margin-bottom: 0.25rem;
-  }
-
-  .format-link {
-    width: 100%;
-    justify-content: center;
+    font-size: 0.75rem;
   }
 }
 

--- a/themes/default/static/css/components.css
+++ b/themes/default/static/css/components.css
@@ -641,114 +641,56 @@
 
 /* ==========================================================================
    Format Links Component
+   Minimal link-style appearance (not button-like)
    ========================================================================== */
 
 .format-links {
-  display: flex;
+  display: inline-flex;
   flex-wrap: wrap;
-  align-items: center;
-  gap: 0.5rem;
-  margin: 1rem 0;
-  padding: 0.75rem 1rem;
-  background-color: var(--color-surface);
-  border-radius: 8px;
-  border: 1px solid var(--color-border);
-  font-size: 0.875rem;
+  align-items: baseline;
+  gap: 0.125rem;
+  margin: 0.5rem 0;
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
 }
 
 .format-links-label {
   color: var(--color-text-muted);
-  font-weight: 500;
+  font-weight: 400;
   margin-right: 0.25rem;
 }
 
 .format-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.375rem;
-  padding: 0.25rem 0.625rem;
-  color: var(--color-text);
+  color: var(--color-text-muted);
   text-decoration: none;
-  background-color: var(--color-background);
-  border: 1px solid var(--color-border);
-  border-radius: 4px;
-  transition: all 0.2s ease;
+  transition: color 0.15s ease;
 }
 
-.format-link:hover {
+.format-link:hover,
+.format-link:focus {
   color: var(--color-primary);
-  border-color: var(--color-primary);
-  background-color: var(--color-surface);
+  text-decoration: underline;
 }
 
-/* Format-specific icons using CSS pseudo-elements */
-.format-link--markdown::before {
-  content: "M";
-  font-weight: 700;
-  font-size: 0.75rem;
-  padding: 0.125rem 0.25rem;
-  background-color: var(--color-text-muted);
-  color: var(--color-background);
+.format-link:focus {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
   border-radius: 2px;
 }
 
-.format-link--markdown:hover::before {
-  background-color: var(--color-primary);
+/* Separator between links */
+.format-link:not(:last-child)::after {
+  content: "|";
+  margin: 0 0.375rem;
+  color: var(--color-border);
+  text-decoration: none;
+  display: inline-block;
 }
 
-.format-link--text::before {
-  content: "TXT";
-  font-weight: 600;
-  font-size: 0.625rem;
-  letter-spacing: 0.025em;
-  color: var(--color-text-muted);
-}
-
-.format-link--text:hover::before {
-  color: var(--color-primary);
-}
-
-.format-link--og::before {
-  content: "\1F5BC"; /* frame/picture emoji */
-  font-size: 0.875rem;
-}
-
-.format-link--rss::before {
-  content: "\25CF"; /* filled circle */
-  font-size: 0.5rem;
-  color: #f26522; /* RSS orange */
-}
-
-.format-link--atom::before {
-  content: "\26A1"; /* lightning bolt */
-  font-size: 0.75rem;
-}
-
-.format-link--json::before {
-  content: "{ }";
-  font-size: 0.625rem;
-  font-weight: 600;
-  color: var(--color-text-muted);
-}
-
-.format-link--json:hover::before {
-  color: var(--color-primary);
-}
-
-/* Responsive: Stack on small screens */
+/* Responsive: wrap naturally on small screens */
 @media (max-width: 480px) {
   .format-links {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .format-links-label {
-    margin-bottom: 0.25rem;
-  }
-
-  .format-link {
-    width: 100%;
-    justify-content: center;
+    font-size: 0.75rem;
   }
 }
 


### PR DESCRIPTION
## Summary

This PR restyles the "view as" buttons to look like minimal hyperlinks instead of large buttons, improving the visual hierarchy and reducing UI clutter.

**Changes:**
- Removed button styling from view-as links
- Applied minimal hyperlink styling
- Reduced visual weight
- Improved page hierarchy
- Better integration with content

**Result:**
- Cleaner, more professional appearance
- Less visual distraction
- Consistent with link styling elsewhere
- Improved readability

Fixes #362