### PR TITLE
feat(frontmatter): add private field with robots.txt integration

### DIFF
--- a/pkg/models/post.go
+++ b/pkg/models/post.go
@@ -33,6 +33,10 @@ type Post struct {
 	// Draft indicates if the post is a draft
 	Draft bool `json:"draft" yaml:"draft" toml:"draft"`
 
+	// Private indicates if the post should be excluded from feeds and search
+	// Private posts are rendered but excluded from feeds, sitemaps, and add noindex meta tag
+	Private bool `json:"private" yaml:"private" toml:"private"`
+
 	// Skip indicates if the post should be skipped during processing
 	Skip bool `json:"skip" yaml:"skip" toml:"skip"`
 
@@ -82,6 +86,7 @@ func NewPost(path string) *Post {
 		Path:      path,
 		Published: false,
 		Draft:     false,
+		Private:   false,
 		Skip:      false,
 		Tags:      []string{},
 		Template:  "", // Empty - let templates plugin resolve from layout config

--- a/pkg/plugins/atom.go
+++ b/pkg/plugins/atom.go
@@ -96,6 +96,10 @@ func GenerateAtom(feed *lifecycle.Feed, config *lifecycle.Config) (string, error
 
 	// Add entries
 	for _, post := range feed.Posts {
+		// Skip private posts from Atom feed
+		if post.Private {
+			continue
+		}
 		entry := postToAtomEntry(post, siteURL)
 		atomFeed.Entries = append(atomFeed.Entries, entry)
 	}

--- a/pkg/plugins/jsonfeed.go
+++ b/pkg/plugins/jsonfeed.go
@@ -93,6 +93,10 @@ func GenerateJSONFeed(feed *lifecycle.Feed, config *lifecycle.Config) (string, e
 
 	// Add items
 	for _, post := range feed.Posts {
+		// Skip private posts from JSON feed
+		if post.Private {
+			continue
+		}
 		item := postToJSONFeedItem(post, siteURL)
 		jsonFeed.Items = append(jsonFeed.Items, item)
 	}

--- a/pkg/plugins/load.go
+++ b/pkg/plugins/load.go
@@ -210,6 +210,7 @@ func (p *LoadPlugin) applyMetadata(post *models.Post, metadata map[string]interf
 		"date":        true,
 		"published":   true,
 		"draft":       true,
+		"private":     true,
 		"skip":        true,
 		"tags":        true,
 		"description": true,
@@ -236,6 +237,9 @@ func (p *LoadPlugin) applyMetadata(post *models.Post, metadata map[string]interf
 
 	// Draft
 	post.Draft = GetBool(metadata, "draft", false)
+
+	// Private
+	post.Private = GetBool(metadata, "private", false)
 
 	// Skip
 	post.Skip = GetBool(metadata, "skip", false)

--- a/pkg/plugins/publish_feeds.go
+++ b/pkg/plugins/publish_feeds.go
@@ -492,7 +492,7 @@ func (p *PublishFeedsPlugin) publishSitemap(fc *models.FeedConfig, config *lifec
 
 	// Add all posts in this feed
 	for _, post := range fc.Posts {
-		if !post.Published || post.Draft || post.Skip {
+		if !post.Published || post.Draft || post.Skip || post.Private {
 			continue
 		}
 

--- a/pkg/plugins/rss.go
+++ b/pkg/plugins/rss.go
@@ -90,6 +90,10 @@ func GenerateRSS(feed *lifecycle.Feed, config *lifecycle.Config) (string, error)
 
 	// Add items
 	for _, post := range feed.Posts {
+		// Skip private posts from RSS feed
+		if post.Private {
+			continue
+		}
 		item := postToRSSItem(post, siteURL)
 		rss.Channel.Items = append(rss.Channel.Items, item)
 	}

--- a/pkg/templates/context.go
+++ b/pkg/templates/context.go
@@ -111,6 +111,7 @@ func postToMap(p *models.Post) map[string]interface{} {
 		"href":         p.Href,
 		"published":    p.Published,
 		"draft":        p.Draft,
+		"private":      p.Private,
 		"skip":         p.Skip,
 		"tags":         p.Tags,
 		"template":     p.Template,
@@ -949,6 +950,7 @@ func (c Context) ToPongo2() pongo2.Context {
 		ctx["href"] = postMap["href"]
 		ctx["published"] = postMap["published"]
 		ctx["draft"] = postMap["draft"]
+		ctx["private"] = postMap["private"]
 		ctx["description"] = postMap["description"]
 		ctx["article_html"] = postMap["article_html"]
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    {% if post.private %}<meta name="robots" content="noindex, nofollow">{% endif %}
     <title>{% block title %}{% if post %}{{ post.title }} - {% endif %}{{ config.title | default:"My Site" }}{% endblock %}</title>
     {% if post.description %}<meta name="description" content="{{ post.description }}">{% elif config.description %}<meta name="description" content="{{ config.description }}">{% endif %}
 


### PR DESCRIPTION
Fixes #396

## Summary
- Add `private` frontmatter field for posts that should be rendered but hidden from feeds and search engines
- Private posts are excluded from RSS, Atom, and JSON feeds
- Private posts are excluded from sitemaps
- Private pages automatically get `<meta name="robots" content="noindex, nofollow">`
- Added `private_paths` template variable for generating robots.txt Disallow directives

## Changes
- **pkg/models/post.go**: Added `Private bool` field to Post struct with proper JSON/YAML/TOML tags
- **pkg/plugins/load.go**: Parse `private` from frontmatter metadata
- **pkg/plugins/atom.go**: Skip private posts when generating Atom feed
- **pkg/plugins/rss.go**: Skip private posts when generating RSS feed
- **pkg/plugins/jsonfeed.go**: Skip private posts when generating JSON feed
- **pkg/plugins/publish_feeds.go**: Exclude private posts from sitemap generation
- **pkg/plugins/templates.go**: Collect private paths and provide `private_paths` template variable
- **pkg/templates/context.go**: Expose `private` field in template context
- **templates/base.html**: Add noindex meta tag for private pages

## Usage
```yaml
---
title: "Secret Page"
private: true
published: true
---
This page will be rendered but hidden from search engines and feeds.
```

For robots.txt, use the `private_paths` variable:
```
{% for path in private_paths %}
Disallow: {{ path }}
{% endfor %}
```