### PR TITLE
fix(plugins): exclude private posts from feeds and sitemap

### DIFF
--- a/pkg/plugins/feeds.go
+++ b/pkg/plugins/feeds.go
@@ -137,12 +137,18 @@ func getFeedDefaults(config *lifecycle.Config) models.FeedDefaults {
 }
 
 // filterPosts applies a filter expression to posts.
+// Private posts are automatically excluded before any filter is applied.
 func filterPosts(posts []*models.Post, filterExpr string) ([]*models.Post, error) {
+	// First filter out private posts automatically
+	var publicPosts []*models.Post
+	for _, post := range posts {
+		if !post.Private {
+			publicPosts = append(publicPosts, post)
+		}
+	}
+
 	if filterExpr == "" {
-		// Return a copy of all posts
-		result := make([]*models.Post, len(posts))
-		copy(result, posts)
-		return result, nil
+		return publicPosts, nil
 	}
 
 	f, err := filter.Parse(filterExpr)
@@ -150,7 +156,7 @@ func filterPosts(posts []*models.Post, filterExpr string) ([]*models.Post, error
 		return nil, fmt.Errorf("invalid filter expression: %w", err)
 	}
 
-	return f.MatchAll(posts), nil
+	return f.MatchAll(publicPosts), nil
 }
 
 // sortPosts sorts posts by the specified field.

--- a/pkg/plugins/sitemap.go
+++ b/pkg/plugins/sitemap.go
@@ -105,7 +105,7 @@ func (p *SitemapPlugin) buildSitemap(m *lifecycle.Manager, siteURL string) *URLS
 
 	// Add all published posts
 	for _, post := range posts {
-		if !post.Published || post.Draft || post.Skip {
+		if !post.Published || post.Draft || post.Skip || post.Private {
 			continue
 		}
 

--- a/pkg/plugins/sitemap_test.go
+++ b/pkg/plugins/sitemap_test.go
@@ -1,0 +1,156 @@
+package plugins
+
+import (
+	"testing"
+	"time"
+
+	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
+	"github.com/WaylonWalker/markata-go/pkg/models"
+)
+
+func TestSitemapPlugin_Name(t *testing.T) {
+	plugin := NewSitemapPlugin()
+	if plugin.Name() != "sitemap" {
+		t.Errorf("Name() = %q, want %q", plugin.Name(), "sitemap")
+	}
+}
+
+func TestSitemapPlugin_Priority(t *testing.T) {
+	plugin := NewSitemapPlugin()
+
+	if got := plugin.Priority(lifecycle.StageWrite); got != lifecycle.PriorityLate {
+		t.Errorf("Priority(StageWrite) = %d, want %d", got, lifecycle.PriorityLate)
+	}
+
+	if got := plugin.Priority(lifecycle.StageRender); got != lifecycle.PriorityDefault {
+		t.Errorf("Priority(StageRender) = %d, want %d", got, lifecycle.PriorityDefault)
+	}
+}
+
+func TestSitemapPlugin_ExcludesPrivatePosts(t *testing.T) {
+	plugin := NewSitemapPlugin()
+	m := lifecycle.NewManager()
+
+	date := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	m.SetPosts([]*models.Post{
+		{
+			Slug:      "public-post",
+			Href:      "/public-post/",
+			Published: true,
+			Draft:     false,
+			Skip:      false,
+			Private:   false,
+			Date:      &date,
+		},
+		{
+			Slug:      "private-post",
+			Href:      "/private-post/",
+			Published: true,
+			Draft:     false,
+			Skip:      false,
+			Private:   true,
+			Date:      &date,
+		},
+		{
+			Slug:      "another-public",
+			Href:      "/another-public/",
+			Published: true,
+			Draft:     false,
+			Skip:      false,
+			Private:   false,
+			Date:      &date,
+		},
+	})
+
+	siteURL := "https://example.com"
+	sitemap := plugin.buildSitemap(m, siteURL)
+
+	// Count post URLs (excluding home page)
+	postURLCount := 0
+	for _, url := range sitemap.URLs {
+		if url.Loc == siteURL+"/" {
+			continue // Skip home page
+		}
+		postURLCount++
+		// Verify private post URL is not present
+		if url.Loc == siteURL+"/private-post/" {
+			t.Error("private post should not appear in sitemap")
+		}
+	}
+
+	// Should have 2 public posts (no feeds configured)
+	if postURLCount != 2 {
+		t.Errorf("expected 2 post URLs in sitemap, got %d", postURLCount)
+	}
+}
+
+func TestSitemapPlugin_ExcludesDraftAndSkipPosts(t *testing.T) {
+	plugin := NewSitemapPlugin()
+	m := lifecycle.NewManager()
+
+	date := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	m.SetPosts([]*models.Post{
+		{
+			Slug:      "published",
+			Href:      "/published/",
+			Published: true,
+			Draft:     false,
+			Skip:      false,
+			Private:   false,
+			Date:      &date,
+		},
+		{
+			Slug:      "draft",
+			Href:      "/draft/",
+			Published: true,
+			Draft:     true,
+			Skip:      false,
+			Private:   false,
+			Date:      &date,
+		},
+		{
+			Slug:      "skipped",
+			Href:      "/skipped/",
+			Published: true,
+			Draft:     false,
+			Skip:      true,
+			Private:   false,
+			Date:      &date,
+		},
+		{
+			Slug:      "unpublished",
+			Href:      "/unpublished/",
+			Published: false,
+			Draft:     false,
+			Skip:      false,
+			Private:   false,
+			Date:      &date,
+		},
+	})
+
+	siteURL := "https://example.com"
+	sitemap := plugin.buildSitemap(m, siteURL)
+
+	// Count post URLs (excluding home page)
+	postURLCount := 0
+	for _, url := range sitemap.URLs {
+		if url.Loc == siteURL+"/" {
+			continue
+		}
+		postURLCount++
+	}
+
+	// Should only have 1 published, non-draft, non-skip, non-private post
+	if postURLCount != 1 {
+		t.Errorf("expected 1 post URL in sitemap, got %d", postURLCount)
+	}
+}
+
+// Ensure SitemapPlugin implements the required interfaces.
+func TestSitemapPlugin_ImplementsInterfaces(_ *testing.T) {
+	var _ lifecycle.Plugin = (*SitemapPlugin)(nil)
+	var _ lifecycle.WritePlugin = (*SitemapPlugin)(nil)
+	var _ lifecycle.PriorityPlugin = (*SitemapPlugin)(nil)
+}


### PR DESCRIPTION
## Summary
- Ensures private posts are excluded from HTML archives and sitemap

Fixes #451

## Changes
- `filterPosts()` now automatically excludes private posts from HTML archives
- `sitemap.go` now checks `post.Private` before including in sitemap
- Added tests for private post exclusion

## Testing
All tests pass including new test cases.