### PR TITLE
feat(templates): support per-format template specification

### DIFF
--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -265,6 +265,15 @@ type Config struct {
 
 	// Mentions configures the @mentions resolution plugin
 	Mentions MentionsConfig `json:"mentions" yaml:"mentions" toml:"mentions"`
+
+	// TemplatePresets defines named template preset configurations
+	// Each preset specifies templates for all output formats
+	TemplatePresets map[string]TemplatePreset `json:"template_presets,omitempty" yaml:"template_presets,omitempty" toml:"template_presets,omitempty"`
+
+	// DefaultTemplates specifies default templates per output format
+	// Keys: "html", "txt", "markdown", "og"
+	// Values: template file names
+	DefaultTemplates map[string]string `json:"default_templates,omitempty" yaml:"default_templates,omitempty" toml:"default_templates,omitempty"`
 }
 
 // HeadConfig configures elements added to the HTML <head> section.
@@ -1090,6 +1099,39 @@ type PostFormatsConfig struct {
 	// OG enables OpenGraph card HTML output for social image generation (default: false)
 	// Generates: /slug/og/index.html (1200x630 optimized for screenshots)
 	OG bool `json:"og" yaml:"og" toml:"og"`
+}
+
+// TemplatePreset defines templates for all output formats.
+// This allows setting all format templates at once with a single preset name.
+type TemplatePreset struct {
+	// HTML template file for HTML output
+	HTML string `json:"html" yaml:"html" toml:"html"`
+
+	// Text template file for txt output
+	Text string `json:"txt" yaml:"txt" toml:"txt"`
+
+	// Markdown template file for markdown output
+	Markdown string `json:"markdown" yaml:"markdown" toml:"markdown"`
+
+	// OG template file for OpenGraph card output
+	OG string `json:"og" yaml:"og" toml:"og"`
+}
+
+// TemplateForFormat returns the template for a specific format.
+// Returns empty string if the format is not recognized.
+func (p *TemplatePreset) TemplateForFormat(format string) string {
+	switch format {
+	case "html":
+		return p.HTML
+	case "txt", "text":
+		return p.Text
+	case "markdown", "md":
+		return p.Markdown
+	case "og":
+		return p.OG
+	default:
+		return ""
+	}
 }
 
 // NewPostFormatsConfig creates a new PostFormatsConfig with default values.

--- a/pkg/models/post.go
+++ b/pkg/models/post.go
@@ -47,7 +47,13 @@ type Post struct {
 	Description *string `json:"description,omitempty" yaml:"description,omitempty" toml:"description,omitempty"`
 
 	// Template is the template file to use for rendering (default: "post.html")
+	// Can be a preset name ("blog", "docs") or explicit file ("post.html")
 	Template string `json:"template" yaml:"template" toml:"template"`
+
+	// Templates provides per-format template overrides
+	// Keys: "html", "txt", "markdown", "og"
+	// Values: template file names
+	Templates map[string]string `json:"templates,omitempty" yaml:"templates,omitempty" toml:"templates,omitempty"`
 
 	// HTML is the final rendered HTML including template wrapper
 	HTML string `json:"html" yaml:"html" toml:"html"`

--- a/pkg/plugins/publish_html_test.go
+++ b/pkg/plugins/publish_html_test.go
@@ -10,6 +10,15 @@ import (
 	"github.com/WaylonWalker/markata-go/pkg/models"
 )
 
+// createTestManager creates a minimal lifecycle manager for testing.
+func createTestManager(t *testing.T, config *lifecycle.Config) *lifecycle.Manager {
+	t.Helper()
+	m := lifecycle.NewManager()
+	// Set the config in the manager
+	m.SetConfig(config)
+	return m
+}
+
 // TestPublishHTMLPlugin_ShadowPages tests that unpublished posts are rendered as shadow pages.
 func TestPublishHTMLPlugin_ShadowPages(t *testing.T) {
 	tests := []struct {
@@ -104,8 +113,11 @@ func TestPublishHTMLPlugin_ShadowPages(t *testing.T) {
 				Extra:     make(map[string]interface{}),
 			}
 
+			// Create manager for testing
+			m := createTestManager(t, config)
+
 			// Write post
-			err := plugin.writePost(tt.post, config, nil)
+			err := plugin.writePost(tt.post, config, nil, m)
 			if err != nil {
 				t.Fatalf("writePost() error = %v", err)
 			}
@@ -150,8 +162,11 @@ func TestPublishHTMLPlugin_OGCardCanonicalURL(t *testing.T) {
 		ArticleHTML: "<p>Test content</p>",
 	}
 
+	// Create manager for testing
+	m := createTestManager(t, config)
+
 	// Write post (which includes OG format)
-	if err := plugin.writePost(post, config, nil); err != nil {
+	if err := plugin.writePost(post, config, nil, m); err != nil {
 		t.Fatalf("writePost() error = %v", err)
 	}
 
@@ -203,7 +218,10 @@ func TestPublishHTMLPlugin_ShadowPagesDocumentation(t *testing.T) {
 		ArticleHTML: "<p>Shadow content accessible via direct URL</p>",
 	}
 
-	if err := plugin.writePost(shadowPost, config, nil); err != nil {
+	// Create manager for testing
+	m := createTestManager(t, config)
+
+	if err := plugin.writePost(shadowPost, config, nil, m); err != nil {
 		t.Fatalf("writePost() error = %v", err)
 	}
 
@@ -260,8 +278,11 @@ func TestPublishHTMLPlugin_FormatRedirectsCreateDirectories(t *testing.T) {
 		ArticleHTML: "<p>Test</p>",
 	}
 
+	// Create manager for testing
+	m := createTestManager(t, config)
+
 	// Write post (which includes format redirects)
-	if err := plugin.writePost(post, config, nil); err != nil {
+	if err := plugin.writePost(post, config, nil, m); err != nil {
 		t.Fatalf("writePost() error = %v", err)
 	}
 
@@ -361,6 +382,9 @@ func TestPublishHTMLPlugin_StandardWebTxtFiles(t *testing.T) {
 		},
 	}
 
+	// Create manager for testing
+	m := createTestManager(t, config)
+
 	// Standard web txt files that should be at root level
 	standardFiles := []struct {
 		slug    string
@@ -386,7 +410,7 @@ func TestPublishHTMLPlugin_StandardWebTxtFiles(t *testing.T) {
 			ArticleHTML: "<p>Test</p>",
 		}
 
-		if err := plugin.writePost(post, config, nil); err != nil {
+		if err := plugin.writePost(post, config, nil, m); err != nil {
 			t.Fatalf("writePost() error for %s: %v", sf.slug, err)
 		}
 	}
@@ -468,8 +492,11 @@ func TestPublishHTMLPlugin_TxtTemplateRendering(t *testing.T) {
 		ArticleHTML: "<p>Test</p>",
 	}
 
+	// Create manager for testing
+	m := createTestManager(t, config)
+
 	// Write post without template engine (should use fallback)
-	if err := plugin.writePost(post, config, nil); err != nil {
+	if err := plugin.writePost(post, config, nil, m); err != nil {
 		t.Fatalf("writePost() error = %v", err)
 	}
 
@@ -533,8 +560,11 @@ func TestPublishHTMLPlugin_RawTxtForSpecialFiles(t *testing.T) {
 		ArticleHTML: "<p>Test</p>",
 	}
 
+	// Create manager for testing
+	m := createTestManager(t, config)
+
 	// Write post without template engine (should use fallback)
-	if err := plugin.writePost(robotsPost, config, nil); err != nil {
+	if err := plugin.writePost(robotsPost, config, nil, m); err != nil {
 		t.Fatalf("writePost() error = %v", err)
 	}
 


### PR DESCRIPTION
## Summary

Implements #398: Add support for specifying templates per output format (HTML, txt, markdown, OG) rather than having a single template field.

## Changes

- Add `Templates map[string]string` to Post model for per-format overrides
- Add `TemplatePreset` struct and `TemplatePresets map` to Config for reusable presets
- Add `DefaultTemplates map[string]string` to Config for global defaults
- Implement `resolveTemplateForFormat(format string)` function with full resolution priority
- Add format constants to avoid magic strings (goconst lint compliance)

## Resolution Priority

1. Frontmatter per-format override (`templates.html`, `templates.txt`, etc.)
2. Frontmatter template preset (`template: blog` → expand to preset)
3. Frontmatter simple template (`template: post.html` → adapt for format)
4. Layout config (path/feed-based)
5. Global default for format (`default_templates.html`, etc.)
6. Hardcoded default (`post.html`, `default.txt`, etc.)

## Example Usage

```yaml
---
template: blog       # Default for all formats
templates:
  txt: raw.txt      # Override txt format only
  og: special-og.html
---
```

## Testing

- Added comprehensive tests for `resolveTemplateForFormat`
- Added tests for `adaptTemplateForFormat`
- Added tests for `getHardcodedDefault`
- All existing tests continue to pass

Fixes #398