### PR TITLE
fix(lsp): prevent mention hover crash with minimal blogroll data

### DIFF
--- a/pkg/lsp/hover.go
+++ b/pkg/lsp/hover.go
@@ -128,26 +128,40 @@ func (s *Server) handleMentionHover(msg *Message, handle string, mentionRange *R
 		sb.WriteString("\n\n")
 	}
 
-	sb.WriteString("---\n")
-	if mention.SiteURL != "" {
-		sb.WriteString("*Site:* ")
-		sb.WriteString(mention.SiteURL)
-		sb.WriteString("\n\n")
+	// Build metadata section - only add separator if we have content
+	hasMetadata := mention.SiteURL != "" || mention.FeedURL != "" || len(mention.Aliases) > 0
+	if hasMetadata {
+		sb.WriteString("---\n")
+		if mention.SiteURL != "" {
+			sb.WriteString("*Site:* ")
+			sb.WriteString(mention.SiteURL)
+			sb.WriteString("\n\n")
+		}
+		if mention.FeedURL != "" {
+			sb.WriteString("*Feed:* ")
+			sb.WriteString(mention.FeedURL)
+			sb.WriteString("\n\n")
+		}
+		if len(mention.Aliases) > 0 {
+			sb.WriteString("*Aliases:* @")
+			sb.WriteString(strings.Join(mention.Aliases, ", @"))
+			sb.WriteString("\n")
+		}
+	} else if mention.Description == "" {
+		// Show placeholder for mentions with no metadata at all
+		sb.WriteString("*No additional information available.*\n")
 	}
-	if mention.FeedURL != "" {
-		sb.WriteString("*Feed:* ")
-		sb.WriteString(mention.FeedURL)
-		sb.WriteString("\n\n")
-	}
-	if len(mention.Aliases) > 0 {
-		sb.WriteString("*Aliases:* @")
-		sb.WriteString(strings.Join(mention.Aliases, ", @"))
+
+	// Trim trailing whitespace to avoid width calculation issues in editors
+	content := strings.TrimRight(sb.String(), "\n ")
+	if content == "" {
+		content = "## @" + mention.Handle
 	}
 
 	hover := &Hover{
 		Contents: MarkupContent{
 			Kind:  "markdown",
-			Value: sb.String(),
+			Value: content,
 		},
 		Range: mentionRange,
 	}


### PR DESCRIPTION
## Summary

Fix issue where hovering over @mentions with minimal data (only handle, no site_url/feed_url/aliases) caused Neovim to crash due to floating window width calculation issues.

Fixes #444

## Changes

- Only add `---` separator in hover content when metadata exists
- Show "No additional information available" for mentions with no metadata
- Trim trailing whitespace to avoid editor rendering issues
- Add comprehensive tests for all mention hover scenarios

## Root Cause

The `handleMentionHover()` function always added a `---\n` separator even when no content followed (when a mention only had a handle and no site_url, feed_url, or aliases). This caused Neovim's floating window to fail width calculations when rendering the hover popup.

## Testing

Added 8 new test cases in `TestMentionHoverContent`:
- Mention with only handle
- Mention with handle + title only
- Mention with handle + description only
- Mention with site_url only
- Mention with feed_url only
- Mention with aliases only
- Mention with all fields (regression test)
- Mention with title + site_url

All tests verify:
- Expected content is present
- No trailing separator without content
- No trailing whitespace that could cause editor issues