### PR TITLE
fix: implement ellipsis pagination to prevent overflow

### DIFF
--- a/pkg/themes/default/static/css/main.css
+++ b/pkg/themes/default/static/css/main.css
@@ -693,8 +693,22 @@ body:has(.background-decoration) div.feed {
 
 .pagination-pages {
   display: flex;
+  flex-wrap: wrap;
   gap: var(--space-1);
   align-items: center;
+  justify-content: center;
+  max-width: 100%;
+}
+
+.pagination-ellipsis {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 36px;
+  height: 36px;
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  user-select: none;
 }
 
 .pagination-page {

--- a/pkg/themes/default/templates/partials/pagination.html
+++ b/pkg/themes/default/templates/partials/pagination.html
@@ -1,4 +1,5 @@
 {# Pagination partial - auto-selects template based on pagination_type #}
+{# Ellipsis pagination: shows 1, ..., current-2 to current+2, ..., last #}
 {% if page.total_pages > 1 %}
 {% if page.pagination_type == "htmx" %}
 {# HTMX Pagination - uses hx-* attributes for AJAX loading #}
@@ -17,20 +18,35 @@
   <span class="pagination-prev disabled">&laquo; Newer</span>
   {% endif %}
 
-  {# Page numbers #}
+  {# Page numbers with ellipsis #}
   <div class="pagination-pages">
     {% for url in page.page_urls %}
-    {% if forloop.Counter == page.number %}
-    <span class="pagination-page current" aria-current="page">{{ forloop.Counter }}</span>
-    {% else %}
-    <a href="{{ url }}"
-       class="pagination-page"
-       hx-get="{{ url }}"
-       hx-target=".posts-list"
-       hx-select=".posts-list"
-       hx-swap="outerHTML"
-       hx-push-url="true">{{ forloop.Counter }}</a>
+    {% with page_num=forloop.Counter %}
+    {# Show page if: first page, last page, or within 2 of current page #}
+    {% if page_num == 1 or page_num == page.total_pages or (page_num >= page.number|add:"-2" and page_num <= page.number|add:"2") %}
+      {# Show ellipsis before this page if there's a gap #}
+      {% if page_num == page.total_pages and page.number < page.total_pages|add:"-3" %}
+      <span class="pagination-ellipsis" aria-hidden="true">...</span>
+      {% elif page_num > 1 and page_num == page.number|add:"-2" and page.number > 4 %}
+      <span class="pagination-ellipsis" aria-hidden="true">...</span>
+      {% endif %}
+      {% if page_num == page.number %}
+      <span class="pagination-page current" aria-current="page">{{ page_num }}</span>
+      {% else %}
+      <a href="{{ url }}"
+         class="pagination-page"
+         hx-get="{{ url }}"
+         hx-target=".posts-list"
+         hx-select=".posts-list"
+         hx-swap="outerHTML"
+         hx-push-url="true">{{ page_num }}</a>
+      {% endif %}
+      {# Show ellipsis after page 1 if there's a gap #}
+      {% if page_num == 1 and page.number > 4 %}
+      <span class="pagination-ellipsis" aria-hidden="true">...</span>
+      {% endif %}
     {% endif %}
+    {% endwith %}
     {% endfor %}
   </div>
 
@@ -73,11 +89,23 @@
     {% endif %}
     <div class="pagination-pages">
       {% for url in page.page_urls %}
-      {% if forloop.Counter == page.number %}
-      <span class="pagination-page current" aria-current="page">{{ forloop.Counter }}</span>
-      {% else %}
-      <a href="{{ url }}" class="pagination-page">{{ forloop.Counter }}</a>
+      {% with page_num=forloop.Counter %}
+      {% if page_num == 1 or page_num == page.total_pages or (page_num >= page.number|add:"-2" and page_num <= page.number|add:"2") %}
+        {% if page_num == page.total_pages and page.number < page.total_pages|add:"-3" %}
+        <span class="pagination-ellipsis" aria-hidden="true">...</span>
+        {% elif page_num > 1 and page_num == page.number|add:"-2" and page.number > 4 %}
+        <span class="pagination-ellipsis" aria-hidden="true">...</span>
+        {% endif %}
+        {% if page_num == page.number %}
+        <span class="pagination-page current" aria-current="page">{{ page_num }}</span>
+        {% else %}
+        <a href="{{ url }}" class="pagination-page">{{ page_num }}</a>
+        {% endif %}
+        {% if page_num == 1 and page.number > 4 %}
+        <span class="pagination-ellipsis" aria-hidden="true">...</span>
+        {% endif %}
       {% endif %}
+      {% endwith %}
       {% endfor %}
     </div>
     {% if page.has_next %}
@@ -97,14 +125,29 @@
   <span class="pagination-prev disabled">&laquo; Newer</span>
   {% endif %}
 
-  {# Page numbers #}
+  {# Page numbers with ellipsis #}
   <div class="pagination-pages">
     {% for url in page.page_urls %}
-    {% if forloop.Counter == page.number %}
-    <span class="pagination-page current" aria-current="page">{{ forloop.Counter }}</span>
-    {% else %}
-    <a href="{{ url }}" class="pagination-page">{{ forloop.Counter }}</a>
+    {% with page_num=forloop.Counter %}
+    {# Show page if: first page, last page, or within 2 of current page #}
+    {% if page_num == 1 or page_num == page.total_pages or (page_num >= page.number|add:"-2" and page_num <= page.number|add:"2") %}
+      {# Show ellipsis before this page if there's a gap #}
+      {% if page_num == page.total_pages and page.number < page.total_pages|add:"-3" %}
+      <span class="pagination-ellipsis" aria-hidden="true">...</span>
+      {% elif page_num > 1 and page_num == page.number|add:"-2" and page.number > 4 %}
+      <span class="pagination-ellipsis" aria-hidden="true">...</span>
+      {% endif %}
+      {% if page_num == page.number %}
+      <span class="pagination-page current" aria-current="page">{{ page_num }}</span>
+      {% else %}
+      <a href="{{ url }}" class="pagination-page">{{ page_num }}</a>
+      {% endif %}
+      {# Show ellipsis after page 1 if there's a gap #}
+      {% if page_num == 1 and page.number > 4 %}
+      <span class="pagination-ellipsis" aria-hidden="true">...</span>
+      {% endif %}
     {% endif %}
+    {% endwith %}
     {% endfor %}
   </div>
 


### PR DESCRIPTION
## Summary
- Implemented ellipsis pagination for feeds with many pages
- Shows: first page, ellipsis, 2 pages before/after current, ellipsis, last page
- Example: `1 ... 15 16 [17] 18 19 ... 30`
- Added `flex-wrap: wrap` to `.pagination-pages` for responsive behavior
- Added `.pagination-ellipsis` class for consistent styling

## Files Changed
- `pkg/themes/default/templates/partials/pagination.html`
- `pkg/themes/default/static/css/main.css`

Fixes #464