### PR TITLE
feat(search): add Pagefind search UI component

### DIFF
--- a/pkg/themes/default/static/css/search.css
+++ b/pkg/themes/default/static/css/search.css
@@ -1,0 +1,220 @@
+/* Search Component Styles */
+/* Customizes Pagefind UI to match the site theme */
+
+/* Container positioning */
+.search-container {
+  position: relative;
+}
+
+.search-container--navbar {
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+/* Override Pagefind UI variables to use theme colors */
+.pagefind-ui {
+  --pagefind-ui-scale: 0.9;
+  --pagefind-ui-primary: var(--color-primary, #6366f1);
+  --pagefind-ui-text: var(--color-text, #1f2937);
+  --pagefind-ui-background: var(--color-surface, #ffffff);
+  --pagefind-ui-border: var(--color-border, #e5e7eb);
+  --pagefind-ui-tag: var(--color-surface-alt, #f3f4f6);
+  --pagefind-ui-border-width: 1px;
+  --pagefind-ui-border-radius: 0.5rem;
+  --pagefind-ui-image-border-radius: 0.375rem;
+  --pagefind-ui-image-box-ratio: 3 / 2;
+  --pagefind-ui-font: inherit;
+}
+
+/* Dark mode adjustments */
+@media (prefers-color-scheme: dark) {
+  .pagefind-ui {
+    --pagefind-ui-text: var(--color-text, #f3f4f6);
+    --pagefind-ui-background: var(--color-surface, #1f2937);
+    --pagefind-ui-border: var(--color-border, #374151);
+    --pagefind-ui-tag: var(--color-surface-alt, #374151);
+  }
+}
+
+/* Also support data-theme attribute for palette switcher */
+[data-theme="dark"] .pagefind-ui {
+  --pagefind-ui-text: var(--color-text, #f3f4f6);
+  --pagefind-ui-background: var(--color-surface, #1f2937);
+  --pagefind-ui-border: var(--color-border, #374151);
+  --pagefind-ui-tag: var(--color-surface-alt, #374151);
+}
+
+/* Search input styling */
+.pagefind-ui__search-input {
+  font-size: 0.875rem;
+  padding: 0.5rem 0.75rem;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.pagefind-ui__search-input:focus {
+  outline: none;
+  border-color: var(--color-primary, #6366f1);
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.1);
+}
+
+/* Search button */
+.pagefind-ui__search-clear {
+  color: var(--color-text-muted, #6b7280);
+}
+
+.pagefind-ui__search-clear:hover {
+  color: var(--color-text, #1f2937);
+}
+
+/* Results dropdown */
+.pagefind-ui__results-area {
+  margin-top: 0.5rem;
+}
+
+/* In navbar: position results as dropdown */
+.search-container--navbar .pagefind-ui__drawer {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  width: 400px;
+  max-width: 90vw;
+  background: var(--color-surface, #ffffff);
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 0.5rem;
+  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
+  z-index: 100;
+  max-height: 70vh;
+  overflow-y: auto;
+}
+
+/* Result items */
+.pagefind-ui__result {
+  padding: 0.75rem;
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+}
+
+.pagefind-ui__result:last-child {
+  border-bottom: none;
+}
+
+.pagefind-ui__result:hover {
+  background: var(--color-surface-hover, #f9fafb);
+}
+
+.pagefind-ui__result-link {
+  color: var(--color-primary, #6366f1);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.pagefind-ui__result-link:hover {
+  text-decoration: underline;
+}
+
+.pagefind-ui__result-title {
+  font-size: 1rem;
+  margin-bottom: 0.25rem;
+}
+
+.pagefind-ui__result-excerpt {
+  font-size: 0.875rem;
+  color: var(--color-text-muted, #6b7280);
+  line-height: 1.5;
+}
+
+.pagefind-ui__result-excerpt mark {
+  background: rgba(99, 102, 241, 0.2);
+  color: inherit;
+  padding: 0.125rem 0.25rem;
+  border-radius: 0.25rem;
+}
+
+/* Result images */
+.pagefind-ui__result-image {
+  border-radius: var(--pagefind-ui-image-border-radius);
+  object-fit: cover;
+}
+
+/* Tags in results */
+.pagefind-ui__result-tag {
+  font-size: 0.75rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: 9999px;
+  background: var(--color-surface-alt, #f3f4f6);
+  color: var(--color-text-muted, #6b7280);
+}
+
+/* Loading state */
+.pagefind-ui__loading {
+  padding: 1rem;
+  text-align: center;
+  color: var(--color-text-muted, #6b7280);
+}
+
+/* No results */
+.pagefind-ui__message {
+  padding: 1rem;
+  text-align: center;
+  color: var(--color-text-muted, #6b7280);
+}
+
+/* Keyboard shortcut hint */
+.search-container--navbar::after {
+  content: '/';
+  position: absolute;
+  right: 0.75rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 0.75rem;
+  padding: 0.125rem 0.375rem;
+  background: var(--color-surface-alt, #f3f4f6);
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 0.25rem;
+  color: var(--color-text-muted, #6b7280);
+  pointer-events: none;
+  opacity: 0.7;
+}
+
+/* Hide hint when input is focused */
+.search-container--navbar:focus-within::after {
+  display: none;
+}
+
+/* Mobile responsive */
+@media (max-width: 768px) {
+  .search-container--navbar {
+    width: 100%;
+    margin-top: 0.5rem;
+  }
+
+  .search-container--navbar .pagefind-ui__drawer {
+    width: 100%;
+    position: fixed;
+    left: 0;
+    right: 0;
+    max-width: 100%;
+    border-radius: 0;
+    border-left: none;
+    border-right: none;
+  }
+
+  .search-container--navbar::after {
+    display: none;
+  }
+}
+
+/* Header layout adjustment to accommodate search */
+.site-header .container {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.site-header .site-title {
+  flex-shrink: 0;
+}
+
+.site-header .site-nav {
+  flex-grow: 1;
+}

--- a/pkg/themes/default/templates/base.html
+++ b/pkg/themes/default/templates/base.html
@@ -23,6 +23,12 @@
   <link rel="stylesheet" href="{{ 'css/palette-switcher.css' | theme_asset }}">
   {% endif %}
 
+  <!-- Pagefind Search CSS (when enabled) -->
+  {% if config.search.enabled %}
+  <link rel="stylesheet" href="/{{ config.search.pagefind.bundle_dir | default:'_pagefind' }}/pagefind-ui.css">
+  <link rel="stylesheet" href="{{ 'css/search.css' | theme_asset }}">
+  {% endif %}
+
   <!-- Conditional CSS Loading -->
   <script>
     // GLightbox CSS - only load if glightbox elements will exist
@@ -114,6 +120,9 @@
     <div class="container">
       <a href="/" class="site-title">{{ config.title | default:'My Site' }}</a>
       {% include "components/nav.html" %}
+      {% if config.search.enabled and config.search.position == 'navbar' %}
+      {% include "components/search.html" %}
+      {% endif %}
     </div>
   </header>
   {% endblock %}
@@ -195,6 +204,30 @@
     }
     {% endif %}
   </script>
+
+  <!-- Pagefind Search JS (when enabled) -->
+  {% if config.search.enabled %}
+  <script src="/{{ config.search.pagefind.bundle_dir | default:'_pagefind' }}/pagefind-ui.js" onload="initPagefindSearch()"></script>
+  <script>
+    function initPagefindSearch() {
+      if (typeof PagefindUI !== 'undefined' && document.getElementById('pagefind-search')) {
+        new PagefindUI({
+          element: '#pagefind-search',
+          showSubResults: true,
+          showImages: {{ config.search.show_images | yesno:"true,false" }},
+          excerptLength: {{ config.search.excerpt_length | default:200 }},
+          translations: {
+            placeholder: '{{ config.search.placeholder | default:"Search..." }}'
+          }
+        });
+      }
+    }
+    // Fallback if script already loaded
+    if (typeof PagefindUI !== 'undefined') {
+      document.addEventListener('DOMContentLoaded', initPagefindSearch);
+    }
+  </script>
+  {% endif %}
 
   <!-- Palette Switcher JS (when enabled) -->
   {% if config.theme.switcher.enabled %}

--- a/pkg/themes/default/templates/components/search.html
+++ b/pkg/themes/default/templates/components/search.html
@@ -1,0 +1,9 @@
+{# Search component template #}
+{# Usage: {% include "components/search.html" %} #}
+{# Requires: config.search (SearchConfig) #}
+
+{% if config.search.enabled %}
+<div class="search-container search-container--{{ config.search.position | default:'navbar' }}" id="search-container">
+  <div id="pagefind-search"></div>
+</div>
+{% endif %}

--- a/themes/default/static/css/search.css
+++ b/themes/default/static/css/search.css
@@ -1,0 +1,220 @@
+/* Search Component Styles */
+/* Customizes Pagefind UI to match the site theme */
+
+/* Container positioning */
+.search-container {
+  position: relative;
+}
+
+.search-container--navbar {
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+/* Override Pagefind UI variables to use theme colors */
+.pagefind-ui {
+  --pagefind-ui-scale: 0.9;
+  --pagefind-ui-primary: var(--color-primary, #6366f1);
+  --pagefind-ui-text: var(--color-text, #1f2937);
+  --pagefind-ui-background: var(--color-surface, #ffffff);
+  --pagefind-ui-border: var(--color-border, #e5e7eb);
+  --pagefind-ui-tag: var(--color-surface-alt, #f3f4f6);
+  --pagefind-ui-border-width: 1px;
+  --pagefind-ui-border-radius: 0.5rem;
+  --pagefind-ui-image-border-radius: 0.375rem;
+  --pagefind-ui-image-box-ratio: 3 / 2;
+  --pagefind-ui-font: inherit;
+}
+
+/* Dark mode adjustments */
+@media (prefers-color-scheme: dark) {
+  .pagefind-ui {
+    --pagefind-ui-text: var(--color-text, #f3f4f6);
+    --pagefind-ui-background: var(--color-surface, #1f2937);
+    --pagefind-ui-border: var(--color-border, #374151);
+    --pagefind-ui-tag: var(--color-surface-alt, #374151);
+  }
+}
+
+/* Also support data-theme attribute for palette switcher */
+[data-theme="dark"] .pagefind-ui {
+  --pagefind-ui-text: var(--color-text, #f3f4f6);
+  --pagefind-ui-background: var(--color-surface, #1f2937);
+  --pagefind-ui-border: var(--color-border, #374151);
+  --pagefind-ui-tag: var(--color-surface-alt, #374151);
+}
+
+/* Search input styling */
+.pagefind-ui__search-input {
+  font-size: 0.875rem;
+  padding: 0.5rem 0.75rem;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.pagefind-ui__search-input:focus {
+  outline: none;
+  border-color: var(--color-primary, #6366f1);
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.1);
+}
+
+/* Search button */
+.pagefind-ui__search-clear {
+  color: var(--color-text-muted, #6b7280);
+}
+
+.pagefind-ui__search-clear:hover {
+  color: var(--color-text, #1f2937);
+}
+
+/* Results dropdown */
+.pagefind-ui__results-area {
+  margin-top: 0.5rem;
+}
+
+/* In navbar: position results as dropdown */
+.search-container--navbar .pagefind-ui__drawer {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  width: 400px;
+  max-width: 90vw;
+  background: var(--color-surface, #ffffff);
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 0.5rem;
+  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
+  z-index: 100;
+  max-height: 70vh;
+  overflow-y: auto;
+}
+
+/* Result items */
+.pagefind-ui__result {
+  padding: 0.75rem;
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+}
+
+.pagefind-ui__result:last-child {
+  border-bottom: none;
+}
+
+.pagefind-ui__result:hover {
+  background: var(--color-surface-hover, #f9fafb);
+}
+
+.pagefind-ui__result-link {
+  color: var(--color-primary, #6366f1);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.pagefind-ui__result-link:hover {
+  text-decoration: underline;
+}
+
+.pagefind-ui__result-title {
+  font-size: 1rem;
+  margin-bottom: 0.25rem;
+}
+
+.pagefind-ui__result-excerpt {
+  font-size: 0.875rem;
+  color: var(--color-text-muted, #6b7280);
+  line-height: 1.5;
+}
+
+.pagefind-ui__result-excerpt mark {
+  background: rgba(99, 102, 241, 0.2);
+  color: inherit;
+  padding: 0.125rem 0.25rem;
+  border-radius: 0.25rem;
+}
+
+/* Result images */
+.pagefind-ui__result-image {
+  border-radius: var(--pagefind-ui-image-border-radius);
+  object-fit: cover;
+}
+
+/* Tags in results */
+.pagefind-ui__result-tag {
+  font-size: 0.75rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: 9999px;
+  background: var(--color-surface-alt, #f3f4f6);
+  color: var(--color-text-muted, #6b7280);
+}
+
+/* Loading state */
+.pagefind-ui__loading {
+  padding: 1rem;
+  text-align: center;
+  color: var(--color-text-muted, #6b7280);
+}
+
+/* No results */
+.pagefind-ui__message {
+  padding: 1rem;
+  text-align: center;
+  color: var(--color-text-muted, #6b7280);
+}
+
+/* Keyboard shortcut hint */
+.search-container--navbar::after {
+  content: '/';
+  position: absolute;
+  right: 0.75rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 0.75rem;
+  padding: 0.125rem 0.375rem;
+  background: var(--color-surface-alt, #f3f4f6);
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 0.25rem;
+  color: var(--color-text-muted, #6b7280);
+  pointer-events: none;
+  opacity: 0.7;
+}
+
+/* Hide hint when input is focused */
+.search-container--navbar:focus-within::after {
+  display: none;
+}
+
+/* Mobile responsive */
+@media (max-width: 768px) {
+  .search-container--navbar {
+    width: 100%;
+    margin-top: 0.5rem;
+  }
+
+  .search-container--navbar .pagefind-ui__drawer {
+    width: 100%;
+    position: fixed;
+    left: 0;
+    right: 0;
+    max-width: 100%;
+    border-radius: 0;
+    border-left: none;
+    border-right: none;
+  }
+
+  .search-container--navbar::after {
+    display: none;
+  }
+}
+
+/* Header layout adjustment to accommodate search */
+.site-header .container {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.site-header .site-title {
+  flex-shrink: 0;
+}
+
+.site-header .site-nav {
+  flex-grow: 1;
+}

--- a/themes/default/templates/base.html
+++ b/themes/default/templates/base.html
@@ -23,6 +23,12 @@
   <link rel="stylesheet" href="{{ 'css/palette-switcher.css' | theme_asset }}">
   {% endif %}
 
+  <!-- Pagefind Search CSS (when enabled) -->
+  {% if config.search.enabled %}
+  <link rel="stylesheet" href="/{{ config.search.pagefind.bundle_dir | default:'_pagefind' }}/pagefind-ui.css">
+  <link rel="stylesheet" href="{{ 'css/search.css' | theme_asset }}">
+  {% endif %}
+
   <!-- Conditional CSS Loading -->
   <script>
     // GLightbox CSS - only load if glightbox elements will exist
@@ -114,6 +120,9 @@
     <div class="container">
       <a href="/" class="site-title">{{ config.title | default:'My Site' }}</a>
       {% include "components/nav.html" %}
+      {% if config.search.enabled and config.search.position == 'navbar' %}
+      {% include "components/search.html" %}
+      {% endif %}
     </div>
   </header>
   {% endblock %}
@@ -195,6 +204,30 @@
     }
     {% endif %}
   </script>
+
+  <!-- Pagefind Search JS (when enabled) -->
+  {% if config.search.enabled %}
+  <script src="/{{ config.search.pagefind.bundle_dir | default:'_pagefind' }}/pagefind-ui.js" onload="initPagefindSearch()"></script>
+  <script>
+    function initPagefindSearch() {
+      if (typeof PagefindUI !== 'undefined' && document.getElementById('pagefind-search')) {
+        new PagefindUI({
+          element: '#pagefind-search',
+          showSubResults: true,
+          showImages: {{ config.search.show_images | yesno:"true,false" }},
+          excerptLength: {{ config.search.excerpt_length | default:200 }},
+          translations: {
+            placeholder: '{{ config.search.placeholder | default:"Search..." }}'
+          }
+        });
+      }
+    }
+    // Fallback if script already loaded
+    if (typeof PagefindUI !== 'undefined') {
+      document.addEventListener('DOMContentLoaded', initPagefindSearch);
+    }
+  </script>
+  {% endif %}
 
   <!-- Palette Switcher JS (when enabled) -->
   {% if config.theme.switcher.enabled %}

--- a/themes/default/templates/components/search.html
+++ b/themes/default/templates/components/search.html
@@ -1,0 +1,9 @@
+{# Search component template #}
+{# Usage: {% include "components/search.html" %} #}
+{# Requires: config.search (SearchConfig) #}
+
+{% if config.search.enabled %}
+<div class="search-container search-container--{{ config.search.position | default:'navbar' }}" id="search-container">
+  <div id="pagefind-search"></div>
+</div>
+{% endif %}


### PR DESCRIPTION
## Summary

Add the missing search UI component that displays Pagefind search in the navbar.

Fixes #505

## What's Added

- `templates/components/search.html` - Search container for Pagefind UI
- `static/css/search.css` - Theme-aware search styling (5KB)
- Updated `base.html` to:
  - Load `pagefind-ui.css` and `search.css` when search enabled
  - Include search component in header when `position = "navbar"`
  - Initialize PagefindUI with config options

## Features

- **Enabled by default** - Search appears automatically with no config needed
- **Theme-aware** - Uses CSS variables for colors, supports dark mode
- **Dropdown results** - Results appear in positioned dropdown from navbar
- **Keyboard hint** - Shows `/` shortcut hint in search box
- **Configurable** - Respects `config.search.*` settings (placeholder, show_images, etc.)

## Configuration

Search is enabled by default. To customize:

```toml
[search]
enabled = true              # default
position = "navbar"         # where search appears
placeholder = "Search..."   # input placeholder
show_images = true          # thumbnails in results
```

## Testing

- Built test site successfully
- Search container renders in navbar
- Pagefind UI CSS/JS loads correctly
- All existing tests pass