### PR TITLE
feat(publish): support standard txt files with reversed redirects

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -887,17 +887,19 @@ See the [Blogroll Guide](/docs/guides/blogroll/) for detailed configuration and 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `html` | bool | `true` | Generate standard HTML pages |
-| `markdown` | bool | `false` | Generate raw markdown source |
-| `text` | bool | `false` | Generate plain text output |
+| `markdown` | bool | `true` | Generate raw markdown source |
+| `text` | bool | `true` | Generate plain text output |
 | `og` | bool | `false` | Generate OpenGraph card HTML |
 
 ```toml
 [markata-go.post_formats]
 html = true       # /slug/index.html (default)
-markdown = true   # /slug/index.md (raw source)
-text = true       # /slug/index.txt (plain text)
-og = true         # /slug/og/index.html (social card)
+markdown = true   # /slug.md (canonical) - enabled by default
+text = true       # /slug.txt (canonical) - enabled by default
+og = false        # /slug/og/index.html (social card)
 ```
+
+**Reversed Redirects for txt/md**: For `.txt` and `.md` formats, content is placed at the canonical URL (`/slug.txt`, `/slug.md`) with a backwards-compatible redirect at `/slug/index.txt`. This supports standard web txt files like `robots.txt`, `llms.txt`, and `humans.txt`.
 
 **Canonical URLs and Alternate Links**: When post formats are enabled, markata-go automatically adds:
 

--- a/docs/guides/standard-txt-files.md
+++ b/docs/guides/standard-txt-files.md
@@ -1,0 +1,250 @@
+---
+title: "Standard Web Txt Files"
+description: "Generate robots.txt, llms.txt, humans.txt and other standard web txt files at their canonical URLs"
+date: 2026-01-26
+published: true
+tags:
+  - configuration
+  - output
+  - seo
+  - standards
+---
+
+# Standard Web Txt Files
+
+markata-go supports generating standard web txt files at their expected canonical URLs. This enables creating files like `robots.txt`, `llms.txt`, and `humans.txt` that web crawlers, AI models, and humans expect to find at the root of your site.
+
+## Quick Start
+
+1. **Text format is enabled by default** - no configuration needed
+
+2. **Create a markdown file** for your txt content:
+
+```markdown
+<!-- robots.md -->
+---
+title: "Robots"
+slug: robots
+published: true
+---
+
+User-agent: *
+Allow: /
+Disallow: /private/
+```
+
+3. **Build your site** - markata-go generates:
+   - `/robots.txt` - The canonical robots.txt file
+   - `/robots/index.txt` - Redirect for backwards compatibility
+
+## Common Txt Files
+
+### robots.txt
+
+The robot exclusion standard for web crawlers:
+
+```markdown
+---
+title: "Robots"
+slug: robots
+published: true
+---
+
+User-agent: *
+Allow: /
+
+User-agent: GPTBot
+Disallow: /
+
+Sitemap: https://example.com/sitemap.xml
+```
+
+### llms.txt
+
+Guidance for AI language models ([llms.txt standard](https://llmstxt.org)):
+
+```markdown
+---
+title: "LLMs"
+slug: llms
+published: true
+---
+
+# LLMs.txt
+
+> This site welcomes AI training on its content.
+
+## Site Information
+- Name: Example Site
+- URL: https://example.com
+- Author: Jane Doe
+
+## Guidelines
+- Attribution appreciated but not required
+- Commercial use allowed
+- Respect rate limits
+
+## Notable Content
+- /blog/ - Technical articles
+- /docs/ - Documentation
+```
+
+### humans.txt
+
+Human-readable site credits ([humanstxt.org](https://humanstxt.org)):
+
+```markdown
+---
+title: "Humans"
+slug: humans
+published: true
+---
+
+/* TEAM */
+Developer: Jane Doe
+Contact: jane@example.com
+Twitter: @janedoe
+Location: San Francisco, CA
+
+/* SITE */
+Last update: 2026/01/26
+Standards: HTML5, CSS3
+Software: markata-go
+```
+
+### security.txt
+
+Security contact information ([securitytxt.org](https://securitytxt.org)):
+
+```markdown
+---
+title: "Security"
+slug: .well-known/security
+published: true
+---
+
+Contact: security@example.com
+Expires: 2027-01-01T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://example.com/.well-known/security.txt
+```
+
+## How It Works
+
+### Reversed Redirects
+
+For `.txt` and `.md` formats, markata-go uses **reversed redirects**:
+
+| Canonical Location | Redirect From |
+|-------------------|---------------|
+| `/robots.txt` | `/robots/index.txt` |
+| `/llms.txt` | `/llms/index.txt` |
+
+This ensures:
+- Standard files work at their expected URLs
+- Backwards compatibility with directory-based URLs
+- Both URL styles are accessible
+
+### File Structure
+
+After building, your output directory contains:
+
+```
+output/
+├── robots.txt              ← Canonical content
+├── robots/
+│   └── index.txt           ← Redirect to /robots.txt
+├── llms.txt                ← Canonical content
+├── llms/
+│   └── index.txt           ← Redirect to /llms.txt
+└── humans.txt              ← Canonical content
+    humans/
+    └── index.txt           ← Redirect to /humans.txt
+```
+
+## Configuration
+
+Text output is enabled by default. To customize:
+
+```toml
+[markata-go.post_formats]
+html = true       # Standard HTML (default: true)
+markdown = true   # Raw markdown at /slug.md (default: true)
+text = true       # Plain text at /slug.txt (default: true)
+og = false        # OpenGraph cards (default: false)
+```
+
+To disable text output:
+
+```toml
+[markata-go.post_formats]
+text = false
+```
+
+## Text File Format
+
+The plain text output includes:
+
+1. **Title** (underlined with `=`)
+2. **Description** (if present)
+3. **Date** (if present)
+4. **Raw content** (no markdown processing)
+
+Example output for a post:
+
+```
+My Post Title
+=============
+
+A description of the post.
+
+Date: January 26, 2026
+
+The actual content of the post...
+```
+
+For standard txt files like `robots.txt`, keep the content minimal:
+
+```markdown
+---
+title: "Robots"
+slug: robots
+published: true
+---
+
+User-agent: *
+Allow: /
+```
+
+This generates clean output without the title/description header:
+
+```
+Robots
+======
+
+User-agent: *
+Allow: /
+```
+
+## Testing
+
+Verify your txt files work:
+
+```bash
+# Build and serve locally
+markata-go serve
+
+# Test in another terminal
+curl http://localhost:8000/robots.txt
+curl http://localhost:8000/llms.txt
+curl http://localhost:8000/humans.txt
+
+# Test redirects
+curl -L http://localhost:8000/robots/index.txt
+```
+
+## See Also
+
+- [Post Output Formats](/docs/guides/post-formats/) - Full guide to all output formats
+- [Configuration Guide](/docs/guides/configuration/) - Complete configuration reference
+- [SEO Guide](/docs/guides/structured-data/) - Search engine optimization

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -1090,13 +1090,13 @@ type PostFormatsConfig struct {
 }
 
 // NewPostFormatsConfig creates a new PostFormatsConfig with default values.
-// By default, only HTML output is enabled.
+// By default, HTML, Markdown, and Text output are enabled.
 func NewPostFormatsConfig() PostFormatsConfig {
 	enabled := true
 	return PostFormatsConfig{
 		HTML:     &enabled,
-		Markdown: false,
-		Text:     false,
+		Markdown: true,
+		Text:     true,
 		OG:       false,
 	}
 }

--- a/spec/spec/CONFIG.md
+++ b/spec/spec/CONFIG.md
@@ -670,7 +670,8 @@ See [THEMES.md](./THEMES.md) for complete theming documentation.
 ```toml
 [my-ssg.post_formats]
 html = true       # /slug/index.html (default: true)
-markdown = false  # /slug/index.md - raw source with frontmatter
+markdown = true   # /slug.md - raw source with frontmatter (default: true)
+text = true       # /slug.txt - plain text content (default: true)
 og = false        # /slug/og/index.html - social card for screenshots
 ```
 
@@ -679,18 +680,30 @@ This section controls what output formats are generated for each post:
 | Format | Default | Output Path | Description |
 |--------|---------|-------------|-------------|
 | `html` | `true` | `/slug/index.html` | Standard rendered HTML page |
-| `markdown` | `false` | `/slug/index.md` | Raw markdown with reconstructed frontmatter |
+| `markdown` | `true` | `/slug.md` | Raw markdown with reconstructed frontmatter |
+| `text` | `true` | `/slug.txt` | Plain text content |
 | `og` | `false` | `/slug/og/index.html` | OpenGraph card HTML (1200x630) for social screenshots |
+
+**Reversed Redirects for txt/md:**
+
+For `.txt` and `.md` formats, the content is placed at the canonical URL (`/slug.txt`, `/slug.md`) rather than in a subdirectory. A backwards-compatible redirect is created at `/slug/index.txt` pointing to `/slug.txt`.
+
+This enables standard web txt files to be served at their expected locations:
+- `/robots.txt` - Robot exclusion standard
+- `/llms.txt` - AI/LLM guidance file  
+- `/humans.txt` - Human-readable site info
 
 **Use cases:**
 - **markdown**: API consumers, "view source" links, copy-paste code
+- **text**: Standard web txt files, plain text readers, CLI tools
 - **og**: Automated social image generation with puppeteer/playwright
 
 **Example:**
 ```toml
 [markata-go.post_formats]
 html = true
-markdown = true  # Enable raw markdown output
+markdown = true  # Enable raw markdown output at /slug.md
+text = true      # Enable plain text output at /slug.txt
 og = true        # Enable social card HTML for screenshot tools
 ```
 


### PR DESCRIPTION
## Summary

- Reverse redirect direction for `.txt` and `.md` formats so canonical URLs are at `/slug.txt` instead of `/slug/index.txt`
- Enable Markdown and Text output formats by default
- Add comprehensive documentation for standard web txt files

## Changes

### Reversed Redirect Structure

**Before (wrong for txt/md):**
```
output/
  robots/
    index.txt           ← Content was here
  robots.txt/
    index.html          ← HTML redirect
```

**After (correct):**
```
output/
  robots.txt            ← Content lives here (canonical) ✅
  robots/
    index.txt           ← Redirect to /robots.txt (backwards compat)
```

### Default Config Changes

| Format | Old Default | New Default |
|--------|-------------|-------------|
| HTML | `true` | `true` |
| Markdown | `false` | `true` |
| Text | `false` | `true` |
| OG | `false` | `false` |

### Files Changed

- `pkg/plugins/publish_html.go` - Implement reversed redirect logic
- `pkg/models/config.go` - Enable markdown/text by default
- `pkg/plugins/publish_html_test.go` - Add tests for new behavior
- `spec/spec/CONFIG.md` - Update spec documentation
- `docs/guides/post-formats.md` - Update user documentation
- `docs/guides/configuration.md` - Update config reference
- `docs/guides/standard-txt-files.md` - New guide for standard txt files

## Testing

All existing tests pass, plus new tests:
- `TestPublishHTMLPlugin_FormatRedirectsCreateDirectories` - Verifies reversed redirect structure
- `TestPublishHTMLPlugin_StandardWebTxtFiles` - Verifies robots.txt, llms.txt, humans.txt generation
- `TestPublishHTMLPlugin_PostFormatsDefaultEnabled` - Verifies new defaults

Fixes #395