### PR TITLE
feat(lsp): add auto-completion for admonition types

### DIFF
--- a/pkg/lsp/admonitions.go
+++ b/pkg/lsp/admonitions.go
@@ -1,0 +1,292 @@
+package lsp
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+// AdmonitionType represents a built-in admonition type with metadata.
+type AdmonitionType struct {
+	// Name is the admonition type name (e.g., "note", "warning")
+	Name string
+
+	// Description provides a brief explanation of when to use this type
+	Description string
+
+	// Color is the primary color associated with this type (CSS color name or hex)
+	Color string
+
+	// Icon is an optional icon identifier for this type
+	Icon string
+}
+
+// builtinAdmonitionTypes defines all supported admonition types.
+// These match the types defined in pkg/plugins/admonitions.go.
+var builtinAdmonitionTypes = []AdmonitionType{
+	{
+		Name:        "note",
+		Description: "Additional information or context",
+		Color:       "#448aff",
+		Icon:        "pencil",
+	},
+	{
+		Name:        "info",
+		Description: "General information",
+		Color:       "#00b8d4",
+		Icon:        "info-circle",
+	},
+	{
+		Name:        "tip",
+		Description: "Helpful suggestions or best practices",
+		Color:       "#00bfa5",
+		Icon:        "lightbulb",
+	},
+	{
+		Name:        "hint",
+		Description: "Subtle guidance or clues",
+		Color:       "#00bfa5",
+		Icon:        "question-circle",
+	},
+	{
+		Name:        "success",
+		Description: "Positive outcomes or confirmations",
+		Color:       "#00c853",
+		Icon:        "check-circle",
+	},
+	{
+		Name:        "warning",
+		Description: "Potential issues or things to be careful about",
+		Color:       "#ff9100",
+		Icon:        "exclamation-triangle",
+	},
+	{
+		Name:        "caution",
+		Description: "Proceed with care",
+		Color:       "#ff9100",
+		Icon:        "exclamation-circle",
+	},
+	{
+		Name:        "important",
+		Description: "Critical information that shouldn't be missed",
+		Color:       "#00bfa5",
+		Icon:        "exclamation",
+	},
+	{
+		Name:        "danger",
+		Description: "Actions that may cause data loss or security issues",
+		Color:       "#ff5252",
+		Icon:        "bolt",
+	},
+	{
+		Name:        "error",
+		Description: "Error conditions or failure states",
+		Color:       "#ff5252",
+		Icon:        "times-circle",
+	},
+	{
+		Name:        "bug",
+		Description: "Known issues or bugs to be aware of",
+		Color:       "#f50057",
+		Icon:        "bug",
+	},
+	{
+		Name:        "example",
+		Description: "Code examples or demonstrations",
+		Color:       "#7c4dff",
+		Icon:        "code",
+	},
+	{
+		Name:        "quote",
+		Description: "Quotations or citations",
+		Color:       "#9e9e9e",
+		Icon:        "quote-left",
+	},
+	{
+		Name:        "abstract",
+		Description: "Summary or overview of content",
+		Color:       "#00b0ff",
+		Icon:        "clipboard-list",
+	},
+	{
+		Name:        "aside",
+		Description: "Side notes or tangential information",
+		Color:       "#64dd17",
+		Icon:        "comment-alt",
+	},
+}
+
+// admonitionTypeMap provides fast lookup by name.
+// Initialized via initAdmonitionTypeMap.
+var admonitionTypeMap = make(map[string]*AdmonitionType, len(builtinAdmonitionTypes))
+
+// titleCaser provides title case conversion.
+var titleCaser = cases.Title(language.English)
+
+// initAdmonitionTypeMap initializes the type lookup map.
+// Called automatically on first use.
+func initAdmonitionTypeMap() {
+	if len(admonitionTypeMap) > 0 {
+		return
+	}
+	for i := range builtinAdmonitionTypes {
+		admonitionTypeMap[builtinAdmonitionTypes[i].Name] = &builtinAdmonitionTypes[i]
+	}
+}
+
+// GetAdmonitionType returns the admonition type by name, or nil if not found.
+func GetAdmonitionType(name string) *AdmonitionType {
+	initAdmonitionTypeMap()
+	return admonitionTypeMap[strings.ToLower(name)]
+}
+
+// AllAdmonitionTypes returns all built-in admonition types.
+func AllAdmonitionTypes() []AdmonitionType {
+	return builtinAdmonitionTypes
+}
+
+// admonitionMarkerRegex matches admonition markers at the start of a line.
+// Matches: !!!, ???, ???+ followed by optional space and partial type.
+var admonitionMarkerRegex = regexp.MustCompile(`^(\?{3}\+?|!!!)(?:\s+(\w*))?$`)
+
+// AdmonitionContext contains information about the admonition context at a position.
+type AdmonitionContext struct {
+	// Marker is the admonition marker (!!!, ???, ???+)
+	Marker string
+
+	// TypePrefix is the partial type that has been typed (may be empty)
+	TypePrefix string
+
+	// MarkerStart is the column where the marker starts
+	MarkerStart int
+
+	// TypeStart is the column where the type starts (after marker + space)
+	TypeStart int
+}
+
+// getAdmonitionContext checks if the cursor is in an admonition context and returns details.
+// An admonition context is when the cursor is after an admonition marker (!!!, ???, ???+)
+// at the start of a line.
+// Returns (context, isInAdmonitionContext).
+func getAdmonitionContext(line string, col int) (*AdmonitionContext, bool) {
+	if col > len(line) {
+		col = len(line)
+	}
+
+	textBeforeCursor := line[:col]
+
+	// Check if the line starts with an admonition marker
+	trimmed := strings.TrimLeft(textBeforeCursor, " \t")
+	leadingSpaces := len(textBeforeCursor) - len(trimmed)
+
+	match := admonitionMarkerRegex.FindStringSubmatch(trimmed)
+	if match == nil {
+		return nil, false
+	}
+
+	marker := match[1]
+	typePrefix := ""
+	if len(match) > 2 {
+		typePrefix = match[2]
+	}
+
+	// Calculate positions
+	markerStart := leadingSpaces
+	typeStart := markerStart + len(marker) + 1 // +1 for the space after marker
+
+	return &AdmonitionContext{
+		Marker:      marker,
+		TypePrefix:  typePrefix,
+		MarkerStart: markerStart,
+		TypeStart:   typeStart,
+	}, true
+}
+
+// getAdmonitionCompletions returns completion items for admonition types.
+func getAdmonitionCompletions(ctx *AdmonitionContext, params CompletionParams) []CompletionItem {
+	prefix := strings.ToLower(ctx.TypePrefix)
+
+	// Filter and sort types
+	var matchingTypes []AdmonitionType
+	for _, adType := range builtinAdmonitionTypes {
+		if prefix == "" || strings.HasPrefix(adType.Name, prefix) {
+			matchingTypes = append(matchingTypes, adType)
+		}
+	}
+
+	// Sort alphabetically
+	sort.Slice(matchingTypes, func(i, j int) bool {
+		return matchingTypes[i].Name < matchingTypes[j].Name
+	})
+
+	// Pre-allocate items slice
+	items := make([]CompletionItem, 0, len(matchingTypes))
+
+	for i, adType := range matchingTypes {
+		// Build documentation with color info
+		titleName := titleCaser.String(adType.Name)
+		docValue := fmt.Sprintf("**%s**\n\n%s\n\n*Color: %s*",
+			titleName,
+			adType.Description,
+			adType.Color,
+		)
+
+		// Create snippet with placeholder for title
+		// e.g., "note \"${1:Title}\""
+		snippetText := fmt.Sprintf("%s \"${1:%s}\"", adType.Name, titleName)
+
+		item := CompletionItem{
+			Label:  adType.Name,
+			Kind:   CompletionItemKindKeyword,
+			Detail: adType.Description,
+			Documentation: &MarkupContent{
+				Kind:  "markdown",
+				Value: docValue,
+			},
+			InsertText:       snippetText,
+			InsertTextFormat: InsertTextFormatSnippet,
+			FilterText:       adType.Name,
+			SortText:         fmt.Sprintf("%05d", i), // Preserve alphabetical order
+		}
+
+		// If there's a prefix, use TextEdit to replace it
+		if ctx.TypePrefix != "" {
+			item.TextEdit = &TextEdit{
+				Range: Range{
+					Start: Position{Line: params.Position.Line, Character: ctx.TypeStart},
+					End:   Position{Line: params.Position.Line, Character: params.Position.Character},
+				},
+				NewText: snippetText,
+			}
+		}
+
+		items = append(items, item)
+	}
+
+	return items
+}
+
+// formatAdmonitionDocumentation formats admonition type info for display.
+func formatAdmonitionDocumentation(adType *AdmonitionType) string {
+	var sb strings.Builder
+
+	sb.WriteString("**")
+	sb.WriteString(titleCaser.String(adType.Name))
+	sb.WriteString("**\n\n")
+
+	sb.WriteString(adType.Description)
+	sb.WriteString("\n\n")
+
+	sb.WriteString("*Color: ")
+	sb.WriteString(adType.Color)
+	sb.WriteString("*\n\n")
+
+	sb.WriteString("**Usage:**\n```markdown\n")
+	sb.WriteString(fmt.Sprintf("!!! %s \"Optional Title\"\n    Content goes here.\n```", adType.Name))
+
+	return sb.String()
+}

--- a/pkg/lsp/admonitions_test.go
+++ b/pkg/lsp/admonitions_test.go
@@ -1,0 +1,468 @@
+package lsp
+
+import (
+	"testing"
+)
+
+func TestGetAdmonitionContext(t *testing.T) {
+	tests := []struct {
+		name            string
+		line            string
+		col             int
+		wantMarker      string
+		wantTypePrefix  string
+		wantMarkerStart int
+		wantTypeStart   int
+		wantInContext   bool
+	}{
+		{
+			name:            "after !!! marker only",
+			line:            "!!! ",
+			col:             4,
+			wantMarker:      "!!!",
+			wantTypePrefix:  "",
+			wantMarkerStart: 0,
+			wantTypeStart:   4,
+			wantInContext:   true,
+		},
+		{
+			name:            "partial type after !!!",
+			line:            "!!! no",
+			col:             6,
+			wantMarker:      "!!!",
+			wantTypePrefix:  "no",
+			wantMarkerStart: 0,
+			wantTypeStart:   4,
+			wantInContext:   true,
+		},
+		{
+			name:            "full type after !!!",
+			line:            "!!! note",
+			col:             8,
+			wantMarker:      "!!!",
+			wantTypePrefix:  "note",
+			wantMarkerStart: 0,
+			wantTypeStart:   4,
+			wantInContext:   true,
+		},
+		{
+			name:            "after ??? marker",
+			line:            "??? ",
+			col:             4,
+			wantMarker:      "???",
+			wantTypePrefix:  "",
+			wantMarkerStart: 0,
+			wantTypeStart:   4,
+			wantInContext:   true,
+		},
+		{
+			name:            "after ???+ marker",
+			line:            "???+ ",
+			col:             5,
+			wantMarker:      "???+",
+			wantTypePrefix:  "",
+			wantMarkerStart: 0,
+			wantTypeStart:   5,
+			wantInContext:   true,
+		},
+		{
+			name:            "partial type after ???+",
+			line:            "???+ war",
+			col:             8,
+			wantMarker:      "???+",
+			wantTypePrefix:  "war",
+			wantMarkerStart: 0,
+			wantTypeStart:   5,
+			wantInContext:   true,
+		},
+		{
+			name:            "with leading spaces",
+			line:            "  !!! tip",
+			col:             9,
+			wantMarker:      "!!!",
+			wantTypePrefix:  "tip",
+			wantMarkerStart: 2,
+			wantTypeStart:   6,
+			wantInContext:   true,
+		},
+		{
+			name:          "not an admonition - regular text",
+			line:          "This is not an admonition",
+			col:           10,
+			wantInContext: false,
+		},
+		{
+			name:          "not an admonition - incomplete marker",
+			line:          "!! note",
+			col:           7,
+			wantInContext: false,
+		},
+		{
+			name:          "not an admonition - marker mid-line",
+			line:          "Some text !!! note",
+			col:           18,
+			wantInContext: false,
+		},
+		{
+			name:          "empty line",
+			line:          "",
+			col:           0,
+			wantInContext: false,
+		},
+		{
+			name:            "marker without space yet",
+			line:            "!!!",
+			col:             3,
+			wantMarker:      "!!!",
+			wantTypePrefix:  "",
+			wantMarkerStart: 0,
+			wantTypeStart:   4,
+			wantInContext:   true,
+		},
+		{
+			name:            "??? without space",
+			line:            "???",
+			col:             3,
+			wantMarker:      "???",
+			wantTypePrefix:  "",
+			wantMarkerStart: 0,
+			wantTypeStart:   4,
+			wantInContext:   true,
+		},
+		{
+			name:            "???+ without space",
+			line:            "???+",
+			col:             4,
+			wantMarker:      "???+",
+			wantTypePrefix:  "",
+			wantMarkerStart: 0,
+			wantTypeStart:   5,
+			wantInContext:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, inContext := getAdmonitionContext(tt.line, tt.col)
+
+			if inContext != tt.wantInContext {
+				t.Errorf("inContext = %v, want %v", inContext, tt.wantInContext)
+				return
+			}
+
+			if !tt.wantInContext {
+				return
+			}
+
+			if ctx.Marker != tt.wantMarker {
+				t.Errorf("marker = %q, want %q", ctx.Marker, tt.wantMarker)
+			}
+			if ctx.TypePrefix != tt.wantTypePrefix {
+				t.Errorf("typePrefix = %q, want %q", ctx.TypePrefix, tt.wantTypePrefix)
+			}
+			if ctx.MarkerStart != tt.wantMarkerStart {
+				t.Errorf("markerStart = %d, want %d", ctx.MarkerStart, tt.wantMarkerStart)
+			}
+			if ctx.TypeStart != tt.wantTypeStart {
+				t.Errorf("typeStart = %d, want %d", ctx.TypeStart, tt.wantTypeStart)
+			}
+		})
+	}
+}
+
+func TestGetAdmonitionType(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantNil  bool
+		wantName string
+	}{
+		{
+			name:     "note type",
+			input:    "note",
+			wantNil:  false,
+			wantName: "note",
+		},
+		{
+			name:     "warning type",
+			input:    "warning",
+			wantNil:  false,
+			wantName: "warning",
+		},
+		{
+			name:     "case insensitive",
+			input:    "NOTE",
+			wantNil:  false,
+			wantName: "note",
+		},
+		{
+			name:     "tip type",
+			input:    "tip",
+			wantNil:  false,
+			wantName: "tip",
+		},
+		{
+			name:    "unknown type",
+			input:   "unknown",
+			wantNil: true,
+		},
+		{
+			name:    "empty string",
+			input:   "",
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adType := GetAdmonitionType(tt.input)
+
+			if tt.wantNil && adType != nil {
+				t.Errorf("expected nil, got %v", adType)
+				return
+			}
+			if !tt.wantNil && adType == nil {
+				t.Error("expected non-nil, got nil")
+				return
+			}
+			if adType != nil && adType.Name != tt.wantName {
+				t.Errorf("name = %q, want %q", adType.Name, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestAllAdmonitionTypes(t *testing.T) {
+	types := AllAdmonitionTypes()
+
+	// Check we have all expected types
+	expectedTypes := []string{
+		"note", "info", "tip", "hint", "success",
+		"warning", "caution", "important", "danger", "error",
+		"bug", "example", "quote", "abstract", "aside",
+	}
+
+	if len(types) != len(expectedTypes) {
+		t.Errorf("got %d types, want %d", len(types), len(expectedTypes))
+	}
+
+	// Check all expected types exist
+	typeMap := make(map[string]bool)
+	for _, at := range types {
+		typeMap[at.Name] = true
+	}
+
+	for _, expected := range expectedTypes {
+		if !typeMap[expected] {
+			t.Errorf("missing expected type: %s", expected)
+		}
+	}
+}
+
+func TestGetAdmonitionCompletions(t *testing.T) {
+	tests := []struct {
+		name       string
+		ctx        *AdmonitionContext
+		wantCount  int
+		wantFirst  string
+		wantFilter string
+	}{
+		{
+			name: "no prefix returns all types",
+			ctx: &AdmonitionContext{
+				Marker:     "!!!",
+				TypePrefix: "",
+				TypeStart:  4,
+			},
+			wantCount: 15, // All admonition types
+		},
+		{
+			name: "prefix 'n' filters to note",
+			ctx: &AdmonitionContext{
+				Marker:     "!!!",
+				TypePrefix: "n",
+				TypeStart:  4,
+			},
+			wantCount:  1,
+			wantFirst:  "note",
+			wantFilter: "note",
+		},
+		{
+			name: "prefix 'wa' filters to warning",
+			ctx: &AdmonitionContext{
+				Marker:     "!!!",
+				TypePrefix: "wa",
+				TypeStart:  4,
+			},
+			wantCount:  1,
+			wantFirst:  "warning",
+			wantFilter: "warning",
+		},
+		{
+			name: "prefix 'e' matches error and example",
+			ctx: &AdmonitionContext{
+				Marker:     "!!!",
+				TypePrefix: "e",
+				TypeStart:  4,
+			},
+			wantCount: 2, // error and example
+		},
+		{
+			name: "prefix 'xyz' matches nothing",
+			ctx: &AdmonitionContext{
+				Marker:     "!!!",
+				TypePrefix: "xyz",
+				TypeStart:  4,
+			},
+			wantCount: 0,
+		},
+		{
+			name: "case insensitive prefix",
+			ctx: &AdmonitionContext{
+				Marker:     "!!!",
+				TypePrefix: "NOTE",
+				TypeStart:  4,
+			},
+			wantCount: 1,
+			wantFirst: "note",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := CompletionParams{
+				Position: Position{Line: 0, Character: tt.ctx.TypeStart + len(tt.ctx.TypePrefix)},
+			}
+			items := getAdmonitionCompletions(tt.ctx, params)
+
+			if len(items) != tt.wantCount {
+				t.Errorf("got %d items, want %d", len(items), tt.wantCount)
+				for _, item := range items {
+					t.Logf("  - %s", item.Label)
+				}
+			}
+
+			if tt.wantFirst != "" && len(items) > 0 && items[0].Label != tt.wantFirst {
+				t.Errorf("first item label = %q, want %q", items[0].Label, tt.wantFirst)
+			}
+
+			if tt.wantFilter != "" && len(items) > 0 && items[0].FilterText != tt.wantFilter {
+				t.Errorf("first item filterText = %q, want %q", items[0].FilterText, tt.wantFilter)
+			}
+
+			// Check all items have required fields
+			for i, item := range items {
+				if item.Label == "" {
+					t.Errorf("item %d has empty label", i)
+				}
+				if item.Kind != CompletionItemKindKeyword {
+					t.Errorf("item %d kind = %d, want %d (Keyword)", i, item.Kind, CompletionItemKindKeyword)
+				}
+				if item.InsertText == "" {
+					t.Errorf("item %d has empty insertText", i)
+				}
+				if item.InsertTextFormat != InsertTextFormatSnippet {
+					t.Errorf("item %d format = %d, want %d (Snippet)", i, item.InsertTextFormat, InsertTextFormatSnippet)
+				}
+				if item.Documentation == nil {
+					t.Errorf("item %d has nil documentation", i)
+				}
+			}
+		})
+	}
+}
+
+func TestAdmonitionCompletionHasCorrectSnippet(t *testing.T) {
+	ctx := &AdmonitionContext{
+		Marker:     "!!!",
+		TypePrefix: "note",
+		TypeStart:  4,
+	}
+	params := CompletionParams{
+		Position: Position{Line: 0, Character: 8},
+	}
+
+	items := getAdmonitionCompletions(ctx, params)
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+
+	// Check the snippet format
+	expected := "note \"${1:Note}\""
+	if items[0].InsertText != expected {
+		t.Errorf("insertText = %q, want %q", items[0].InsertText, expected)
+	}
+}
+
+func TestAdmonitionTypeMetadata(t *testing.T) {
+	// Verify key types have expected metadata
+	tests := []struct {
+		name        string
+		wantColor   string
+		wantIcon    string
+		wantDescLen int // minimum description length
+	}{
+		{"note", "#448aff", "pencil", 10},
+		{"warning", "#ff9100", "exclamation-triangle", 10},
+		{"danger", "#ff5252", "bolt", 10},
+		{"tip", "#00bfa5", "lightbulb", 10},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adType := GetAdmonitionType(tt.name)
+			if adType == nil {
+				t.Fatalf("type %q not found", tt.name)
+			}
+
+			if adType.Color != tt.wantColor {
+				t.Errorf("color = %q, want %q", adType.Color, tt.wantColor)
+			}
+			if adType.Icon != tt.wantIcon {
+				t.Errorf("icon = %q, want %q", adType.Icon, tt.wantIcon)
+			}
+			if len(adType.Description) < tt.wantDescLen {
+				t.Errorf("description too short: %q", adType.Description)
+			}
+		})
+	}
+}
+
+func TestFormatAdmonitionDocumentation(t *testing.T) {
+	adType := GetAdmonitionType("warning")
+	if adType == nil {
+		t.Fatal("warning type not found")
+	}
+
+	doc := formatAdmonitionDocumentation(adType)
+
+	// Check that the documentation contains expected parts
+	expectedParts := []string{
+		"**Warning**",
+		adType.Description,
+		"Color:",
+		adType.Color,
+		"Usage:",
+		"!!! warning",
+	}
+
+	for _, part := range expectedParts {
+		if !contains(doc, part) {
+			t.Errorf("documentation missing expected part: %q", part)
+		}
+	}
+}
+
+// contains checks if s contains substr (case-sensitive).
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || s != "" && containsHelper(s, substr))
+}
+
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/lsp/completion.go
+++ b/pkg/lsp/completion.go
@@ -107,6 +107,12 @@ func (s *Server) handleCompletion(_ context.Context, msg *Message) error {
 		col = len(line)
 	}
 
+	// Check if we're in an admonition context (after !!!, ???, or ???+)
+	if adCtx, inAdmonition := getAdmonitionContext(line, col); inAdmonition {
+		items := getAdmonitionCompletions(adCtx, params)
+		return s.sendResponse(msg.ID, &CompletionList{Items: items})
+	}
+
 	// Check if we're inside a mention (@handle)
 	if prefix, startCol, inMention := getMentionContext(line, col); inMention {
 		return s.handleMentionCompletion(msg, params, prefix, startCol, col)

--- a/pkg/lsp/handlers.go
+++ b/pkg/lsp/handlers.go
@@ -33,7 +33,7 @@ func (s *Server) handleInitialize(_ context.Context, msg *Message) error {
 				},
 			},
 			CompletionProvider: &CompletionOptions{
-				TriggerCharacters: []string{"[", "@"},
+				TriggerCharacters: []string{"[", "@", "!", "?", " "},
 				ResolveProvider:   false,
 			},
 			HoverProvider:      true,


### PR DESCRIPTION
## Summary

Add LSP auto-completion support for admonition type markers (`!!!`, `???`, `???+`) to improve the editing experience for markdown files.

## Changes

- **New file `pkg/lsp/admonitions.go`**: Contains built-in admonition types (note, info, tip, hint, success, warning, caution, important, danger, error, bug, example, quote, abstract, aside) with descriptions and color metadata
- **Admonition context detection**: Detects when cursor is after an admonition marker at the start of a line
- **Completion items**: Returns completion items with type names, descriptions, colors, and snippet templates with title placeholders (e.g., `note "${1:Note}"`)
- **Updated trigger characters**: Added `!`, `?`, and space as completion trigger characters
- **Comprehensive tests**: Added `pkg/lsp/admonitions_test.go` with tests for context detection, type lookup, and completion generation

## Demo

When typing `!!! ` or `??? ` at the start of a line, the LSP will offer completions for all admonition types with:
- Type name as label
- Description of when to use the type
- Color information in documentation
- Snippet with placeholder for title

Fixes #424