### PR TITLE
fix(templates): add theme config to template context

### DIFF
--- a/pkg/templates/context.go
+++ b/pkg/templates/context.go
@@ -233,6 +233,9 @@ func configToMap(c *models.Config) map[string]interface{} {
 	// Convert header to map
 	headerMap := headerToMap(&c.Header)
 
+	// Convert theme to map
+	themeMap := themeToMap(&c.Theme)
+
 	return map[string]interface{}{
 		"output_dir":    c.OutputDir,
 		"url":           c.URL,
@@ -254,6 +257,7 @@ func configToMap(c *models.Config) map[string]interface{} {
 		"sidebar":       sidebarMap,
 		"toc":           tocMap,
 		"header":        headerMap,
+		"theme":         themeMap,
 	}
 }
 
@@ -684,6 +688,73 @@ func headerToMap(h *models.HeaderLayoutConfig) map[string]interface{} {
 	}
 
 	return result
+}
+
+// themeToMap converts a ThemeConfig to a map for template access.
+func themeToMap(t *models.ThemeConfig) map[string]interface{} {
+	if t == nil {
+		return nil
+	}
+
+	backgroundMap := backgroundToMap(&t.Background)
+	fontMap := fontToMap(&t.Font)
+
+	return map[string]interface{}{
+		"name":          t.Name,
+		"palette":       t.Palette,
+		"palette_light": t.PaletteLight,
+		"palette_dark":  t.PaletteDark,
+		"variables":     t.Variables,
+		"custom_css":    t.CustomCSS,
+		"background":    backgroundMap,
+		"font":          fontMap,
+	}
+}
+
+// backgroundToMap converts a BackgroundConfig to a map for template access.
+func backgroundToMap(b *models.BackgroundConfig) map[string]interface{} {
+	if b == nil {
+		return nil
+	}
+
+	backgroundElements := make([]map[string]interface{}, len(b.Backgrounds))
+	for i, bg := range b.Backgrounds {
+		backgroundElements[i] = map[string]interface{}{
+			"html":    bg.HTML,
+			"z_index": bg.ZIndex,
+		}
+	}
+
+	result := map[string]interface{}{
+		"backgrounds": backgroundElements,
+		"scripts":     b.Scripts,
+		"css":         b.CSS,
+	}
+
+	if b.Enabled != nil {
+		result["enabled"] = *b.Enabled
+	} else {
+		result["enabled"] = false
+	}
+
+	return result
+}
+
+// fontToMap converts a FontConfig to a map for template access.
+func fontToMap(f *models.FontConfig) map[string]interface{} {
+	if f == nil {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"family":         f.Family,
+		"heading_family": f.HeadingFamily,
+		"code_family":    f.CodeFamily,
+		"size":           f.Size,
+		"line_height":    f.LineHeight,
+		"google_fonts":   f.GoogleFonts,
+		"custom_urls":    f.CustomURLs,
+	}
 }
 
 // tocEntriesToMaps converts TOC entries (from the toc plugin) to template-friendly maps.


### PR DESCRIPTION
## Summary

- Fixed bug where background decorations were not rendering despite enabled config
- Root cause: `config.theme` was missing from the template context
- Added `themeToMap()`, `backgroundToMap()`, and `fontToMap()` conversion functions
- Updated `configToMap()` to include theme field in the return map

## Changes

### Added Functions (pkg/templates/context.go)

1. **themeToMap()** - Converts ThemeConfig to template-accessible map
2. **backgroundToMap()** - Converts BackgroundConfig with enabled flag, backgrounds array, scripts, and CSS
3. **fontToMap()** - Converts FontConfig with all font configuration options

### Modified Function

- **configToMap()** - Now calls `themeToMap(&c.Theme)` and includes `"theme": themeMap` in return value

## Testing

- All existing tests in `./pkg/templates/...` pass
- Background decorations now accessible via `config.theme.background.enabled` in templates
- No breaking changes - purely additive fix

## Issue

Fixes #385

## Technical Context

The template `templates/base.html` expects `config.theme.background.enabled` and `config.theme.background.backgrounds`, but the `configToMap()` function was not including the `Theme` field when converting the Config struct to a map for Pongo2 template access. This meant that even when users configured backgrounds correctly, the template condition `{% if config.theme.background.enabled %}` would always fail.

This fix ensures all theme configuration (backgrounds, fonts, palettes, variables, custom CSS) is now properly available in templates.