### PR TITLE
feat: add explicit slug override for blog homepage

### DIFF
--- a/posts/blog/index.md
+++ b/posts/blog/index.md
@@ -1,0 +1,7 @@
+---
+slug: ""
+title: Blog Homepage
+published: true
+---
+
+This should be the homepage, not /blog/index.html.


### PR DESCRIPTION
## Summary
- Add blog homepage with explicit empty slug override
- Ensures blog index renders at homepage rather than /blog/index.html

## Changes
- New posts/blog/index.md with slug: "" to override default path generation
- Simple demonstration of explicit slug functionality

## Testing
- Verified homepage renders correctly with empty slug
- Blog content displays at root URL as expected

Fixes #