### PR TITLE
fix: parse and merge theme.background and theme.font config

### DIFF
--- a/pkg/config/merge.go
+++ b/pkg/config/merge.go
@@ -122,6 +122,68 @@ func mergeThemeConfig(base, override models.ThemeConfig) models.ThemeConfig {
 		}
 	}
 
+	// Merge background config
+	result.Background = mergeBackgroundConfig(base.Background, override.Background)
+
+	// Merge font config
+	result.Font = mergeFontConfig(base.Font, override.Font)
+
+	return result
+}
+
+// mergeBackgroundConfig merges BackgroundConfig, preferring override values.
+func mergeBackgroundConfig(base, override models.BackgroundConfig) models.BackgroundConfig {
+	result := base
+
+	// Override enabled if explicitly set
+	if override.Enabled != nil {
+		result.Enabled = override.Enabled
+	}
+
+	// Replace backgrounds array if non-empty
+	if len(override.Backgrounds) > 0 {
+		result.Backgrounds = override.Backgrounds
+	}
+
+	// Replace scripts array if non-empty
+	if len(override.Scripts) > 0 {
+		result.Scripts = override.Scripts
+	}
+
+	// Override CSS if non-empty
+	if override.CSS != "" {
+		result.CSS = override.CSS
+	}
+
+	return result
+}
+
+// mergeFontConfig merges FontConfig, preferring override values.
+func mergeFontConfig(base, override models.FontConfig) models.FontConfig {
+	result := base
+
+	if override.Family != "" {
+		result.Family = override.Family
+	}
+	if override.HeadingFamily != "" {
+		result.HeadingFamily = override.HeadingFamily
+	}
+	if override.CodeFamily != "" {
+		result.CodeFamily = override.CodeFamily
+	}
+	if override.Size != "" {
+		result.Size = override.Size
+	}
+	if override.LineHeight != "" {
+		result.LineHeight = override.LineHeight
+	}
+	if len(override.GoogleFonts) > 0 {
+		result.GoogleFonts = override.GoogleFonts
+	}
+	if len(override.CustomURLs) > 0 {
+		result.CustomURLs = override.CustomURLs
+	}
+
 	return result
 }
 

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -269,12 +269,36 @@ type tomlFooterConfig struct {
 }
 
 type tomlThemeConfig struct {
-	Name         string            `toml:"name"`
-	Palette      string            `toml:"palette"`
-	PaletteLight string            `toml:"palette_light"`
-	PaletteDark  string            `toml:"palette_dark"`
-	Variables    map[string]string `toml:"variables"`
-	CustomCSS    string            `toml:"custom_css"`
+	Name         string               `toml:"name"`
+	Palette      string               `toml:"palette"`
+	PaletteLight string               `toml:"palette_light"`
+	PaletteDark  string               `toml:"palette_dark"`
+	Variables    map[string]string    `toml:"variables"`
+	CustomCSS    string               `toml:"custom_css"`
+	Background   tomlBackgroundConfig `toml:"background"`
+	Font         tomlFontConfig       `toml:"font"`
+}
+
+type tomlBackgroundConfig struct {
+	Enabled     *bool                   `toml:"enabled"`
+	Backgrounds []tomlBackgroundElement `toml:"backgrounds"`
+	Scripts     []string                `toml:"scripts"`
+	CSS         string                  `toml:"css"`
+}
+
+type tomlBackgroundElement struct {
+	HTML   string `toml:"html"`
+	ZIndex int    `toml:"z_index"`
+}
+
+type tomlFontConfig struct {
+	Family        string   `toml:"family"`
+	HeadingFamily string   `toml:"heading_family"`
+	CodeFamily    string   `toml:"code_family"`
+	Size          string   `toml:"size"`
+	LineHeight    string   `toml:"line_height"`
+	GoogleFonts   []string `toml:"google_fonts"`
+	CustomURLs    []string `toml:"custom_urls"`
 }
 
 type tomlGlobConfig struct {
@@ -894,6 +918,36 @@ func (t *tomlThemeConfig) toThemeConfig() models.ThemeConfig {
 		PaletteDark:  t.PaletteDark,
 		Variables:    variables,
 		CustomCSS:    t.CustomCSS,
+		Background:   t.Background.toBackgroundConfig(),
+		Font:         t.Font.toFontConfig(),
+	}
+}
+
+func (b *tomlBackgroundConfig) toBackgroundConfig() models.BackgroundConfig {
+	backgrounds := make([]models.BackgroundElement, len(b.Backgrounds))
+	for i, bg := range b.Backgrounds {
+		backgrounds[i] = models.BackgroundElement{
+			HTML:   bg.HTML,
+			ZIndex: bg.ZIndex,
+		}
+	}
+	return models.BackgroundConfig{
+		Enabled:     b.Enabled,
+		Backgrounds: backgrounds,
+		Scripts:     b.Scripts,
+		CSS:         b.CSS,
+	}
+}
+
+func (f *tomlFontConfig) toFontConfig() models.FontConfig {
+	return models.FontConfig{
+		Family:        f.Family,
+		HeadingFamily: f.HeadingFamily,
+		CodeFamily:    f.CodeFamily,
+		Size:          f.Size,
+		LineHeight:    f.LineHeight,
+		GoogleFonts:   f.GoogleFonts,
+		CustomURLs:    f.CustomURLs,
 	}
 }
 
@@ -1088,12 +1142,36 @@ type yamlWebmentionConfig struct {
 }
 
 type yamlThemeConfig struct {
-	Name         string            `yaml:"name"`
-	Palette      string            `yaml:"palette"`
-	PaletteLight string            `yaml:"palette_light"`
-	PaletteDark  string            `yaml:"palette_dark"`
-	Variables    map[string]string `yaml:"variables"`
-	CustomCSS    string            `yaml:"custom_css"`
+	Name         string               `yaml:"name"`
+	Palette      string               `yaml:"palette"`
+	PaletteLight string               `yaml:"palette_light"`
+	PaletteDark  string               `yaml:"palette_dark"`
+	Variables    map[string]string    `yaml:"variables"`
+	CustomCSS    string               `yaml:"custom_css"`
+	Background   yamlBackgroundConfig `yaml:"background"`
+	Font         yamlFontConfig       `yaml:"font"`
+}
+
+type yamlBackgroundConfig struct {
+	Enabled     *bool                   `yaml:"enabled"`
+	Backgrounds []yamlBackgroundElement `yaml:"backgrounds"`
+	Scripts     []string                `yaml:"scripts"`
+	CSS         string                  `yaml:"css"`
+}
+
+type yamlBackgroundElement struct {
+	HTML   string `yaml:"html"`
+	ZIndex int    `yaml:"z_index"`
+}
+
+type yamlFontConfig struct {
+	Family        string   `yaml:"family"`
+	HeadingFamily string   `yaml:"heading_family"`
+	CodeFamily    string   `yaml:"code_family"`
+	Size          string   `yaml:"size"`
+	LineHeight    string   `yaml:"line_height"`
+	GoogleFonts   []string `yaml:"google_fonts"`
+	CustomURLs    []string `yaml:"custom_urls"`
 }
 
 func (t *yamlThemeConfig) toThemeConfig() models.ThemeConfig {
@@ -1108,6 +1186,36 @@ func (t *yamlThemeConfig) toThemeConfig() models.ThemeConfig {
 		PaletteDark:  t.PaletteDark,
 		Variables:    variables,
 		CustomCSS:    t.CustomCSS,
+		Background:   t.Background.toBackgroundConfig(),
+		Font:         t.Font.toFontConfig(),
+	}
+}
+
+func (b *yamlBackgroundConfig) toBackgroundConfig() models.BackgroundConfig {
+	backgrounds := make([]models.BackgroundElement, len(b.Backgrounds))
+	for i, bg := range b.Backgrounds {
+		backgrounds[i] = models.BackgroundElement{
+			HTML:   bg.HTML,
+			ZIndex: bg.ZIndex,
+		}
+	}
+	return models.BackgroundConfig{
+		Enabled:     b.Enabled,
+		Backgrounds: backgrounds,
+		Scripts:     b.Scripts,
+		CSS:         b.CSS,
+	}
+}
+
+func (f *yamlFontConfig) toFontConfig() models.FontConfig {
+	return models.FontConfig{
+		Family:        f.Family,
+		HeadingFamily: f.HeadingFamily,
+		CodeFamily:    f.CodeFamily,
+		Size:          f.Size,
+		LineHeight:    f.LineHeight,
+		GoogleFonts:   f.GoogleFonts,
+		CustomURLs:    f.CustomURLs,
 	}
 }
 
@@ -1826,12 +1934,36 @@ type jsonWebmentionConfig struct {
 }
 
 type jsonThemeConfig struct {
-	Name         string            `json:"name"`
-	Palette      string            `json:"palette"`
-	PaletteLight string            `json:"palette_light"`
-	PaletteDark  string            `json:"palette_dark"`
-	Variables    map[string]string `json:"variables"`
-	CustomCSS    string            `json:"custom_css"`
+	Name         string               `json:"name"`
+	Palette      string               `json:"palette"`
+	PaletteLight string               `json:"palette_light"`
+	PaletteDark  string               `json:"palette_dark"`
+	Variables    map[string]string    `json:"variables"`
+	CustomCSS    string               `json:"custom_css"`
+	Background   jsonBackgroundConfig `json:"background"`
+	Font         jsonFontConfig       `json:"font"`
+}
+
+type jsonBackgroundConfig struct {
+	Enabled     *bool                   `json:"enabled"`
+	Backgrounds []jsonBackgroundElement `json:"backgrounds"`
+	Scripts     []string                `json:"scripts"`
+	CSS         string                  `json:"css"`
+}
+
+type jsonBackgroundElement struct {
+	HTML   string `json:"html"`
+	ZIndex int    `json:"z_index"`
+}
+
+type jsonFontConfig struct {
+	Family        string   `json:"family"`
+	HeadingFamily string   `json:"heading_family"`
+	CodeFamily    string   `json:"code_family"`
+	Size          string   `json:"size"`
+	LineHeight    string   `json:"line_height"`
+	GoogleFonts   []string `json:"google_fonts"`
+	CustomURLs    []string `json:"custom_urls"`
 }
 
 func (t *jsonThemeConfig) toThemeConfig() models.ThemeConfig {
@@ -1846,6 +1978,36 @@ func (t *jsonThemeConfig) toThemeConfig() models.ThemeConfig {
 		PaletteDark:  t.PaletteDark,
 		Variables:    variables,
 		CustomCSS:    t.CustomCSS,
+		Background:   t.Background.toBackgroundConfig(),
+		Font:         t.Font.toFontConfig(),
+	}
+}
+
+func (b *jsonBackgroundConfig) toBackgroundConfig() models.BackgroundConfig {
+	backgrounds := make([]models.BackgroundElement, len(b.Backgrounds))
+	for i, bg := range b.Backgrounds {
+		backgrounds[i] = models.BackgroundElement{
+			HTML:   bg.HTML,
+			ZIndex: bg.ZIndex,
+		}
+	}
+	return models.BackgroundConfig{
+		Enabled:     b.Enabled,
+		Backgrounds: backgrounds,
+		Scripts:     b.Scripts,
+		CSS:         b.CSS,
+	}
+}
+
+func (f *jsonFontConfig) toFontConfig() models.FontConfig {
+	return models.FontConfig{
+		Family:        f.Family,
+		HeadingFamily: f.HeadingFamily,
+		CodeFamily:    f.CodeFamily,
+		Size:          f.Size,
+		LineHeight:    f.LineHeight,
+		GoogleFonts:   f.GoogleFonts,
+		CustomURLs:    f.CustomURLs,
 	}
 }
 


### PR DESCRIPTION
## Summary
Fixes #390 

The TOML/YAML/JSON config parsers were not parsing `theme.background` and `theme.font` configuration, even though the `models.ThemeConfig` struct supported these fields. Additionally, the config merge logic was not merging these fields, causing them to be lost when merging with defaults.

## Changes

### Parser Updates (`pkg/config/parser.go`)
- Added `Background` and `Font` fields to `tomlThemeConfig`, `yamlThemeConfig`, and `jsonThemeConfig` structs
- Created conversion structs: `tomlBackgroundConfig`, `tomlBackgroundElement`, `tomlFontConfig` (and yaml/json equivalents)
- Added conversion methods: `toBackgroundConfig()` and `toFontConfig()` for all three formats
- Updated `toThemeConfig()` methods to convert Background and Font fields

### Merge Logic Updates (`pkg/config/merge.go`)
- Added `mergeBackgroundConfig()` function to properly merge background configurations
- Added `mergeFontConfig()` function to properly merge font configurations  
- Updated `mergeThemeConfig()` to call these new merge functions

## Testing
- Config now loads correctly with background and font settings
- Verified TOML parsing works with nested background configuration
- Verified config merge preserves background and font settings

## Impact
Users can now configure background decorations (like snow effects) and custom fonts via TOML/YAML/JSON config files. Previously, these settings were ignored even if present in config files.