### PR TITLE
feat(feeds): add include_private option for feeds

### DIFF
--- a/docs/guides/feeds.md
+++ b/docs/guides/feeds.md
@@ -83,6 +83,7 @@ description = "Latest blog posts"  # Meta description
 filter = "published == True and date <= today"
 sort = "date"
 reverse = true                     # Newest first
+include_private = false            # Include private posts (default: false)
 
 # Pagination
 items_per_page = 10                # 0 = no pagination (all on one page)
@@ -710,6 +711,24 @@ html = true
 rss = false
 ```
 
+### Private Archive (Including Private Posts)
+
+If you want a feed that includes private posts (useful for personal archives or admin pages):
+
+```toml
+[[markata-go.feeds]]
+slug = "private-archive"
+title = "Private Archive"
+filter = "published == True"
+sort = "date"
+reverse = true
+include_private = true             # Include private posts in this feed
+
+[markata-go.feeds.formats]
+html = true
+rss = false                        # Usually don't syndicate private posts
+```
+
 ### Tag Pages (Manual)
 
 If you don't want auto-generated tag feeds:
@@ -973,6 +992,7 @@ Add `<link>` tags in your base template for feed autodiscovery:
 | `filter` | string | `""` | Filter expression |
 | `sort` | string | `"date"` | Sort field |
 | `reverse` | bool | `true` | Sort direction (true=descending) |
+| `include_private` | bool | `false` | Include private posts in feed |
 | `items_per_page` | int | `10` | Posts per page (0=no pagination) |
 | `orphan_threshold` | int | `3` | Min items for separate page |
 | `pagination_type` | string | `"manual"` | `manual`, `htmx`, or `js` |

--- a/pkg/models/feed.go
+++ b/pkg/models/feed.go
@@ -78,6 +78,9 @@ type FeedConfig struct {
 	// SidebarGroupBy groups posts by a frontmatter field in the sidebar (e.g., "category")
 	SidebarGroupBy string `json:"sidebar_group_by" yaml:"sidebar_group_by" toml:"sidebar_group_by"`
 
+	// IncludePrivate allows including private posts in this feed (default: false)
+	IncludePrivate bool `json:"include_private,omitempty" yaml:"include_private,omitempty" toml:"include_private,omitempty"`
+
 	// Posts holds the filtered posts at runtime (not serialized)
 	Posts []*Post `json:"-" yaml:"-" toml:"-"`
 

--- a/pkg/plugins/auto_feeds.go
+++ b/pkg/plugins/auto_feeds.go
@@ -284,7 +284,7 @@ func (p *AutoFeedsPlugin) Collect(m *lifecycle.Manager) error {
 		fc.ApplyDefaults(feedDefaults)
 
 		// Filter posts for this feed
-		filteredPosts, err := filterPosts(posts, fc.Filter)
+		filteredPosts, err := filterPosts(posts, fc.Filter, fc.IncludePrivate)
 		if err != nil {
 			return fmt.Errorf("auto feed %q: %w", fc.Slug, err)
 		}

--- a/spec/spec/FEEDS.md
+++ b/spec/spec/FEEDS.md
@@ -57,6 +57,7 @@ description = "Latest blog posts"  # Meta description
 filter = "published == True and date <= today"
 sort = "date"
 reverse = true                     # Newest first
+include_private = false            # Include private posts (default: false)
 
 # Pagination
 items_per_page = 10                # 0 = no pagination (all on one page)
@@ -97,6 +98,7 @@ sitemap = "sitemap.xml"            # Template for sitemap
 | `filter` | string | Filter expression |
 | `sort` | string? | Sort field |
 | `reverse` | bool | Sort direction |
+| `include_private` | bool | Include private posts in feed (default: false) |
 | `posts` | List[Post] | All matching posts (pre-pagination) |
 | `page_posts` | List[Post] | Posts for current page |
 | `pagination` | Pagination | Pagination info |


### PR DESCRIPTION
## Summary
- Adds include_private flag to feed configuration

Fixes #452

## Changes
- Add `include_private` field to FeedConfig (defaults to false)
- Private posts are excluded by default from feeds
- Setting `include_private = true` allows including private posts in specific feeds
- Updated spec and docs

## Usage
```toml
[[markata-go.feeds]]
slug = "private-archive"
filter = "published == True"
include_private = true  # Include private posts in this feed
```

## Testing
All tests pass including new test cases.