### PR TITLE
feat(theme): add conditional JS loading and sync missing assets

### DIFF
--- a/pkg/themes/default/static/css/components.css
+++ b/pkg/themes/default/static/css/components.css
@@ -1254,3 +1254,213 @@
     font-size: 0.8125rem;
   }
 }
+
+/* ==========================================================================
+   Mention Hover Cards
+
+   Displays contextual information (avatar, name, bio) when hovering over
+   @mention links in content.
+   ========================================================================== */
+
+/* Base card styling */
+.mention-card {
+  position: absolute;
+  z-index: 9999;
+  width: 320px;
+  max-width: calc(100vw - 32px);
+  background-color: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12), 0 2px 8px rgba(0, 0, 0, 0.08);
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(4px);
+  transition: opacity 0.15s ease, transform 0.15s ease, visibility 0.15s;
+  pointer-events: auto;
+}
+
+.mention-card--visible {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+.mention-card--above {
+  transform: translateY(-4px);
+}
+
+.mention-card--above.mention-card--visible {
+  transform: translateY(0);
+}
+
+/* Card header - avatar and name/handle */
+.mention-card-header {
+  display: flex;
+  align-items: center;
+  gap: 0.875rem;
+  padding: 1rem;
+}
+
+/* Avatar container */
+.mention-card-avatar {
+  flex-shrink: 0;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  overflow: hidden;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.mention-card-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+/* Fallback initials when no avatar */
+.mention-card-initials {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+}
+
+/* Content area (name, handle) */
+.mention-card-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.mention-card-name {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-text);
+  line-height: 1.3;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.mention-card-handle {
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+  line-height: 1.3;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Bio/description */
+.mention-card-bio {
+  padding: 0 1rem;
+  padding-bottom: 0.75rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: var(--color-text);
+
+  /* 2-line truncation */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* Footer with link */
+.mention-card-footer {
+  padding: 0.75rem 1rem;
+  border-top: 1px solid var(--color-border);
+}
+
+.mention-card-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--color-primary);
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+.mention-card-link:hover {
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+
+.mention-card-link:focus {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+/* Loading state */
+.mention-card-loading {
+  padding: 1.5rem;
+  text-align: center;
+}
+
+.mention-card-loading-text {
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+}
+
+/* Error state */
+.mention-card-error {
+  padding: 1rem;
+  text-align: center;
+}
+
+.mention-card-error-text {
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+  font-style: italic;
+}
+
+/* Disable on touch devices */
+@media (hover: none), (pointer: coarse) {
+  .mention-card {
+    display: none !important;
+  }
+}
+
+/* Respect reduced motion preference */
+@media (prefers-reduced-motion: reduce) {
+  .mention-card {
+    transition: opacity 0.1s ease, visibility 0.1s;
+    transform: none;
+  }
+
+  .mention-card--above,
+  .mention-card--visible,
+  .mention-card--above.mention-card--visible {
+    transform: none;
+  }
+}
+
+/* High contrast mode support */
+@media (prefers-contrast: more) {
+  .mention-card {
+    border-width: 2px;
+    border-color: var(--color-text);
+  }
+
+  .mention-card-avatar {
+    border-width: 2px;
+  }
+
+  .mention-card-footer {
+    border-top-width: 2px;
+  }
+}
+
+/* Print styles - hide hover cards */
+@media print {
+  .mention-card {
+    display: none !important;
+  }
+}

--- a/pkg/themes/default/static/js/mention-cards.js
+++ b/pkg/themes/default/static/js/mention-cards.js
@@ -1,0 +1,594 @@
+/**
+ * Mention Hover Cards for markata-go
+ *
+ * Displays contextual information (avatar, name, bio) when hovering over @mention links.
+ *
+ * Features:
+ * - Smart positioning (above/below based on viewport)
+ * - Data fetching from blogroll cache first, then meta tags from URL
+ * - 5-minute cache TTL for performance
+ * - 300ms show delay, 200ms hide delay to prevent flickering
+ * - Keyboard support (Escape to dismiss, focus shows card)
+ * - Disabled on touch devices
+ * - Graceful error handling
+ *
+ * @see https://github.com/example/markata-go/issues/297
+ */
+
+(function() {
+  'use strict';
+
+  // Configuration
+  var SHOW_DELAY = 300;   // ms before showing card
+  var HIDE_DELAY = 200;   // ms before hiding card
+  var CACHE_TTL = 5 * 60 * 1000;  // 5 minutes in ms
+
+  // State
+  var cache = {};
+  var currentCard = null;
+  var showTimer = null;
+  var hideTimer = null;
+  var currentTarget = null;
+
+  /**
+   * Check if device supports touch (likely mobile)
+   * @returns {boolean}
+   */
+  function isTouchDevice() {
+    return ('ontouchstart' in window) ||
+           (navigator.maxTouchPoints > 0) ||
+           (navigator.msMaxTouchPoints > 0);
+  }
+
+  /**
+   * Get initials from a name or handle
+   * @param {string} name - The name or handle
+   * @returns {string} - Up to 2 initials
+   */
+  function getInitials(name) {
+    if (!name) return '?';
+
+    // Remove @ prefix if present
+    name = name.replace(/^@/, '');
+
+    // Split by common separators
+    var parts = name.split(/[\s._-]+/);
+
+    if (parts.length >= 2) {
+      return (parts[0][0] + parts[1][0]).toUpperCase();
+    }
+
+    return name.substring(0, 2).toUpperCase();
+  }
+
+  /**
+   * Extract domain from URL for display
+   * @param {string} url
+   * @returns {string}
+   */
+  function getDomain(url) {
+    try {
+      var domain = new URL(url).hostname;
+      return domain.replace(/^www\./, '');
+    } catch (e) {
+      return url;
+    }
+  }
+
+  /**
+   * Look up mention data in blogroll cache
+   * @param {string} url - The mention URL
+   * @returns {object|null} - Blogroll entry data or null
+   */
+  function lookupBlogroll(url) {
+    if (!window.blogrollData || !Array.isArray(window.blogrollData)) {
+      return null;
+    }
+
+    var targetDomain = getDomain(url).toLowerCase();
+
+    for (var i = 0; i < window.blogrollData.length; i++) {
+      var entry = window.blogrollData[i];
+      if (entry.url) {
+        var entryDomain = getDomain(entry.url).toLowerCase();
+        if (entryDomain === targetDomain) {
+          return {
+            name: entry.name || entry.title,
+            handle: '@' + getDomain(entry.url),
+            bio: entry.description || '',
+            avatar: entry.avatar || entry.icon || null,
+            url: entry.url
+          };
+        }
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Fetch meta tags from a URL
+   * @param {string} url
+   * @returns {Promise<object>}
+   */
+  function fetchMetaTags(url) {
+    return new Promise(function(resolve, reject) {
+      // Use a CORS proxy or direct fetch
+      // Note: This may fail due to CORS restrictions on many sites
+      fetch(url, {
+        method: 'GET',
+        mode: 'cors',
+        credentials: 'omit'
+      })
+      .then(function(response) {
+        if (!response.ok) {
+          throw new Error('HTTP ' + response.status);
+        }
+        return response.text();
+      })
+      .then(function(html) {
+        var parser = new DOMParser();
+        var doc = parser.parseFromString(html, 'text/html');
+
+        var data = {
+          name: null,
+          bio: null,
+          avatar: null
+        };
+
+        // Try various meta tags for name/title
+        var titleMeta = doc.querySelector('meta[property="og:site_name"]') ||
+                       doc.querySelector('meta[property="og:title"]') ||
+                       doc.querySelector('meta[name="author"]') ||
+                       doc.querySelector('title');
+
+        if (titleMeta) {
+          data.name = titleMeta.content || titleMeta.textContent;
+        }
+
+        // Try various meta tags for description
+        var descMeta = doc.querySelector('meta[property="og:description"]') ||
+                      doc.querySelector('meta[name="description"]');
+
+        if (descMeta) {
+          data.bio = descMeta.content;
+        }
+
+        // Try various meta tags for image/avatar
+        var imageMeta = doc.querySelector('meta[property="og:image"]') ||
+                       doc.querySelector('link[rel="icon"]') ||
+                       doc.querySelector('link[rel="apple-touch-icon"]');
+
+        if (imageMeta) {
+          var imageUrl = imageMeta.content || imageMeta.href;
+          if (imageUrl) {
+            // Make relative URLs absolute
+            if (imageUrl.startsWith('/')) {
+              try {
+                var baseUrl = new URL(url);
+                imageUrl = baseUrl.origin + imageUrl;
+              } catch (e) {
+                // Keep as-is
+              }
+            }
+            data.avatar = imageUrl;
+          }
+        }
+
+        resolve(data);
+      })
+      .catch(function(err) {
+        reject(err);
+      });
+    });
+  }
+
+  /**
+   * Get mention data (from cache, blogroll, or fetch)
+   * @param {string} url - The mention URL
+   * @param {string} handle - The @handle text
+   * @returns {Promise<object>}
+   */
+  function getMentionData(url, handle) {
+    // Check cache first
+    var cacheKey = url;
+    var cached = cache[cacheKey];
+
+    if (cached && (Date.now() - cached.timestamp < CACHE_TTL)) {
+      return Promise.resolve(cached.data);
+    }
+
+    // Check blogroll
+    var blogrollData = lookupBlogroll(url);
+    if (blogrollData) {
+      cache[cacheKey] = {
+        data: blogrollData,
+        timestamp: Date.now()
+      };
+      return Promise.resolve(blogrollData);
+    }
+
+    // Fetch from URL
+    return fetchMetaTags(url)
+      .then(function(metaData) {
+        var data = {
+          name: metaData.name || getDomain(url),
+          handle: handle || '@' + getDomain(url),
+          bio: metaData.bio || '',
+          avatar: metaData.avatar || null,
+          url: url
+        };
+
+        cache[cacheKey] = {
+          data: data,
+          timestamp: Date.now()
+        };
+
+        return data;
+      })
+      .catch(function() {
+        // Return fallback data on error
+        var data = {
+          name: getDomain(url),
+          handle: handle || '@' + getDomain(url),
+          bio: '',
+          avatar: null,
+          url: url,
+          error: true
+        };
+
+        // Still cache even on error to prevent repeated failed requests
+        cache[cacheKey] = {
+          data: data,
+          timestamp: Date.now()
+        };
+
+        return data;
+      });
+  }
+
+  /**
+   * Create the hover card element
+   * @param {object} data - Mention data
+   * @returns {HTMLElement}
+   */
+  function createCard(data) {
+    var card = document.createElement('div');
+    card.className = 'mention-card';
+    card.setAttribute('role', 'tooltip');
+    card.setAttribute('aria-live', 'polite');
+
+    var avatarHtml;
+    if (data.avatar) {
+      avatarHtml = '<div class="mention-card-avatar">' +
+                   '<img src="' + escapeHtml(data.avatar) + '" alt="" ' +
+                   'onerror="this.parentNode.innerHTML=\'<span class=mention-card-initials>' +
+                   escapeHtml(getInitials(data.name || data.handle)) + '</span>\'">' +
+                   '</div>';
+    } else {
+      avatarHtml = '<div class="mention-card-avatar">' +
+                   '<span class="mention-card-initials">' +
+                   escapeHtml(getInitials(data.name || data.handle)) +
+                   '</span></div>';
+    }
+
+    var nameHtml = '<div class="mention-card-name">' + escapeHtml(data.name || data.handle) + '</div>';
+    var handleHtml = '<div class="mention-card-handle">' + escapeHtml(data.handle) + '</div>';
+
+    var bioHtml = '';
+    if (data.bio) {
+      bioHtml = '<div class="mention-card-bio">' + escapeHtml(data.bio) + '</div>';
+    }
+
+    var linkHtml = '<a href="' + escapeHtml(data.url) + '" class="mention-card-link" target="_blank" rel="noopener noreferrer">' +
+                   '<span aria-hidden="true">→</span> Visit site</a>';
+
+    card.innerHTML =
+      '<div class="mention-card-header">' + avatarHtml +
+      '<div class="mention-card-content">' + nameHtml + handleHtml + '</div></div>' +
+      bioHtml +
+      '<div class="mention-card-footer">' + linkHtml + '</div>';
+
+    return card;
+  }
+
+  /**
+   * Create a loading state card
+   * @returns {HTMLElement}
+   */
+  function createLoadingCard() {
+    var card = document.createElement('div');
+    card.className = 'mention-card mention-card-loading';
+    card.setAttribute('role', 'tooltip');
+    card.setAttribute('aria-live', 'polite');
+    card.innerHTML = '<div class="mention-card-loading-text">Loading...</div>';
+    return card;
+  }
+
+  /**
+   * Escape HTML to prevent XSS
+   * @param {string} str
+   * @returns {string}
+   */
+  function escapeHtml(str) {
+    if (!str) return '';
+    var div = document.createElement('div');
+    div.textContent = str;
+    return div.innerHTML;
+  }
+
+  /**
+   * Position the card relative to the target element
+   * @param {HTMLElement} card
+   * @param {HTMLElement} target
+   */
+  function positionCard(card, target) {
+    var rect = target.getBoundingClientRect();
+    var cardRect = card.getBoundingClientRect();
+    var viewportHeight = window.innerHeight;
+    var viewportWidth = window.innerWidth;
+    var scrollY = window.scrollY || window.pageYOffset;
+    var scrollX = window.scrollX || window.pageXOffset;
+
+    // Default: position below
+    var top = rect.bottom + scrollY + 8;
+    var left = rect.left + scrollX;
+
+    // Check if card would go below viewport
+    if (rect.bottom + cardRect.height + 16 > viewportHeight) {
+      // Position above instead
+      top = rect.top + scrollY - cardRect.height - 8;
+      card.classList.add('mention-card--above');
+      card.classList.remove('mention-card--below');
+    } else {
+      card.classList.add('mention-card--below');
+      card.classList.remove('mention-card--above');
+    }
+
+    // Check if card would go past right edge
+    if (left + cardRect.width > viewportWidth + scrollX - 16) {
+      left = viewportWidth + scrollX - cardRect.width - 16;
+    }
+
+    // Check if card would go past left edge
+    if (left < scrollX + 16) {
+      left = scrollX + 16;
+    }
+
+    card.style.top = top + 'px';
+    card.style.left = left + 'px';
+  }
+
+  /**
+   * Show the hover card for a mention link
+   * @param {HTMLElement} target - The mention link element
+   */
+  function showCard(target) {
+    // Don't show if another card is visible for a different target
+    if (currentCard && currentTarget !== target) {
+      hideCard();
+    }
+
+    currentTarget = target;
+
+    var url = target.href;
+    var handle = target.textContent.trim();
+
+    // Show loading state
+    var loadingCard = createLoadingCard();
+    document.body.appendChild(loadingCard);
+    currentCard = loadingCard;
+
+    // Position after adding to DOM so we can measure
+    requestAnimationFrame(function() {
+      if (currentCard === loadingCard) {
+        positionCard(loadingCard, target);
+        loadingCard.classList.add('mention-card--visible');
+      }
+    });
+
+    // Fetch data and update card
+    getMentionData(url, handle)
+      .then(function(data) {
+        // Check if we're still showing the card for this target
+        if (currentTarget !== target) return;
+
+        var newCard = createCard(data);
+        document.body.appendChild(newCard);
+
+        // Position and show
+        requestAnimationFrame(function() {
+          positionCard(newCard, target);
+          newCard.classList.add('mention-card--visible');
+
+          // Remove loading card
+          if (loadingCard.parentNode) {
+            loadingCard.remove();
+          }
+
+          currentCard = newCard;
+        });
+      })
+      .catch(function() {
+        // On error, just hide the loading card
+        if (loadingCard.parentNode) {
+          loadingCard.remove();
+        }
+        currentCard = null;
+      });
+  }
+
+  /**
+   * Hide the current hover card
+   */
+  function hideCard() {
+    if (currentCard) {
+      currentCard.classList.remove('mention-card--visible');
+
+      // Remove after transition
+      var cardToRemove = currentCard;
+      setTimeout(function() {
+        if (cardToRemove.parentNode) {
+          cardToRemove.remove();
+        }
+      }, 150);
+
+      currentCard = null;
+      currentTarget = null;
+    }
+  }
+
+  /**
+   * Clear all timers
+   */
+  function clearTimers() {
+    if (showTimer) {
+      clearTimeout(showTimer);
+      showTimer = null;
+    }
+    if (hideTimer) {
+      clearTimeout(hideTimer);
+      hideTimer = null;
+    }
+  }
+
+  /**
+   * Handle mouse enter on mention link
+   * @param {Event} e
+   */
+  function handleMouseEnter(e) {
+    var target = e.currentTarget;
+
+    clearTimers();
+
+    showTimer = setTimeout(function() {
+      showCard(target);
+    }, SHOW_DELAY);
+  }
+
+  /**
+   * Handle mouse leave on mention link
+   * @param {Event} e
+   */
+  function handleMouseLeave(e) {
+    clearTimers();
+
+    hideTimer = setTimeout(function() {
+      hideCard();
+    }, HIDE_DELAY);
+  }
+
+  /**
+   * Handle mouse enter on the card itself (to keep it visible)
+   * @param {Event} e
+   */
+  function handleCardMouseEnter(e) {
+    clearTimers();
+  }
+
+  /**
+   * Handle mouse leave on the card itself
+   * @param {Event} e
+   */
+  function handleCardMouseLeave(e) {
+    clearTimers();
+
+    hideTimer = setTimeout(function() {
+      hideCard();
+    }, HIDE_DELAY);
+  }
+
+  /**
+   * Handle focus on mention link (keyboard navigation)
+   * @param {Event} e
+   */
+  function handleFocus(e) {
+    var target = e.currentTarget;
+
+    clearTimers();
+
+    showTimer = setTimeout(function() {
+      showCard(target);
+    }, SHOW_DELAY);
+  }
+
+  /**
+   * Handle blur on mention link
+   * @param {Event} e
+   */
+  function handleBlur(e) {
+    clearTimers();
+
+    hideTimer = setTimeout(function() {
+      hideCard();
+    }, HIDE_DELAY);
+  }
+
+  /**
+   * Handle Escape key to dismiss card
+   * @param {KeyboardEvent} e
+   */
+  function handleKeyDown(e) {
+    if (e.key === 'Escape' && currentCard) {
+      clearTimers();
+      hideCard();
+    }
+  }
+
+  /**
+   * Setup event delegation for dynamically added cards
+   */
+  function setupCardEventDelegation() {
+    document.addEventListener('mouseenter', function(e) {
+      if (e.target.closest && e.target.closest('.mention-card')) {
+        handleCardMouseEnter(e);
+      }
+    }, true);
+
+    document.addEventListener('mouseleave', function(e) {
+      if (e.target.closest && e.target.closest('.mention-card')) {
+        handleCardMouseLeave(e);
+      }
+    }, true);
+  }
+
+  /**
+   * Initialize mention cards
+   */
+  function init() {
+    // Skip on touch devices
+    if (isTouchDevice()) {
+      return;
+    }
+
+    // Find all mention links
+    var mentions = document.querySelectorAll('a.mention');
+
+    mentions.forEach(function(mention) {
+      mention.addEventListener('mouseenter', handleMouseEnter);
+      mention.addEventListener('mouseleave', handleMouseLeave);
+      mention.addEventListener('focus', handleFocus);
+      mention.addEventListener('blur', handleBlur);
+    });
+
+    // Global keyboard handler for Escape
+    document.addEventListener('keydown', handleKeyDown);
+
+    // Setup card event delegation
+    setupCardEventDelegation();
+  }
+
+  // Initialize when DOM is ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+
+  // Expose for external use if needed
+  window.mentionCards = {
+    show: showCard,
+    hide: hideCard,
+    clearCache: function() { cache = {}; }
+  };
+})();

--- a/pkg/themes/default/static/js/pagination.js
+++ b/pkg/themes/default/static/js/pagination.js
@@ -1,0 +1,156 @@
+/**
+ * Client-side pagination for markata-go
+ * Supports pagination_type: "js"
+ */
+(function() {
+  'use strict';
+
+  // Initialize pagination when DOM is ready
+  document.addEventListener('DOMContentLoaded', initPagination);
+
+  function initPagination() {
+    const paginationNav = document.querySelector('.pagination-js');
+    if (!paginationNav) return;
+
+    const feedSlug = paginationNav.dataset.feedSlug || '';
+    const itemsPerPage = parseInt(paginationNav.dataset.itemsPerPage, 10) || 10;
+    const totalPages = parseInt(paginationNav.dataset.totalPages, 10) || 1;
+
+    // Get current page from URL hash or default to 1
+    let currentPage = getPageFromHash() || 1;
+
+    const postsList = document.querySelector('.posts-list');
+    const allPosts = postsList ? Array.from(postsList.querySelectorAll('.card')) : [];
+
+    if (allPosts.length === 0) return;
+
+    // Store all posts and create pagination state
+    const state = {
+      feedSlug,
+      itemsPerPage,
+      totalPages: Math.ceil(allPosts.length / itemsPerPage),
+      currentPage,
+      allPosts,
+      postsList
+    };
+
+    // Initial render
+    renderPage(state);
+    renderPaginationControls(paginationNav, state);
+    setupEventListeners(paginationNav, state);
+
+    // Handle browser back/forward
+    window.addEventListener('hashchange', function() {
+      state.currentPage = getPageFromHash() || 1;
+      renderPage(state);
+      renderPaginationControls(paginationNav, state);
+    });
+  }
+
+  function getPageFromHash() {
+    const hash = window.location.hash;
+    const match = hash.match(/page=(\d+)/);
+    return match ? parseInt(match[1], 10) : null;
+  }
+
+  function setPageHash(page) {
+    if (page === 1) {
+      history.pushState(null, '', window.location.pathname);
+    } else {
+      history.pushState(null, '', '#page=' + page);
+    }
+  }
+
+  function renderPage(state) {
+    const { allPosts, postsList, currentPage, itemsPerPage } = state;
+
+    const startIndex = (currentPage - 1) * itemsPerPage;
+    const endIndex = startIndex + itemsPerPage;
+
+    // Hide all posts
+    allPosts.forEach(function(post) {
+      post.style.display = 'none';
+    });
+
+    // Show posts for current page
+    for (let i = startIndex; i < endIndex && i < allPosts.length; i++) {
+      allPosts[i].style.display = '';
+    }
+
+    // Scroll to top of posts list
+    if (postsList) {
+      postsList.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  }
+
+  function renderPaginationControls(nav, state) {
+    const { currentPage, totalPages } = state;
+
+    const prevBtn = nav.querySelector('[data-action="prev"]');
+    const nextBtn = nav.querySelector('[data-action="next"]');
+    const pagesContainer = nav.querySelector('.pagination-pages');
+
+    // Update prev/next buttons
+    if (prevBtn) {
+      prevBtn.disabled = currentPage <= 1;
+      prevBtn.classList.toggle('disabled', currentPage <= 1);
+    }
+
+    if (nextBtn) {
+      nextBtn.disabled = currentPage >= totalPages;
+      nextBtn.classList.toggle('disabled', currentPage >= totalPages);
+    }
+
+    // Render page numbers
+    if (pagesContainer) {
+      pagesContainer.innerHTML = '';
+
+      for (let i = 1; i <= totalPages; i++) {
+        const pageEl = document.createElement(i === currentPage ? 'span' : 'button');
+        pageEl.className = 'pagination-page' + (i === currentPage ? ' current' : '');
+        pageEl.textContent = i;
+
+        if (i === currentPage) {
+          pageEl.setAttribute('aria-current', 'page');
+        } else {
+          pageEl.dataset.page = i;
+          pageEl.addEventListener('click', function() {
+            state.currentPage = i;
+            setPageHash(i);
+            renderPage(state);
+            renderPaginationControls(nav, state);
+          });
+        }
+
+        pagesContainer.appendChild(pageEl);
+      }
+    }
+  }
+
+  function setupEventListeners(nav, state) {
+    const prevBtn = nav.querySelector('[data-action="prev"]');
+    const nextBtn = nav.querySelector('[data-action="next"]');
+
+    if (prevBtn) {
+      prevBtn.addEventListener('click', function() {
+        if (state.currentPage > 1) {
+          state.currentPage--;
+          setPageHash(state.currentPage);
+          renderPage(state);
+          renderPaginationControls(nav, state);
+        }
+      });
+    }
+
+    if (nextBtn) {
+      nextBtn.addEventListener('click', function() {
+        if (state.currentPage < state.totalPages) {
+          state.currentPage++;
+          setPageHash(state.currentPage);
+          renderPage(state);
+          renderPaginationControls(nav, state);
+        }
+      });
+    }
+  }
+})();

--- a/pkg/themes/default/static/js/shortcuts.js
+++ b/pkg/themes/default/static/js/shortcuts.js
@@ -1,0 +1,305 @@
+/**
+ * Keyboard Shortcuts System for markata-go
+ *
+ * Provides keyboard navigation shortcuts for the generated site:
+ * - `/` or `Cmd/Ctrl+K` - Focus search input
+ * - `Escape` - Close search/modals
+ * - `?` - Show shortcuts help modal
+ *
+ * Accessibility: Shortcuts can be disabled via localStorage
+ * WCAG 2.1.4 compliant - shortcuts are ignored when typing in inputs
+ */
+
+(function() {
+  'use strict';
+
+  // Storage key for disabled state
+  var STORAGE_KEY = 'markata-shortcuts-disabled';
+
+  /**
+   * Check if shortcuts are disabled via localStorage
+   * @returns {boolean}
+   */
+  function areShortcutsDisabled() {
+    try {
+      return localStorage.getItem(STORAGE_KEY) === 'true';
+    } catch (e) {
+      // localStorage may be unavailable (e.g., private browsing)
+      return false;
+    }
+  }
+
+  /**
+   * Toggle shortcuts enabled/disabled state
+   * @returns {boolean} New state (true = disabled)
+   */
+  function toggleShortcuts() {
+    try {
+      var currentlyDisabled = areShortcutsDisabled();
+      localStorage.setItem(STORAGE_KEY, (!currentlyDisabled).toString());
+      updateToggleButton();
+      return !currentlyDisabled;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  /**
+   * Update the toggle button state in the modal
+   */
+  function updateToggleButton() {
+    var toggleBtn = document.getElementById('shortcuts-toggle');
+    if (toggleBtn) {
+      var disabled = areShortcutsDisabled();
+      toggleBtn.textContent = disabled ? 'Enable Shortcuts' : 'Disable Shortcuts';
+      toggleBtn.setAttribute('aria-pressed', (!disabled).toString());
+    }
+  }
+
+  /**
+   * Detect if the user is on a Mac platform
+   * @returns {boolean}
+   */
+  function isMacPlatform() {
+    // Check userAgentData first (modern browsers)
+    if (navigator.userAgentData && navigator.userAgentData.platform) {
+      return navigator.userAgentData.platform.toUpperCase().indexOf('MAC') >= 0;
+    }
+    // Fallback to navigator.platform
+    return navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+  }
+
+  /**
+   * Update the modifier key display in the modal based on platform
+   */
+  function updateModifierKeyDisplay() {
+    var isMac = isMacPlatform();
+    var macKeys = document.querySelectorAll('.kbd-mac');
+    var winKeys = document.querySelectorAll('.kbd-win');
+
+    macKeys.forEach(function(el) {
+      el.style.display = isMac ? 'inline-block' : 'none';
+    });
+
+    winKeys.forEach(function(el) {
+      el.style.display = isMac ? 'none' : 'inline-block';
+    });
+  }
+
+  /**
+   * Focus the search input (Pagefind)
+   */
+  function focusSearch() {
+    // Try Pagefind's input first
+    var pagefindInput = document.querySelector('.pagefind-ui__search-input');
+    if (pagefindInput) {
+      pagefindInput.focus();
+      return true;
+    }
+
+    // Fallback to any search input
+    var searchInput = document.querySelector('#pagefind-search input, #search input, [type="search"]');
+    if (searchInput) {
+      searchInput.focus();
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Show the shortcuts help modal
+   */
+  function showShortcutsModal() {
+    var modal = document.getElementById('shortcuts-modal');
+    if (modal) {
+      modal.classList.add('shortcuts-modal--open');
+      modal.setAttribute('aria-hidden', 'false');
+      // Focus the close button for accessibility
+      var closeBtn = modal.querySelector('.shortcuts-modal-close');
+      if (closeBtn) {
+        closeBtn.focus();
+      }
+      // Prevent body scrolling while modal is open
+      document.body.style.overflow = 'hidden';
+    }
+  }
+
+  /**
+   * Hide the shortcuts help modal
+   */
+  function hideShortcutsModal() {
+    var modal = document.getElementById('shortcuts-modal');
+    if (modal && modal.classList.contains('shortcuts-modal--open')) {
+      modal.classList.remove('shortcuts-modal--open');
+      modal.setAttribute('aria-hidden', 'true');
+      document.body.style.overflow = '';
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Close all open modals and clear search focus
+   */
+  function closeModals() {
+    var closed = false;
+
+    // Close shortcuts modal
+    if (hideShortcutsModal()) {
+      closed = true;
+    }
+
+    // Blur search input if focused
+    var activeElement = document.activeElement;
+    if (activeElement && (activeElement.tagName === 'INPUT' || activeElement.tagName === 'TEXTAREA')) {
+      activeElement.blur();
+      closed = true;
+    }
+
+    // Clear Pagefind results if present
+    var pagefindResults = document.querySelector('.pagefind-ui__results-area');
+    if (pagefindResults && pagefindResults.children.length > 0) {
+      var pagefindInput = document.querySelector('.pagefind-ui__search-input');
+      if (pagefindInput) {
+        pagefindInput.value = '';
+        pagefindInput.dispatchEvent(new Event('input', { bubbles: true }));
+        closed = true;
+      }
+    }
+
+    return closed;
+  }
+
+  /**
+   * Check if the current element is an input field where typing should be allowed
+   * @param {Element} element
+   * @returns {boolean}
+   */
+  function isInputElement(element) {
+    if (!element) return false;
+
+    var tagName = element.tagName;
+    if (tagName === 'INPUT' || tagName === 'TEXTAREA' || tagName === 'SELECT') {
+      return true;
+    }
+
+    // Check for contenteditable
+    if (element.isContentEditable) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Main keyboard event handler
+   * @param {KeyboardEvent} e
+   */
+  function handleKeyDown(e) {
+    var target = e.target;
+
+    // Always allow Escape to work, even in inputs
+    if (e.key === 'Escape') {
+      if (closeModals()) {
+        e.preventDefault();
+      }
+      return;
+    }
+
+    // Skip other shortcuts when typing in input fields
+    if (isInputElement(target)) {
+      return;
+    }
+
+    // Check if shortcuts are disabled (except for Escape which always works)
+    if (areShortcutsDisabled()) {
+      return;
+    }
+
+    // Detect platform for modifier key
+    var modifier = isMacPlatform() ? e.metaKey : e.ctrlKey;
+
+    // Cmd/Ctrl+K - Focus search
+    if (modifier && e.key === 'k') {
+      e.preventDefault();
+      focusSearch();
+      return;
+    }
+
+    // Don't process other shortcuts if modifier keys are held (except the ones we handle)
+    if (e.ctrlKey || e.metaKey || e.altKey) {
+      return;
+    }
+
+    // Handle single-key shortcuts
+    switch (e.key) {
+      case '/':
+        e.preventDefault();
+        focusSearch();
+        break;
+
+      case '?':
+        e.preventDefault();
+        showShortcutsModal();
+        break;
+    }
+  }
+
+  /**
+   * Handle click outside modal to close it
+   * @param {MouseEvent} e
+   */
+  function handleModalBackdropClick(e) {
+    var modal = document.getElementById('shortcuts-modal');
+    if (modal && e.target === modal) {
+      hideShortcutsModal();
+    }
+  }
+
+  /**
+   * Initialize the keyboard shortcuts system
+   */
+  function init() {
+    // Update modifier key display for the current platform
+    updateModifierKeyDisplay();
+
+    // Add keyboard event listener
+    document.addEventListener('keydown', handleKeyDown);
+
+    // Setup modal close button
+    var closeBtn = document.querySelector('.shortcuts-modal-close');
+    if (closeBtn) {
+      closeBtn.addEventListener('click', hideShortcutsModal);
+    }
+
+    // Setup toggle button
+    var toggleBtn = document.getElementById('shortcuts-toggle');
+    if (toggleBtn) {
+      toggleBtn.addEventListener('click', toggleShortcuts);
+      updateToggleButton();
+    }
+
+    // Close modal on backdrop click
+    var modal = document.getElementById('shortcuts-modal');
+    if (modal) {
+      modal.addEventListener('click', handleModalBackdropClick);
+    }
+  }
+
+  // Initialize when DOM is ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+
+  // Expose functions for external use if needed
+  window.markataShortcuts = {
+    focusSearch: focusSearch,
+    showShortcutsModal: showShortcutsModal,
+    hideShortcutsModal: hideShortcutsModal,
+    toggleShortcuts: toggleShortcuts,
+    areShortcutsDisabled: areShortcutsDisabled
+  };
+})();

--- a/pkg/themes/default/static/js/tooltips.js
+++ b/pkg/themes/default/static/js/tooltips.js
@@ -1,21 +1,25 @@
-document.addEventListener('DOMContentLoaded', () => {
-  const links = document.querySelectorAll('.wikilink[data-title]');
+/**
+ * Wikilink Hover Tooltips
+ * Shows a tooltip with title, description, and date when hovering over wikilinks.
+ */
+(function() {
+  'use strict';
+
   let tooltip = null;
 
   function createTooltip(link) {
     tooltip = document.createElement('div');
     tooltip.className = 'wikilink-tooltip';
-    tooltip.innerHTML = `
-      <div class="tooltip-title">${link.dataset.title}</div>
-      ${link.dataset.description ? `<div class="tooltip-desc">${link.dataset.description}</div>` : ''}
-      ${link.dataset.date ? `<div class="tooltip-date">${link.dataset.date}</div>` : ''}
-    `;
+    tooltip.innerHTML =
+      '<div class="tooltip-title">' + (link.dataset.title || '') + '</div>' +
+      (link.dataset.description ? '<div class="tooltip-desc">' + link.dataset.description + '</div>' : '') +
+      (link.dataset.date ? '<div class="tooltip-date">' + link.dataset.date + '</div>' : '');
     document.body.appendChild(tooltip);
     positionTooltip(link);
   }
 
   function positionTooltip(link) {
-    const rect = link.getBoundingClientRect();
+    var rect = link.getBoundingClientRect();
     tooltip.style.left = rect.left + 'px';
     tooltip.style.top = (rect.bottom + 8) + 'px';
   }
@@ -27,8 +31,18 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  links.forEach(link => {
-    link.addEventListener('mouseenter', () => createTooltip(link));
-    link.addEventListener('mouseleave', removeTooltip);
-  });
-});
+  function init() {
+    var links = document.querySelectorAll('.wikilink[data-title]');
+    links.forEach(function(link) {
+      link.addEventListener('mouseenter', function() { createTooltip(link); });
+      link.addEventListener('mouseleave', removeTooltip);
+    });
+  }
+
+  // Initialize immediately if DOM is ready, otherwise wait
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/pkg/themes/default/templates/base.html
+++ b/pkg/themes/default/templates/base.html
@@ -18,14 +18,19 @@
   <link rel="stylesheet" href="{{ 'css/code.css' | theme_asset }}">
   <link rel="stylesheet" href="/css/chroma.css">
 
-  <!-- GLightbox CSS for image zoom -->
-  {% if config.Extra.glightbox_enabled %}
-  {% if config.Extra.glightbox_cdn %}
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/glightbox@3.3.0/dist/css/glightbox.min.css">
-  {% else %}
-  <link rel="stylesheet" href="/css/glightbox.min.css">
-  {% endif %}
-  {% endif %}
+  <!-- Conditional CSS Loading -->
+  <script>
+    // GLightbox CSS - only load if glightbox elements will exist
+    {% if config.Extra.glightbox_enabled %}
+    // Check synchronously during page load
+    if (document.documentElement.innerHTML.includes('glightbox')) {
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = '{% if config.Extra.glightbox_cdn %}https://cdn.jsdelivr.net/npm/glightbox@3.3.0/dist/css/glightbox.min.css{% else %}/css/glightbox.min.css{% endif %}';
+      document.head.appendChild(link);
+    }
+    {% endif %}
+  </script>
 
   <!-- CSS variable overrides from theme config -->
   {% if config.theme.variables %}
@@ -131,27 +136,60 @@
   {% block htmx %}{% endblock %}
   {% block scripts %}{% endblock %}
 
-  <!-- GLightbox JS for image zoom -->
-  {% if config.Extra.glightbox_enabled %}
-  {% if config.Extra.glightbox_cdn %}
-  <script src="https://cdn.jsdelivr.net/npm/glightbox@3.3.0/dist/js/glightbox.min.js"></script>
-  {% else %}
-  <script src="/js/glightbox.min.js"></script>
-  {% endif %}
+  <!-- Conditional Script Loading: Only load when needed -->
   <script>
-    document.addEventListener('DOMContentLoaded', function() {
-      const lightbox = GLightbox({
-        selector: '{{ config.Extra.glightbox_options.selector | default:".glightbox" }}',
-        openEffect: '{{ config.Extra.glightbox_options.openEffect | default:"zoom" }}',
-        closeEffect: '{{ config.Extra.glightbox_options.closeEffect | default:"zoom" }}',
-        slideEffect: '{{ config.Extra.glightbox_options.slideEffect | default:"slide" }}',
-        touchNavigation: {{ config.Extra.glightbox_options.touchNavigation | default:true | yesno:"true,false" }},
-        loop: {{ config.Extra.glightbox_options.loop | default:false | yesno:"true,false" }},
-        draggable: {{ config.Extra.glightbox_options.draggable | default:true | yesno:"true,false" }}
-      });
-    });
+    // Wikilink Hover Tooltips - only load if wikilinks with data-title exist
+    if (document.querySelector('.wikilink[data-title]')) {
+      const script = document.createElement('script');
+      script.src = '{{ 'js/tooltips.js' | theme_asset }}';
+      script.defer = true;
+      document.body.appendChild(script);
+    }
+
+    // Mention Cards - only load if mention links exist
+    if (document.querySelector('a.mention')) {
+      const mentionScript = document.createElement('script');
+      mentionScript.src = '{{ 'js/mention-cards.js' | theme_asset }}';
+      mentionScript.defer = true;
+      document.body.appendChild(mentionScript);
+    }
+
+    // Keyboard Shortcuts - only load if search or shortcuts modal exist
+    if (document.querySelector('#pagefind-search, #shortcuts-modal, [type="search"]')) {
+      const shortcutsScript = document.createElement('script');
+      shortcutsScript.src = '{{ 'js/shortcuts.js' | theme_asset }}';
+      shortcutsScript.defer = true;
+      document.body.appendChild(shortcutsScript);
+    }
+
+    // Pagination (JS mode) - only load if JS pagination element exists
+    if (document.querySelector('.pagination-js')) {
+      const paginationScript = document.createElement('script');
+      paginationScript.src = '{{ 'js/pagination.js' | theme_asset }}';
+      paginationScript.defer = true;
+      document.body.appendChild(paginationScript);
+    }
+
+    // GLightbox - only load if glightbox elements exist
+    {% if config.Extra.glightbox_enabled %}
+    if (document.querySelector('.glightbox')) {
+      const glightboxScript = document.createElement('script');
+      glightboxScript.src = '{% if config.Extra.glightbox_cdn %}https://cdn.jsdelivr.net/npm/glightbox@3.3.0/dist/js/glightbox.min.js{% else %}/js/glightbox.min.js{% endif %}';
+      glightboxScript.onload = function() {
+        const lightbox = GLightbox({
+          selector: '{{ config.Extra.glightbox_options.selector | default:".glightbox" }}',
+          openEffect: '{{ config.Extra.glightbox_options.openEffect | default:"zoom" }}',
+          closeEffect: '{{ config.Extra.glightbox_options.closeEffect | default:"zoom" }}',
+          slideEffect: '{{ config.Extra.glightbox_options.slideEffect | default:"slide" }}',
+          touchNavigation: {{ config.Extra.glightbox_options.touchNavigation | default:true | yesno:"true,false" }},
+          loop: {{ config.Extra.glightbox_options.loop | default:false | yesno:"true,false" }},
+          draggable: {{ config.Extra.glightbox_options.draggable | default:true | yesno:"true,false" }}
+        });
+      };
+      document.body.appendChild(glightboxScript);
+    }
+    {% endif %}
   </script>
-  {% endif %}
 
   {% include "partials/background-scripts.html" %}
 </body>


### PR DESCRIPTION
## Summary

- Add conditional script loading to only load JS when elements requiring them exist on the page
- Sync missing JS files from development theme to embedded theme
- Fix tooltips.js timing issue for dynamic script loading

## Changes

### Conditional Script Loading (`base.html`)
Scripts are now loaded on-demand based on DOM queries:
- `tooltips.js` - loads when `.wikilink[data-title]` exists
- `mention-cards.js` - loads when `a.mention` exists  
- `shortcuts.js` - loads when `#pagefind-search`, `#shortcuts-modal`, or `[type="search"]` exists
- `pagination.js` - loads when `.pagination-js` exists
- GLightbox - loads when `.glightbox` exists (still config-gated)

### Missing Assets Added to `pkg/themes/default/`
- `static/js/shortcuts.js` - keyboard navigation (/, Cmd+K, ?, Escape)
- `static/js/pagination.js` - client-side JS pagination
- `static/js/mention-cards.js` - hover cards for @mentions
- `static/css/components.css` - added mention-card CSS styles

### Bug Fix
- Fixed `tooltips.js` to check `document.readyState` instead of relying solely on `DOMContentLoaded`, which doesn't fire for dynamically loaded scripts

## Testing

Tested on waylonwalker.com-markata-go-migration:
- Wikilink hover tooltips now work on `/mentions/`
- Mention cards work when hovering `@simonwillison`
- Scripts only load on pages that need them