### PR TITLE
feat(lsp): add frontmatter auto-completion

### DIFF
--- a/pkg/lsp/completion.go
+++ b/pkg/lsp/completion.go
@@ -107,6 +107,16 @@ func (s *Server) handleCompletion(_ context.Context, msg *Message) error {
 		col = len(line)
 	}
 
+	// Check if we're inside frontmatter
+	frontmatterCtx := getFrontmatterContext(doc.Content, params.Position.Line, col)
+	if frontmatterCtx.InFrontmatter && (frontmatterCtx.IsFieldName || frontmatterCtx.IsFieldValue) {
+		items := getFrontmatterCompletions(frontmatterCtx, params)
+		return s.sendResponse(msg.ID, &CompletionList{
+			IsIncomplete: false,
+			Items:        items,
+		})
+	}
+
 	// Check if we're in an admonition context (after !!!, ???, or ???+)
 	if adCtx, inAdmonition := getAdmonitionContext(line, col); inAdmonition {
 		items := getAdmonitionCompletions(adCtx, params)

--- a/pkg/lsp/frontmatter.go
+++ b/pkg/lsp/frontmatter.go
@@ -1,0 +1,490 @@
+package lsp
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// FrontmatterField represents a frontmatter field definition for auto-completion.
+type FrontmatterField struct {
+	// Name is the field name (e.g., "title", "date")
+	Name string
+
+	// Type is the field type for documentation (e.g., "string", "boolean", "date")
+	Type string
+
+	// Description is a human-readable description of the field
+	Description string
+
+	// Required indicates if the field is required
+	Required bool
+
+	// Values contains allowed values for enum-like fields (e.g., ["true", "false"])
+	Values []string
+
+	// DefaultValue is the default value if any
+	DefaultValue string
+
+	// Snippet is the completion snippet (uses $1, $2 for placeholders)
+	Snippet string
+}
+
+// frontmatterFields contains all known frontmatter fields for markata-go posts.
+var frontmatterFields = []FrontmatterField{
+	{
+		Name:        "title",
+		Type:        "string",
+		Description: "The post title displayed in the browser and feeds",
+		Required:    true,
+		Snippet:     "title: ${1:My Post Title}",
+	},
+	{
+		Name:        "date",
+		Type:        "date",
+		Description: "Publication date in YYYY-MM-DD format",
+		Required:    true,
+		Snippet:     "date: ${1:2024-01-01}",
+	},
+	{
+		Name:        "published",
+		Type:        "boolean",
+		Description: "Whether the post is published (visible on the site)",
+		Required:    false,
+		Values:      []string{"true", "false"},
+		Snippet:     "published: ${1|true,false|}",
+	},
+	{
+		Name:         "draft",
+		Type:         "boolean",
+		Description:  "Whether the post is a draft (not published)",
+		Required:     false,
+		Values:       []string{"true", "false"},
+		DefaultValue: "false",
+		Snippet:      "draft: ${1|true,false|}",
+	},
+	{
+		Name:        "description",
+		Type:        "string",
+		Description: "Short description for SEO and feed summaries",
+		Required:    false,
+		Snippet:     "description: ${1:A brief description of the post}",
+	},
+	{
+		Name:        "slug",
+		Type:        "string",
+		Description: "URL-safe identifier (auto-generated from filename if not set)",
+		Required:    false,
+		Snippet:     "slug: ${1:my-post-slug}",
+	},
+	{
+		Name:        "tags",
+		Type:        "list",
+		Description: "List of tags for categorization",
+		Required:    false,
+		Snippet:     "tags:\n  - ${1:tag1}\n  - ${2:tag2}",
+	},
+	{
+		Name:        "template",
+		Type:        "string",
+		Description: "Template file to use for rendering (default: post.html)",
+		Required:    false,
+		Snippet:     "template: ${1:post.html}",
+	},
+	{
+		Name:         "skip",
+		Type:         "boolean",
+		Description:  "Skip this post during processing",
+		Required:     false,
+		Values:       []string{"true", "false"},
+		DefaultValue: "false",
+		Snippet:      "skip: ${1|true,false|}",
+	},
+	{
+		Name:        "prevnext_feed",
+		Type:        "string",
+		Description: "Feed/series slug for prev/next navigation",
+		Required:    false,
+		Snippet:     "prevnext_feed: ${1:series-name}",
+	},
+	{
+		Name:        "image",
+		Type:        "string",
+		Description: "Featured image URL for Open Graph and social sharing",
+		Required:    false,
+		Snippet:     "image: ${1:/images/featured.jpg}",
+	},
+	{
+		Name:        "author",
+		Type:        "string",
+		Description: "Post author name",
+		Required:    false,
+		Snippet:     "author: ${1:Author Name}",
+	},
+	{
+		Name:        "canonical_url",
+		Type:        "string",
+		Description: "Canonical URL if this post is republished from another source",
+		Required:    false,
+		Snippet:     "canonical_url: ${1:https://example.com/original-post}",
+	},
+	{
+		Name:        "layout",
+		Type:        "string",
+		Description: "Layout to use for this post (overrides default)",
+		Required:    false,
+		Snippet:     "layout: ${1|default,wide,full|}",
+	},
+	{
+		Name:        "toc",
+		Type:        "boolean",
+		Description: "Enable table of contents for this post",
+		Required:    false,
+		Values:      []string{"true", "false"},
+		Snippet:     "toc: ${1|true,false|}",
+	},
+	{
+		Name:        "sidebar",
+		Type:        "boolean",
+		Description: "Enable sidebar for this post",
+		Required:    false,
+		Values:      []string{"true", "false"},
+		Snippet:     "sidebar: ${1|true,false|}",
+	},
+}
+
+// FrontmatterContext contains information about the cursor position within frontmatter.
+type FrontmatterContext struct {
+	// InFrontmatter indicates if the cursor is within the frontmatter section
+	InFrontmatter bool
+
+	// IsFieldName indicates if the cursor is in a position for a field name
+	IsFieldName bool
+
+	// IsFieldValue indicates if the cursor is in a position for a field value
+	IsFieldValue bool
+
+	// CurrentField is the field name if we're editing a value
+	CurrentField string
+
+	// Prefix is the text before the cursor (for filtering)
+	Prefix string
+
+	// StartCol is the column where the prefix starts
+	StartCol int
+
+	// ExistingFields contains field names already present in the frontmatter
+	ExistingFields map[string]bool
+}
+
+// getFrontmatterContext analyzes the document to determine frontmatter context.
+// Returns information about whether the cursor is in frontmatter and what kind of completion is needed.
+func getFrontmatterContext(content string, line, col int) *FrontmatterContext {
+	lines := strings.Split(content, "\n")
+
+	// Find frontmatter boundaries
+	startLine, endLine := findFrontmatterBoundaries(lines)
+	if startLine == -1 || endLine == -1 {
+		return &FrontmatterContext{InFrontmatter: false}
+	}
+
+	// Check if cursor is within frontmatter
+	if line <= startLine || line >= endLine {
+		return &FrontmatterContext{InFrontmatter: false}
+	}
+
+	// Collect existing fields
+	existingFields := collectExistingFields(lines, startLine, endLine)
+
+	// Get the current line content
+	if line >= len(lines) {
+		return &FrontmatterContext{InFrontmatter: true, ExistingFields: existingFields}
+	}
+
+	currentLine := lines[line]
+	if col > len(currentLine) {
+		col = len(currentLine)
+	}
+
+	// Analyze what we're completing
+	return analyzeLineContext(currentLine, col, existingFields)
+}
+
+// findFrontmatterBoundaries finds the start and end lines of frontmatter.
+// Returns (-1, -1) if no valid frontmatter is found.
+func findFrontmatterBoundaries(lines []string) (startLine, endLine int) {
+	startLine = -1
+	endLine = -1
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "---" {
+			if startLine == -1 {
+				startLine = i
+			} else {
+				endLine = i
+				break
+			}
+		}
+	}
+
+	return startLine, endLine
+}
+
+// collectExistingFields collects field names already present in the frontmatter.
+func collectExistingFields(lines []string, startLine, endLine int) map[string]bool {
+	existingFields := make(map[string]bool)
+
+	for i := startLine + 1; i < endLine && i < len(lines); i++ {
+		line := lines[i]
+		// Match field name at the start of line (not indented)
+		if !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "\t") {
+			if idx := strings.Index(line, ":"); idx > 0 {
+				fieldName := strings.TrimSpace(line[:idx])
+				if fieldName != "" {
+					existingFields[fieldName] = true
+				}
+			}
+		}
+	}
+
+	return existingFields
+}
+
+// analyzeLineContext determines what kind of completion is needed on the current line.
+func analyzeLineContext(line string, col int, existingFields map[string]bool) *FrontmatterContext {
+	ctx := &FrontmatterContext{
+		InFrontmatter:  true,
+		ExistingFields: existingFields,
+	}
+
+	textBeforeCursor := ""
+	if col <= len(line) {
+		textBeforeCursor = line[:col]
+	}
+
+	// Check if we're in a list item (indented with - )
+	trimmedLine := strings.TrimLeft(line, " \t")
+	if strings.HasPrefix(trimmedLine, "- ") {
+		// We're in a list value, don't provide field completion
+		return ctx
+	}
+
+	// Check if this line has a colon
+	colonIdx := strings.Index(textBeforeCursor, ":")
+	if colonIdx == -1 {
+		// No colon yet - completing a field name
+		ctx.IsFieldName = true
+		ctx.Prefix = strings.TrimSpace(textBeforeCursor)
+		// Start column is after any leading whitespace
+		ctx.StartCol = len(line) - len(strings.TrimLeft(line, " \t"))
+		return ctx
+	}
+
+	// We have a colon - check if we're before or after it
+	if col <= colonIdx {
+		// Cursor is before the colon - completing field name
+		ctx.IsFieldName = true
+		ctx.Prefix = strings.TrimSpace(textBeforeCursor)
+		ctx.StartCol = len(line) - len(strings.TrimLeft(line, " \t"))
+		return ctx
+	}
+
+	// Cursor is after the colon - completing field value
+	ctx.IsFieldValue = true
+	fieldName := strings.TrimSpace(line[:colonIdx])
+	ctx.CurrentField = fieldName
+
+	// Get the value part after the colon
+	valueStart := colonIdx + 1
+	if valueStart < col {
+		ctx.Prefix = strings.TrimSpace(line[valueStart:col])
+		ctx.StartCol = valueStart
+		// Skip leading space after colon
+		if valueStart < len(line) && line[valueStart] == ' ' {
+			ctx.StartCol = valueStart + 1
+		}
+	}
+
+	return ctx
+}
+
+// getFrontmatterCompletions returns completion items for frontmatter.
+func getFrontmatterCompletions(ctx *FrontmatterContext, params CompletionParams) []CompletionItem {
+	var items []CompletionItem
+
+	if ctx.IsFieldName {
+		items = getFieldNameCompletions(ctx, params)
+	} else if ctx.IsFieldValue {
+		items = getFieldValueCompletions(ctx, params)
+	}
+
+	return items
+}
+
+// getFieldNameCompletions returns completions for field names.
+func getFieldNameCompletions(ctx *FrontmatterContext, params CompletionParams) []CompletionItem {
+	items := make([]CompletionItem, 0, len(frontmatterFields))
+	prefix := strings.ToLower(ctx.Prefix)
+
+	// Sort fields: required first, then by name
+	sortedFields := make([]FrontmatterField, len(frontmatterFields))
+	copy(sortedFields, frontmatterFields)
+	sort.Slice(sortedFields, func(i, j int) bool {
+		if sortedFields[i].Required != sortedFields[j].Required {
+			return sortedFields[i].Required
+		}
+		return sortedFields[i].Name < sortedFields[j].Name
+	})
+
+	for i, field := range sortedFields {
+		// Skip fields that already exist
+		if ctx.ExistingFields[field.Name] {
+			continue
+		}
+
+		// Filter by prefix
+		if prefix != "" && !strings.HasPrefix(strings.ToLower(field.Name), prefix) {
+			continue
+		}
+
+		// Build documentation
+		doc := formatFieldDocumentation(&field)
+
+		// Determine detail text
+		detail := field.Type
+		if field.Required {
+			detail += " (required)"
+		}
+
+		item := CompletionItem{
+			Label:  field.Name,
+			Kind:   CompletionItemKindProperty,
+			Detail: detail,
+			Documentation: &MarkupContent{
+				Kind:  "markdown",
+				Value: doc,
+			},
+			InsertText:       field.Snippet,
+			InsertTextFormat: InsertTextFormatSnippet,
+			FilterText:       field.Name,
+			SortText:         fmt.Sprintf("%d%s", boolToInt(!field.Required), field.Name),
+		}
+
+		// Use TextEdit to replace prefix if we have one
+		if ctx.Prefix != "" {
+			item.TextEdit = &TextEdit{
+				Range: Range{
+					Start: Position{Line: params.Position.Line, Character: ctx.StartCol},
+					End:   Position{Line: params.Position.Line, Character: params.Position.Character},
+				},
+				NewText: field.Snippet,
+			}
+		}
+
+		items = append(items, item)
+
+		// Limit to reasonable number
+		if len(items) >= 20 {
+			break
+		}
+
+		_ = i // avoid unused variable warning
+	}
+
+	return items
+}
+
+// getFieldValueCompletions returns completions for field values.
+func getFieldValueCompletions(ctx *FrontmatterContext, params CompletionParams) []CompletionItem {
+	var items []CompletionItem
+
+	// Find the field definition
+	var field *FrontmatterField
+	for i := range frontmatterFields {
+		if frontmatterFields[i].Name == ctx.CurrentField {
+			field = &frontmatterFields[i]
+			break
+		}
+	}
+
+	if field == nil {
+		return items
+	}
+
+	// If the field has predefined values, suggest them
+	if len(field.Values) > 0 {
+		prefix := strings.ToLower(ctx.Prefix)
+		for i, value := range field.Values {
+			if prefix != "" && !strings.HasPrefix(strings.ToLower(value), prefix) {
+				continue
+			}
+
+			item := CompletionItem{
+				Label:            value,
+				Kind:             CompletionItemKindValue,
+				Detail:           fmt.Sprintf("Value for %s", field.Name),
+				InsertText:       value,
+				InsertTextFormat: InsertTextFormatPlainText,
+				SortText:         fmt.Sprintf("%02d", i),
+			}
+
+			// Use TextEdit to replace prefix
+			if ctx.Prefix != "" {
+				item.TextEdit = &TextEdit{
+					Range: Range{
+						Start: Position{Line: params.Position.Line, Character: ctx.StartCol},
+						End:   Position{Line: params.Position.Line, Character: params.Position.Character},
+					},
+					NewText: value,
+				}
+			}
+
+			items = append(items, item)
+		}
+	}
+
+	return items
+}
+
+// formatFieldDocumentation formats field info for display in completion documentation.
+func formatFieldDocumentation(field *FrontmatterField) string {
+	var sb strings.Builder
+
+	sb.WriteString("**")
+	sb.WriteString(field.Name)
+	sb.WriteString("**")
+	if field.Required {
+		sb.WriteString(" (required)")
+	}
+	sb.WriteString("\n\n")
+
+	sb.WriteString(field.Description)
+	sb.WriteString("\n\n")
+
+	sb.WriteString("*Type: ")
+	sb.WriteString(field.Type)
+	sb.WriteString("*")
+
+	if len(field.Values) > 0 {
+		sb.WriteString("\n\n*Allowed values: ")
+		sb.WriteString(strings.Join(field.Values, ", "))
+		sb.WriteString("*")
+	}
+
+	if field.DefaultValue != "" {
+		sb.WriteString("\n\n*Default: ")
+		sb.WriteString(field.DefaultValue)
+		sb.WriteString("*")
+	}
+
+	return sb.String()
+}
+
+// boolToInt converts a boolean to int (0 for false, 1 for true).
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/pkg/lsp/frontmatter_test.go
+++ b/pkg/lsp/frontmatter_test.go
@@ -1,0 +1,482 @@
+package lsp
+
+import (
+	"testing"
+)
+
+func TestFindFrontmatterBoundaries(t *testing.T) {
+	tests := []struct {
+		name      string
+		content   string
+		wantStart int
+		wantEnd   int
+	}{
+		{
+			name:      "valid frontmatter",
+			content:   "---\ntitle: Test\n---\n\nContent",
+			wantStart: 0,
+			wantEnd:   2,
+		},
+		{
+			name:      "no frontmatter",
+			content:   "# Title\n\nContent",
+			wantStart: -1,
+			wantEnd:   -1,
+		},
+		{
+			name:      "unclosed frontmatter",
+			content:   "---\ntitle: Test\n",
+			wantStart: 0,
+			wantEnd:   -1,
+		},
+		{
+			name:      "multiline frontmatter",
+			content:   "---\ntitle: Test\ndescription: A description\npublished: true\n---\n\nContent",
+			wantStart: 0,
+			wantEnd:   4,
+		},
+		{
+			name:      "empty file",
+			content:   "",
+			wantStart: -1,
+			wantEnd:   -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lines := splitLines(tt.content)
+			gotStart, gotEnd := findFrontmatterBoundaries(lines)
+			if gotStart != tt.wantStart {
+				t.Errorf("startLine = %d, want %d", gotStart, tt.wantStart)
+			}
+			if gotEnd != tt.wantEnd {
+				t.Errorf("endLine = %d, want %d", gotEnd, tt.wantEnd)
+			}
+		})
+	}
+}
+
+func TestCollectExistingFields(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		wantKeys []string
+	}{
+		{
+			name:     "basic fields",
+			content:  "---\ntitle: Test\ndescription: A test\n---",
+			wantKeys: []string{"title", "description"},
+		},
+		{
+			name:     "with list",
+			content:  "---\ntitle: Test\ntags:\n  - tag1\n  - tag2\n---",
+			wantKeys: []string{"title", "tags"},
+		},
+		{
+			name:     "empty frontmatter",
+			content:  "---\n---",
+			wantKeys: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lines := splitLines(tt.content)
+			startLine, endLine := findFrontmatterBoundaries(lines)
+			got := collectExistingFields(lines, startLine, endLine)
+
+			if len(got) != len(tt.wantKeys) {
+				t.Errorf("got %d fields, want %d", len(got), len(tt.wantKeys))
+			}
+			for _, key := range tt.wantKeys {
+				if !got[key] {
+					t.Errorf("missing expected field: %s", key)
+				}
+			}
+		})
+	}
+}
+
+func TestGetFrontmatterContext(t *testing.T) {
+	tests := []struct {
+		name             string
+		content          string
+		line             int
+		col              int
+		wantInFM         bool
+		wantIsFieldName  bool
+		wantIsFieldValue bool
+		wantCurrentField string
+		wantPrefix       string
+	}{
+		{
+			name:            "on field name",
+			content:         "---\ntit\n---",
+			line:            1,
+			col:             3,
+			wantInFM:        true,
+			wantIsFieldName: true,
+			wantPrefix:      "tit",
+		},
+		{
+			name:             "on field value",
+			content:          "---\ntitle: Test\n---",
+			line:             1,
+			col:              14, // Position at end of "Test"
+			wantInFM:         true,
+			wantIsFieldValue: true,
+			wantCurrentField: "title",
+			wantPrefix:       "Test",
+		},
+		{
+			name:             "on empty field value",
+			content:          "---\ntitle: \n---",
+			line:             1,
+			col:              7,
+			wantInFM:         true,
+			wantIsFieldValue: true,
+			wantCurrentField: "title",
+			wantPrefix:       "",
+		},
+		{
+			name:            "empty line in frontmatter",
+			content:         "---\ntitle: Test\n\n---",
+			line:            2,
+			col:             0,
+			wantInFM:        true,
+			wantIsFieldName: true,
+			wantPrefix:      "",
+		},
+		{
+			name:     "outside frontmatter - before",
+			content:  "---\ntitle: Test\n---\n\nContent",
+			line:     0,
+			col:      0,
+			wantInFM: false,
+		},
+		{
+			name:     "outside frontmatter - after",
+			content:  "---\ntitle: Test\n---\n\nContent",
+			line:     4,
+			col:      3,
+			wantInFM: false,
+		},
+		{
+			name:     "on closing delimiter",
+			content:  "---\ntitle: Test\n---\n\nContent",
+			line:     2,
+			col:      0,
+			wantInFM: false,
+		},
+		{
+			name:             "published field value",
+			content:          "---\npublished: tr\n---",
+			line:             1,
+			col:              14,
+			wantInFM:         true,
+			wantIsFieldValue: true,
+			wantCurrentField: "published",
+			wantPrefix:       "tr",
+		},
+		{
+			name:     "in list item",
+			content:  "---\ntags:\n  - tag1\n---",
+			line:     2,
+			col:      8,
+			wantInFM: true,
+			// List items don't trigger field name completion
+			wantIsFieldName:  false,
+			wantIsFieldValue: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := getFrontmatterContext(tt.content, tt.line, tt.col)
+
+			if ctx.InFrontmatter != tt.wantInFM {
+				t.Errorf("InFrontmatter = %v, want %v", ctx.InFrontmatter, tt.wantInFM)
+			}
+			if ctx.IsFieldName != tt.wantIsFieldName {
+				t.Errorf("IsFieldName = %v, want %v", ctx.IsFieldName, tt.wantIsFieldName)
+			}
+			if ctx.IsFieldValue != tt.wantIsFieldValue {
+				t.Errorf("IsFieldValue = %v, want %v", ctx.IsFieldValue, tt.wantIsFieldValue)
+			}
+			if ctx.CurrentField != tt.wantCurrentField {
+				t.Errorf("CurrentField = %q, want %q", ctx.CurrentField, tt.wantCurrentField)
+			}
+			if ctx.Prefix != tt.wantPrefix {
+				t.Errorf("Prefix = %q, want %q", ctx.Prefix, tt.wantPrefix)
+			}
+		})
+	}
+}
+
+func TestGetFieldNameCompletions(t *testing.T) {
+	ctx := &FrontmatterContext{
+		InFrontmatter:  true,
+		IsFieldName:    true,
+		Prefix:         "",
+		StartCol:       0,
+		ExistingFields: map[string]bool{},
+	}
+
+	params := CompletionParams{
+		Position: Position{Line: 1, Character: 0},
+	}
+
+	items := getFieldNameCompletions(ctx, params)
+
+	// Should return all frontmatter fields
+	if len(items) == 0 {
+		t.Error("expected completion items, got none")
+	}
+
+	// Check that required fields appear first (sorted)
+	foundTitle := false
+	foundDate := false
+	for _, item := range items {
+		if item.Label == "title" {
+			foundTitle = true
+		}
+		if item.Label == "date" {
+			foundDate = true
+		}
+	}
+
+	if !foundTitle {
+		t.Error("expected 'title' field in completions")
+	}
+	if !foundDate {
+		t.Error("expected 'date' field in completions")
+	}
+}
+
+func TestGetFieldNameCompletions_WithPrefix(t *testing.T) {
+	ctx := &FrontmatterContext{
+		InFrontmatter:  true,
+		IsFieldName:    true,
+		Prefix:         "pub",
+		StartCol:       0,
+		ExistingFields: map[string]bool{},
+	}
+
+	params := CompletionParams{
+		Position: Position{Line: 1, Character: 3},
+	}
+
+	items := getFieldNameCompletions(ctx, params)
+
+	// Should filter to fields starting with "pub"
+	if len(items) != 1 {
+		t.Errorf("expected 1 completion item for prefix 'pub', got %d", len(items))
+	}
+	if len(items) > 0 && items[0].Label != "published" {
+		t.Errorf("expected 'published' field, got %q", items[0].Label)
+	}
+}
+
+func TestGetFieldNameCompletions_ExcludesExisting(t *testing.T) {
+	ctx := &FrontmatterContext{
+		InFrontmatter: true,
+		IsFieldName:   true,
+		Prefix:        "",
+		StartCol:      0,
+		ExistingFields: map[string]bool{
+			"title": true,
+			"date":  true,
+		},
+	}
+
+	params := CompletionParams{
+		Position: Position{Line: 1, Character: 0},
+	}
+
+	items := getFieldNameCompletions(ctx, params)
+
+	// Should not include title or date
+	for _, item := range items {
+		if item.Label == "title" {
+			t.Error("should not suggest 'title' when it already exists")
+		}
+		if item.Label == "date" {
+			t.Error("should not suggest 'date' when it already exists")
+		}
+	}
+}
+
+func TestGetFieldValueCompletions(t *testing.T) {
+	tests := []struct {
+		name       string
+		field      string
+		prefix     string
+		wantCount  int
+		wantValues []string
+	}{
+		{
+			name:       "published field",
+			field:      "published",
+			prefix:     "",
+			wantCount:  2,
+			wantValues: []string{"true", "false"},
+		},
+		{
+			name:       "draft field with prefix",
+			field:      "draft",
+			prefix:     "t",
+			wantCount:  1,
+			wantValues: []string{"true"},
+		},
+		{
+			name:       "title field - no predefined values",
+			field:      "title",
+			prefix:     "",
+			wantCount:  0,
+			wantValues: []string{},
+		},
+		{
+			name:       "unknown field",
+			field:      "unknown_field",
+			prefix:     "",
+			wantCount:  0,
+			wantValues: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &FrontmatterContext{
+				InFrontmatter:  true,
+				IsFieldValue:   true,
+				CurrentField:   tt.field,
+				Prefix:         tt.prefix,
+				StartCol:       7,
+				ExistingFields: map[string]bool{},
+			}
+
+			params := CompletionParams{
+				Position: Position{Line: 1, Character: 7 + len(tt.prefix)},
+			}
+
+			items := getFieldValueCompletions(ctx, params)
+
+			if len(items) != tt.wantCount {
+				t.Errorf("got %d items, want %d", len(items), tt.wantCount)
+			}
+
+			for i, wantValue := range tt.wantValues {
+				if i < len(items) && items[i].Label != wantValue {
+					t.Errorf("item %d: got %q, want %q", i, items[i].Label, wantValue)
+				}
+			}
+		})
+	}
+}
+
+func TestFormatFieldDocumentation(t *testing.T) {
+	field := &FrontmatterField{
+		Name:         "published",
+		Type:         "boolean",
+		Description:  "Whether the post is published",
+		Required:     false,
+		Values:       []string{"true", "false"},
+		DefaultValue: "false",
+	}
+
+	doc := formatFieldDocumentation(field)
+
+	// Check that documentation contains expected parts
+	if doc == "" {
+		t.Error("expected non-empty documentation")
+	}
+
+	expectedParts := []string{
+		"**published**",
+		"Whether the post is published",
+		"*Type: boolean*",
+		"*Allowed values: true, false*",
+		"*Default: false*",
+	}
+
+	for _, part := range expectedParts {
+		if !containsFrontmatter(doc, part) {
+			t.Errorf("documentation missing: %q", part)
+		}
+	}
+}
+
+func TestFrontmatterFieldsDefinitions(t *testing.T) {
+	// Verify that required fields have proper snippets
+	requiredFields := []string{"title", "date"}
+
+	for _, name := range requiredFields {
+		found := false
+		for _, field := range frontmatterFields {
+			if field.Name == name {
+				found = true
+				if !field.Required {
+					t.Errorf("field %q should be marked as required", name)
+				}
+				if field.Snippet == "" {
+					t.Errorf("field %q missing snippet", name)
+				}
+				break
+			}
+		}
+		if !found {
+			t.Errorf("required field %q not found in frontmatterFields", name)
+		}
+	}
+
+	// Verify boolean fields have values
+	boolFields := []string{"published", "draft", "skip", "toc", "sidebar"}
+	for _, name := range boolFields {
+		for _, field := range frontmatterFields {
+			if field.Name == name {
+				if field.Type != "boolean" {
+					t.Errorf("field %q should have type 'boolean', got %q", name, field.Type)
+				}
+				if len(field.Values) != 2 {
+					t.Errorf("field %q should have 2 values (true/false), got %d", name, len(field.Values))
+				}
+				break
+			}
+		}
+	}
+}
+
+// Helper function to split content into lines
+func splitLines(content string) []string {
+	if content == "" {
+		return []string{}
+	}
+	result := []string{}
+	start := 0
+	for i := 0; i < len(content); i++ {
+		if content[i] == '\n' {
+			result = append(result, content[start:i])
+			start = i + 1
+		}
+	}
+	if start <= len(content) {
+		result = append(result, content[start:])
+	}
+	return result
+}
+
+// Helper function to check if string contains substring
+// Note: uses strings.Contains - this is a wrapper for readability in tests
+func containsFrontmatter(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || s != "" && containsHelperFrontmatter(s, substr))
+}
+
+func containsHelperFrontmatter(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Implements frontmatter field auto-completion in the LSP server for markdown files.

- Detects when cursor is within frontmatter section (between `---` delimiters)
- Provides field name suggestions (title, date, published, tags, description, etc.)
- Provides value suggestions for enum-like fields (e.g., `published: true/false`)
- Filters suggestions by prefix and excludes already-present fields
- Includes snippets with placeholders for faster editing

## Changes

- **pkg/lsp/frontmatter.go**: New file with frontmatter field definitions, context detection, and completion logic
- **pkg/lsp/frontmatter_test.go**: Comprehensive tests for frontmatter completion
- **pkg/lsp/completion.go**: Integrated frontmatter completion into the main completion handler

## Testing

- All existing LSP tests pass
- New tests added for frontmatter context detection and completion generation

## Related

Refs #420