### PR TITLE
fix: standardize footer across all page types

### DIFF
--- a/pkg/themes/default/templates/components/footer.html
+++ b/pkg/themes/default/templates/components/footer.html
@@ -1,10 +1,12 @@
 {# Footer component template #}
 {# Usage: {% include "components/footer.html" %} #}
+{# Optional: footer_style - "full", "minimal", or "none" (defaults to config or "full") #}
 {# Requires: config.components.footer (FooterComponentConfig) #}
 
 {% with footer = config.components.footer %}
+{% with style = footer_style|default:config.footer_style|default:"full" %}
 {% if footer.enabled %}
-<footer class="site-footer">
+<footer class="site-footer site-footer--{{ style }}" role="contentinfo">
     <div class="container">
         {% if footer.text %}
         <p class="footer-text">{{ footer.text }}</p>
@@ -27,4 +29,5 @@
     </div>
 </footer>
 {% endif %}
+{% endwith %}
 {% endwith %}

--- a/pkg/themes/default/templates/partials/footer.html
+++ b/pkg/themes/default/templates/partials/footer.html
@@ -1,5 +1,9 @@
-<footer class="site-footer">
+{# Simple footer partial - for use when components/footer.html is not needed #}
+{# Prefer using components/footer.html for full footer functionality #}
+{% with style = footer_style|default:config.footer_style|default:"full" %}
+<footer class="site-footer site-footer--{{ style }}" role="contentinfo">
   <div class="container">
     <p>&copy; {{ "now" | date:"2006" }} {{ config.author | default:config.title | default:'My Site' }}. All rights reserved.</p>
   </div>
 </footer>
+{% endwith %}

--- a/templates/layouts/blog.html
+++ b/templates/layouts/blog.html
@@ -105,8 +105,8 @@
 
 {% block footer %}
 {% if config.layout.blog.footer_style != 'none' %}
-<footer class="site-footer site-footer--{{ config.layout.blog.footer_style | default:'full' }}" role="contentinfo">
-    {% include "components/footer.html" %}
-</footer>
+{% with footer_style=config.layout.blog.footer_style|default:"full" %}
+{% include "components/footer.html" %}
+{% endwith %}
 {% endif %}
 {% endblock %}

--- a/templates/layouts/docs.html
+++ b/templates/layouts/docs.html
@@ -86,9 +86,9 @@
 
 {% block footer %}
 {% if config.layout.docs.footer_style != 'none' %}
-<footer class="site-footer site-footer--{{ config.layout.docs.footer_style | default:'minimal' }}" role="contentinfo">
-    {% include "components/footer.html" %}
-</footer>
+{% with footer_style=config.layout.docs.footer_style|default:"minimal" %}
+{% include "components/footer.html" %}
+{% endwith %}
 {% endif %}
 {% endblock %}
 

--- a/templates/layouts/landing.html
+++ b/templates/layouts/landing.html
@@ -72,8 +72,8 @@
 
 {% block footer %}
 {% if config.layout.landing.footer_style != 'none' %}
-<footer class="site-footer site-footer--{{ config.layout.landing.footer_style | default:'full' }}" role="contentinfo">
-    {% include "components/footer.html" %}
-</footer>
+{% with footer_style=config.layout.landing.footer_style|default:"full" %}
+{% include "components/footer.html" %}
+{% endwith %}
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- Fixed footer inconsistency across page types (post, feed, blogroll, reader)
- Removed nested `<footer>` elements from layout templates
- Added `footer_style` parameter support to footer component with default "full"
- Added consistent `role="contentinfo"` accessibility attribute
- All page types now use the same footer component with consistent styling

## Files Changed
- `pkg/themes/default/templates/components/footer.html`
- `pkg/themes/default/templates/partials/footer.html`
- `templates/layouts/docs.html`
- `templates/layouts/blog.html`
- `templates/layouts/landing.html`

Fixes #463