### PR TITLE
feat(theme): add comprehensive keyboard navigation

### DIFF
--- a/docs/guides/keyboard-navigation.md
+++ b/docs/guides/keyboard-navigation.md
@@ -1,0 +1,173 @@
+---
+title: "Keyboard Navigation"
+description: "Complete guide to keyboard shortcuts for navigating markata-go sites"
+date: 2024-01-15
+published: true
+slug: /docs/guides/keyboard-navigation/
+tags:
+  - documentation
+  - accessibility
+  - keyboard
+  - navigation
+---
+
+# Keyboard Navigation
+
+markata-go sites include comprehensive keyboard shortcuts for power users and those who prefer keyboard navigation. All shortcuts are designed to be intuitive, following conventions from popular tools like Vim and GitHub.
+
+> **Accessibility:** Shortcuts respect user preferences and can be disabled. They never interfere with form inputs or accessibility tools.
+
+## Quick Reference
+
+Press `?` at any time to see the full shortcuts help modal.
+
+---
+
+## Scrolling
+
+Navigate through page content using vim-style shortcuts:
+
+| Shortcut | Action |
+|----------|--------|
+| `j` | Scroll down (~2 lines) |
+| `k` | Scroll up (~2 lines) |
+| `d` | Scroll half-page down |
+| `u` | Scroll half-page up |
+| `g g` | Scroll to top of page |
+| `Shift+G` | Scroll to bottom of page |
+
+**Note:** On feed/list pages with multiple posts, `j`/`k` will navigate between posts instead of scrolling.
+
+---
+
+## Feed Navigation
+
+When viewing a page with multiple posts (index, archive, tag pages), keyboard navigation lets you browse through posts:
+
+| Shortcut | Action |
+|----------|--------|
+| `j` or `Down Arrow` | Highlight next post |
+| `k` or `Up Arrow` | Highlight previous post |
+| `Enter` or `o` | Open highlighted post |
+| `Shift+O` | Open highlighted post in new tab |
+
+The highlighted post is visually indicated with an outline. Press `Escape` to clear the highlight.
+
+---
+
+## Go-To Shortcuts
+
+GitHub-style two-key sequences for quick navigation:
+
+| Shortcut | Action |
+|----------|--------|
+| `g h` | Go to home page |
+| `g s` | Focus search input |
+
+Press the first key (`g`), then the second key within 800ms.
+
+---
+
+## Utility Shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| `/` | Focus search input |
+| `Cmd/Ctrl+K` | Focus search (alternative) |
+| `y y` | Copy current URL to clipboard |
+| `[` | Go to previous page (pagination) |
+| `]` | Go to next page (pagination) |
+| `?` | Show shortcuts help modal |
+| `Escape` | Close modals, clear highlight, blur inputs |
+
+---
+
+## Accessibility Features
+
+### Respects User Preferences
+
+- **Reduced Motion:** When `prefers-reduced-motion` is enabled, smooth scrolling is disabled for instant navigation.
+- **Input Context:** Shortcuts are automatically disabled when typing in text inputs, textareas, or contenteditable elements.
+
+### Disable Shortcuts
+
+If keyboard shortcuts interfere with your workflow or assistive technology:
+
+1. Press `?` to open the shortcuts modal
+2. Click "Disable Shortcuts"
+
+This preference is saved in your browser and persists across visits.
+
+### Re-enable Shortcuts
+
+1. Press `?` (this still works even when shortcuts are disabled)
+2. Click "Enable Shortcuts"
+
+---
+
+## Customization
+
+### For Site Owners
+
+Keyboard shortcuts are part of the default theme. If you need to customize or extend them:
+
+1. **Override the JavaScript:** Copy `shortcuts.js` from the theme to your `static/js/` directory and modify as needed.
+
+2. **Add to the modal:** Override the `partials/shortcuts-modal.html` template to add your custom shortcuts.
+
+3. **Styling:** The keyboard highlight class `.kb-highlighted` can be customized in your CSS:
+
+```css
+/* Custom highlight style */
+.kb-highlighted {
+  outline: 3px solid var(--color-primary);
+  outline-offset: 4px;
+  background-color: rgba(var(--color-primary-rgb), 0.1);
+}
+```
+
+### JavaScript API
+
+The shortcuts system exposes functions for programmatic use:
+
+```javascript
+// Show toast notification
+markataShortcuts.showToast('Custom message');
+
+// Programmatic scrolling
+markataShortcuts.smoothScroll(100);  // Scroll down 100px
+markataShortcuts.smoothScrollToTop();
+markataShortcuts.smoothScrollToBottom();
+
+// Copy URL
+markataShortcuts.copyUrlToClipboard();
+
+// Check if shortcuts are disabled
+if (!markataShortcuts.areShortcutsDisabled()) {
+  // Shortcuts are enabled
+}
+
+// Modal control
+markataShortcuts.showShortcutsModal();
+markataShortcuts.hideShortcutsModal();
+```
+
+---
+
+## Browser Compatibility
+
+Keyboard shortcuts work in all modern browsers:
+
+- Chrome/Edge 80+
+- Firefox 75+
+- Safari 13+
+
+The clipboard API (`yy` to copy URL) requires a secure context (HTTPS or localhost).
+
+---
+
+## See Also
+
+- [Themes Guide](/docs/guides/themes/) - Theme customization including keyboard shortcuts
+- [Configuration Guide](/docs/guides/configuration/) - Site configuration options
+- [Accessibility](/docs/guides/accessibility/) - Accessibility features and best practices

--- a/docs/guides/themes.md
+++ b/docs/guides/themes.md
@@ -1077,6 +1077,7 @@ Now that you've styled your site, here are recommended next steps:
 
 ## See Also
 
+- [Keyboard Navigation Guide](/docs/guides/keyboard-navigation/) - Comprehensive keyboard shortcuts for site navigation
 - [Configuration Guide](/docs/guides/configuration/) - All configuration options
 - [Templates Guide](/docs/guides/templates/) - Template syntax and customization
 - [Frontmatter Guide](/docs/guides/frontmatter/) - Post-level configuration

--- a/pkg/themes/default/static/css/components.css
+++ b/pkg/themes/default/static/css/components.css
@@ -1322,6 +1322,133 @@
    @mention links in content.
    ========================================================================== */
 
+/* ==========================================================================
+   Keyboard Navigation Styles
+
+   Styles for keyboard-navigated elements including post highlighting
+   and toast notifications.
+   ========================================================================== */
+
+/* Highlighted post in feed when using keyboard navigation (j/k) */
+.kb-highlighted {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+  border-radius: 4px;
+  background-color: color-mix(in srgb, var(--color-primary) 10%, transparent);
+  transition: outline-color 0.15s ease, background-color 0.15s ease;
+}
+
+/* Ensure highlighted cards are visible */
+.card.kb-highlighted,
+.post-card.kb-highlighted,
+article.kb-highlighted {
+  outline-offset: 4px;
+}
+
+/* Toast notification for keyboard actions (e.g., URL copied) */
+.kb-toast {
+  position: fixed;
+  bottom: 2rem;
+  left: 50%;
+  transform: translateX(-50%) translateY(1rem);
+  padding: 0.75rem 1.5rem;
+  background-color: var(--color-surface);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  font-size: 0.875rem;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s;
+  z-index: 10000;
+}
+
+.kb-toast--visible {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(0);
+}
+
+/* Shortcuts modal section styling */
+.shortcuts-section {
+  margin-bottom: 1.5rem;
+}
+
+.shortcuts-section:last-child {
+  margin-bottom: 0;
+}
+
+.shortcuts-section-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+  margin: 0 0 0.5rem 0;
+  padding-bottom: 0.25rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+/* Compact table for shortcuts in sectioned modal */
+.shortcuts-section .shortcuts-table {
+  margin-bottom: 0;
+}
+
+.shortcuts-section .shortcuts-table td {
+  padding: 0.25rem 0.5rem;
+}
+
+.shortcuts-section .shortcuts-table td:first-child {
+  padding-left: 0;
+  white-space: nowrap;
+}
+
+/* Respect reduced motion preference */
+@media (prefers-reduced-motion: reduce) {
+  .kb-highlighted {
+    transition: none;
+  }
+
+  .kb-toast {
+    transition: opacity 0.1s ease, visibility 0.1s;
+    transform: translateX(-50%);
+  }
+
+  .kb-toast--visible {
+    transform: translateX(-50%);
+  }
+}
+
+/* High contrast mode support */
+@media (prefers-contrast: more) {
+  .kb-highlighted {
+    outline-width: 3px;
+    outline-color: var(--color-text);
+  }
+
+  .kb-toast {
+    border-width: 2px;
+    border-color: var(--color-text);
+  }
+}
+
+/* Print styles - hide keyboard-related elements */
+@media print {
+  .kb-highlighted {
+    outline: none;
+    background-color: transparent;
+  }
+
+  .kb-toast {
+    display: none !important;
+  }
+}
+
+/* ==========================================================================
+   End Keyboard Navigation Styles
+   ========================================================================== */
+
 /* Base card styling */
 .mention-card {
   position: absolute;

--- a/pkg/themes/default/static/js/shortcuts.js
+++ b/pkg/themes/default/static/js/shortcuts.js
@@ -6,6 +6,25 @@
  * - `Escape` - Close search/modals
  * - `?` - Show shortcuts help modal
  *
+ * Vim-style scrolling:
+ * - `j`/`k` - Scroll down/up (~60px)
+ * - `gg` - Scroll to top (double-g with timeout)
+ * - `G` (Shift+g) - Scroll to bottom
+ * - `d`/`u` - Scroll half-page down/up
+ *
+ * Feed/list navigation:
+ * - `j`/`k` or arrows - Navigate posts in feed
+ * - `Enter`/`o` - Open highlighted post
+ * - `O` (Shift+o) - Open in new tab
+ *
+ * GitHub-style "go to":
+ * - `g h` - Go to home
+ * - `g s` - Focus search
+ *
+ * Utility:
+ * - `yy` - Copy URL to clipboard
+ * - `[`/`]` - Previous/next post (pagination)
+ *
  * Accessibility: Shortcuts can be disabled via localStorage
  * WCAG 2.1.4 compliant - shortcuts are ignored when typing in inputs
  */
@@ -15,6 +34,15 @@
 
   // Storage key for disabled state
   var STORAGE_KEY = 'markata-shortcuts-disabled';
+
+  // Multi-key sequence tracking
+  var pendingKey = null;
+  var pendingKeyTimeout = null;
+  var MULTI_KEY_TIMEOUT = 800; // ms
+
+  // Feed navigation state
+  var feedPostLinks = [];
+  var highlightedPostIndex = -1;
 
   /**
    * Check if shortcuts are disabled via localStorage
@@ -168,7 +196,229 @@
       }
     }
 
+    // Clear feed highlight
+    if (highlightedPostIndex >= 0) {
+      clearFeedHighlight();
+      closed = true;
+    }
+
     return closed;
+  }
+
+  /**
+   * Smooth scroll with reduced motion support
+   * @param {number} amount - Pixels to scroll (positive = down, negative = up)
+   */
+  function smoothScroll(amount) {
+    var reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    window.scrollBy({
+      top: amount,
+      behavior: reducedMotion ? 'auto' : 'smooth'
+    });
+  }
+
+  /**
+   * Smooth scroll to top of page
+   */
+  function smoothScrollToTop() {
+    var reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    window.scrollTo({
+      top: 0,
+      behavior: reducedMotion ? 'auto' : 'smooth'
+    });
+  }
+
+  /**
+   * Smooth scroll to bottom of page
+   */
+  function smoothScrollToBottom() {
+    var reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    window.scrollTo({
+      top: document.body.scrollHeight,
+      behavior: reducedMotion ? 'auto' : 'smooth'
+    });
+  }
+
+  /**
+   * Clear pending multi-key sequence
+   */
+  function clearPendingKey() {
+    pendingKey = null;
+    if (pendingKeyTimeout) {
+      clearTimeout(pendingKeyTimeout);
+      pendingKeyTimeout = null;
+    }
+  }
+
+  /**
+   * Set pending key for multi-key sequence
+   * @param {string} key - The pending key
+   */
+  function setPendingKey(key) {
+    pendingKey = key;
+    if (pendingKeyTimeout) {
+      clearTimeout(pendingKeyTimeout);
+    }
+    pendingKeyTimeout = setTimeout(clearPendingKey, MULTI_KEY_TIMEOUT);
+  }
+
+  /**
+   * Initialize feed navigation by finding post links
+   * @returns {boolean} True if feed posts were found
+   */
+  function initFeedNavigation() {
+    // Find all post links in feeds/lists
+    feedPostLinks = Array.from(document.querySelectorAll(
+      '.post-list article a[href], ' +
+      '.feed-list .post-link, ' +
+      '.card a[href], ' +
+      '.post-card a[href], ' +
+      '.reader-entry-title a[href]'
+    ));
+    return feedPostLinks.length > 0;
+  }
+
+  /**
+   * Check if the page has feed navigation available
+   * @returns {boolean}
+   */
+  function hasFeedNavigation() {
+    return feedPostLinks.length > 0;
+  }
+
+  /**
+   * Highlight a post in the feed
+   * @param {number} index - Index of post to highlight
+   */
+  function highlightPost(index) {
+    // Remove previous highlight
+    feedPostLinks.forEach(function(link) {
+      link.classList.remove('kb-highlighted');
+    });
+
+    // Add highlight to current
+    if (index >= 0 && index < feedPostLinks.length) {
+      feedPostLinks[index].classList.add('kb-highlighted');
+      feedPostLinks[index].scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      highlightedPostIndex = index;
+    }
+  }
+
+  /**
+   * Clear feed highlight
+   */
+  function clearFeedHighlight() {
+    feedPostLinks.forEach(function(link) {
+      link.classList.remove('kb-highlighted');
+    });
+    highlightedPostIndex = -1;
+  }
+
+  /**
+   * Navigate to the highlighted post
+   * @param {boolean} newTab - Open in new tab
+   */
+  function navigateToHighlighted(newTab) {
+    if (highlightedPostIndex >= 0 && highlightedPostIndex < feedPostLinks.length) {
+      var url = feedPostLinks[highlightedPostIndex].href;
+      if (newTab) {
+        window.open(url, '_blank');
+      } else {
+        window.location.href = url;
+      }
+    }
+  }
+
+  /**
+   * Copy current URL to clipboard and show toast notification
+   */
+  function copyUrlToClipboard() {
+    var url = window.location.href;
+
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(url).then(function() {
+        showToast('URL copied to clipboard');
+      }).catch(function() {
+        fallbackCopyUrl(url);
+      });
+    } else {
+      fallbackCopyUrl(url);
+    }
+  }
+
+  /**
+   * Fallback URL copy method for older browsers
+   * @param {string} url - URL to copy
+   */
+  function fallbackCopyUrl(url) {
+    var textArea = document.createElement('textarea');
+    textArea.value = url;
+    textArea.style.position = 'fixed';
+    textArea.style.left = '-9999px';
+    document.body.appendChild(textArea);
+    textArea.focus();
+    textArea.select();
+
+    try {
+      var successful = document.execCommand('copy');
+      if (successful) {
+        showToast('URL copied to clipboard');
+      } else {
+        showToast('Failed to copy URL');
+      }
+    } catch (err) {
+      showToast('Failed to copy URL');
+    }
+
+    document.body.removeChild(textArea);
+  }
+
+  /**
+   * Show a toast notification
+   * @param {string} message - Message to display
+   */
+  function showToast(message) {
+    // Remove existing toast if any
+    var existingToast = document.querySelector('.kb-toast');
+    if (existingToast) {
+      existingToast.remove();
+    }
+
+    var toast = document.createElement('div');
+    toast.className = 'kb-toast';
+    toast.textContent = message;
+    toast.setAttribute('role', 'status');
+    toast.setAttribute('aria-live', 'polite');
+    document.body.appendChild(toast);
+
+    // Trigger animation
+    setTimeout(function() {
+      toast.classList.add('kb-toast--visible');
+    }, 10);
+
+    // Remove after delay
+    setTimeout(function() {
+      toast.classList.remove('kb-toast--visible');
+      setTimeout(function() {
+        if (toast.parentNode) {
+          toast.remove();
+        }
+      }, 300);
+    }, 2000);
+  }
+
+  /**
+   * Navigate to previous/next post via pagination links
+   * @param {string} direction - 'prev' or 'next'
+   */
+  function navigatePagination(direction) {
+    var selector = direction === 'prev'
+      ? '.pagination-prev a, .prev-post a, a[rel="prev"]'
+      : '.pagination-next a, .next-post a, a[rel="next"]';
+    var link = document.querySelector(selector);
+    if (link && link.href) {
+      window.location.href = link.href;
+    }
   }
 
   /**
@@ -201,6 +451,7 @@
 
     // Always allow Escape to work, even in inputs
     if (e.key === 'Escape') {
+      clearPendingKey();
       if (closeModals()) {
         e.preventDefault();
       }
@@ -223,6 +474,7 @@
     // Cmd/Ctrl+K - Focus search
     if (modifier && e.key === 'k') {
       e.preventDefault();
+      clearPendingKey();
       focusSearch();
       return;
     }
@@ -232,16 +484,168 @@
       return;
     }
 
+    // Handle multi-key sequences
+    if (pendingKey === 'g') {
+      clearPendingKey();
+      switch (e.key) {
+        case 'g':
+          // gg - scroll to top
+          e.preventDefault();
+          smoothScrollToTop();
+          return;
+        case 'h':
+          // g h - go to home
+          e.preventDefault();
+          window.location.href = '/';
+          return;
+        case 's':
+          // g s - focus search
+          e.preventDefault();
+          focusSearch();
+          return;
+      }
+      // Pending 'g' consumed, fall through for other keys
+    }
+
+    if (pendingKey === 'y') {
+      clearPendingKey();
+      if (e.key === 'y') {
+        // yy - copy URL to clipboard
+        e.preventDefault();
+        copyUrlToClipboard();
+        return;
+      }
+      // Pending 'y' consumed, fall through for other keys
+    }
+
     // Handle single-key shortcuts
     switch (e.key) {
       case '/':
         e.preventDefault();
+        clearPendingKey();
         focusSearch();
         break;
 
       case '?':
         e.preventDefault();
+        clearPendingKey();
         showShortcutsModal();
+        break;
+
+      case 'j':
+        e.preventDefault();
+        clearPendingKey();
+        if (hasFeedNavigation()) {
+          // Feed navigation: move to next post
+          highlightPost(Math.min(highlightedPostIndex + 1, feedPostLinks.length - 1));
+        } else {
+          // Vim-style scroll down
+          smoothScroll(60);
+        }
+        break;
+
+      case 'k':
+        e.preventDefault();
+        clearPendingKey();
+        if (hasFeedNavigation()) {
+          // Feed navigation: move to previous post
+          highlightPost(Math.max(highlightedPostIndex - 1, 0));
+        } else {
+          // Vim-style scroll up
+          smoothScroll(-60);
+        }
+        break;
+
+      case 'ArrowDown':
+        if (hasFeedNavigation()) {
+          e.preventDefault();
+          clearPendingKey();
+          highlightPost(Math.min(highlightedPostIndex + 1, feedPostLinks.length - 1));
+        }
+        break;
+
+      case 'ArrowUp':
+        if (hasFeedNavigation()) {
+          e.preventDefault();
+          clearPendingKey();
+          highlightPost(Math.max(highlightedPostIndex - 1, 0));
+        }
+        break;
+
+      case 'g':
+        // Start 'g' sequence (for gg, gh, gs)
+        e.preventDefault();
+        setPendingKey('g');
+        break;
+
+      case 'G':
+        // Shift+G - scroll to bottom
+        if (e.shiftKey) {
+          e.preventDefault();
+          clearPendingKey();
+          smoothScrollToBottom();
+        }
+        break;
+
+      case 'd':
+        // Half-page down
+        e.preventDefault();
+        clearPendingKey();
+        smoothScroll(window.innerHeight / 2);
+        break;
+
+      case 'u':
+        // Half-page up
+        e.preventDefault();
+        clearPendingKey();
+        smoothScroll(-window.innerHeight / 2);
+        break;
+
+      case 'y':
+        // Start 'y' sequence (for yy)
+        e.preventDefault();
+        setPendingKey('y');
+        break;
+
+      case 'o':
+        // Open highlighted post
+        if (highlightedPostIndex >= 0) {
+          e.preventDefault();
+          clearPendingKey();
+          navigateToHighlighted(false);
+        }
+        break;
+
+      case 'O':
+        // Open highlighted post in new tab (Shift+o)
+        if (e.shiftKey && highlightedPostIndex >= 0) {
+          e.preventDefault();
+          clearPendingKey();
+          navigateToHighlighted(true);
+        }
+        break;
+
+      case 'Enter':
+        // Open highlighted post
+        if (highlightedPostIndex >= 0) {
+          e.preventDefault();
+          clearPendingKey();
+          navigateToHighlighted(false);
+        }
+        break;
+
+      case '[':
+        // Previous post (pagination)
+        e.preventDefault();
+        clearPendingKey();
+        navigatePagination('prev');
+        break;
+
+      case ']':
+        // Next post (pagination)
+        e.preventDefault();
+        clearPendingKey();
+        navigatePagination('next');
         break;
     }
   }
@@ -263,6 +667,9 @@
   function init() {
     // Update modifier key display for the current platform
     updateModifierKeyDisplay();
+
+    // Initialize feed navigation
+    initFeedNavigation();
 
     // Add keyboard event listener
     document.addEventListener('keydown', handleKeyDown);
@@ -300,6 +707,11 @@
     showShortcutsModal: showShortcutsModal,
     hideShortcutsModal: hideShortcutsModal,
     toggleShortcuts: toggleShortcuts,
-    areShortcutsDisabled: areShortcutsDisabled
+    areShortcutsDisabled: areShortcutsDisabled,
+    smoothScroll: smoothScroll,
+    smoothScrollToTop: smoothScrollToTop,
+    smoothScrollToBottom: smoothScrollToBottom,
+    copyUrlToClipboard: copyUrlToClipboard,
+    showToast: showToast
   };
 })();

--- a/templates/partials/shortcuts-modal.html
+++ b/templates/partials/shortcuts-modal.html
@@ -12,34 +12,110 @@
         </header>
 
         <div class="shortcuts-modal-body">
-            <table class="shortcuts-table">
-                <thead>
-                    <tr>
-                        <th>Shortcut</th>
-                        <th>Action</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td><kbd>/</kbd></td>
-                        <td>Focus search input</td>
-                    </tr>
-                    <tr>
-                        <td>
-                            <kbd class="kbd-mac">&#8984;</kbd><kbd class="kbd-win">Ctrl</kbd><kbd>K</kbd>
-                        </td>
-                        <td>Focus search (alternative)</td>
-                    </tr>
-                    <tr>
-                        <td><kbd>Esc</kbd></td>
-                        <td>Close search / modals</td>
-                    </tr>
-                    <tr>
-                        <td><kbd>?</kbd></td>
-                        <td>Show this help</td>
-                    </tr>
-                </tbody>
-            </table>
+            {# Scrolling Section #}
+            <section class="shortcuts-section">
+                <h3 class="shortcuts-section-title">Scrolling</h3>
+                <table class="shortcuts-table">
+                    <tbody>
+                        <tr>
+                            <td><kbd>j</kbd></td>
+                            <td>Scroll down</td>
+                        </tr>
+                        <tr>
+                            <td><kbd>k</kbd></td>
+                            <td>Scroll up</td>
+                        </tr>
+                        <tr>
+                            <td><kbd>g</kbd> <kbd>g</kbd></td>
+                            <td>Scroll to top</td>
+                        </tr>
+                        <tr>
+                            <td><kbd>Shift</kbd> <kbd>G</kbd></td>
+                            <td>Scroll to bottom</td>
+                        </tr>
+                        <tr>
+                            <td><kbd>d</kbd></td>
+                            <td>Half-page down</td>
+                        </tr>
+                        <tr>
+                            <td><kbd>u</kbd></td>
+                            <td>Half-page up</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </section>
+
+            {# Navigation Section #}
+            <section class="shortcuts-section">
+                <h3 class="shortcuts-section-title">Navigation</h3>
+                <table class="shortcuts-table">
+                    <tbody>
+                        <tr>
+                            <td><kbd>j</kbd> / <kbd>&darr;</kbd></td>
+                            <td>Next post (in feeds)</td>
+                        </tr>
+                        <tr>
+                            <td><kbd>k</kbd> / <kbd>&uarr;</kbd></td>
+                            <td>Previous post (in feeds)</td>
+                        </tr>
+                        <tr>
+                            <td><kbd>Enter</kbd> / <kbd>o</kbd></td>
+                            <td>Open highlighted post</td>
+                        </tr>
+                        <tr>
+                            <td><kbd>Shift</kbd> <kbd>O</kbd></td>
+                            <td>Open in new tab</td>
+                        </tr>
+                        <tr>
+                            <td><kbd>g</kbd> <kbd>h</kbd></td>
+                            <td>Go to home</td>
+                        </tr>
+                        <tr>
+                            <td><kbd>g</kbd> <kbd>s</kbd></td>
+                            <td>Focus search</td>
+                        </tr>
+                        <tr>
+                            <td><kbd>[</kbd></td>
+                            <td>Previous page</td>
+                        </tr>
+                        <tr>
+                            <td><kbd>]</kbd></td>
+                            <td>Next page</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </section>
+
+            {# Utility Section #}
+            <section class="shortcuts-section">
+                <h3 class="shortcuts-section-title">Utility</h3>
+                <table class="shortcuts-table">
+                    <tbody>
+                        <tr>
+                            <td><kbd>/</kbd></td>
+                            <td>Focus search input</td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <kbd class="kbd-mac">&#8984;</kbd><kbd class="kbd-win">Ctrl</kbd><kbd>K</kbd>
+                            </td>
+                            <td>Focus search (alternative)</td>
+                        </tr>
+                        <tr>
+                            <td><kbd>y</kbd> <kbd>y</kbd></td>
+                            <td>Copy URL to clipboard</td>
+                        </tr>
+                        <tr>
+                            <td><kbd>?</kbd></td>
+                            <td>Show this help</td>
+                        </tr>
+                        <tr>
+                            <td><kbd>Esc</kbd></td>
+                            <td>Close / clear highlight</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </section>
         </div>
 
         <footer class="shortcuts-modal-footer">


### PR DESCRIPTION
## Summary

- Adds vim-style scrolling shortcuts (j/k/gg/G/d/u) for power users
- Implements feed/list navigation with keyboard highlighting
- Adds GitHub-style "go to" shortcuts (g+h for home, g+s for search)
- Includes utility commands (yy to copy URL, [/] for pagination)

## Changes

### JavaScript (`shortcuts.js`)
- Multi-key sequence tracking with 800ms timeout for `gg`, `gh`, `gs`, `yy`
- Feed navigation with `.kb-highlighted` class for visual feedback
- Smooth scrolling respecting `prefers-reduced-motion`
- Toast notifications for clipboard operations
- Input context detection preserved (WCAG 2.1.4 compliant)

### CSS (`components.css`)
- Added `.kb-highlighted` styles for post highlighting
- Added `.kb-toast` styles for notification toasts
- Added `.shortcuts-section` styles for categorized modal
- High contrast and reduced motion media query support

### Templates (`shortcuts-modal.html`)
- Reorganized into categories: Scrolling, Navigation, Utility
- Documents all new shortcuts

### Documentation
- Created `/docs/guides/keyboard-navigation.md` with full guide
- Updated `/docs/guides/themes.md` to reference keyboard navigation

## Keyboard Shortcuts Added

| Category | Shortcut | Action |
|----------|----------|--------|
| Scrolling | `j` | Scroll down |
| Scrolling | `k` | Scroll up |
| Scrolling | `gg` | Scroll to top |
| Scrolling | `G` | Scroll to bottom |
| Scrolling | `d` | Half-page down |
| Scrolling | `u` | Half-page up |
| Navigation | `j`/`k` | Next/prev post (feeds) |
| Navigation | `Enter`/`o` | Open highlighted |
| Navigation | `O` | Open in new tab |
| Navigation | `gh` | Go to home |
| Navigation | `gs` | Focus search |
| Utility | `yy` | Copy URL |
| Utility | `[`/`]` | Prev/next page |

## Testing

- [x] Build passes (`go build ./...`)
- [x] All tests pass (`go test ./...`)
- [x] Pre-commit hooks pass

## Accessibility

- Respects `prefers-reduced-motion` for smooth scrolling
- Input context checks preserved (shortcuts disabled in inputs)
- `Escape` clears highlight state
- Shortcuts can be disabled via modal toggle

Fixes #502