### PR TITLE
fix: remove background-layer wrapper divs causing spacing issues

### DIFF
--- a/pkg/themes/default/templates/partials/background-decorations.html
+++ b/pkg/themes/default/templates/partials/background-decorations.html
@@ -1,8 +1,6 @@
     <!-- Background Decorations -->
     {% if config.theme.background.enabled %}
     {% for bg in config.theme.background.backgrounds %}
-    <div class="background-layer" style="position: fixed; inset: 0; pointer-events: none; z-index: {% if bg.z_index %}{{ bg.z_index }}{% else %}-1{% endif %};">
-      {{ bg.html | safe }}
-    </div>
+    {{ bg.html | safe }}
     {% endfor %}
     {% endif %}

--- a/templates/partials/background-decorations.html
+++ b/templates/partials/background-decorations.html
@@ -1,8 +1,6 @@
     <!-- Background Decorations -->
     {% if config.theme.background.enabled %}
     {% for bg in config.theme.background.backgrounds %}
-    <div class="background-layer" style="position: fixed; inset: 0; pointer-events: none; z-index: {% if bg.z_index %}{{ bg.z_index }}{% else %}-1{% endif %};">
-      {{ bg.html | safe }}
-    </div>
+    {{ bg.html | safe }}
     {% endfor %}
     {% endif %}


### PR DESCRIPTION
## Summary
- Removed wrapper `<div class="background-layer">` from background decorations template
- Background HTML is now output directly, matching the live site behavior
- Fixes vertical spacing issues with W.svg pattern

## Changes
- `templates/partials/background-decorations.html` - removed wrapper div
- `pkg/themes/default/templates/partials/background-decorations.html` - same fix

## Migration Note
If you were relying on the wrapper div for positioning, you now need to include positioning styles in your background HTML config. For example:

```toml
[[markata-go.theme.background.backgrounds]]
html = """<div style="position: fixed; inset: 0; pointer-events: none; z-index: -2; background-image: url('/w.svg'); ..."></div>"""
```

Fixes #399