### PR TITLE
feat(lint): add static_file_conflicts lint rule to detect when static files clobber generated content

### DIFF
--- a/pkg/plugins/registry.go
+++ b/pkg/plugins/registry.go
@@ -73,6 +73,7 @@ func registerBuiltinPluginsLocked() {
 	pluginRegistry.constructors["webmentions"] = func() lifecycle.Plugin { return NewWebMentionsPlugin() }
 	pluginRegistry.constructors["background"] = func() lifecycle.Plugin { return NewBackgroundPlugin() }
 	pluginRegistry.constructors["image_zoom"] = func() lifecycle.Plugin { return NewImageZoomPlugin() }
+	pluginRegistry.constructors["static_file_conflicts"] = func() lifecycle.Plugin { return NewStaticFileConflictsPlugin() }
 }
 
 // RegisterPluginConstructor registers a plugin constructor with the given name.
@@ -149,10 +150,11 @@ func DefaultPlugins() []lifecycle.Plugin {
 		// Collect stage plugins
 		NewFeedsPlugin(),
 		NewAutoFeedsPlugin(),
-		NewBlogrollPlugin(),       // Fetch external feeds for blogroll
-		NewStatsPlugin(),          // Aggregate stats after feeds are built (runs Collect)
-		NewPrevNextPlugin(),       // Calculate prev/next after feeds are built
-		NewOverwriteCheckPlugin(), // Detect conflicting output paths
+		NewBlogrollPlugin(),            // Fetch external feeds for blogroll
+		NewStatsPlugin(),               // Aggregate stats after feeds are built (runs Collect)
+		NewPrevNextPlugin(),            // Calculate prev/next after feeds are built
+		NewOverwriteCheckPlugin(),      // Detect conflicting output paths
+		NewStaticFileConflictsPlugin(), // Detect static files that would clobber generated content
 
 		// Write stage plugins
 		NewStaticAssetsPlugin(), // Copy static assets first

--- a/pkg/plugins/static_file_conflicts.go
+++ b/pkg/plugins/static_file_conflicts.go
@@ -1,0 +1,359 @@
+// Package plugins provides lifecycle plugins for markata-go.
+package plugins
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
+	"github.com/WaylonWalker/markata-go/pkg/models"
+)
+
+// StaticFileConflict represents a conflict between a generated file and a static file.
+type StaticFileConflict struct {
+	// GeneratedSource is the source of the generated file (e.g., "pages/robots.md")
+	GeneratedSource string
+
+	// GeneratedOutput is the output path of the generated file (e.g., "/robots.txt")
+	GeneratedOutput string
+
+	// StaticFile is the path to the conflicting static file (e.g., "static/robots.txt")
+	StaticFile string
+
+	// OutputPath is the final output path that both would write to
+	OutputPath string
+}
+
+// StaticFileConflictsPlugin detects when static files would clobber generated content.
+// This is a lint rule that warns users when they have both:
+// - A generated file (e.g., robots.md → robots.txt)
+// - A static file (e.g., static/robots.txt)
+//
+// The static file always wins (copied last), which can cause unexpected behavior
+// like private posts not being added to robots.txt.
+type StaticFileConflictsPlugin struct {
+	// conflicts stores detected conflicts
+	conflicts []StaticFileConflict
+
+	// staticDir is the directory containing static files
+	staticDir string
+
+	// enabled controls whether the plugin runs
+	enabled bool
+}
+
+// NewStaticFileConflictsPlugin creates a new StaticFileConflictsPlugin.
+func NewStaticFileConflictsPlugin() *StaticFileConflictsPlugin {
+	return &StaticFileConflictsPlugin{
+		conflicts: make([]StaticFileConflict, 0),
+		staticDir: "static",
+		enabled:   true,
+	}
+}
+
+// Name returns the unique name of the plugin.
+func (p *StaticFileConflictsPlugin) Name() string {
+	return "static_file_conflicts"
+}
+
+// SetStaticDir sets the static directory path.
+func (p *StaticFileConflictsPlugin) SetStaticDir(dir string) {
+	p.staticDir = dir
+}
+
+// SetEnabled enables or disables the plugin.
+func (p *StaticFileConflictsPlugin) SetEnabled(enabled bool) {
+	p.enabled = enabled
+}
+
+// Conflicts returns the detected conflicts.
+func (p *StaticFileConflictsPlugin) Conflicts() []StaticFileConflict {
+	return p.conflicts
+}
+
+// Priority returns the plugin execution priority for the given stage.
+// Run during collect stage after posts are processed but before writing.
+func (p *StaticFileConflictsPlugin) Priority(stage lifecycle.Stage) int {
+	if stage == lifecycle.StageCollect {
+		return lifecycle.PriorityLate // Run late to catch all generated content
+	}
+	return lifecycle.PriorityDefault
+}
+
+// Collect checks for conflicts between generated and static files.
+func (p *StaticFileConflictsPlugin) Collect(m *lifecycle.Manager) error {
+	if !p.enabled {
+		return nil
+	}
+
+	// Check if static directory exists
+	if _, err := os.Stat(p.staticDir); os.IsNotExist(err) {
+		return nil // No static directory, no conflicts possible
+	}
+
+	// Build a map of static files
+	staticFiles := make(map[string]string) // normalized output path -> static file path
+	err := filepath.Walk(p.staticDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+
+		// Get relative path from static dir
+		relPath, err := filepath.Rel(p.staticDir, path)
+		if err != nil {
+			return err
+		}
+
+		// Normalize to output path (static/foo.txt -> /foo.txt)
+		outputPath := "/" + filepath.ToSlash(relPath)
+		staticFiles[outputPath] = path
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("scanning static directory: %w", err)
+	}
+
+	// Reset conflicts
+	p.conflicts = make([]StaticFileConflict, 0)
+
+	// Check each post for potential conflicts
+	for _, post := range m.Posts() {
+		// Skip posts that won't be written
+		if post.Skip || post.Draft {
+			continue
+		}
+
+		// Check for various output formats this post might generate
+		conflicts := p.checkPostConflicts(post, staticFiles)
+		p.conflicts = append(p.conflicts, conflicts...)
+	}
+
+	// Check feed configs for conflicts
+	feedConflicts := p.checkFeedConflicts(m, staticFiles)
+	p.conflicts = append(p.conflicts, feedConflicts...)
+
+	// Report conflicts as warnings
+	if len(p.conflicts) > 0 {
+		return p.reportConflicts()
+	}
+
+	return nil
+}
+
+// checkPostConflicts checks if a post's generated files conflict with static files.
+func (p *StaticFileConflictsPlugin) checkPostConflicts(post *models.Post, staticFiles map[string]string) []StaticFileConflict {
+	conflicts := make([]StaticFileConflict, 0)
+
+	// Get the base filename without extension
+	base := filepath.Base(post.Path)
+	ext := filepath.Ext(base)
+	stem := strings.TrimSuffix(base, ext)
+
+	// Common patterns for root-level generated files
+	// robots.md → /robots.txt
+	// sitemap.md → /sitemap.xml
+	// humans.md → /humans.txt
+	// security.md → /security.txt (or /.well-known/security.txt)
+
+	// Check if this is a root-level special file
+	dir := filepath.Dir(post.Path)
+	isRootLevel := dir == "." || dir == "" || dir == "pages"
+
+	if !isRootLevel {
+		return conflicts
+	}
+
+	// Map of stem names to their expected output extensions
+	specialFiles := map[string][]string{
+		"robots":   {".txt"},
+		"sitemap":  {".xml"},
+		"humans":   {".txt"},
+		"security": {".txt"},
+		"manifest": {".json", ".webmanifest"},
+		"feed":     {".xml", ".json", ".atom"},
+		"rss":      {".xml"},
+		"atom":     {".xml"},
+	}
+
+	stemLower := strings.ToLower(stem)
+	if extensions, ok := specialFiles[stemLower]; ok {
+		for _, outputExt := range extensions {
+			outputPath := "/" + stemLower + outputExt
+			if staticPath, exists := staticFiles[outputPath]; exists {
+				conflicts = append(conflicts, StaticFileConflict{
+					GeneratedSource: post.Path,
+					GeneratedOutput: outputPath,
+					StaticFile:      staticPath,
+					OutputPath:      outputPath,
+				})
+			}
+		}
+	}
+
+	// Also check for .txt files that might be generated from .md
+	// e.g., changelog.md → /changelog.txt (if txt output is enabled)
+	txtOutputPath := "/" + stemLower + ".txt"
+	if staticPath, exists := staticFiles[txtOutputPath]; exists {
+		// Check if this post has txt template configured
+		if post.Templates != nil {
+			if _, hasTxt := post.Templates["txt"]; hasTxt {
+				conflicts = append(conflicts, StaticFileConflict{
+					GeneratedSource: post.Path,
+					GeneratedOutput: txtOutputPath,
+					StaticFile:      staticPath,
+					OutputPath:      txtOutputPath,
+				})
+			}
+		}
+	}
+
+	return conflicts
+}
+
+// checkFeedConflicts checks if feed-generated files conflict with static files.
+func (p *StaticFileConflictsPlugin) checkFeedConflicts(m *lifecycle.Manager, staticFiles map[string]string) []StaticFileConflict {
+	conflicts := make([]StaticFileConflict, 0)
+
+	// Check for common feed output paths
+	feedPaths := []struct {
+		path   string
+		source string
+	}{
+		{"/rss.xml", "feed:rss"},
+		{"/atom.xml", "feed:atom"},
+		{"/feed.xml", "feed:rss"},
+		{"/index.json", "feed:json"},
+		{"/feed.json", "feed:json"},
+		{"/sitemap.xml", "sitemap"},
+	}
+
+	for _, fp := range feedPaths {
+		if staticPath, exists := staticFiles[fp.path]; exists {
+			conflicts = append(conflicts, StaticFileConflict{
+				GeneratedSource: fp.source,
+				GeneratedOutput: fp.path,
+				StaticFile:      staticPath,
+				OutputPath:      fp.path,
+			})
+		}
+	}
+
+	// Check feed configs from cache
+	var feedConfigs []models.FeedConfig
+	if cached, ok := m.Cache().Get("feed_configs"); ok {
+		if fcs, ok := cached.([]models.FeedConfig); ok {
+			feedConfigs = fcs
+		}
+	}
+
+	for i := range feedConfigs {
+		fc := &feedConfigs[i]
+		feedDir := fc.Slug
+		if feedDir == "" {
+			feedDir = ""
+		}
+
+		// Check each feed format
+		if fc.Formats.RSS {
+			rssPath := "/" + feedDir
+			if feedDir != "" {
+				rssPath += "/"
+			}
+			rssPath += "rss.xml"
+			if staticPath, exists := staticFiles[rssPath]; exists {
+				conflicts = append(conflicts, StaticFileConflict{
+					GeneratedSource: fmt.Sprintf("feed:%s:rss", fc.Slug),
+					GeneratedOutput: rssPath,
+					StaticFile:      staticPath,
+					OutputPath:      rssPath,
+				})
+			}
+		}
+
+		if fc.Formats.Atom {
+			atomPath := "/" + feedDir
+			if feedDir != "" {
+				atomPath += "/"
+			}
+			atomPath += "atom.xml"
+			if staticPath, exists := staticFiles[atomPath]; exists {
+				conflicts = append(conflicts, StaticFileConflict{
+					GeneratedSource: fmt.Sprintf("feed:%s:atom", fc.Slug),
+					GeneratedOutput: atomPath,
+					StaticFile:      staticPath,
+					OutputPath:      atomPath,
+				})
+			}
+		}
+
+		if fc.Formats.JSON {
+			jsonPath := "/" + feedDir
+			if feedDir != "" {
+				jsonPath += "/"
+			}
+			jsonPath += "index.json"
+			if staticPath, exists := staticFiles[jsonPath]; exists {
+				conflicts = append(conflicts, StaticFileConflict{
+					GeneratedSource: fmt.Sprintf("feed:%s:json", fc.Slug),
+					GeneratedOutput: jsonPath,
+					StaticFile:      staticPath,
+					OutputPath:      jsonPath,
+				})
+			}
+		}
+	}
+
+	return conflicts
+}
+
+// reportConflicts returns an error with all detected conflicts formatted as warnings.
+func (p *StaticFileConflictsPlugin) reportConflicts() error {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("WARNING: %d static file conflict(s) detected\n", len(p.conflicts)))
+	sb.WriteString("Static files will override generated content.\n\n")
+
+	for _, c := range p.conflicts {
+		sb.WriteString(fmt.Sprintf("  Conflicting %s:\n", c.OutputPath))
+		sb.WriteString(fmt.Sprintf("    Generated: %s → %s\n", c.GeneratedSource, c.GeneratedOutput))
+		sb.WriteString(fmt.Sprintf("    Static:    %s → %s\n", c.StaticFile, c.OutputPath))
+		sb.WriteString("    The static file will override the generated one.\n\n")
+	}
+
+	sb.WriteString("To fix:\n")
+	sb.WriteString("  - Remove the static file if you want the generated version\n")
+	sb.WriteString("  - Remove or rename the source file if you want the static version\n")
+	sb.WriteString("  - Disable the static_file_conflicts lint rule in config if intentional\n")
+
+	// Return as a non-critical warning (not an error that stops the build)
+	// We use a custom error type that the lifecycle manager can detect as non-critical
+	return &StaticFileConflictWarning{Message: sb.String(), Conflicts: p.conflicts}
+}
+
+// StaticFileConflictWarning is a warning (not error) about static file conflicts.
+type StaticFileConflictWarning struct {
+	Message   string
+	Conflicts []StaticFileConflict
+}
+
+// Error implements the error interface.
+func (w *StaticFileConflictWarning) Error() string {
+	return w.Message
+}
+
+// IsWarning indicates this is a non-critical warning.
+func (w *StaticFileConflictWarning) IsWarning() bool {
+	return true
+}
+
+// Ensure StaticFileConflictsPlugin implements the required interfaces.
+var (
+	_ lifecycle.Plugin         = (*StaticFileConflictsPlugin)(nil)
+	_ lifecycle.CollectPlugin  = (*StaticFileConflictsPlugin)(nil)
+	_ lifecycle.PriorityPlugin = (*StaticFileConflictsPlugin)(nil)
+)

--- a/pkg/plugins/static_file_conflicts_test.go
+++ b/pkg/plugins/static_file_conflicts_test.go
@@ -1,0 +1,472 @@
+package plugins
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
+	"github.com/WaylonWalker/markata-go/pkg/models"
+)
+
+func TestStaticFileConflictsPlugin_Name(t *testing.T) {
+	plugin := NewStaticFileConflictsPlugin()
+	if plugin.Name() != "static_file_conflicts" {
+		t.Errorf("expected name 'static_file_conflicts', got %q", plugin.Name())
+	}
+}
+
+func TestStaticFileConflictsPlugin_Priority(t *testing.T) {
+	plugin := NewStaticFileConflictsPlugin()
+
+	// Should return PriorityLate for Collect stage
+	if got := plugin.Priority(lifecycle.StageCollect); got != lifecycle.PriorityLate {
+		t.Errorf("expected PriorityLate for Collect, got %d", got)
+	}
+
+	// Should return PriorityDefault for other stages
+	if got := plugin.Priority(lifecycle.StageRender); got != lifecycle.PriorityDefault {
+		t.Errorf("expected PriorityDefault for Render, got %d", got)
+	}
+}
+
+func TestStaticFileConflictsPlugin_NoStaticDir(t *testing.T) {
+	// Test that plugin handles missing static directory gracefully
+	plugin := NewStaticFileConflictsPlugin()
+	plugin.SetStaticDir("nonexistent-static-dir")
+
+	m := lifecycle.NewManager()
+	m.AddPost(&models.Post{
+		Path: "robots.md",
+		Slug: "robots",
+	})
+
+	err := plugin.Collect(m)
+	if err != nil {
+		t.Errorf("expected no error with missing static dir, got %v", err)
+	}
+
+	if len(plugin.Conflicts()) != 0 {
+		t.Errorf("expected no conflicts with missing static dir, got %d", len(plugin.Conflicts()))
+	}
+}
+
+func TestStaticFileConflictsPlugin_Disabled(t *testing.T) {
+	// Test that disabled plugin does nothing
+	plugin := NewStaticFileConflictsPlugin()
+	plugin.SetEnabled(false)
+
+	m := lifecycle.NewManager()
+	m.AddPost(&models.Post{
+		Path: "robots.md",
+		Slug: "robots",
+	})
+
+	err := plugin.Collect(m)
+	if err != nil {
+		t.Errorf("expected no error when disabled, got %v", err)
+	}
+
+	if len(plugin.Conflicts()) != 0 {
+		t.Errorf("expected no conflicts when disabled, got %d", len(plugin.Conflicts()))
+	}
+}
+
+func TestStaticFileConflictsPlugin_DetectsRobotsTxtConflict(t *testing.T) {
+	// Create temp directory structure
+	tmpDir := t.TempDir()
+	staticDir := filepath.Join(tmpDir, "static")
+	if err := os.MkdirAll(staticDir, 0o755); err != nil {
+		t.Fatalf("failed to create static dir: %v", err)
+	}
+
+	// Create static/robots.txt
+	robotsPath := filepath.Join(staticDir, "robots.txt")
+	if err := os.WriteFile(robotsPath, []byte("User-agent: *\nDisallow: /"), 0o600); err != nil {
+		t.Fatalf("failed to create robots.txt: %v", err)
+	}
+
+	// Create plugin and set static dir
+	plugin := NewStaticFileConflictsPlugin()
+	plugin.SetStaticDir(staticDir)
+
+	// Create manager with a robots.md post
+	m := lifecycle.NewManager()
+	m.AddPost(&models.Post{
+		Path:      "pages/robots.md",
+		Slug:      "robots",
+		Published: true,
+	})
+
+	err := plugin.Collect(m)
+
+	// Should return a warning (error)
+	if err == nil {
+		t.Error("expected warning about conflict, got nil")
+	}
+
+	// Check that conflict was detected
+	conflicts := plugin.Conflicts()
+	if len(conflicts) == 0 {
+		t.Error("expected at least one conflict, got none")
+	}
+
+	// Verify the conflict details
+	found := false
+	for _, c := range conflicts {
+		if c.GeneratedSource == "pages/robots.md" && c.OutputPath == "/robots.txt" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected conflict for robots.md → /robots.txt, conflicts: %+v", conflicts)
+	}
+}
+
+func TestStaticFileConflictsPlugin_DetectsSitemapConflict(t *testing.T) {
+	tmpDir := t.TempDir()
+	staticDir := filepath.Join(tmpDir, "static")
+	if err := os.MkdirAll(staticDir, 0o755); err != nil {
+		t.Fatalf("failed to create static dir: %v", err)
+	}
+
+	// Create static/sitemap.xml
+	sitemapPath := filepath.Join(staticDir, "sitemap.xml")
+	if err := os.WriteFile(sitemapPath, []byte("<?xml version=\"1.0\"?>"), 0o600); err != nil {
+		t.Fatalf("failed to create sitemap.xml: %v", err)
+	}
+
+	plugin := NewStaticFileConflictsPlugin()
+	plugin.SetStaticDir(staticDir)
+
+	m := lifecycle.NewManager()
+	m.AddPost(&models.Post{
+		Path:      "sitemap.md",
+		Slug:      "sitemap",
+		Published: true,
+	})
+
+	err := plugin.Collect(m)
+
+	if err == nil {
+		t.Error("expected warning about conflict, got nil")
+	}
+
+	conflicts := plugin.Conflicts()
+	found := false
+	for _, c := range conflicts {
+		if c.OutputPath == "/sitemap.xml" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected conflict for sitemap.xml, conflicts: %+v", conflicts)
+	}
+}
+
+func TestStaticFileConflictsPlugin_SkipsDraftPosts(t *testing.T) {
+	tmpDir := t.TempDir()
+	staticDir := filepath.Join(tmpDir, "static")
+	if err := os.MkdirAll(staticDir, 0o755); err != nil {
+		t.Fatalf("failed to create static dir: %v", err)
+	}
+
+	// Create static/robots.txt
+	robotsPath := filepath.Join(staticDir, "robots.txt")
+	if err := os.WriteFile(robotsPath, []byte("User-agent: *"), 0o600); err != nil {
+		t.Fatalf("failed to create robots.txt: %v", err)
+	}
+
+	plugin := NewStaticFileConflictsPlugin()
+	plugin.SetStaticDir(staticDir)
+
+	m := lifecycle.NewManager()
+	m.AddPost(&models.Post{
+		Path:  "pages/robots.md",
+		Slug:  "robots",
+		Draft: true, // Draft post should be skipped
+	})
+
+	err := plugin.Collect(m)
+
+	if err != nil {
+		t.Errorf("expected no error for draft post, got %v", err)
+	}
+
+	if len(plugin.Conflicts()) != 0 {
+		t.Errorf("expected no conflicts for draft post, got %d", len(plugin.Conflicts()))
+	}
+}
+
+func TestStaticFileConflictsPlugin_SkipsSkippedPosts(t *testing.T) {
+	tmpDir := t.TempDir()
+	staticDir := filepath.Join(tmpDir, "static")
+	if err := os.MkdirAll(staticDir, 0o755); err != nil {
+		t.Fatalf("failed to create static dir: %v", err)
+	}
+
+	robotsPath := filepath.Join(staticDir, "robots.txt")
+	if err := os.WriteFile(robotsPath, []byte("User-agent: *"), 0o600); err != nil {
+		t.Fatalf("failed to create robots.txt: %v", err)
+	}
+
+	plugin := NewStaticFileConflictsPlugin()
+	plugin.SetStaticDir(staticDir)
+
+	m := lifecycle.NewManager()
+	m.AddPost(&models.Post{
+		Path: "pages/robots.md",
+		Slug: "robots",
+		Skip: true, // Skipped post should be skipped
+	})
+
+	err := plugin.Collect(m)
+
+	if err != nil {
+		t.Errorf("expected no error for skipped post, got %v", err)
+	}
+
+	if len(plugin.Conflicts()) != 0 {
+		t.Errorf("expected no conflicts for skipped post, got %d", len(plugin.Conflicts()))
+	}
+}
+
+func TestStaticFileConflictsPlugin_NoConflictForNonRootPosts(t *testing.T) {
+	tmpDir := t.TempDir()
+	staticDir := filepath.Join(tmpDir, "static")
+	if err := os.MkdirAll(staticDir, 0o755); err != nil {
+		t.Fatalf("failed to create static dir: %v", err)
+	}
+
+	// Create static/robots.txt
+	robotsPath := filepath.Join(staticDir, "robots.txt")
+	if err := os.WriteFile(robotsPath, []byte("User-agent: *"), 0o600); err != nil {
+		t.Fatalf("failed to create robots.txt: %v", err)
+	}
+
+	plugin := NewStaticFileConflictsPlugin()
+	plugin.SetStaticDir(staticDir)
+
+	m := lifecycle.NewManager()
+	// Post in a subdirectory - should not conflict with root static files
+	m.AddPost(&models.Post{
+		Path:      "blog/posts/robots.md",
+		Slug:      "blog/posts/robots",
+		Published: true,
+	})
+
+	err := plugin.Collect(m)
+
+	if err != nil {
+		t.Errorf("expected no error for non-root post, got %v", err)
+	}
+
+	if len(plugin.Conflicts()) != 0 {
+		t.Errorf("expected no conflicts for non-root post, got %d", len(plugin.Conflicts()))
+	}
+}
+
+func TestStaticFileConflictsPlugin_MultipleConflicts(t *testing.T) {
+	tmpDir := t.TempDir()
+	staticDir := filepath.Join(tmpDir, "static")
+	if err := os.MkdirAll(staticDir, 0o755); err != nil {
+		t.Fatalf("failed to create static dir: %v", err)
+	}
+
+	// Create multiple conflicting static files
+	files := map[string]string{
+		"robots.txt":  "User-agent: *",
+		"sitemap.xml": "<?xml version=\"1.0\"?>",
+		"humans.txt":  "/* TEAM */",
+	}
+	for name, content := range files {
+		path := filepath.Join(staticDir, name)
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("failed to create %s: %v", name, err)
+		}
+	}
+
+	plugin := NewStaticFileConflictsPlugin()
+	plugin.SetStaticDir(staticDir)
+
+	m := lifecycle.NewManager()
+	m.AddPost(&models.Post{
+		Path:      "robots.md",
+		Slug:      "robots",
+		Published: true,
+	})
+	m.AddPost(&models.Post{
+		Path:      "pages/sitemap.md",
+		Slug:      "sitemap",
+		Published: true,
+	})
+	m.AddPost(&models.Post{
+		Path:      "humans.md",
+		Slug:      "humans",
+		Published: true,
+	})
+
+	err := plugin.Collect(m)
+
+	if err == nil {
+		t.Error("expected warning about conflicts, got nil")
+	}
+
+	conflicts := plugin.Conflicts()
+	if len(conflicts) < 3 {
+		t.Errorf("expected at least 3 conflicts, got %d: %+v", len(conflicts), conflicts)
+	}
+}
+
+func TestStaticFileConflictsPlugin_FeedConflicts(t *testing.T) {
+	tmpDir := t.TempDir()
+	staticDir := filepath.Join(tmpDir, "static")
+	if err := os.MkdirAll(staticDir, 0o755); err != nil {
+		t.Fatalf("failed to create static dir: %v", err)
+	}
+
+	// Create static/rss.xml
+	rssPath := filepath.Join(staticDir, "rss.xml")
+	if err := os.WriteFile(rssPath, []byte("<?xml version=\"1.0\"?>"), 0o600); err != nil {
+		t.Fatalf("failed to create rss.xml: %v", err)
+	}
+
+	plugin := NewStaticFileConflictsPlugin()
+	plugin.SetStaticDir(staticDir)
+
+	m := lifecycle.NewManager()
+	// Even with no posts, feed generation creates rss.xml
+	// The plugin should detect this conflict
+
+	err := plugin.Collect(m)
+
+	if err == nil {
+		t.Error("expected warning about RSS conflict, got nil")
+	}
+
+	conflicts := plugin.Conflicts()
+	found := false
+	for _, c := range conflicts {
+		if c.OutputPath == "/rss.xml" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected conflict for /rss.xml, conflicts: %+v", conflicts)
+	}
+}
+
+func TestStaticFileConflictsPlugin_WarningType(t *testing.T) {
+	tmpDir := t.TempDir()
+	staticDir := filepath.Join(tmpDir, "static")
+	if err := os.MkdirAll(staticDir, 0o755); err != nil {
+		t.Fatalf("failed to create static dir: %v", err)
+	}
+
+	robotsPath := filepath.Join(staticDir, "robots.txt")
+	if err := os.WriteFile(robotsPath, []byte("User-agent: *"), 0o600); err != nil {
+		t.Fatalf("failed to create robots.txt: %v", err)
+	}
+
+	plugin := NewStaticFileConflictsPlugin()
+	plugin.SetStaticDir(staticDir)
+
+	m := lifecycle.NewManager()
+	m.AddPost(&models.Post{
+		Path:      "pages/robots.md",
+		Slug:      "robots",
+		Published: true,
+	})
+
+	err := plugin.Collect(m)
+
+	// Verify the error is a warning type using errors.As
+	var warning *StaticFileConflictWarning
+	if !errors.As(err, &warning) {
+		t.Errorf("expected *StaticFileConflictWarning, got %T", err)
+	}
+
+	if warning != nil && !warning.IsWarning() {
+		t.Error("expected IsWarning() to return true")
+	}
+}
+
+func TestStaticFileConflictsPlugin_NestedStaticFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	staticDir := filepath.Join(tmpDir, "static")
+	wellKnownDir := filepath.Join(staticDir, ".well-known")
+	if err := os.MkdirAll(wellKnownDir, 0o755); err != nil {
+		t.Fatalf("failed to create .well-known dir: %v", err)
+	}
+
+	// Create static/.well-known/security.txt
+	securityPath := filepath.Join(wellKnownDir, "security.txt")
+	if err := os.WriteFile(securityPath, []byte("Contact: security@example.com"), 0o600); err != nil {
+		t.Fatalf("failed to create security.txt: %v", err)
+	}
+
+	plugin := NewStaticFileConflictsPlugin()
+	plugin.SetStaticDir(staticDir)
+
+	m := lifecycle.NewManager()
+	// security.md at root level would generate /security.txt, not /.well-known/security.txt
+	// So this should NOT conflict
+	m.AddPost(&models.Post{
+		Path:      "security.md",
+		Slug:      "security",
+		Published: true,
+	})
+
+	// First call - no conflict expected for .well-known path
+	if err := plugin.Collect(m); err != nil {
+		// If there's an error, it should not be about the .well-known path
+		conflicts := plugin.Conflicts()
+		for _, c := range conflicts {
+			if c.OutputPath == "/.well-known/security.txt" {
+				t.Errorf("unexpected conflict for .well-known path: %+v", c)
+			}
+		}
+	}
+
+	// The .well-known/security.txt should not conflict with /security.txt
+	// But we should still detect /security.txt if it existed
+	conflicts := plugin.Conflicts()
+	for _, c := range conflicts {
+		if c.OutputPath == "/.well-known/security.txt" {
+			t.Errorf("unexpected conflict for .well-known path: %+v", c)
+		}
+	}
+
+	// Now add static/security.txt to create a real conflict
+	directSecurityPath := filepath.Join(staticDir, "security.txt")
+	if err := os.WriteFile(directSecurityPath, []byte("Contact: security@example.com"), 0o600); err != nil {
+		t.Fatalf("failed to create direct security.txt: %v", err)
+	}
+
+	// Reset and re-run
+	err := plugin.Collect(m)
+	if err == nil {
+		t.Error("expected warning about /security.txt conflict")
+	}
+}
+
+func TestStaticFileConflictWarning_Error(t *testing.T) {
+	warning := &StaticFileConflictWarning{
+		Message: "test warning message",
+		Conflicts: []StaticFileConflict{
+			{OutputPath: "/robots.txt"},
+		},
+	}
+
+	if warning.Error() != "test warning message" {
+		t.Errorf("expected message 'test warning message', got %q", warning.Error())
+	}
+
+	if !warning.IsWarning() {
+		t.Error("expected IsWarning() to return true")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #436

This PR adds a new lint rule `static_file_conflicts` that detects when static files in the `static/` directory would silently override generated content during the build.

## Problem

When a user has both:
- A generated file (e.g., `robots.txt` from `pages/robots.md`)
- A static file (e.g., `static/robots.txt`)

The static file silently clobbers the generated one, causing unexpected behavior like:
- Private posts NOT being added to robots.txt Disallow rules
- Generated sitemaps being replaced with static versions
- Feed files (RSS, Atom, JSON) being overwritten

## Solution

The new `static_file_conflicts` plugin:
- Runs during the Collect stage (late priority, after content is processed)
- Scans the `static/` directory for files
- Checks for posts that would generate root-level files (robots.md → robots.txt)
- Checks for feed output paths (rss.xml, atom.xml, sitemap.xml)
- Reports clear warnings with fix instructions
- Is a non-blocking warning (build continues)

### Warning Output Example

```
WARNING: 2 static file conflict(s) detected
Static files will override generated content.

  Conflicting /robots.txt:
    Generated: pages/robots.md → /robots.txt
    Static:    static/robots.txt → /robots.txt
    The static file will override the generated one.

To fix:
  - Remove the static file if you want the generated version
  - Remove or rename the source file if you want the static version
  - Disable the static_file_conflicts lint rule in config if intentional
```

### Configuration

```toml
[markata-go.static_file_conflicts]
enabled = true        # default
static_dir = "static" # default
```

## Changes

- **New files:**
  - `pkg/plugins/static_file_conflicts.go` - Plugin implementation
  - `pkg/plugins/static_file_conflicts_test.go` - Comprehensive tests (14 test cases)

- **Modified files:**
  - `pkg/plugins/registry.go` - Register new plugin
  - `docs/reference/plugins.md` - Add documentation for the new lint rule

## Testing

- All existing tests pass
- Added 14 new test cases covering:
  - robots.txt, sitemap.xml, humans.txt conflicts
  - Draft and skipped posts are ignored
  - Non-root posts don't trigger false positives
  - Multiple conflicts detection
  - Feed conflicts (RSS, Atom, JSON)
  - Nested static files (.well-known/security.txt)
  - Warning type verification