### PR TITLE
docs: update web server configs for reversed txt/md redirects

### DIFF
--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -119,10 +119,30 @@ server {
     root /var/www/mysite/public;
     index index.html;
 
+    # MIME types for txt/md files
+    location ~ \.(txt|md)$ {
+        default_type text/plain;
+        charset utf-8;
+    }
+
+    # Try exact file first (for /robots.txt), then index.html, then directory
     location / {
-        try_files $uri $uri/ =404;
+        try_files $uri $uri/index.html $uri/ =404;
     }
 }
+```
+
+**Testing nginx configuration:**
+
+```bash
+# Test syntax
+sudo nginx -t
+
+# Reload
+sudo systemctl reload nginx
+
+# Verify txt files work
+curl -I http://localhost/robots.txt
 ```
 
 ### Caddy
@@ -131,7 +151,13 @@ server {
 example.com {
     root * /var/www/mysite/public
     file_server
-    try_files {path} {path}/ {path}/index.html
+
+    # MIME types for txt/md files
+    @txtmd path *.txt *.md
+    header @txtmd Content-Type "text/plain; charset=utf-8"
+
+    # Try exact file first (for /robots.txt), then index.html
+    try_files {path} {path}/index.html {path}/
 }
 ```
 


### PR DESCRIPTION
## Summary

Updates all nginx, Caddy, and Apache configuration examples in documentation to correctly handle the reversed redirect direction introduced in #395.

### Changes

- **nginx configs**: Updated `try_files` order from `$uri $uri/ =404` to `$uri $uri/index.html $uri/ =404` so canonical files like `/robots.txt` are served directly
- **Caddy configs**: Updated `try_files` order from `{path} {path}/ {path}/index.html` to `{path} {path}/index.html {path}/`
- **Apache configs**: Added `RewriteCond %{REQUEST_FILENAME} -f` rule to serve exact files first
- **MIME types**: Added proper text/plain charset=utf-8 handling for .txt and .md files
- **Testing examples**: Added curl commands to verify configurations work correctly

### Files Updated

1. `docs/guides/self-hosting.md` - nginx/Caddy configs
2. `docs/guides/deployment/docker.md` - Docker nginx.conf
3. `docs/guides/post-formats.md` - Content negotiation configs
4. `docs/guides/deployment.md` - Production nginx/Caddy configs
5. `deploy/systemd/README.md` - systemd nginx config

### New File Structure (after #395)

```
/robots.txt            ← Canonical file (content here)
/robots/index.txt      ← Redirect to /robots.txt (backwards compat)
```

Supplements #395
Fixes #401