### PR TITLE
fix(blogroll): convert config structs to maps for pongo2 template access

### DIFF
--- a/pkg/themes/default/static/css/components.css
+++ b/pkg/themes/default/static/css/components.css
@@ -1255,6 +1255,34 @@
   line-height: 1.6;
 }
 
+/* Reader entry with image layout */
+.reader-entry-article {
+  display: block;
+}
+
+.reader-entry-article.has-image {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.reader-entry-image-link {
+  flex-shrink: 0;
+}
+
+.reader-entry-image {
+  width: 120px;
+  height: 80px;
+  object-fit: cover;
+  border-radius: 6px;
+  background-color: var(--color-surface);
+}
+
+.reader-entry-content {
+  flex: 1;
+  min-width: 0;
+}
+
 /* Responsive adjustments */
 @media (max-width: 640px) {
   .reader-page {
@@ -1275,6 +1303,15 @@
 
   .reader-entry-meta {
     font-size: 0.8125rem;
+  }
+
+  .reader-entry-article.has-image {
+    flex-direction: column;
+  }
+
+  .reader-entry-image {
+    width: 100%;
+    height: 160px;
   }
 }
 

--- a/pkg/themes/default/templates/reader.html
+++ b/pkg/themes/default/templates/reader.html
@@ -29,19 +29,26 @@
   <ul class="reader-entries">
     {% for entry in entries %}
     <li class="reader-entry">
-      <article>
-        <h2 class="reader-entry-title">
-          <a href="{{ entry.url }}" target="_blank" rel="noopener">{{ entry.title }}</a>
-        </h2>
-        <div class="reader-entry-meta">
-          <span class="reader-entry-source">{{ entry.feed_title }}</span>
-          {% if entry.published %}
-          <time datetime="{{ entry.published | atom_date }}">{{ entry.published | date:"Jan 2, 2006" }}</time>
+      <article class="reader-entry-article{% if entry.image_url %} has-image{% endif %}">
+        {% if entry.image_url %}
+        <a href="{{ entry.url }}" target="_blank" rel="noopener" class="reader-entry-image-link">
+          <img src="{{ entry.image_url }}" alt="" class="reader-entry-image" loading="lazy">
+        </a>
+        {% endif %}
+        <div class="reader-entry-content">
+          <h2 class="reader-entry-title">
+            <a href="{{ entry.url }}" target="_blank" rel="noopener">{{ entry.title }}</a>
+          </h2>
+          <div class="reader-entry-meta">
+            <span class="reader-entry-source">{{ entry.feed_title }}</span>
+            {% if entry.published %}
+            <time datetime="{{ entry.published | atom_date }}">{{ entry.published | date:"Jan 2, 2006" }}</time>
+            {% endif %}
+          </div>
+          {% if entry.description %}
+          <p class="reader-entry-description">{{ entry.description | striptags | truncatewords:40 }}</p>
           {% endif %}
         </div>
-        {% if entry.description %}
-        <p class="reader-entry-description">{{ entry.description | striptags | truncatewords:40 }}</p>
-        {% endif %}
       </article>
     </li>
     {% endfor %}


### PR DESCRIPTION
## Summary

- Fix nav/footer not rendering on `/blogroll/` and `/reader/` pages
- Add image support to reader template with responsive CSS

## Problem

The blogroll plugin was storing raw Go structs in the template context, but pongo2 templates cannot access struct fields with dot notation - they require maps. This caused templates like `{% if config.components.nav.enabled %}` to fail silently.

## Changes

**`pkg/plugins/blogroll.go`** (+260 lines)
- Add `componentsToMap()` to convert `ComponentsConfig` to nested maps
- Add helper functions: `footerConfigToMap()`, `sidebarToMap()`, `tocToMap()`, `headerToMap()`, `postFormatsToMap()`, `headToMap()`
- Update `extractStructConfigs()` to use map conversions instead of raw structs

**`pkg/themes/default/templates/reader.html`** (+11 lines)
- Add image rendering with `entry.image_url` support
- Wrap content in flexbox layout for entries with images

**`pkg/themes/default/static/css/components.css`** (+37 lines)
- Add `.reader-entry-article` flexbox layout
- Add `.reader-entry-image` styling with responsive breakpoints

## Testing

- All existing tests pass
- Verified on test site (waylonwalker.com-markata-go-migration):
  - `/blogroll/` now shows 8 nav links and 9 footer links
  - `/reader/` now shows nav, footer, and 100 entry images

Fixes #494