### PR TITLE
feat(mentions): add resolution from internal posts

### DIFF
--- a/cmd/markata-go/cmd/benchmark.go
+++ b/cmd/markata-go/cmd/benchmark.go
@@ -413,6 +413,9 @@ func createBenchmarkManager(cfgPath, workDir string) (*lifecycle.Manager, error)
 	// Pass blogroll configuration
 	lcConfig.Extra["blogroll"] = cfg.Blogroll
 
+	// Pass mentions configuration
+	lcConfig.Extra["mentions"] = cfg.Mentions
+
 	m.SetConfig(lcConfig)
 
 	if cfg.Concurrency > 0 {

--- a/cmd/markata-go/cmd/core.go
+++ b/cmd/markata-go/cmd/core.go
@@ -79,6 +79,9 @@ func createManager(cfgPath string) (*lifecycle.Manager, error) {
 	// Pass blogroll configuration
 	lcConfig.Extra["blogroll"] = cfg.Blogroll
 
+	// Pass mentions configuration
+	lcConfig.Extra["mentions"] = cfg.Mentions
+
 	// Pass sidebar, toc, and header configurations
 	lcConfig.Extra["sidebar"] = cfg.Sidebar
 	lcConfig.Extra["toc"] = cfg.Toc

--- a/docs/guides/mentions.md
+++ b/docs/guides/mentions.md
@@ -1,0 +1,239 @@
+---
+title: "@Mentions"
+description: "Resolve @handles to links from blogroll feeds and internal posts"
+date: 2025-01-26
+published: true
+tags:
+  - documentation
+  - mentions
+  - social
+---
+
+# @Mentions
+
+The mentions plugin transforms `@handle` syntax in your markdown content into HTML links. It resolves handles from two sources:
+
+1. **Blogroll feeds** - External RSS/Atom feeds from your blogroll configuration
+2. **Internal posts** - Posts in your site matching filter expressions (like contact pages)
+
+## Basic Usage
+
+Write mentions in your markdown using `@handle` syntax:
+
+```markdown
+I was reading @alice's post about static site generators.
+Also check out @bob for more great content.
+```
+
+When handles are resolved, they become clickable links:
+
+```html
+I was reading <a href="/contact/alice/" class="mention">@alice</a>'s post...
+```
+
+## Configuration
+
+Configure mentions in your `markata-go.toml`:
+
+```toml
+[markata-go.mentions]
+enabled = true
+css_class = "mention"  # CSS class for links (default: "mention")
+
+# Source handles from internal posts
+[[markata-go.mentions.from_posts]]
+filter = "'contact' in tags"
+handle_field = "handle"       # Frontmatter field for handle (optional, uses slug if not set)
+aliases_field = "aliases"     # Frontmatter field for aliases (optional)
+```
+
+## Resolving from Internal Posts
+
+The `from_posts` configuration lets you resolve `@handles` from posts in your site. This is useful for:
+
+- **Contact pages** - Team member or author profiles
+- **Contributor pages** - Guest authors or collaborators  
+- **Partner pages** - Companies or organizations you work with
+
+### Example: Contact Pages
+
+Create contact pages with handle information in frontmatter:
+
+```yaml
+# pages/contact/alice-smith.md
+---
+title: "Alice Smith"
+tags:
+  - contact
+handle: alice
+aliases:
+  - alices
+  - asmith
+---
+
+Alice is a software engineer specializing in Go and web development.
+```
+
+Configure the mentions plugin to use these posts:
+
+```toml
+[[markata-go.mentions.from_posts]]
+filter = "'contact' in tags"
+handle_field = "handle"
+aliases_field = "aliases"
+```
+
+Now `@alice`, `@alices`, and `@asmith` all link to `/contact/alice-smith/`.
+
+### Multiple Sources
+
+You can define multiple `from_posts` sources for different content types:
+
+```toml
+# Contact pages
+[[markata-go.mentions.from_posts]]
+filter = "'contact' in tags"
+handle_field = "handle"
+aliases_field = "aliases"
+
+# Team members
+[[markata-go.mentions.from_posts]]
+filter = "template == 'team-member.html'"
+handle_field = "github_handle"
+
+# Projects (no explicit handle - uses slug)
+[[markata-go.mentions.from_posts]]
+filter = "'project' in tags"
+```
+
+### Fallback to Slug
+
+If `handle_field` is not specified or the frontmatter field is empty, the post's slug is used as the handle.
+
+```toml
+[[markata-go.mentions.from_posts]]
+filter = "'contributor' in tags"
+# No handle_field - uses slug
+```
+
+A post at `contributors/jane-doe.md` becomes `@jane-doe`.
+
+## Resolving from Blogroll
+
+If you have a [blogroll](/guides/blogroll/) configured, handles are automatically extracted from your RSS/Atom feeds:
+
+```toml
+[markata-go.blogroll]
+enabled = true
+
+[[markata-go.blogroll.feeds]]
+url = "https://daverupert.com/feed.xml"
+title = "Dave Rupert"
+handle = "daverupert"
+site_url = "https://daverupert.com"
+aliases = ["dave", "davatron"]
+```
+
+Now `@daverupert`, `@dave`, and `@davatron` all link to `https://daverupert.com`.
+
+## Handle Resolution Priority
+
+When building the handle map, sources are processed in this order:
+
+1. **Blogroll feeds** (if enabled) - First registered wins
+2. **From posts** sources - Processed in order they appear in config
+
+If the same handle is registered multiple times, the first registration wins and subsequent duplicates are logged as warnings.
+
+## Styling Mentions
+
+Mention links have the configured CSS class (default: `mention`). Add styles to your CSS:
+
+```css
+a.mention {
+  color: var(--color-primary);
+  font-weight: 500;
+}
+
+a.mention::before {
+  content: "";  /* Remove @ if you want */
+}
+
+a.mention:hover {
+  text-decoration: underline;
+}
+```
+
+## Code Block Protection
+
+Mentions inside fenced code blocks are preserved and not transformed:
+
+````markdown
+Check out @alice's post.
+
+```
+// @alice is not transformed here
+const handle = "@alice";
+```
+````
+
+## Email Protection
+
+Email addresses are not transformed as mentions. The plugin detects the `@` preceded by word characters and ignores them:
+
+```markdown
+Contact me at test@example.com  <!-- Not transformed -->
+Follow @example on social       <!-- Transformed -->
+```
+
+## Configuration Reference
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `enabled` | bool | `true` | Enable/disable mentions processing |
+| `css_class` | string | `"mention"` | CSS class for mention links |
+| `from_posts` | array | `[]` | List of internal post sources |
+
+### from_posts Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `filter` | string | required | Filter expression to select posts |
+| `handle_field` | string | (slug) | Frontmatter field for handle |
+| `aliases_field` | string | - | Frontmatter field for aliases |
+
+## Examples
+
+### Team Directory
+
+```toml
+[[markata-go.mentions.from_posts]]
+filter = "'team' in tags and published == true"
+handle_field = "slack_handle"
+aliases_field = "nicknames"
+```
+
+### Author Profiles
+
+```toml
+[[markata-go.mentions.from_posts]]
+filter = "template == 'author.html'"
+handle_field = "username"
+```
+
+### Combined Sources
+
+```toml
+[markata-go.blogroll]
+enabled = true
+
+[[markata-go.blogroll.feeds]]
+url = "https://external-blog.com/rss"
+handle = "external"
+
+[[markata-go.mentions.from_posts]]
+filter = "'internal' in tags"
+handle_field = "handle"
+```
+
+Now you can use `@external` for external links and `@internal-user` for internal profile links in the same post.

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -262,6 +262,9 @@ type Config struct {
 
 	// Blogroll configures the blogroll and RSS reader functionality
 	Blogroll BlogrollConfig `json:"blogroll" yaml:"blogroll" toml:"blogroll"`
+
+	// Mentions configures the @mentions resolution plugin
+	Mentions MentionsConfig `json:"mentions" yaml:"mentions" toml:"mentions"`
 }
 
 // HeadConfig configures elements added to the HTML <head> section.
@@ -1357,6 +1360,7 @@ func NewConfig() *Config {
 		FooterLayout:     NewFooterLayoutConfig(),
 		ContentTemplates: NewContentTemplatesConfig(),
 		Blogroll:         NewBlogrollConfig(),
+		Mentions:         NewMentionsConfig(),
 	}
 }
 

--- a/pkg/models/mentions.go
+++ b/pkg/models/mentions.go
@@ -1,0 +1,57 @@
+package models
+
+// MentionsConfig configures the @mentions resolution plugin.
+type MentionsConfig struct {
+	// Enabled controls whether mentions processing is active (default: true)
+	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty" toml:"enabled,omitempty"`
+
+	// CSSClass is the CSS class applied to mention links (default: "mention")
+	CSSClass string `json:"css_class,omitempty" yaml:"css_class,omitempty" toml:"css_class,omitempty"`
+
+	// FromPosts configures mention sources from internal posts
+	FromPosts []MentionPostSource `json:"from_posts,omitempty" yaml:"from_posts,omitempty" toml:"from_posts,omitempty"`
+}
+
+// MentionPostSource configures a source of @mentions from internal posts.
+// This allows resolving @handles from posts like contact pages or team member pages.
+type MentionPostSource struct {
+	// Filter is a filter expression to select which posts to extract handles from
+	// Example: "'contact' in tags" or "template == 'team-member.html'"
+	Filter string `json:"filter" yaml:"filter" toml:"filter"`
+
+	// HandleField is the frontmatter field containing the handle (default: uses slug)
+	// Example: "handle" for frontmatter like `handle: alice`
+	HandleField string `json:"handle_field,omitempty" yaml:"handle_field,omitempty" toml:"handle_field,omitempty"`
+
+	// AliasesField is the frontmatter field containing handle aliases (optional)
+	// Example: "aliases" for frontmatter like `aliases: [alices, asmith]`
+	AliasesField string `json:"aliases_field,omitempty" yaml:"aliases_field,omitempty" toml:"aliases_field,omitempty"`
+}
+
+// NewMentionsConfig creates a new MentionsConfig with default values.
+func NewMentionsConfig() MentionsConfig {
+	enabled := true
+	return MentionsConfig{
+		Enabled:   &enabled,
+		CSSClass:  "mention",
+		FromPosts: []MentionPostSource{},
+	}
+}
+
+// IsEnabled returns whether mentions processing is enabled.
+// Defaults to true if not explicitly set.
+func (m *MentionsConfig) IsEnabled() bool {
+	if m.Enabled == nil {
+		return true
+	}
+	return *m.Enabled
+}
+
+// GetCSSClass returns the CSS class for mention links.
+// Defaults to "mention" if not set.
+func (m *MentionsConfig) GetCSSClass() string {
+	if m.CSSClass == "" {
+		return "mention"
+	}
+	return m.CSSClass
+}

--- a/spec/spec/MENTIONS.md
+++ b/spec/spec/MENTIONS.md
@@ -1,0 +1,278 @@
+# Mentions Plugin Specification
+
+The mentions plugin transforms `@handle` syntax in markdown content into HTML links, resolving handles from blogroll feeds and internal posts.
+
+## Overview
+
+The mentions plugin processes `@handle` patterns in post content and replaces them with HTML anchor links. Handles are resolved from two sources:
+
+1. **Blogroll feeds** - External RSS/Atom feed entries with handles
+2. **Internal posts** - Posts matching filter expressions (e.g., contact pages, team pages)
+
+## Syntax
+
+```markdown
+@handle           # Basic mention
+@alice-smith      # Hyphenated handle
+@alice123         # Handle with numbers
+```
+
+Handle pattern: `@[a-zA-Z][a-zA-Z0-9_-]*`
+
+## Configuration
+
+```toml
+[markata-go.mentions]
+enabled = true                    # Enable/disable the plugin (default: true)
+css_class = "mention"             # CSS class for links (default: "mention")
+
+# Source handles from internal posts
+[[markata-go.mentions.from_posts]]
+filter = "'contact' in tags"      # Filter expression to select posts
+handle_field = "handle"           # Frontmatter field for handle (optional, uses slug if not set)
+aliases_field = "aliases"         # Frontmatter field for aliases (optional)
+```
+
+### Configuration Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `true` | Enable/disable mentions processing |
+| `css_class` | string | `"mention"` | CSS class applied to mention links |
+| `from_posts` | array | `[]` | List of internal post sources |
+
+### from_posts Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `filter` | string | Yes | Filter expression to select posts |
+| `handle_field` | string | No | Frontmatter field containing the handle (defaults to post slug) |
+| `aliases_field` | string | No | Frontmatter field containing handle aliases |
+
+## Handle Resolution
+
+### Resolution Order
+
+Handles are registered in this order (first registration wins):
+
+1. **Blogroll feeds** - If blogroll is enabled, handles from feeds are registered first
+2. **from_posts sources** - Processed in the order they appear in configuration
+
+If a handle or alias is already registered, subsequent registrations are ignored with a warning.
+
+### From Blogroll
+
+When blogroll is enabled, handles are extracted from feed configurations:
+
+```toml
+[[markata-go.blogroll.feeds]]
+url = "https://example.com/feed.xml"
+title = "Example Blog"
+handle = "example"                  # Primary handle
+site_url = "https://example.com"    # Link target
+aliases = ["ex", "exblog"]          # Additional handles
+```
+
+The `site_url` becomes the link target for `@example`, `@ex`, and `@exblog`.
+
+### From Internal Posts
+
+Internal posts are filtered using the filter expression, then handles are extracted:
+
+1. **Handle extraction**: Uses `handle_field` frontmatter value, or falls back to post slug
+2. **Alias extraction**: Uses `aliases_field` frontmatter value if specified
+3. **Link target**: The post's permalink URL
+
+Example post frontmatter:
+
+```yaml
+---
+title: "Alice Smith"
+slug: alice-smith
+tags:
+  - contact
+handle: alice
+aliases:
+  - alices
+  - asmith
+---
+```
+
+With config:
+
+```toml
+[[markata-go.mentions.from_posts]]
+filter = "'contact' in tags"
+handle_field = "handle"
+aliases_field = "aliases"
+```
+
+This registers:
+- `@alice` → `/contact/alice-smith/`
+- `@alices` → `/contact/alice-smith/`
+- `@asmith` → `/contact/alice-smith/`
+
+### Slug Fallback
+
+If `handle_field` is empty or the specified field is not present in frontmatter, the post's slug is used:
+
+```toml
+[[markata-go.mentions.from_posts]]
+filter = "'project' in tags"
+# No handle_field - uses slug
+```
+
+A post with `slug: my-project` registers `@my-project`.
+
+## Transform Behavior
+
+### Processing
+
+1. Extract code blocks and store them (to protect from transformation)
+2. Find all `@handle` patterns in content
+3. For each handle:
+   - Look up in handle map
+   - If found: replace with anchor link
+   - If not found: leave as-is
+4. Restore code blocks
+
+### Email Protection
+
+Email addresses are not transformed. The regex matches `@` only when:
+- NOT preceded by word characters (letters, digits, underscore)
+
+```markdown
+test@example.com     <!-- Not transformed (email) -->
+Follow @example      <!-- Transformed -->
+Say hello@example    <!-- Not transformed (no space before @) -->
+```
+
+### Code Block Protection
+
+Mentions inside fenced code blocks are preserved:
+
+````markdown
+Check out @alice's post.
+
+```
+// @alice is not transformed here
+const handle = "@alice";
+```
+````
+
+### Generated HTML
+
+```html
+<a href="/contact/alice/" class="mention">@alice</a>
+```
+
+Attributes:
+- `href` - Link target URL
+- `class` - Configured CSS class (default: "mention")
+
+The `@` symbol is included in the link text.
+
+## Lifecycle Stage
+
+The mentions plugin runs in the **Transform** stage with default priority (0).
+
+## Data Model
+
+### MentionsConfig
+
+```go
+type MentionsConfig struct {
+    Enabled   *bool               // Enable/disable (default: true)
+    CSSClass  string              // CSS class (default: "mention")
+    FromPosts []MentionPostSource // Internal post sources
+}
+```
+
+### MentionPostSource
+
+```go
+type MentionPostSource struct {
+    Filter       string // Filter expression (required)
+    HandleField  string // Frontmatter field for handle (optional)
+    AliasesField string // Frontmatter field for aliases (optional)
+}
+```
+
+### Internal Handle Map
+
+```go
+// handleMap maps handles to URLs
+type handleMap map[string]string
+
+// Example:
+// "alice" → "/contact/alice/"
+// "alices" → "/contact/alice/"
+// "daverupert" → "https://daverupert.com"
+```
+
+## Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| Unknown handle | Left as plain text (`@unknown`) |
+| Duplicate handle registration | Warning logged, first registration wins |
+| Invalid filter expression | Error logged, source skipped |
+| Missing handle_field in frontmatter | Falls back to slug |
+| Empty aliases_field | No aliases registered for that post |
+
+## CSS Classes
+
+| Class | Purpose |
+|-------|---------|
+| `.mention` | Default class for all mention links |
+
+Custom class can be configured via `css_class` option.
+
+## Examples
+
+### Team Directory
+
+```toml
+[[markata-go.mentions.from_posts]]
+filter = "'team' in tags and published == true"
+handle_field = "slack_handle"
+aliases_field = "nicknames"
+```
+
+### Multiple Sources
+
+```toml
+# External blogroll
+[markata-go.blogroll]
+enabled = true
+
+[[markata-go.blogroll.feeds]]
+url = "https://external.com/feed.xml"
+handle = "external"
+site_url = "https://external.com"
+
+# Internal contacts
+[[markata-go.mentions.from_posts]]
+filter = "'contact' in tags"
+handle_field = "handle"
+aliases_field = "aliases"
+
+# Internal projects
+[[markata-go.mentions.from_posts]]
+filter = "'project' in tags"
+# Uses slug as handle
+```
+
+### Minimal Configuration
+
+```toml
+# Just enable with defaults - uses blogroll handles only
+[markata-go.mentions]
+enabled = true
+```
+
+## Related Features
+
+- **Blogroll** - Source of external handles
+- **Wikilinks** (`[[slug]]`) - Internal links by slug
+- **Filter Expressions** - Query language for selecting posts


### PR DESCRIPTION
## Summary

Enable @mentions to resolve from internal posts like contact pages, not just external blogroll feeds.

- Add `from_posts` configuration to source handles from posts matching filter expressions
- Support custom `handle_field` and `aliases_field` in frontmatter
- Fall back to post slug when no handle field is specified

Fixes #414

## Changes

### New Config Types (`pkg/models/mentions.go`)
- `MentionsConfig` - Top-level mentions configuration
- `MentionPostSource` - Configures a source of handles from internal posts

### Plugin Updates (`pkg/plugins/mentions.go`)
- Updated `Configure()` to read from new `MentionsConfig`
- Added `registerFromPosts()` to filter posts and extract handles
- Added helpers for extracting handles and aliases from frontmatter

### Configuration
- Added `Mentions` field to `Config` struct
- Pass mentions config through `lcConfig.Extra["mentions"]`

### Documentation
- `docs/guides/mentions.md` - User guide with examples
- `spec/spec/MENTIONS.md` - Technical specification

## Example Configuration

```toml
[markata-go.mentions]
enabled = true
css_class = "mention"

[[markata-go.mentions.from_posts]]
filter = "'contact' in tags"
handle_field = "handle"
aliases_field = "aliases"
```

## Testing

Added tests for:
- `TestMentionsPlugin_FromPosts` - Filter and alias resolution
- `TestMentionsPlugin_FromPosts_FallbackToSlug` - Slug fallback behavior
- `TestMentionsPlugin_Transform_FromPosts` - End-to-end transformation
- `TestMentionsPlugin_CombinedSources` - Blogroll + from_posts together

All tests pass: `go test -v ./pkg/plugins/... -run "TestMentions"`