### PR TITLE
feat(lsp): add @mention autocomplete, hover, definition, and diagnostics

### DIFF
--- a/pkg/lsp/handlers.go
+++ b/pkg/lsp/handlers.go
@@ -33,7 +33,7 @@ func (s *Server) handleInitialize(_ context.Context, msg *Message) error {
 				},
 			},
 			CompletionProvider: &CompletionOptions{
-				TriggerCharacters: []string{"["},
+				TriggerCharacters: []string{"[", "@"},
 				ResolveProvider:   false,
 			},
 			HoverProvider:      true,


### PR DESCRIPTION
## Summary

Adds full LSP support for @mentions to achieve feature parity with wikilinks.

## Changes

- **Autocomplete**: Type `@` to get mention suggestions from blogroll config
- **Hover**: Hover over `@handle` to see title, description, site URL, feed URL, and aliases
- **Go-to-definition**: Jump to site URL from `@handle`
- **Diagnostics**: Warns about unknown @mentions not in blogroll config
- **Bug fix**: Fixed LSP message reading using proper Content-Length framing

## Files Modified

| File | Changes |
|------|---------|
| `pkg/lsp/completion.go` | Added `@` mention autocomplete with `getMentionAtPosition` helper |
| `pkg/lsp/definition.go` | Extended go-to-definition to support @mentions (opens site URL) |
| `pkg/lsp/diagnostics.go` | Added warnings for unknown @mentions |
| `pkg/lsp/handlers.go` | Added `@` as a trigger character |
| `pkg/lsp/hover.go` | Added hover support for @mentions |
| `pkg/lsp/index.go` | Added `GetByHandle` method and blogroll mention indexing |
| `pkg/lsp/lsp_test.go` | Added comprehensive tests for all new features |
| `pkg/lsp/server.go` | Fixed LSP message reading bug (Content-Length framing) |

## Testing

- Added 4 new test functions with 28+ test cases
- All tests pass: `go test ./pkg/lsp/...`
- Manually tested in Neovim with markata-go LSP

Fixes #393