### PR TITLE
feat(templates): add txt file template support

### DIFF
--- a/pkg/templates/filters.go
+++ b/pkg/templates/filters.go
@@ -62,6 +62,9 @@ func registerFilters() {
 
 		// Font configuration filter
 		pongo2.RegisterFilter("google_fonts_url", filterGoogleFontsURL)
+
+		// String repeat filter for text output
+		pongo2.RegisterFilter("repeat", filterRepeat)
 	})
 }
 
@@ -469,6 +472,20 @@ func filterGoogleFontsURL(in, _ *pongo2.Value) (*pongo2.Value, *pongo2.Error) {
 
 	url := "https://fonts.googleapis.com/css2?" + strings.Join(families, "&") + "&display=swap"
 	return pongo2.AsValue(url), nil
+}
+
+// filterRepeat repeats a string N times.
+// The input is the count (length), and the parameter is the string to repeat.
+// Usage: {{ post.title|length|repeat:"=" }}
+func filterRepeat(in, param *pongo2.Value) (*pongo2.Value, *pongo2.Error) {
+	count := in.Integer()
+	char := param.String()
+
+	if count <= 0 || char == "" {
+		return pongo2.AsValue(""), nil
+	}
+
+	return pongo2.AsValue(strings.Repeat(char, count)), nil
 }
 
 // toTime attempts to convert a pongo2 value to a time.Time.

--- a/pkg/themes/default/templates/default.txt
+++ b/pkg/themes/default/templates/default.txt
@@ -1,0 +1,8 @@
+{% if post.title %}{{ post.title }}
+{{ post.title|length|repeat:"=" }}
+
+{% endif %}{% if post.description %}{{ post.description }}
+
+{% endif %}{% if post.date %}Date: {{ post.date|date:"January 2, 2006" }}
+
+{% endif %}{{ post.content }}

--- a/pkg/themes/default/templates/raw.txt
+++ b/pkg/themes/default/templates/raw.txt
@@ -1,0 +1,1 @@
+{{ post.content }}


### PR DESCRIPTION
Fixes #397

## Summary
- Remove hardcoded txt format from `writeTextFormat()` method
- Add template rendering for txt files with template resolution logic
- Create `default.txt` and `raw.txt` templates

## Changes

### `pkg/plugins/publish_html.go`
- Added `renderTextContent()` - renders txt output using templates when engine available
- Added `resolveTextTemplate()` - determines which template to use for txt output
- Renamed `buildTextContent()` to `buildTextContentFallback()` - fallback when no template engine
- Template resolution order: post frontmatter → format-specific template → special file detection → default.txt

### `pkg/templates/filters.go`
- Added `repeat` filter for title underlining (e.g., `{{ post.title|length|repeat:"=" }}`)

### New Templates
- `pkg/themes/default/templates/default.txt` - Replicates current hardcoded format with title underline
- `pkg/themes/default/templates/raw.txt` - Content only (for robots.txt, llms.txt, etc.)

## Features
- Special files (robots, llms, humans, security, ads) automatically use `raw.txt` template
- Frontmatter `template: custom.txt` for custom txt templates
- Format-specific template via `templates.txt` or `txt_template` in Extra
- Graceful fallback to hardcoded format if template rendering fails

## Testing
- Added `TestPublishHTMLPlugin_TxtTemplateRendering` - verifies txt output with fallback
- Added `TestPublishHTMLPlugin_RawTxtForSpecialFiles` - verifies special file handling