### PR TITLE
feat(lint): add rule to detect H1 headings in markdown content

### DIFF
--- a/docs/guides/markdown.md
+++ b/docs/guides/markdown.md
@@ -67,6 +67,28 @@ Use `#` characters to create headings (levels 1-6):
 <h6>Heading 6</h6>
 ```
 
+!!! warning "Avoid H1 in Content"
+
+    **Don't use H1 (`#`) headings in your markdown content.** Templates automatically generate an H1 from your frontmatter `title`, so using H1 in content creates duplicate H1 tags.
+
+    This harms:
+    - **SEO** - Search engines expect one H1 per page
+    - **Accessibility** - Screen readers use H1 for page identification
+
+    **Start your content with H2 (`##`) or deeper:**
+
+    ```markdown
+    ---
+    title: My Page Title  # This becomes the H1
+    ---
+
+    ## First Section       # Start with H2
+
+    Content here...
+    ```
+
+    The linter will warn you if H1 headings are detected in content.
+
 ### Paragraphs
 
 Paragraphs are separated by blank lines:

--- a/pkg/lint/heading_test.go
+++ b/pkg/lint/heading_test.go
@@ -1,0 +1,219 @@
+package lint
+
+import (
+	"testing"
+)
+
+func TestLint_H1Headings(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		wantLen int
+	}{
+		{
+			name: "no H1 heading",
+			content: `---
+title: Test Post
+---
+## This is H2
+
+Some content here.
+
+### This is H3`,
+			wantLen: 0,
+		},
+		{
+			name: "single H1 heading",
+			content: `---
+title: Test Post
+---
+# This is H1
+
+Some content here.`,
+			wantLen: 1,
+		},
+		{
+			name: "multiple H1 headings",
+			content: `---
+title: Test Post
+---
+# First H1
+
+Some content.
+
+# Second H1
+
+More content.
+
+# Third H1`,
+			wantLen: 3,
+		},
+		{
+			name: "H1 in code block should not trigger",
+			content: `---
+title: Test Post
+---
+## Introduction
+
+Here's some markdown syntax:
+
+` + "```markdown" + `
+# This is a heading example
+` + "```" + `
+
+## Conclusion`,
+			wantLen: 0,
+		},
+		{
+			name: "H1 in triple tilde code block should not trigger",
+			content: `---
+title: Test Post
+---
+## Introduction
+
+~~~markdown
+# This is a heading example
+~~~
+
+## Conclusion`,
+			wantLen: 0,
+		},
+		{
+			name: "H1 outside code block triggers but inside does not",
+			content: `---
+title: Test Post
+---
+# Real H1 before code
+
+` + "```markdown" + `
+# This is in code block
+` + "```" + `
+
+# Real H1 after code`,
+			wantLen: 2,
+		},
+		{
+			name: "H2 and H3 do not trigger",
+			content: `---
+title: Test Post
+---
+## H2 heading
+
+### H3 heading
+
+#### H4 heading
+
+##### H5 heading
+
+###### H6 heading`,
+			wantLen: 0,
+		},
+		{
+			name: "H1 without frontmatter",
+			content: `# This is H1
+
+Some content without frontmatter.`,
+			wantLen: 1,
+		},
+		{
+			name: "bare hash without space is not H1",
+			content: `---
+title: Test
+---
+#notaheading
+#also-not-a-heading`,
+			wantLen: 0,
+		},
+		{
+			name: "lone hash is H1",
+			content: `---
+title: Test
+---
+#
+
+Some content.`,
+			wantLen: 1,
+		},
+		{
+			name: "H1 with special characters in title",
+			content: `---
+title: Test
+---
+# Hello World! How's it going?
+
+Content here.`,
+			wantLen: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Lint("test.md", tt.content)
+
+			var h1Issues []Issue
+			for _, issue := range result.Issues {
+				if issue.Type == "h1-in-content" {
+					h1Issues = append(h1Issues, issue)
+				}
+			}
+
+			if len(h1Issues) != tt.wantLen {
+				t.Errorf("got %d h1-in-content issues, want %d", len(h1Issues), tt.wantLen)
+				for _, issue := range h1Issues {
+					t.Logf("  - Line %d: %s", issue.Line, issue.Message)
+				}
+			}
+
+			// Verify severity is warning
+			for _, issue := range h1Issues {
+				if issue.Severity != SeverityWarning {
+					t.Errorf("expected severity %v, got %v", SeverityWarning, issue.Severity)
+				}
+				if issue.Fixable {
+					t.Error("H1 issues should not be auto-fixable")
+				}
+			}
+		})
+	}
+}
+
+func TestLint_H1Headings_LineNumbers(t *testing.T) {
+	content := `---
+title: Test
+date: 2024-01-01
+---
+## Introduction
+
+# First H1
+
+Some content.
+
+# Second H1`
+
+	result := Lint("test.md", content)
+
+	var h1Issues []Issue
+	for _, issue := range result.Issues {
+		if issue.Type == "h1-in-content" {
+			h1Issues = append(h1Issues, issue)
+		}
+	}
+
+	if len(h1Issues) != 2 {
+		t.Fatalf("expected 2 H1 issues, got %d", len(h1Issues))
+	}
+
+	// First H1 is on line 7 (4 frontmatter lines + 2 body lines + 1)
+	// Frontmatter: line 1 (---), 2 (title), 3 (date), 4 (---)
+	// Body: line 5 (## Introduction), 6 (empty), 7 (# First H1)
+	expectedLine1 := 7
+	if h1Issues[0].Line != expectedLine1 {
+		t.Errorf("first H1 line: got %d, want %d", h1Issues[0].Line, expectedLine1)
+	}
+
+	// Second H1 is on line 11
+	expectedLine2 := 11
+	if h1Issues[1].Line != expectedLine2 {
+		t.Errorf("second H1 line: got %d, want %d", h1Issues[1].Line, expectedLine2)
+	}
+}

--- a/spec/spec/CONTENT.md
+++ b/spec/spec/CONTENT.md
@@ -193,6 +193,28 @@ Every implementation MUST support:
 | Ordered lists | `1. item` |
 | Horizontal rules | `---` or `***` |
 
+### Heading Best Practices
+
+**Avoid H1 headings in content.** Templates automatically generate an H1 from the frontmatter `title` field. Using H1 (`# Heading`) in markdown content creates duplicate H1 tags, which:
+
+- Harms SEO (search engines expect a single H1 per page)
+- Reduces accessibility (screen readers use H1 for page identification)
+- Violates HTML document outline best practices
+
+**Start content with H2 (`##`) or deeper headings.** The linter will warn if H1 headings are detected in content.
+
+```markdown
+---
+title: My Page Title  # This becomes the H1
+---
+
+## First Section       # Start with H2, not H1
+
+Content here...
+
+### Subsection         # H3 for nested sections
+```
+
 ### Extended Features
 
 Implementations SHOULD support:


### PR DESCRIPTION
## Summary

Add a linting rule that detects H1 headings (`# Heading`) in markdown content. Templates already add an H1 from the frontmatter title, so H1 in content creates duplicate H1 tags which harms SEO and accessibility.

## Changes

- Add `checkH1Headings` function to `pkg/lint/lint.go` that detects H1 headings in body content
- Properly handle code blocks (``` and ~~~) to avoid false positives
- Add comprehensive tests in `pkg/lint/heading_test.go`
- Update `spec/spec/CONTENT.md` with heading best practices
- Update `docs/guides/markdown.md` with user-facing guidance and admonition warning

## Example

The linter will now warn on content like this:

```markdown
---
title: My Post
---
# This H1 creates a duplicate heading  <-- WARNING
```

And suggest using H2 or deeper:

```markdown
---
title: My Post  # This becomes the H1
---
## First Section  # Start with H2
```

Fixes #413