### PR TITLE
feat(wikilinks): support alias resolution from frontmatter

### DIFF
--- a/docs/guides/frontmatter.md
+++ b/docs/guides/frontmatter.md
@@ -493,6 +493,34 @@ github_repo: "https://github.com/user/project"
 demo_url: "https://demo.example.com"
 ```
 
+#### Aliases (for Wikilinks)
+
+Define alternative names that can be used in wikilinks to link to this post:
+
+```yaml
+---
+title: "ECMAScript Language Specification"
+slug: "ecmascript"
+aliases:
+  - js
+  - javascript
+  - JavaScript
+---
+```
+
+With these aliases, any of the following wikilinks will resolve to this post:
+
+- `[[ecmascript]]` - matches the slug
+- `[[js]]` - matches an alias
+- `[[javascript]]` - matches an alias
+- `[[JavaScript]]` - case-insensitive alias match
+
+!!! note "Slug Precedence"
+
+    If another post has `slug: "javascript"`, then `[[javascript]]` will link to
+    that post (slug match) rather than the post with the alias. Slugs always take
+    precedence over aliases.
+
 ---
 
 ## Examples

--- a/docs/guides/markdown.md
+++ b/docs/guides/markdown.md
@@ -1140,9 +1140,45 @@ Check the [[templates-guide#available-variables|template variables section]].
 
 markata-go resolves wikilinks by:
 
-1. Finding a post where `slug == link_target`
-2. If found: renders as `<a href="{post.href}">{text}</a>`
-3. If not found: leaves as literal `[[link]]` and warns
+1. Finding a post where `slug == link_target` (case-insensitive)
+2. If no slug match, checking for posts with matching `aliases` in frontmatter
+3. If found: renders as `<a href="{post.href}">{text}</a>`
+4. If not found: leaves as literal `[[link]]` and warns
+
+### Using Aliases
+
+You can define aliases in your post's frontmatter to create alternative names for linking:
+
+**Target post (`ecmascript.md`):**
+
+```yaml
+---
+title: "ECMAScript Language Specification"
+slug: "ecmascript"
+aliases:
+  - js
+  - javascript
+  - JavaScript
+---
+```
+
+**Source post:**
+
+```markdown
+Learn about [[js]] and [[javascript]] - both link to the ECMAScript post!
+```
+
+**Output:**
+
+```html
+<p>Learn about <a href="/ecmascript/" class="wikilink">ECMAScript Language Specification</a> and <a href="/ecmascript/" class="wikilink">ECMAScript Language Specification</a> - both link to the ECMAScript post!</p>
+```
+
+!!! note "Slug Precedence"
+
+    If a slug and an alias have the same name, the slug always takes precedence.
+    For example, if post A has `slug: "javascript"` and post B has
+    `aliases: ["javascript"]`, then `[[javascript]]` will link to post A.
 
 ### Broken Link Handling
 


### PR DESCRIPTION
## Summary

- Wikilinks now resolve via `aliases` defined in frontmatter, not just `slug`
- Slug resolution takes precedence over alias resolution to avoid conflicts
- Case-insensitive matching for aliases (consistent with slug matching)

## Problem

Wikilinks (`[[slug]]`) only resolved by matching the `slug` field. They did not support resolving via `aliases` defined in frontmatter.

Example - this post:
```yaml
---
title: "ECMAScript Language Specification"
slug: "ecmascript"
aliases: ["js", "javascript", "JavaScript"]
---
```

Previously `[[js]]` did NOT resolve but now resolves to `/ecmascript/`.

## Solution

Modified `pkg/plugins/wikilinks.go` to also check aliases from `post.Extra["aliases"]` when building the lookup map. Slugs are registered first to ensure they take precedence over aliases.

## Testing

Added comprehensive tests for:
- Basic alias resolution
- Slug precedence over alias
- Case-insensitive matching
- Multiple aliases pointing to same post
- Alias with custom display text
- Non-matching aliases still produce warnings

## Documentation

Updated:
- `docs/guides/markdown.md` - Wikilink Resolution section now documents alias support
- `docs/guides/frontmatter.md` - Added Aliases section under Custom Fields

Fixes #415