### PR TITLE
feat(templates): add card system with excerpt filter and fix admonitions

### DIFF
--- a/docs/guides/cards.md
+++ b/docs/guides/cards.md
@@ -1,0 +1,223 @@
+---
+title: "Card Types"
+description: "How posts are displayed differently in feeds based on their template type"
+date: 2026-01-29
+published: true
+tags:
+  - templates
+  - feeds
+  - cards
+---
+
+# Card Types
+
+Cards are how posts appear in feed listings. Different types of content benefit from different visual treatments - a photo post should emphasize the image, while a blog post should show the title and excerpt.
+
+## How Cards Are Selected
+
+Cards are selected based on the `template` frontmatter field:
+
+```yaml
+---
+title: "My Photo"
+template: photo
+---
+```
+
+> **Note:** `templateKey` is supported as an alias for backwards compatibility with Python markata.
+
+The `template` field determines:
+1. Which **card template** renders the post in feeds
+2. Which **page template** renders the full post (if defined)
+
+## Field Name Comparison
+
+markata-go uses `template` as the primary field, following Zola and Pelican conventions:
+
+| SSG | Field Name |
+|-----|------------|
+| Hugo, Jekyll, Eleventy, Astro | `layout` |
+| Zola, Pelican, **markata-go** | `template` |
+
+Both `template` and `templateKey` work in markata-go frontmatter.
+
+## Card Types
+
+| Card Type | template Values | Best For |
+|-----------|-----------------|----------|
+| `article` | `blog-post`, `article`, `post`, `essay`, `tutorial` | Long-form content with title, excerpt, tags |
+| `note` | `note`, `ping`, `thought`, `status`, `tweet` | Short thoughts, micro-posts |
+| `photo` | `photo`, `shot`, `shots`, `image`, `gallery` | Image-focused posts |
+| `video` | `video`, `clip`, `cast`, `stream` | Video content with thumbnail |
+| `link` | `link`, `bookmark`, `til`, `stars` | External links, bookmarks |
+| `quote` | `quote`, `quotation` | Quoted text with attribution |
+| `guide` | `guide`, `series`, `step`, `chapter` | Multi-part tutorials |
+| `inline` | `gratitude`, `inline`, `micro` | Full content shown in feed |
+| `default` | (any other value) | Fallback for unmapped types |
+
+## Card Anatomy
+
+Each card type has different visual elements:
+
+### Article Card
+- Large title (linked)
+- Content excerpt (first 3 paragraphs or 1500 characters)
+- Date, reading time
+- Tags
+
+### Note Card
+- Compact layout with left accent border
+- Title (optional)
+- Short text content
+- Date
+
+### Photo Card
+- Large image (16:9 aspect ratio)
+- Caption below
+- Date
+
+### Inline Card
+- Full `article_html` content rendered in the feed
+- No "read more" - everything is visible
+- Useful for gratitude journals, micro-posts
+
+### Link Card
+- Domain indicator
+- Title and description
+- External link styling
+
+## Examples
+
+### Blog Post (article card)
+```yaml
+---
+title: "Understanding Go Interfaces"
+template: blog-post
+tags:
+  - go
+  - programming
+---
+
+Your article content here. The first three paragraphs (or up to 1500 characters) will automatically be shown as the excerpt in feed listings.
+```
+
+### Quick Thought (note card)
+```yaml
+---
+title: "Ping 42"
+template: ping
+---
+
+Just discovered that vim has a built-in terminal. Mind blown.
+```
+
+### Photo (photo card)
+```yaml
+---
+title: "Sunset at the Beach"
+template: shots
+image: /images/sunset.jpg
+---
+```
+
+### Gratitude Entry (inline card)
+```yaml
+---
+template: gratitude
+---
+
+Today I'm grateful for good coffee and working CI pipelines.
+```
+
+## Configuring Excerpts
+
+Article cards automatically show an excerpt from your content - the first 3 paragraphs or 1500 characters, whichever is shorter.
+
+### Default Behavior
+
+By default, article cards extract:
+- **Up to 3 paragraphs** from your rendered HTML content
+- **OR up to 1500 characters** (whichever comes first)
+- With intelligent truncation at word boundaries
+- An ellipsis (`...`) is added when content is truncated
+
+### How It Works
+
+1. The `excerpt` filter extracts `<p>` tags from your rendered `article_html`
+2. It collects paragraphs until reaching 3 paragraphs OR 1500 characters
+3. It strips inner HTML tags but preserves text
+4. It adds ellipsis (`...`) if content was truncated
+5. Output is safe HTML ready to render
+
+### Tips
+
+- **Short posts:** If your post is shorter than the limit, the entire post shows (no ellipsis)
+- **No paragraphs:** If content has no `<p>` tags, the filter falls back to plain text truncation
+- **Removal of description:** The old `description` frontmatter field is no longer used for article cards - excerpts are auto-generated from content
+
+## Customizing Cards
+
+To override a built-in card, create a file in your site's `templates/partials/cards/` directory:
+
+```
+templates/
+  partials/
+    cards/
+      article-card.html   # Overrides built-in article card
+      my-custom-card.html # New card type
+```
+
+To add a new card type, create a custom `card-router.html`:
+
+```html
+{% elif post.template == "my-type" %}
+{% include "partials/cards/my-custom-card.html" %}
+```
+
+## Card CSS
+
+Card styles are in `themes/default/static/css/cards.css`. Each card has a class:
+
+- `.card-article`
+- `.card-note`
+- `.card-photo`
+- `.card-video`
+- `.card-link`
+- `.card-quote`
+- `.card-guide`
+- `.card-inline`
+- `.card-default`
+
+## How It Works
+
+1. Feed template (`feed.html`) loops through posts
+2. For each post, includes `partials/cards/card-router.html`
+3. Card router checks `post.template` and includes the matching card template
+4. Card template renders the post with appropriate HTML structure
+
+```html
+<!-- feed.html -->
+{% for post in page.posts %}
+{% include "partials/cards/card-router.html" %}
+{% endfor %}
+```
+
+```html
+<!-- card-router.html -->
+{% if post.template == "blog-post" %}
+{% include "partials/cards/article-card.html" %}
+{% elif post.template == "ping" %}
+{% include "partials/cards/note-card.html" %}
+...
+{% endif %}
+```
+
+## Template Access in Custom Templates
+
+In your templates, you can access the template value via either name:
+
+```html
+{# Both work - template is preferred #}
+{{ post.template }}
+{{ post.templateKey }}
+```

--- a/docs/guides/frontmatter.md
+++ b/docs/guides/frontmatter.md
@@ -328,7 +328,9 @@ description: "Learn how to use goroutines for concurrent programming in Go."
 
 - **Type:** string
 - **Default:** Auto-generated from first ~160 characters of content
-- **Used for:** Meta description, feed summaries, social previews, cards
+- **Used for:** Meta description, SEO, social previews
+
+**Note:** The `description` field is no longer used for article card excerpts in feeds. Excerpts are now auto-generated from your content (first 3 paragraphs or 1500 characters). However, `description` may still be used for SEO meta tags and RSS feeds.
 
 **Auto-generation:** If not provided, markata-go extracts the first paragraph or ~160 characters from your content (with HTML tags stripped).
 
@@ -361,7 +363,7 @@ Templates are looked up in:
 | `published` | bool | `false` | No | Whether to include in public feeds |
 | `draft` | bool | `false` | No | Whether this is a work-in-progress |
 | `tags` | []string | `[]` | No | List of categorization tags |
-| `description` | string | Auto-generated | No | Brief summary for SEO/feeds |
+| `description` | string | Auto-generated | No | Brief summary for SEO/meta tags |
 | `template` | string | `"post.html"` | No | Template file to use for rendering |
 | `skip` | bool | `false` | No | Skip this file during processing entirely |
 

--- a/pkg/plugins/admonitions.go
+++ b/pkg/plugins/admonitions.go
@@ -30,6 +30,7 @@ var admonitionTypes = map[string]bool{
 	"quote":     true,
 	"abstract":  true,
 	"aside":     true,
+	"seealso":   true,
 }
 
 // admonitionRegex matches admonition syntax:
@@ -162,10 +163,8 @@ func (p *AdmonitionParser) Open(_ ast.Node, reader text.Reader, _ parser.Context
 func (p *AdmonitionParser) Continue(_ ast.Node, reader text.Reader, _ parser.Context) parser.State {
 	line, segment := reader.PeekLine()
 
-	// Check if this is a blank line
+	// Blank line ends the admonition
 	if util.IsBlank(line) {
-		// Check if the next non-blank line continues the admonition
-		// For now, blank lines end the admonition
 		return parser.Close
 	}
 
@@ -180,7 +179,7 @@ func (p *AdmonitionParser) Continue(_ ast.Node, reader text.Reader, _ parser.Con
 		return parser.Close
 	}
 
-	// Remove the indentation and advance
+	// Advance past this line
 	reader.Advance(segment.Stop - segment.Start)
 	return parser.Continue | parser.HasChildren
 }

--- a/pkg/plugins/templates.go
+++ b/pkg/plugins/templates.go
@@ -58,6 +58,13 @@ func (p *TemplatesPlugin) Configure(m *lifecycle.Manager) error {
 	// Get theme name from config (default to "default")
 	themeName := ThemeDefault
 	if extra := config.Extra; extra != nil {
+		// Check for typed ThemeConfig struct (set by core.go)
+		if theme, ok := extra["theme"].(models.ThemeConfig); ok {
+			if theme.Name != "" {
+				themeName = theme.Name
+			}
+		}
+		// Also check for map[string]interface{} (legacy/dynamic config)
 		if theme, ok := extra["theme"].(map[string]interface{}); ok {
 			if name, ok := theme["name"].(string); ok && name != "" {
 				themeName = name

--- a/pkg/templates/context.go
+++ b/pkg/templates/context.go
@@ -121,6 +121,7 @@ func postToMapUncached(p *models.Post) map[string]interface{} {
 		"skip":         p.Skip,
 		"tags":         p.Tags,
 		"template":     p.Template,
+		"templateKey":  p.Template, // Alias for backwards compatibility
 		"html":         p.HTML,
 		"article_html": p.ArticleHTML,
 	}

--- a/pkg/templates/filters_test.go
+++ b/pkg/templates/filters_test.go
@@ -538,3 +538,51 @@ func TestFilterAbsoluteURL(t *testing.T) {
 		t.Errorf("got %q, want %q", result, expected)
 	}
 }
+
+func TestFilterExcerpt(t *testing.T) {
+	engine, err := NewEngine("")
+	if err != nil {
+		t.Fatalf("Failed to create engine: %v", err)
+	}
+
+	html := `<p>First paragraph with some text.</p>
+<p>Second paragraph with more content.</p>
+<p></p>
+<p>Third paragraph after an empty one.</p>
+<p>Fourth paragraph here.</p>
+<p>Fifth paragraph at the end.</p>`
+
+	ctx := NewContext(nil, "", nil)
+	ctx.Set("html", html)
+
+	result, err := engine.RenderString("{{ html | excerpt }}", ctx)
+	if err != nil {
+		t.Fatalf("RenderString() error: %v", err)
+	}
+
+	t.Logf("Result: %s", result)
+
+	// Should include first 3 non-empty paragraphs
+	if !contains(result, "First paragraph") {
+		t.Errorf("Expected 'First paragraph' in result")
+	}
+	if !contains(result, "Second paragraph") {
+		t.Errorf("Expected 'Second paragraph' in result")
+	}
+	if !contains(result, "Third paragraph") {
+		t.Errorf("Expected 'Third paragraph' in result")
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > len(substr) && (s[:len(substr)] == substr || s[len(s)-len(substr):] == substr || stringContains(s, substr)))
+}
+
+func stringContains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/themes/default/static/css/admonitions.css
+++ b/pkg/themes/default/static/css/admonitions.css
@@ -112,6 +112,12 @@
   --admonition-icon: "#";
 }
 
+.admonition.seealso {
+  --admonition-color: var(--admonition-seealso-border, #8b5cf6);
+  --admonition-bg: var(--admonition-seealso-bg, #f5f3ff);
+  --admonition-icon: "->";
+}
+
 /* Aside - Sidebar/Marginal Note (Tufte-style) */
 /* Asides are positioned in the margin of the article, outside the main content flow */
 

--- a/themes/default/static/css/cards.css
+++ b/themes/default/static/css/cards.css
@@ -1,0 +1,742 @@
+/* ==========================================================================
+   Card Type System - Built-in Card Styles for Different Content Types
+
+   Card types: article, note, photo, video, link, quote, guide, inline, default
+
+   Design principles:
+   - Feed container constrained (max-width: 750px), cards fill container
+   - Differentiate by padding, background, borders - NOT width
+   - All cards same width for visual consistency
+   ========================================================================== */
+
+/* ==========================================================================
+   Feed Container - Constrain the feed, not individual cards
+   ========================================================================== */
+
+.feed .posts,
+.feed .posts-list {
+  max-width: 750px;
+  margin: 0 auto;
+}
+
+/* ==========================================================================
+   Base Card Styles (shared by all card types)
+   Extends the .card class from main.css
+   ========================================================================== */
+
+.card {
+  width: 100%;
+  /* Ensure solid background to prevent pattern bleed-through */
+  background: var(--color-surface);
+}
+
+/* Ensure all card sections have solid backgrounds */
+.card .card-header,
+.card .card-body,
+.card .card-content,
+.card .card-meta,
+.card footer {
+  background: inherit;
+}
+
+/* Card title links */
+.card .card-title {
+  margin: 0 0 var(--space-2);
+  font-size: var(--text-xl);
+  line-height: var(--leading-tight);
+}
+
+.card .card-title a {
+  color: var(--color-text);
+  text-decoration: none;
+}
+
+.card .card-title a:hover {
+  color: var(--color-primary);
+}
+
+/* Card meta (date, reading time, etc.) */
+.card .card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline; /* Align on text baseline */
+  gap: var(--space-3);
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  margin-top: var(--space-3);
+}
+
+.card .card-meta time {
+  display: inline;
+}
+
+/* Card tags - inline with meta, baseline aligned */
+.card .card-tags {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--space-2);
+  margin: 0; /* Remove top margin when inline with meta */
+}
+
+.card .card-tags .tag {
+  font-size: var(--text-xs);
+  padding: var(--space-1) var(--space-2);
+  line-height: 1;
+  vertical-align: baseline;
+}
+
+/* ==========================================================================
+   Article Card - High prominence for blog posts, tutorials, essays
+   Large title, excerpt, tags, reading time, generous padding
+   ========================================================================== */
+
+.card-article {
+  padding: var(--space-6);
+}
+
+.card-article .card-header {
+  margin-bottom: var(--space-3);
+}
+
+.card-article .card-title {
+  font-size: var(--text-2xl);
+  margin-bottom: var(--space-3);
+}
+
+.card-article .card-excerpt {
+  color: var(--color-text);
+  font-size: var(--text-base);
+  line-height: var(--leading-relaxed);
+  margin-bottom: var(--space-3);
+}
+
+.card-article .reading-time::before {
+  content: "\2022";
+  margin-right: var(--space-2);
+}
+
+/* ==========================================================================
+   Note Card - Low prominence for pings, thoughts, status updates
+   Centered, right border accent, subtle shadow, no left border
+   ========================================================================== */
+
+.card-note {
+  padding: var(--space-4);
+  border: none;
+  border-left: 3px solid var(--color-primary);
+  border-radius: var(--radius);
+  background: var(--color-surface);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  max-width: 550px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.card-note:hover {
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+}
+
+.card-note .card-content {
+  margin-bottom: var(--space-3);
+}
+
+.card-note .card-title {
+  font-size: var(--text-lg);
+  font-weight: 500;
+  margin-bottom: var(--space-2);
+}
+
+.card-note .card-title a {
+  color: var(--color-text);
+}
+
+.card-note .card-text {
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  line-height: var(--leading-relaxed);
+
+  /* Limit to 3 lines */
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.card-note .card-meta {
+  justify-content: space-between;
+  gap: var(--space-4);
+  margin-top: var(--space-3);
+  font-size: var(--text-xs);
+}
+
+.card-note .card-link {
+  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+  text-decoration: none;
+}
+
+.card-note .card-link:hover {
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+
+/* ==========================================================================
+   Photo Card - Image/video prominent for shots, photos, gallery posts
+   Large media with aspect-ratio, caption/description below
+   Auto-detects video files (.mp4, .webm, .mov) and displays as looping video
+   ========================================================================== */
+
+.card-photo {
+  padding: 0;
+  overflow: hidden;
+}
+
+.card-photo .card-image-link {
+  display: block;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  background: var(--color-surface);
+}
+
+.card-photo .card-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.3s ease;
+}
+
+/* Video element styling - ensure it fills container */
+.card-photo video.card-image {
+  display: block;
+}
+
+.card-photo:hover .card-image {
+  transform: scale(1.02);
+}
+
+.card-photo .card-body {
+  padding: var(--space-4);
+}
+
+.card-photo .card-title {
+  font-size: var(--text-lg);
+  margin-bottom: var(--space-2);
+}
+
+.card-photo .card-caption {
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  line-height: var(--leading-relaxed);
+  margin-bottom: var(--space-2);
+
+  /* Limit to 2 lines */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* ==========================================================================
+   Video Card - Video/thumbnail prominent for video, clip, stream posts
+   Video thumbnail with play indicator, title below
+   ========================================================================== */
+
+.card-video {
+  padding: 0;
+  overflow: hidden;
+}
+
+.card-video .card-video-link {
+  display: block;
+}
+
+.card-video .card-video-container {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  background: var(--color-surface);
+}
+
+.card-video .card-thumbnail {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.3s ease;
+}
+
+.card-video:hover .card-thumbnail {
+  transform: scale(1.02);
+}
+
+.card-video .card-play-icon {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 64px;
+  height: 64px;
+  background: rgba(0, 0, 0, 0.7);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  transition: background 0.2s, transform 0.2s;
+}
+
+.card-video:hover .card-play-icon {
+  background: var(--color-primary);
+  transform: translate(-50%, -50%) scale(1.1);
+}
+
+.card-video .card-play-icon svg {
+  margin-left: 4px; /* Visual centering for play icon */
+}
+
+.card-video .card-body {
+  padding: var(--space-4);
+}
+
+.card-video .card-title {
+  font-size: var(--text-lg);
+  margin-bottom: var(--space-2);
+}
+
+.card-video .card-description {
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  margin-bottom: var(--space-2);
+}
+
+.card-video .duration {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+}
+
+/* ==========================================================================
+   Link Card - URL preview style for links, bookmarks, TIL posts
+   Shows domain, title, description in preview card style
+   ========================================================================== */
+
+.card-link {
+  padding: 0;
+  overflow: hidden;
+}
+
+.card-link .card-link-wrapper {
+  display: flex;
+  text-decoration: none;
+  color: inherit;
+}
+
+.card-link .card-link-image {
+  flex-shrink: 0;
+  width: 120px;
+  background: var(--color-surface);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.card-link .card-link-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.card-link .card-link-content {
+  flex: 1;
+  padding: var(--space-4);
+  min-width: 0;
+}
+
+.card-link .card-domain {
+  display: block;
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-2);
+  text-transform: lowercase;
+
+  /* Truncate long URLs */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.card-link .card-title {
+  font-size: var(--text-base);
+  font-weight: 600;
+  margin-bottom: var(--space-2);
+
+  /* Limit to 2 lines */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.card-link .card-description {
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+
+  /* Limit to 2 lines */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.card-link .card-meta {
+  padding: var(--space-3) var(--space-4);
+  border-top: 1px solid var(--color-border);
+  background: var(--color-surface);
+}
+
+/* ==========================================================================
+   Quote Card - Blockquote styling for quotes, quotations
+   Large quote with source attribution
+   ========================================================================== */
+
+.card-quote {
+  padding: var(--space-6);
+  background: var(--color-surface);
+  border-left: 4px solid var(--color-primary);
+}
+
+.card-quote .card-blockquote {
+  margin: 0 0 var(--space-4);
+  padding: 0;
+  border: none;
+  background: none;
+  font-style: italic;
+  font-size: var(--text-lg);
+  line-height: var(--leading-relaxed);
+  color: var(--color-text);
+}
+
+.card-quote .card-blockquote p {
+  margin: 0;
+}
+
+.card-quote .card-attribution {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+}
+
+.card-quote .card-attribution cite {
+  font-style: normal;
+}
+
+.card-quote .quote-author {
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.card-quote .quote-author::after {
+  content: ",";
+  margin-right: var(--space-1);
+}
+
+.card-quote .quote-source {
+  font-style: italic;
+}
+
+.card-quote .card-title-link {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.card-quote .card-title-link:hover {
+  text-decoration: underline;
+}
+
+/* ==========================================================================
+   Guide Card - Step/chapter indicator for guides, series, tutorials
+   Shows step number, title, description
+   ========================================================================== */
+
+.card-guide {
+  padding: var(--space-4);
+  display: flex;
+  gap: var(--space-4);
+  align-items: flex-start;
+}
+
+.card-guide .card-step-indicator {
+  flex-shrink: 0;
+  width: 48px;
+  height: 48px;
+  background: var(--color-primary);
+  color: white;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.card-guide .step-number {
+  font-size: var(--text-xl);
+  font-weight: 700;
+  font-family: var(--font-mono);
+}
+
+.card-guide .card-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.card-guide .card-title {
+  font-size: var(--text-lg);
+  margin-bottom: var(--space-2);
+}
+
+.card-guide .card-description {
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  line-height: var(--leading-relaxed);
+  margin-bottom: var(--space-2);
+
+  /* Limit to 2 lines */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* ==========================================================================
+   Inline Card - Full rendered content for gratitude, micro posts
+   Minimal wrapper, displays full article_html content
+   ========================================================================== */
+
+.card-inline {
+  padding: var(--space-4);
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--color-border);
+  border-radius: 0;
+}
+
+.card-inline:hover {
+  border-color: var(--color-border);
+  box-shadow: none;
+}
+
+.card-inline .card-content {
+  font-size: var(--text-base);
+  line-height: var(--leading-relaxed);
+  color: var(--color-text);
+}
+
+/* Style inline content (rendered markdown) */
+.card-inline .card-content h1,
+.card-inline .card-content h2,
+.card-inline .card-content h3,
+.card-inline .card-content h4,
+.card-inline .card-content h5,
+.card-inline .card-content h6 {
+  margin-top: var(--space-4);
+  margin-bottom: var(--space-2);
+}
+
+.card-inline .card-content h1:first-child,
+.card-inline .card-content h2:first-child,
+.card-inline .card-content h3:first-child,
+.card-inline .card-content h4:first-child {
+  margin-top: 0;
+}
+
+.card-inline .card-content p {
+  margin-bottom: var(--space-3);
+}
+
+.card-inline .card-content p:last-child {
+  margin-bottom: 0;
+}
+
+.card-inline .card-content img {
+  max-width: 100%;
+  border-radius: var(--radius);
+  margin: var(--space-3) 0;
+}
+
+.card-inline .card-content blockquote {
+  margin: var(--space-3) 0;
+  padding: var(--space-3);
+  padding-left: var(--space-4);
+  border-left: 3px solid var(--color-primary);
+  background: var(--color-surface);
+  border-radius: 0 var(--radius) var(--radius) 0;
+}
+
+.card-inline .card-meta {
+  margin-top: var(--space-4);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--color-border);
+  justify-content: space-between;
+}
+
+.card-inline .card-permalink {
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  text-decoration: none;
+}
+
+.card-inline .card-permalink:hover {
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+
+/* ==========================================================================
+   Default Card - Fallback for unmapped templateKey values
+   Basic card layout, similar to original card.html
+   ========================================================================== */
+
+.card-default {
+  padding: var(--space-5);
+}
+
+.card-default .card-title {
+  font-size: var(--text-xl);
+  margin-bottom: var(--space-2);
+}
+
+.card-default .card-description {
+  color: var(--color-text-muted);
+  font-size: var(--text-base);
+  line-height: var(--leading-relaxed);
+  margin-bottom: var(--space-3);
+}
+
+/* ==========================================================================
+   Responsive Adjustments
+   ========================================================================== */
+
+@media (max-width: 768px) {
+  /* Reduce feed max-width constraint on mobile */
+  .feed .posts,
+  .feed .posts-list {
+    max-width: 100%;
+  }
+
+  /* Article card */
+  .card-article {
+    padding: var(--space-4);
+  }
+
+  .card-article .card-title {
+    font-size: var(--text-xl);
+  }
+
+  /* Note card */
+  .card-note {
+    padding: var(--space-3);
+    max-width: 100%;
+  }
+
+  /* Photo card */
+  .card-photo .card-body {
+    padding: var(--space-3);
+  }
+
+  /* Video card */
+  .card-video .card-play-icon {
+    width: 48px;
+    height: 48px;
+  }
+
+  .card-video .card-play-icon svg {
+    width: 32px;
+    height: 32px;
+  }
+
+  .card-video .card-body {
+    padding: var(--space-3);
+  }
+
+  /* Link card - stack vertically on mobile */
+  .card-link .card-link-wrapper {
+    flex-direction: column;
+  }
+
+  .card-link .card-link-image {
+    width: 100%;
+    height: 120px;
+  }
+
+  /* Quote card */
+  .card-quote {
+    padding: var(--space-4);
+  }
+
+  .card-quote .card-blockquote {
+    font-size: var(--text-base);
+  }
+
+  /* Guide card - stack on mobile */
+  .card-guide {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+
+  .card-guide .card-step-indicator {
+    width: 40px;
+    height: 40px;
+  }
+
+  .card-guide .step-number {
+    font-size: var(--text-lg);
+  }
+
+  /* Inline card */
+  .card-inline {
+    padding: var(--space-3);
+  }
+
+  /* Default card */
+  .card-default {
+    padding: var(--space-4);
+  }
+}
+
+@media (max-width: 480px) {
+  .card-article .card-title {
+    font-size: var(--text-lg);
+  }
+
+  .card-note .card-text {
+    -webkit-line-clamp: 2;
+  }
+
+  .card-photo .card-image-link {
+    aspect-ratio: 4 / 3;
+  }
+}
+
+/* ==========================================================================
+   Print Styles
+   ========================================================================== */
+
+@media print {
+  .card {
+    break-inside: avoid;
+    page-break-inside: avoid;
+    border: 1px solid #ccc;
+    box-shadow: none;
+  }
+
+  .card-photo .card-image,
+  .card-video .card-thumbnail {
+    max-height: 200px;
+  }
+
+  .card-inline .card-content img {
+    max-height: 150px;
+  }
+}

--- a/themes/default/templates/base.html
+++ b/themes/default/templates/base.html
@@ -14,6 +14,7 @@
   <link rel="stylesheet" href="{{ 'css/variables.css' | theme_asset }}">
   <link rel="stylesheet" href="{{ 'css/main.css' | theme_asset }}">
   <link rel="stylesheet" href="{{ 'css/components.css' | theme_asset }}">
+  <link rel="stylesheet" href="{{ 'css/cards.css' | theme_asset }}">
   <link rel="stylesheet" href="{{ 'css/admonitions.css' | theme_asset }}">
   <link rel="stylesheet" href="{{ 'css/code.css' | theme_asset }}">
   <link rel="stylesheet" href="/css/chroma.css">

--- a/themes/default/templates/feed.html
+++ b/themes/default/templates/feed.html
@@ -23,12 +23,12 @@
     {% if page.pagination_type == "js" %}
     {# For JS pagination, render ALL posts - JavaScript will handle showing/hiding #}
     {% for post in feed.posts %}
-    {% include "card.html" %}
+    {% include "partials/cards/card-router.html" %}
     {% endfor %}
     {% else %}
     {# For manual/htmx pagination, render only current page posts #}
     {% for post in page.posts %}
-    {% include "card.html" %}
+    {% include "partials/cards/card-router.html" %}
     {% endfor %}
     {% endif %}
   </div>

--- a/themes/default/templates/partials/cards/article-card.html
+++ b/themes/default/templates/partials/cards/article-card.html
@@ -1,0 +1,25 @@
+{# Article Card - High prominence for blog posts, tutorials, essays #}
+{# Large title, excerpt, tags, reading time, generous padding #}
+<article class="card card-article">
+  <header class="card-header">
+    <h2 class="card-title"><a href="{{ post.href }}">{{ post.title | default:post.slug }}</a></h2>
+  </header>
+
+  <div class="card-excerpt">
+    {{ post.article_html | excerpt | safe }}
+  </div>
+
+  <footer class="card-meta">
+    {% if post.date %}
+    <time datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+    {% endif %}
+    {% if post.reading_time %}<span class="reading-time">{{ post.reading_time }} min read</span>{% endif %}
+    {% if post.tags %}
+    <div class="card-tags">
+      {% for tag in post.tags %}
+      <span class="tag">{{ tag }}</span>
+      {% endfor %}
+    </div>
+    {% endif %}
+  </footer>
+</article>

--- a/themes/default/templates/partials/cards/card-router.html
+++ b/themes/default/templates/partials/cards/card-router.html
@@ -1,0 +1,30 @@
+{# Card Router - Routes to appropriate card template based on post.template #}
+{# Card types: article (blog-post), note (ping), photo (shots), video, link, quote, guide, inline (gratitude) #}
+
+{% if post.template == "blog-post" or post.template == "article" or post.template == "post" or post.template == "essay" or post.template == "tutorial" %}
+{% include "partials/cards/article-card.html" %}
+
+{% elif post.template == "note" or post.template == "ping" or post.template == "thought" or post.template == "status" or post.template == "tweet" %}
+{% include "partials/cards/note-card.html" %}
+
+{% elif post.template == "photo" or post.template == "shot" or post.template == "shots" or post.template == "image" or post.template == "gallery" %}
+{% include "partials/cards/photo-card.html" %}
+
+{% elif post.template == "video" or post.template == "clip" or post.template == "cast" or post.template == "stream" %}
+{% include "partials/cards/video-card.html" %}
+
+{% elif post.template == "link" or post.template == "bookmark" or post.template == "til" or post.template == "stars" %}
+{% include "partials/cards/link-card.html" %}
+
+{% elif post.template == "quote" or post.template == "quotation" %}
+{% include "partials/cards/quote-card.html" %}
+
+{% elif post.template == "guide" or post.template == "series" or post.template == "step" or post.template == "chapter" %}
+{% include "partials/cards/guide-card.html" %}
+
+{% elif post.template == "gratitude" or post.template == "inline" or post.template == "micro" %}
+{% include "partials/cards/inline-card.html" %}
+
+{% else %}
+{% include "partials/cards/default-card.html" %}
+{% endif %}

--- a/themes/default/templates/partials/cards/default-card.html
+++ b/themes/default/templates/partials/cards/default-card.html
@@ -1,0 +1,16 @@
+{# Default Card - Fallback for unmapped templateKey values #}
+{# Basic card layout similar to original card.html #}
+<article class="card card-default">
+  <h2 class="card-title"><a href="{{ post.href }}">{{ post.title | default:post.slug }}</a></h2>
+
+  {% if post.description %}
+  <p class="card-description">{{ post.description }}</p>
+  {% endif %}
+
+  <footer class="card-meta">
+    {% if post.date %}
+    <time datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+    {% endif %}
+    {% if post.reading_time %}<span class="reading-time">{{ post.reading_time }} min</span>{% endif %}
+  </footer>
+</article>

--- a/themes/default/templates/partials/cards/guide-card.html
+++ b/themes/default/templates/partials/cards/guide-card.html
@@ -1,0 +1,22 @@
+{# Guide Card - Step/chapter indicator for guides, series, tutorials #}
+{# Shows step number (from forloop.counter), title, description #}
+<article class="card card-guide">
+  <div class="card-step-indicator">
+    <span class="step-number">{{ forloop.counter | default:"1" }}</span>
+  </div>
+
+  <div class="card-body">
+    <h3 class="card-title"><a href="{{ post.href }}">{{ post.title | default:post.slug }}</a></h3>
+
+    {% if post.description %}
+    <p class="card-description">{{ post.description | truncatechars:200 }}</p>
+    {% endif %}
+
+    <footer class="card-meta">
+      {% if post.date %}
+      <time datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+      {% endif %}
+      {% if post.reading_time %}<span class="reading-time">{{ post.reading_time }} min</span>{% endif %}
+    </footer>
+  </div>
+</article>

--- a/themes/default/templates/partials/cards/inline-card.html
+++ b/themes/default/templates/partials/cards/inline-card.html
@@ -1,0 +1,14 @@
+{# Inline Card - Full rendered content for gratitude, micro posts #}
+{# Minimal wrapper, displays full article_html content #}
+<article class="card card-inline">
+  <div class="card-content">
+    {{ post.article_html | safe }}
+  </div>
+
+  <footer class="card-meta">
+    {% if post.date %}
+    <time datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+    {% endif %}
+    <a href="{{ post.href }}" class="card-permalink">Permalink</a>
+  </footer>
+</article>

--- a/themes/default/templates/partials/cards/link-card.html
+++ b/themes/default/templates/partials/cards/link-card.html
@@ -1,0 +1,36 @@
+{# Link Card - URL preview style for links, bookmarks, TIL posts #}
+{# Shows domain, title, description in preview card style #}
+<article class="card card-link">
+  <a href="{{ post.href }}" class="card-link-wrapper">
+    {% if post.image %}
+    <div class="card-link-image">
+      <img src="{{ post.image }}" alt="" loading="lazy">
+    </div>
+    {% endif %}
+
+    <div class="card-link-content">
+      {% if post.url %}
+      <span class="card-domain">{{ post.url | default:post.href }}</span>
+      {% endif %}
+
+      <h3 class="card-title">{{ post.title | default:post.slug }}</h3>
+
+      {% if post.description %}
+      <p class="card-description">{{ post.description | truncatechars:120 }}</p>
+      {% endif %}
+    </div>
+  </a>
+
+  <footer class="card-meta">
+    {% if post.date %}
+    <time datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+    {% endif %}
+    {% if post.tags %}
+    <div class="card-tags">
+      {% for tag in post.tags %}
+      <span class="tag">{{ tag }}</span>
+      {% endfor %}
+    </div>
+    {% endif %}
+  </footer>
+</article>

--- a/themes/default/templates/partials/cards/note-card.html
+++ b/themes/default/templates/partials/cards/note-card.html
@@ -1,0 +1,18 @@
+{# Note Card - Low prominence for pings, thoughts, status updates #}
+{# Minimal styling, left border accent, no title shown #}
+<article class="card card-note">
+  <div class="card-content">
+    {% if post.description %}
+    <p class="card-text">{{ post.description }}</p>
+    {% elif post.article_html %}
+    <div class="card-text">{{ post.article_html | striptags | truncatechars:200 }}</div>
+    {% endif %}
+  </div>
+
+  <footer class="card-meta">
+    {% if post.date %}
+    <time datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+    {% endif %}
+    <a href="{{ post.href }}" class="card-link">View</a>
+  </footer>
+</article>

--- a/themes/default/templates/partials/cards/photo-card.html
+++ b/themes/default/templates/partials/cards/photo-card.html
@@ -1,0 +1,34 @@
+{# Photo Card - Image/video prominent for shots, photos, gallery posts #}
+{# Large media with aspect-ratio, caption/description below #}
+{# Auto-detects video files by extension: .mp4, .webm, .mov, .m4v, .ogv #}
+<article class="card card-photo">
+  {% if post.image %}
+  <a href="{{ post.href }}" class="card-image-link">
+    {% with post.image|lower as img_lower %}
+    {% if img_lower|endswith:".mp4" or img_lower|endswith:".webm" or img_lower|endswith:".mov" or img_lower|endswith:".m4v" or img_lower|endswith:".ogv" %}
+    <video class="card-image" autoplay muted loop playsinline>
+      <source src="{{ post.image }}" type="video/{% if img_lower|endswith:".mp4" or img_lower|endswith:".m4v" %}mp4{% elif img_lower|endswith:".webm" %}webm{% elif img_lower|endswith:".mov" %}quicktime{% else %}ogg{% endif %}">
+    </video>
+    {% else %}
+    <img src="{{ post.image }}" alt="{{ post.title | default:post.description | default:'Photo' }}" class="card-image" loading="lazy">
+    {% endif %}
+    {% endwith %}
+  </a>
+  {% endif %}
+
+  <div class="card-body">
+    {% if post.title %}
+    <h3 class="card-title"><a href="{{ post.href }}">{{ post.title }}</a></h3>
+    {% endif %}
+
+    {% if post.description %}
+    <p class="card-caption">{{ post.description }}</p>
+    {% endif %}
+
+    <footer class="card-meta">
+      {% if post.date %}
+      <time datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+      {% endif %}
+    </footer>
+  </div>
+</article>

--- a/themes/default/templates/partials/cards/quote-card.html
+++ b/themes/default/templates/partials/cards/quote-card.html
@@ -1,0 +1,30 @@
+{# Quote Card - Blockquote styling for quotes, quotations #}
+{# Large quote with source attribution #}
+<article class="card card-quote">
+  <blockquote class="card-blockquote">
+    {% if post.quote %}
+    <p>{{ post.quote }}</p>
+    {% elif post.description %}
+    <p>{{ post.description }}</p>
+    {% elif post.article_html %}
+    <div>{{ post.article_html | striptags | truncatechars:300 }}</div>
+    {% endif %}
+  </blockquote>
+
+  <footer class="card-attribution">
+    {% if post.source or post.author %}
+    <cite>
+      {% if post.author %}<span class="quote-author">{{ post.author }}</span>{% endif %}
+      {% if post.source %}<span class="quote-source">{{ post.source }}</span>{% endif %}
+    </cite>
+    {% endif %}
+
+    {% if post.title %}
+    <a href="{{ post.href }}" class="card-title-link">{{ post.title }}</a>
+    {% endif %}
+
+    {% if post.date %}
+    <time datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+    {% endif %}
+  </footer>
+</article>

--- a/themes/default/templates/partials/cards/video-card.html
+++ b/themes/default/templates/partials/cards/video-card.html
@@ -1,0 +1,33 @@
+{# Video Card - Video/thumbnail prominent for video, clip, stream posts #}
+{# Video thumbnail with play indicator, title below #}
+<article class="card card-video">
+  {% if post.image or post.thumbnail %}
+  <a href="{{ post.href }}" class="card-video-link">
+    <div class="card-video-container">
+      <img src="{{ post.image | default:post.thumbnail }}" alt="{{ post.title | default:'Video thumbnail' }}" class="card-thumbnail" loading="lazy">
+      <div class="card-play-icon">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="48" height="48">
+          <path d="M8 5v14l11-7z"/>
+        </svg>
+      </div>
+    </div>
+  </a>
+  {% endif %}
+
+  <div class="card-body">
+    {% if post.title %}
+    <h3 class="card-title"><a href="{{ post.href }}">{{ post.title }}</a></h3>
+    {% endif %}
+
+    {% if post.description %}
+    <p class="card-description">{{ post.description | truncatechars:150 }}</p>
+    {% endif %}
+
+    <footer class="card-meta">
+      {% if post.date %}
+      <time datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+      {% endif %}
+      {% if post.duration %}<span class="duration">{{ post.duration }}</span>{% endif %}
+    </footer>
+  </div>
+</article>


### PR DESCRIPTION
## Summary

- Add card templates for different post types (article, note, photo, video, link, quote, guide, inline)
- Add `excerpt` filter to auto-generate content previews from `article_html`
- Add `seealso` admonition type with CSS styling
- Fix admonition parser to close properly on blank lines

## Changes

### Card System
- New card templates in `themes/default/templates/partials/cards/`
- Card router selects template based on `post.template` field
- Cards have different visual treatments for different content types

### Excerpt Filter
- Extracts first 3 paragraphs or 1500 characters from rendered HTML
- Preserves inline formatting (`<code>`, `<a>`, `<em>`, `<strong>`)
- Skips admonition blocks (supplementary content)
- Adds ellipsis when truncated

### Admonition Fixes
- Added `seealso` type to supported admonition types
- Fixed parser to close on blank lines (was capturing entire document)
- Added CSS styling for seealso admonitions

## Files Changed
- `pkg/templates/filters.go` - excerpt filter implementation
- `pkg/plugins/admonitions.go` - seealso type + parser fix
- `themes/default/templates/partials/cards/*` - card templates
- `themes/default/static/css/cards.css` - card styles
- `docs/guides/cards.md` - documentation