### PR TITLE
fix: GLightbox caption and UI match site theme palette

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -103,6 +103,26 @@
     {% else %}
     <link rel="stylesheet" href="/css/glightbox.min.css">
     {% endif %}
+    <!-- GLightbox theme overrides to match site palette -->
+    <style>
+    .glightbox-clean .gslide-description {
+        background: var(--color-background);
+        color: var(--color-text);
+    }
+    .glightbox-clean .goverlay {
+        background: color-mix(in srgb, var(--color-background) 90%, transparent);
+    }
+    .glightbox-clean .gclose,
+    .glightbox-clean .gnext,
+    .glightbox-clean .gprev {
+        color: var(--color-text);
+    }
+    .glightbox-clean .gclose:hover,
+    .glightbox-clean .gnext:hover,
+    .glightbox-clean .gprev:hover {
+        color: var(--color-accent);
+    }
+    </style>
     {% endif %}
 
     <!-- Theme CSS -->


### PR DESCRIPTION
## Summary
- Add inline CSS overrides in `base.html` to style GLightbox elements using the site's theme CSS variables
- Caption, overlay, and navigation buttons now match the configured theme palette

## Changes
- Added `<style>` block after GLightbox CSS loads (inside the `glightbox_enabled` conditional)
- Overrides `.gslide-description` to use `--color-background` and `--color-text`
- Overrides `.goverlay` to use semi-transparent `--color-background`
- Overrides `.gclose`, `.gnext`, `.gprev` to use `--color-text` with `--color-accent` on hover

## Testing
- `go build ./cmd/markata-go` - Passes
- `go test ./...` - All tests pass
- `go fmt ./...` and `go vet ./...` - No issues

Fixes #435