### PR TITLE
fix: add fallback_image_service config parsing for blogroll

### DIFF
--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -697,16 +697,17 @@ func (h *tomlHeaderLayoutConfig) toHeaderLayoutConfig() models.HeaderLayoutConfi
 // Blogroll-related TOML structs
 
 type tomlBlogrollConfig struct {
-	Enabled            bool                     `toml:"enabled"`
-	BlogrollSlug       string                   `toml:"blogroll_slug"`
-	ReaderSlug         string                   `toml:"reader_slug"`
-	CacheDir           string                   `toml:"cache_dir"`
-	CacheDuration      string                   `toml:"cache_duration"`
-	Timeout            int                      `toml:"timeout"`
-	ConcurrentRequests int                      `toml:"concurrent_requests"`
-	MaxEntriesPerFeed  int                      `toml:"max_entries_per_feed"`
-	Feeds              []tomlExternalFeedConfig `toml:"feeds"`
-	Templates          tomlBlogrollTemplates    `toml:"templates"`
+	Enabled              bool                     `toml:"enabled"`
+	BlogrollSlug         string                   `toml:"blogroll_slug"`
+	ReaderSlug           string                   `toml:"reader_slug"`
+	CacheDir             string                   `toml:"cache_dir"`
+	CacheDuration        string                   `toml:"cache_duration"`
+	Timeout              int                      `toml:"timeout"`
+	ConcurrentRequests   int                      `toml:"concurrent_requests"`
+	MaxEntriesPerFeed    int                      `toml:"max_entries_per_feed"`
+	FallbackImageService string                   `toml:"fallback_image_service"`
+	Feeds                []tomlExternalFeedConfig `toml:"feeds"`
+	Templates            tomlBlogrollTemplates    `toml:"templates"`
 }
 
 type tomlExternalFeedConfig struct {
@@ -733,14 +734,15 @@ type tomlBlogrollTemplates struct {
 //nolint:dupl // Intentional duplication - each format has its own conversion method
 func (b *tomlBlogrollConfig) toBlogrollConfig() models.BlogrollConfig {
 	config := models.BlogrollConfig{
-		Enabled:            b.Enabled,
-		BlogrollSlug:       b.BlogrollSlug,
-		ReaderSlug:         b.ReaderSlug,
-		CacheDir:           b.CacheDir,
-		CacheDuration:      b.CacheDuration,
-		Timeout:            b.Timeout,
-		ConcurrentRequests: b.ConcurrentRequests,
-		MaxEntriesPerFeed:  b.MaxEntriesPerFeed,
+		Enabled:              b.Enabled,
+		BlogrollSlug:         b.BlogrollSlug,
+		ReaderSlug:           b.ReaderSlug,
+		CacheDir:             b.CacheDir,
+		CacheDuration:        b.CacheDuration,
+		Timeout:              b.Timeout,
+		ConcurrentRequests:   b.ConcurrentRequests,
+		MaxEntriesPerFeed:    b.MaxEntriesPerFeed,
+		FallbackImageService: b.FallbackImageService,
 		Templates: models.BlogrollTemplates{
 			Blogroll: b.Templates.Blogroll,
 			Reader:   b.Templates.Reader,
@@ -1448,16 +1450,17 @@ func (h *yamlHeaderLayoutConfig) toHeaderLayoutConfig() models.HeaderLayoutConfi
 // Blogroll-related YAML structs
 
 type yamlBlogrollConfig struct {
-	Enabled            bool                     `yaml:"enabled"`
-	BlogrollSlug       string                   `yaml:"blogroll_slug"`
-	ReaderSlug         string                   `yaml:"reader_slug"`
-	CacheDir           string                   `yaml:"cache_dir"`
-	CacheDuration      string                   `yaml:"cache_duration"`
-	Timeout            int                      `yaml:"timeout"`
-	ConcurrentRequests int                      `yaml:"concurrent_requests"`
-	MaxEntriesPerFeed  int                      `yaml:"max_entries_per_feed"`
-	Feeds              []yamlExternalFeedConfig `yaml:"feeds"`
-	Templates          yamlBlogrollTemplates    `yaml:"templates"`
+	Enabled              bool                     `yaml:"enabled"`
+	BlogrollSlug         string                   `yaml:"blogroll_slug"`
+	ReaderSlug           string                   `yaml:"reader_slug"`
+	CacheDir             string                   `yaml:"cache_dir"`
+	CacheDuration        string                   `yaml:"cache_duration"`
+	Timeout              int                      `yaml:"timeout"`
+	ConcurrentRequests   int                      `yaml:"concurrent_requests"`
+	MaxEntriesPerFeed    int                      `yaml:"max_entries_per_feed"`
+	FallbackImageService string                   `yaml:"fallback_image_service"`
+	Feeds                []yamlExternalFeedConfig `yaml:"feeds"`
+	Templates            yamlBlogrollTemplates    `yaml:"templates"`
 }
 
 type yamlExternalFeedConfig struct {
@@ -1484,14 +1487,15 @@ type yamlBlogrollTemplates struct {
 //nolint:dupl // Intentional duplication - each format has its own conversion method
 func (b *yamlBlogrollConfig) toBlogrollConfig() models.BlogrollConfig {
 	config := models.BlogrollConfig{
-		Enabled:            b.Enabled,
-		BlogrollSlug:       b.BlogrollSlug,
-		ReaderSlug:         b.ReaderSlug,
-		CacheDir:           b.CacheDir,
-		CacheDuration:      b.CacheDuration,
-		Timeout:            b.Timeout,
-		ConcurrentRequests: b.ConcurrentRequests,
-		MaxEntriesPerFeed:  b.MaxEntriesPerFeed,
+		Enabled:              b.Enabled,
+		BlogrollSlug:         b.BlogrollSlug,
+		ReaderSlug:           b.ReaderSlug,
+		CacheDir:             b.CacheDir,
+		CacheDuration:        b.CacheDuration,
+		Timeout:              b.Timeout,
+		ConcurrentRequests:   b.ConcurrentRequests,
+		MaxEntriesPerFeed:    b.MaxEntriesPerFeed,
+		FallbackImageService: b.FallbackImageService,
 		Templates: models.BlogrollTemplates{
 			Blogroll: b.Templates.Blogroll,
 			Reader:   b.Templates.Reader,
@@ -2184,16 +2188,17 @@ func (h *jsonHeaderLayoutConfig) toHeaderLayoutConfig() models.HeaderLayoutConfi
 // Blogroll-related JSON structs
 
 type jsonBlogrollConfig struct {
-	Enabled            bool                     `json:"enabled"`
-	BlogrollSlug       string                   `json:"blogroll_slug"`
-	ReaderSlug         string                   `json:"reader_slug"`
-	CacheDir           string                   `json:"cache_dir"`
-	CacheDuration      string                   `json:"cache_duration"`
-	Timeout            int                      `json:"timeout"`
-	ConcurrentRequests int                      `json:"concurrent_requests"`
-	MaxEntriesPerFeed  int                      `json:"max_entries_per_feed"`
-	Feeds              []jsonExternalFeedConfig `json:"feeds"`
-	Templates          jsonBlogrollTemplates    `json:"templates"`
+	Enabled              bool                     `json:"enabled"`
+	BlogrollSlug         string                   `json:"blogroll_slug"`
+	ReaderSlug           string                   `json:"reader_slug"`
+	CacheDir             string                   `json:"cache_dir"`
+	CacheDuration        string                   `json:"cache_duration"`
+	Timeout              int                      `json:"timeout"`
+	ConcurrentRequests   int                      `json:"concurrent_requests"`
+	MaxEntriesPerFeed    int                      `json:"max_entries_per_feed"`
+	FallbackImageService string                   `json:"fallback_image_service"`
+	Feeds                []jsonExternalFeedConfig `json:"feeds"`
+	Templates            jsonBlogrollTemplates    `json:"templates"`
 }
 
 type jsonExternalFeedConfig struct {
@@ -2220,14 +2225,15 @@ type jsonBlogrollTemplates struct {
 //nolint:dupl // Intentional duplication - each format has its own conversion method
 func (b *jsonBlogrollConfig) toBlogrollConfig() models.BlogrollConfig {
 	config := models.BlogrollConfig{
-		Enabled:            b.Enabled,
-		BlogrollSlug:       b.BlogrollSlug,
-		ReaderSlug:         b.ReaderSlug,
-		CacheDir:           b.CacheDir,
-		CacheDuration:      b.CacheDuration,
-		Timeout:            b.Timeout,
-		ConcurrentRequests: b.ConcurrentRequests,
-		MaxEntriesPerFeed:  b.MaxEntriesPerFeed,
+		Enabled:              b.Enabled,
+		BlogrollSlug:         b.BlogrollSlug,
+		ReaderSlug:           b.ReaderSlug,
+		CacheDir:             b.CacheDir,
+		CacheDuration:        b.CacheDuration,
+		Timeout:              b.Timeout,
+		ConcurrentRequests:   b.ConcurrentRequests,
+		MaxEntriesPerFeed:    b.MaxEntriesPerFeed,
+		FallbackImageService: b.FallbackImageService,
 		Templates: models.BlogrollTemplates{
 			Blogroll: b.Templates.Blogroll,
 			Reader:   b.Templates.Reader,

--- a/pkg/config/parser_test.go
+++ b/pkg/config/parser_test.go
@@ -687,3 +687,109 @@ func TestParseJSON_BlogrollExternalFeedFields(t *testing.T) {
 		t.Errorf("Primary = %v, want true", feed.Primary)
 	}
 }
+
+// TestParseTOML_BlogrollFallbackImageService tests parsing of fallback_image_service from TOML
+func TestParseTOML_BlogrollFallbackImageService(t *testing.T) {
+	data := []byte(`
+[markata-go]
+title = "Test Site"
+
+[markata-go.blogroll]
+enabled = true
+fallback_image_service = "https://shots.waylonwalker.com/shot/?url={url}&height=160&width=240"
+
+[[markata-go.blogroll.feeds]]
+url = "https://simonwillison.net/atom/everything/"
+title = "Simon Willison"
+`)
+
+	config, err := ParseTOML(data)
+	if err != nil {
+		t.Fatalf("ParseTOML() error = %v", err)
+	}
+
+	if !config.Blogroll.Enabled {
+		t.Error("Blogroll.Enabled should be true")
+	}
+
+	expectedURL := "https://shots.waylonwalker.com/shot/?url={url}&height=160&width=240"
+	if config.Blogroll.FallbackImageService != expectedURL {
+		t.Errorf("Blogroll.FallbackImageService = %q, want %q",
+			config.Blogroll.FallbackImageService, expectedURL)
+	}
+
+	if len(config.Blogroll.Feeds) != 1 {
+		t.Errorf("len(Blogroll.Feeds) = %d, want 1", len(config.Blogroll.Feeds))
+	}
+}
+
+// TestParseYAML_BlogrollFallbackImageService tests parsing of fallback_image_service from YAML
+func TestParseYAML_BlogrollFallbackImageService(t *testing.T) {
+	data := []byte(`
+markata-go:
+  title: "Test Site"
+  blogroll:
+    enabled: true
+    fallback_image_service: "https://shots.waylonwalker.com/shot/?url={url}&height=160&width=240"
+    feeds:
+      - url: "https://simonwillison.net/atom/everything/"
+        title: "Simon Willison"
+`)
+
+	config, err := ParseYAML(data)
+	if err != nil {
+		t.Fatalf("ParseYAML() error = %v", err)
+	}
+
+	if !config.Blogroll.Enabled {
+		t.Error("Blogroll.Enabled should be true")
+	}
+
+	expectedURL := "https://shots.waylonwalker.com/shot/?url={url}&height=160&width=240"
+	if config.Blogroll.FallbackImageService != expectedURL {
+		t.Errorf("Blogroll.FallbackImageService = %q, want %q",
+			config.Blogroll.FallbackImageService, expectedURL)
+	}
+
+	if len(config.Blogroll.Feeds) != 1 {
+		t.Errorf("len(Blogroll.Feeds) = %d, want 1", len(config.Blogroll.Feeds))
+	}
+}
+
+// TestParseJSON_BlogrollFallbackImageService tests parsing of fallback_image_service from JSON
+func TestParseJSON_BlogrollFallbackImageService(t *testing.T) {
+	data := []byte(`{
+  "markata-go": {
+    "title": "Test Site",
+    "blogroll": {
+      "enabled": true,
+      "fallback_image_service": "https://shots.waylonwalker.com/shot/?url={url}&height=160&width=240",
+      "feeds": [
+        {
+          "url": "https://simonwillison.net/atom/everything/",
+          "title": "Simon Willison"
+        }
+      ]
+    }
+  }
+}`)
+
+	config, err := ParseJSON(data)
+	if err != nil {
+		t.Fatalf("ParseJSON() error = %v", err)
+	}
+
+	if !config.Blogroll.Enabled {
+		t.Error("Blogroll.Enabled should be true")
+	}
+
+	expectedURL := "https://shots.waylonwalker.com/shot/?url={url}&height=160&width=240"
+	if config.Blogroll.FallbackImageService != expectedURL {
+		t.Errorf("Blogroll.FallbackImageService = %q, want %q",
+			config.Blogroll.FallbackImageService, expectedURL)
+	}
+
+	if len(config.Blogroll.Feeds) != 1 {
+		t.Errorf("len(Blogroll.Feeds) = %d, want 1", len(config.Blogroll.Feeds))
+	}
+}


### PR DESCRIPTION
Fixes #381

## Summary

The `fallback_image_service` configuration option was defined in the `BlogrollConfig` data model but was not being parsed from TOML, YAML, or JSON configuration files. This caused the fallback screenshot feature to silently fail when users configured it.

## Changes

### Configuration Parsing (`pkg/config/parser.go`)

Added the missing `FallbackImageService` field to all three config format structs:

- **TOML**: Added to `tomlBlogrollConfig` struct with `` `toml:"fallback_image_service"` `` tag
- **YAML**: Added to `yamlBlogrollConfig` struct with `` `yaml:"fallback_image_service"` `` tag  
- **JSON**: Added to `jsonBlogrollConfig` struct with `` `json:"fallback_image_service"` `` tag

Added field copying in all three conversion methods:
- `tomlBlogrollConfig.toBlogrollConfig()`
- `yamlBlogrollConfig.toBlogrollConfig()`
- `jsonBlogrollConfig.toBlogrollConfig()`

### Testing (`pkg/config/parser_test.go`)

Added three comprehensive tests to verify parsing works correctly:

- `TestParseTOML_BlogrollFallbackImageService` - Verifies TOML parsing
- `TestParseYAML_BlogrollFallbackImageService` - Verifies YAML parsing
- `TestParseJSON_BlogrollFallbackImageService` - Verifies JSON parsing

Each test validates:
- The field is parsed correctly from the config file
- The blogroll is enabled
- The URL template is preserved exactly
- Feed configuration is also parsed

## Impact

**Before this fix:**
- Users could configure `fallback_image_service` in their config
- The value would be silently ignored
- Reader pages showed no fallback images for entries without images

**After this fix:**
- Configuration is properly parsed from all three formats
- Fallback images are generated for entries without images
- The feature works as documented

## Testing

✅ All new tests pass
✅ All existing tests pass (0 regressions)
✅ Pre-commit hooks pass (formatting, linting, etc.)

Example configuration that now works:

```toml
[markata-go.blogroll]
enabled = true
fallback_image_service = "https://shots.waylonwalker.com/shot/?url={url}&height=160&width=240"
```

## Related

This bug was discovered when investigating a user's site where the reader page wasn't showing fallback images despite the configuration being present. All the underlying implementation (URL generation, template rendering, etc.) was already working correctly - only the config parsing was broken.