### PR TITLE
fix: footer format links use canonical URLs and redirects use HTML

### DIFF
--- a/templates/components/format-links.html
+++ b/templates/components/format-links.html
@@ -8,10 +8,10 @@
 <div class="format-links">
   <span class="format-links-label">View as:</span>
   {% if config.post_formats.markdown %}
-  <a href="{{ post.href }}index.md" class="format-link format-link--markdown" title="View Markdown source">Markdown</a>
+  <a href="/{{ post.slug }}.md" class="format-link format-link--markdown" title="View Markdown source">Markdown</a>
   {% endif %}
   {% if config.post_formats.text %}
-  <a href="{{ post.href }}index.txt" class="format-link format-link--text" title="View as plain text">Text</a>
+  <a href="/{{ post.slug }}.txt" class="format-link format-link--text" title="View as plain text">Text</a>
   {% endif %}
   {% if config.post_formats.og %}
   <a href="{{ post.href }}og/" class="format-link format-link--og" title="View social card">Card</a>
@@ -34,10 +34,10 @@
   <a href="{{ feed.base_url }}/feed.json" class="format-link format-link--json" title="JSON Feed">JSON</a>
   {% endif %}
   {% if feed.formats.markdown %}
-  <a href="{{ feed.base_url }}/index.md" class="format-link format-link--markdown" title="Markdown">Markdown</a>
+  <a href="{{ feed.base_url }}.md" class="format-link format-link--markdown" title="Markdown">Markdown</a>
   {% endif %}
   {% if feed.formats.text %}
-  <a href="{{ feed.base_url }}/index.txt" class="format-link format-link--text" title="Plain Text">Text</a>
+  <a href="{{ feed.base_url }}.txt" class="format-link format-link--text" title="Plain Text">Text</a>
   {% endif %}
 </div>
 {% endif %}


### PR DESCRIPTION
## Summary
- Fix footer format links to use canonical URLs (`/slug.md`, `/slug.txt`) instead of directory paths (`/slug/index.md`, `/slug/index.txt`)
- Fix redirect file extension regression: always use `index.html` for redirects since browsers only parse `<meta http-equiv="refresh">` in HTML files
- Skip redirect creation when HTML format is enabled to avoid overwriting main content

Fixes #437

## Changes

### Template Links (`templates/components/format-links.html`)
- Post format links: `{{ post.href }}index.md` → `/{{ post.slug }}.md`
- Feed format links: `{{ feed.base_url }}/index.md` → `{{ feed.base_url }}.md`

### Redirect Extension (`pkg/plugins/publish_html.go`)
- Changed redirect path from `index.{ext}` to `index.html`
- Added `skipRedirect` parameter to avoid overwriting main HTML content when HTML format is enabled

### Tests
- Updated test to verify redirect behavior correctly
- Tests run with HTML disabled to ensure redirects are created

## Testing
- `go build ./cmd/markata-go` ✓
- `go test ./...` ✓
- `go fmt ./...` ✓
- `go vet ./...` ✓