### PR TITLE
feat(plugins): add contribution graph visualization plugin

### DIFF
--- a/docs/guides/analytics.md
+++ b/docs/guides/analytics.md
@@ -1,0 +1,377 @@
+---
+title: "Analytics & Visualizations"
+description: "Guide to analytics plugins for visualizing data and tracking activity in markata-go"
+date: 2024-01-15
+published: true
+slug: /docs/guides/analytics/
+tags:
+  - documentation
+  - guides
+  - analytics
+  - visualization
+---
+
+# Analytics & Visualizations
+
+markata-go provides several plugins for visualizing data directly in your markdown content. This guide covers the contribution graph and chart visualization plugins.
+
+## Contribution Graph
+
+The `contribution_graph` plugin renders GitHub-style calendar heatmaps showing activity over time. It uses the [Cal-Heatmap](https://cal-heatmap.com/) library.
+
+### Configuration
+
+Enable the plugin in your configuration:
+
+```toml
+[markata-go]
+hooks = ["default", "contribution_graph"]
+
+[markata-go.contribution_graph]
+enabled = true
+cdn_url = "https://cdn.jsdelivr.net/npm/cal-heatmap@4"
+container_class = "contribution-graph-container"
+theme = "light"
+```
+
+### Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `enabled` | bool | `true` | Enable/disable the plugin |
+| `cdn_url` | string | `https://cdn.jsdelivr.net/npm/cal-heatmap@4` | Cal-Heatmap CDN URL |
+| `container_class` | string | `contribution-graph-container` | CSS class for the container |
+| `theme` | string | `light` | Color theme (`light` or `dark`) |
+
+### Basic Usage
+
+Add a contribution graph to your markdown using a fenced code block:
+
+````markdown
+```contribution-graph
+{
+  "data": [
+    {"date": "2024-01-01", "value": 5},
+    {"date": "2024-01-02", "value": 3},
+    {"date": "2024-01-03", "value": 8},
+    {"date": "2024-01-04", "value": 2},
+    {"date": "2024-01-05", "value": 10}
+  ],
+  "options": {
+    "domain": "year",
+    "subDomain": "day"
+  }
+}
+```
+````
+
+### Data Format
+
+The `data` array contains objects with:
+- `date`: Date string in ISO format (YYYY-MM-DD)
+- `value`: Numeric value that determines cell color intensity
+
+### Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `domain` | string | `year` | Time domain: `year`, `month`, `week`, `day` |
+| `subDomain` | string | `day` | Sub-domain: `day`, `hour`, `minute` |
+| `cellSize` | number | `10` | Size of each cell in pixels |
+| `range` | number | `1` | Number of domain units to display |
+
+### Examples
+
+#### Year View
+
+Show a full year of activity:
+
+````markdown
+```contribution-graph
+{
+  "data": [
+    {"date": "2024-01-15", "value": 5},
+    {"date": "2024-02-20", "value": 8},
+    {"date": "2024-03-10", "value": 3},
+    {"date": "2024-06-01", "value": 12}
+  ],
+  "options": {
+    "domain": "year",
+    "subDomain": "day",
+    "range": 1
+  }
+}
+```
+````
+
+#### Monthly View
+
+Show activity by month:
+
+````markdown
+```contribution-graph
+{
+  "data": [
+    {"date": "2024-01-01", "value": 5},
+    {"date": "2024-01-15", "value": 8},
+    {"date": "2024-02-01", "value": 3}
+  ],
+  "options": {
+    "domain": "month",
+    "subDomain": "day",
+    "range": 3
+  }
+}
+```
+````
+
+#### Tracking Blog Post Frequency
+
+Use Jinja templating to automatically generate data from your posts:
+
+````markdown
+---
+title: My Writing Activity
+jinja: true
+---
+
+```contribution-graph
+{
+  "data": [
+    {% for post in filter("published == true") %}
+    {"date": "{{ post.Date.Format "2006-01-02" }}", "value": 1}{% if not loop.last %},{% endif %}
+    {% endfor %}
+  ],
+  "options": {
+    "domain": "year",
+    "subDomain": "day"
+  }
+}
+```
+````
+
+### Styling
+
+Add custom CSS to style your contribution graphs:
+
+```css
+.contribution-graph-container {
+  margin: 2rem 0;
+  overflow-x: auto;
+}
+
+/* Cal-Heatmap specific overrides */
+.ch-domain-text {
+  fill: var(--color-text-muted);
+}
+
+.ch-subdomain-bg {
+  fill: var(--color-surface);
+  stroke: var(--color-border);
+}
+```
+
+---
+
+## Chart.js Charts
+
+The `chartjs` plugin lets you embed interactive charts using [Chart.js](https://www.chartjs.org/).
+
+### Configuration
+
+```toml
+[markata-go]
+hooks = ["default", "chartjs"]
+
+[markata-go.chartjs]
+enabled = true
+cdn_url = "https://cdn.jsdelivr.net/npm/chart.js"
+container_class = "chartjs-container"
+```
+
+### Basic Usage
+
+Create charts with JSON configuration:
+
+````markdown
+```chartjs
+{
+  "type": "bar",
+  "data": {
+    "labels": ["January", "February", "March", "April", "May"],
+    "datasets": [{
+      "label": "Posts Published",
+      "data": [3, 5, 2, 8, 4],
+      "backgroundColor": "rgba(54, 162, 235, 0.7)"
+    }]
+  }
+}
+```
+````
+
+### Supported Chart Types
+
+| Type | Description |
+|------|-------------|
+| `bar` | Bar chart (vertical or horizontal) |
+| `line` | Line chart with optional fill |
+| `pie` | Pie chart |
+| `doughnut` | Doughnut chart |
+| `radar` | Radar/spider chart |
+| `polarArea` | Polar area chart |
+| `bubble` | Bubble chart |
+| `scatter` | Scatter plot |
+
+### Examples
+
+#### Line Chart
+
+````markdown
+```chartjs
+{
+  "type": "line",
+  "data": {
+    "labels": ["Week 1", "Week 2", "Week 3", "Week 4"],
+    "datasets": [{
+      "label": "Page Views",
+      "data": [1200, 1900, 1500, 2400],
+      "borderColor": "rgb(75, 192, 192)",
+      "fill": false,
+      "tension": 0.3
+    }]
+  }
+}
+```
+````
+
+#### Pie Chart
+
+````markdown
+```chartjs
+{
+  "type": "pie",
+  "data": {
+    "labels": ["Tutorials", "Guides", "Reference", "Blog"],
+    "datasets": [{
+      "data": [35, 25, 20, 20],
+      "backgroundColor": [
+        "#ff6384",
+        "#36a2eb",
+        "#ffce56",
+        "#4bc0c0"
+      ]
+    }]
+  }
+}
+```
+````
+
+### Advanced Options
+
+Chart.js supports extensive configuration. Add an `options` key for customization:
+
+````markdown
+```chartjs
+{
+  "type": "bar",
+  "data": {
+    "labels": ["Q1", "Q2", "Q3", "Q4"],
+    "datasets": [{
+      "label": "Revenue",
+      "data": [12000, 19000, 15000, 22000]
+    }]
+  },
+  "options": {
+    "responsive": true,
+    "plugins": {
+      "title": {
+        "display": true,
+        "text": "Quarterly Revenue"
+      },
+      "legend": {
+        "position": "bottom"
+      }
+    },
+    "scales": {
+      "y": {
+        "beginAtZero": true
+      }
+    }
+  }
+}
+```
+````
+
+---
+
+## Use Cases
+
+### Blog Statistics Dashboard
+
+Create a dedicated page showing your blog's activity:
+
+```markdown
+---
+title: Blog Statistics
+template: page.html
+jinja: true
+---
+
+## Publishing Activity
+
+```contribution-graph
+{
+  "data": [...generated from posts...],
+  "options": {"domain": "year", "subDomain": "day"}
+}
+```
+
+## Content by Category
+
+```chartjs
+{
+  "type": "pie",
+  "data": {
+    "labels": ["Go", "Python", "DevOps", "Other"],
+    "datasets": [{"data": [15, 12, 8, 5]}]
+  }
+}
+```
+```
+
+### Project Documentation
+
+Track development activity or feature completion:
+
+```markdown
+## Development Progress
+
+```chartjs
+{
+  "type": "bar",
+  "data": {
+    "labels": ["Features", "Bug Fixes", "Tests", "Docs"],
+    "datasets": [{
+      "label": "Completed",
+      "data": [12, 8, 25, 15],
+      "backgroundColor": "#4CAF50"
+    }, {
+      "label": "In Progress",
+      "data": [3, 2, 5, 2],
+      "backgroundColor": "#FFC107"
+    }]
+  },
+  "options": {
+    "indexAxis": "y"
+  }
+}
+```
+```
+
+---
+
+## Related
+
+- [[configuration-guide|Configuration Guide]] - Full configuration reference
+- [[markdown|Markdown Features]] - Other markdown extensions
+- [[templates|Templates]] - Using Jinja in markdown

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -1633,6 +1633,89 @@ A doughnut chart is useful for showing a primary metric with breakdown:
 
 ---
 
+### contribution_graph
+
+**Name:** `contribution_graph`  
+**Stage:** Render (after render_markdown)  
+**Purpose:** Renders GitHub-style calendar heatmaps showing activity over time using Cal-Heatmap.
+
+**Configuration (TOML):**
+```toml
+[markata-go.contribution_graph]
+enabled = true
+cdn_url = "https://cdn.jsdelivr.net/npm/cal-heatmap@4"
+container_class = "contribution-graph-container"
+theme = "light"
+```
+
+**Options:**
+| Option | Default | Description |
+|--------|---------|-------------|
+| `enabled` | `true` | Enable/disable the plugin |
+| `cdn_url` | `https://cdn.jsdelivr.net/npm/cal-heatmap@4` | Cal-Heatmap CDN URL |
+| `container_class` | `contribution-graph-container` | CSS class for wrapper div |
+| `theme` | `light` | Color theme (light, dark) |
+
+**Markdown syntax:**
+````markdown
+```contribution-graph
+{
+  "data": [
+    {"date": "2024-01-01", "value": 5},
+    {"date": "2024-01-02", "value": 3},
+    {"date": "2024-01-03", "value": 8}
+  ],
+  "options": {
+    "domain": "year",
+    "subDomain": "day",
+    "cellSize": 12
+  }
+}
+```
+````
+
+**HTML output:**
+```html
+<div class="contribution-graph-container">
+  <div id="contribution-graph-1"></div>
+</div>
+
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/cal-heatmap@4/cal-heatmap.css">
+<script src="https://cdn.jsdelivr.net/npm/cal-heatmap@4/cal-heatmap.min.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const cal = new CalHeatmap();
+  cal.paint({
+    itemSelector: '#contribution-graph-1',
+    data: { source: [...], x: 'date', y: 'value' },
+    domain: { type: 'year' },
+    subDomain: { type: 'day' }
+  });
+});
+</script>
+```
+
+**Data format:**
+- `date`: ISO date string (YYYY-MM-DD)
+- `value`: Numeric value (affects cell color intensity)
+
+**Options:**
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `domain` | string | `year` | Time domain: year, month, week, day |
+| `subDomain` | string | `day` | Sub-domain: day, hour, minute |
+| `cellSize` | number | `10` | Cell size in pixels |
+| `range` | number | `1` | Number of domain units to display |
+
+**Use cases:**
+- Blog post publishing frequency
+- Contribution tracking
+- Habit tracking displays
+
+**Related:** [[analytics|Analytics Guide]]
+
+---
+
 ### one_line_link
 
 **Name:** `one_line_link`  

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -888,6 +888,31 @@ func NewChartJSConfig() ChartJSConfig {
 	}
 }
 
+// ContributionGraphConfig configures the contribution_graph plugin.
+type ContributionGraphConfig struct {
+	// Enabled controls whether contribution graph processing is active (default: true)
+	Enabled bool `json:"enabled" yaml:"enabled" toml:"enabled"`
+
+	// CDNURL is the URL for the Cal-Heatmap library
+	CDNURL string `json:"cdn_url" yaml:"cdn_url" toml:"cdn_url"`
+
+	// ContainerClass is the CSS class for the graph container div (default: "contribution-graph-container")
+	ContainerClass string `json:"container_class" yaml:"container_class" toml:"container_class"`
+
+	// Theme is the Cal-Heatmap color theme (default: "light")
+	Theme string `json:"theme" yaml:"theme" toml:"theme"`
+}
+
+// NewContributionGraphConfig creates a new ContributionGraphConfig with default values.
+func NewContributionGraphConfig() ContributionGraphConfig {
+	return ContributionGraphConfig{
+		Enabled:        true,
+		CDNURL:         "https://cdn.jsdelivr.net/npm/cal-heatmap@4",
+		ContainerClass: "contribution-graph-container",
+		Theme:          "light",
+	}
+}
+
 // OneLineLinkConfig configures the one_line_link plugin.
 type OneLineLinkConfig struct {
 	// Enabled controls whether link expansion is active (default: true)

--- a/pkg/plugins/contribution_graph.go
+++ b/pkg/plugins/contribution_graph.go
@@ -1,0 +1,261 @@
+// Package plugins provides lifecycle plugins for markata-go.
+package plugins
+
+import (
+	"encoding/json"
+	"fmt"
+	"html"
+	"regexp"
+	"strings"
+	"sync/atomic"
+
+	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
+	"github.com/WaylonWalker/markata-go/pkg/models"
+)
+
+// ContributionGraphPlugin converts contribution-graph JSON code blocks into
+// rendered Cal-Heatmap calendar heatmaps showing GitHub-style activity.
+// It runs at the render stage (after markdown conversion).
+type ContributionGraphPlugin struct {
+	config    models.ContributionGraphConfig
+	idCounter uint64
+}
+
+// NewContributionGraphPlugin creates a new ContributionGraphPlugin with default settings.
+func NewContributionGraphPlugin() *ContributionGraphPlugin {
+	return &ContributionGraphPlugin{
+		config: models.NewContributionGraphConfig(),
+	}
+}
+
+// Name returns the unique name of the plugin.
+func (p *ContributionGraphPlugin) Name() string {
+	return "contribution_graph"
+}
+
+// Priority returns the plugin's priority for a given stage.
+// This plugin runs after render_markdown (which has default priority 0).
+func (p *ContributionGraphPlugin) Priority(stage lifecycle.Stage) int {
+	if stage == lifecycle.StageRender {
+		return lifecycle.PriorityLate // Run after render_markdown
+	}
+	return lifecycle.PriorityDefault
+}
+
+// Configure reads configuration options for the plugin from config.Extra.
+// Configuration is expected under the "contribution_graph" key.
+func (p *ContributionGraphPlugin) Configure(m *lifecycle.Manager) error {
+	config := m.Config()
+	if config.Extra == nil {
+		return nil
+	}
+
+	// Check for contribution_graph config in Extra
+	graphConfig, ok := config.Extra["contribution_graph"]
+	if !ok {
+		return nil
+	}
+
+	// Handle map configuration
+	if cfgMap, ok := graphConfig.(map[string]interface{}); ok {
+		if enabled, ok := cfgMap["enabled"].(bool); ok {
+			p.config.Enabled = enabled
+		}
+		if cdnURL, ok := cfgMap["cdn_url"].(string); ok && cdnURL != "" {
+			p.config.CDNURL = cdnURL
+		}
+		if containerClass, ok := cfgMap["container_class"].(string); ok && containerClass != "" {
+			p.config.ContainerClass = containerClass
+		}
+		if theme, ok := cfgMap["theme"].(string); ok && theme != "" {
+			p.config.Theme = theme
+		}
+	}
+
+	return nil
+}
+
+// Render processes contribution-graph code blocks in the rendered HTML for all posts.
+func (p *ContributionGraphPlugin) Render(m *lifecycle.Manager) error {
+	if !p.config.Enabled {
+		return nil
+	}
+
+	return m.ProcessPostsConcurrently(p.processPost)
+}
+
+// contributionGraphCodeBlockRegex matches <pre><code class="language-contribution-graph"> blocks.
+// It captures the JSON content inside.
+var contributionGraphCodeBlockRegex = regexp.MustCompile(
+	`<pre><code class="language-contribution-graph"[^>]*>([\s\S]*?)</code></pre>`,
+)
+
+// processPost processes a single post's HTML for contribution-graph code blocks.
+func (p *ContributionGraphPlugin) processPost(post *models.Post) error {
+	// Skip posts marked as skip or with no HTML content
+	if post.Skip || post.ArticleHTML == "" {
+		return nil
+	}
+
+	// Check if there are any contribution-graph code blocks
+	if !strings.Contains(post.ArticleHTML, `class="language-contribution-graph"`) {
+		return nil
+	}
+
+	// Track if we found any contribution-graph blocks and collect initialization scripts
+	var initScripts []string
+
+	// Replace contribution-graph code blocks with div elements
+	result := contributionGraphCodeBlockRegex.ReplaceAllStringFunc(post.ArticleHTML, func(match string) string {
+		// Extract the JSON content
+		submatches := contributionGraphCodeBlockRegex.FindStringSubmatch(match)
+		if len(submatches) < 2 {
+			return match
+		}
+
+		// Decode HTML entities in the JSON (goldmark encodes them)
+		jsonContent := html.UnescapeString(submatches[1])
+		jsonContent = strings.TrimSpace(jsonContent)
+
+		// Validate and parse the JSON content
+		var graphConfig map[string]interface{}
+		if err := json.Unmarshal([]byte(jsonContent), &graphConfig); err != nil {
+			// Invalid JSON, return with an error comment
+			return fmt.Sprintf(`<div class="%s contribution-graph-error">
+  <p>Contribution Graph Error: Invalid JSON configuration</p>
+  <pre>%s</pre>
+</div>`, p.config.ContainerClass, html.EscapeString(err.Error()))
+		}
+
+		// Generate a unique ID for this graph
+		graphID := fmt.Sprintf("contribution-graph-%d", atomic.AddUint64(&p.idCounter, 1))
+
+		// Extract data and options from the config
+		data := graphConfig["data"]
+		options := graphConfig["options"]
+		if options == nil {
+			options = map[string]interface{}{}
+		}
+
+		// Marshal data and options back to JSON for the script
+		dataJSON, err := json.Marshal(data)
+		if err != nil {
+			return fmt.Sprintf(`<div class="%s contribution-graph-error">
+  <p>Contribution Graph Error: Failed to serialize data</p>
+  <pre>%s</pre>
+</div>`, p.config.ContainerClass, html.EscapeString(err.Error()))
+		}
+		optionsJSON, err := json.Marshal(options)
+		if err != nil {
+			return fmt.Sprintf(`<div class="%s contribution-graph-error">
+  <p>Contribution Graph Error: Failed to serialize options</p>
+  <pre>%s</pre>
+</div>`, p.config.ContainerClass, html.EscapeString(err.Error()))
+		}
+
+		// Create the initialization script for this graph
+		initScript := fmt.Sprintf(`
+  (function() {
+    const cal = new CalHeatmap();
+    cal.paint({
+      itemSelector: '#%s',
+      data: {
+        source: %s,
+        x: 'date',
+        y: 'value'
+      },
+      %s
+    });
+  })();`, graphID, string(dataJSON), p.buildOptionsScript(optionsJSON))
+		initScripts = append(initScripts, initScript)
+
+		// Return the container div
+		return fmt.Sprintf(`<div class="%s">
+  <div id="%s"></div>
+</div>`, p.config.ContainerClass, graphID)
+	})
+
+	// If we found contribution-graph blocks, inject the scripts
+	if len(initScripts) > 0 {
+		result = p.injectCalHeatmapScripts(result, initScripts)
+	}
+
+	post.ArticleHTML = result
+	return nil
+}
+
+// buildOptionsScript converts options JSON into Cal-Heatmap configuration.
+func (p *ContributionGraphPlugin) buildOptionsScript(optionsJSON []byte) string {
+	var options map[string]interface{}
+	if err := json.Unmarshal(optionsJSON, &options); err != nil {
+		return ""
+	}
+
+	// Build configuration options string
+	var configParts []string
+
+	// Handle domain configuration
+	if domain, ok := options["domain"].(string); ok {
+		configParts = append(configParts, fmt.Sprintf(`domain: { type: '%s' }`, domain))
+	} else {
+		configParts = append(configParts, `domain: { type: 'year' }`)
+	}
+
+	// Handle subDomain configuration
+	if subDomain, ok := options["subDomain"].(string); ok {
+		configParts = append(configParts, fmt.Sprintf(`subDomain: { type: '%s' }`, subDomain))
+	} else {
+		configParts = append(configParts, `subDomain: { type: 'day' }`)
+	}
+
+	// Handle cellSize/width
+	if cellSize, ok := options["cellSize"].(float64); ok {
+		configParts = append(configParts, fmt.Sprintf(`subDomain: { type: 'day', width: %d, height: %d }`, int(cellSize), int(cellSize)))
+	}
+
+	// Handle range
+	if rangeVal, ok := options["range"].(float64); ok {
+		configParts = append(configParts, fmt.Sprintf(`range: %d`, int(rangeVal)))
+	}
+
+	// Handle theme
+	if p.config.Theme != "" {
+		configParts = append(configParts, fmt.Sprintf(`theme: '%s'`, p.config.Theme))
+	}
+
+	return strings.Join(configParts, ",\n      ")
+}
+
+// injectCalHeatmapScripts adds the Cal-Heatmap library and initialization scripts to the HTML.
+func (p *ContributionGraphPlugin) injectCalHeatmapScripts(htmlContent string, initScripts []string) string {
+	// Build the combined script
+	script := fmt.Sprintf(`
+<link rel="stylesheet" href="%s/cal-heatmap.css">
+<script src="%s/cal-heatmap.min.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', function() {%s
+});
+</script>`, p.config.CDNURL, p.config.CDNURL, strings.Join(initScripts, ""))
+
+	// Append the script to the end of the content
+	return htmlContent + script
+}
+
+// SetConfig sets the contribution graph configuration directly.
+// This is useful for testing or programmatic configuration.
+func (p *ContributionGraphPlugin) SetConfig(config models.ContributionGraphConfig) {
+	p.config = config
+}
+
+// Config returns the current contribution graph configuration.
+func (p *ContributionGraphPlugin) Config() models.ContributionGraphConfig {
+	return p.config
+}
+
+// Ensure ContributionGraphPlugin implements the required interfaces.
+var (
+	_ lifecycle.Plugin          = (*ContributionGraphPlugin)(nil)
+	_ lifecycle.ConfigurePlugin = (*ContributionGraphPlugin)(nil)
+	_ lifecycle.RenderPlugin    = (*ContributionGraphPlugin)(nil)
+	_ lifecycle.PriorityPlugin  = (*ContributionGraphPlugin)(nil)
+)

--- a/pkg/plugins/contribution_graph_test.go
+++ b/pkg/plugins/contribution_graph_test.go
@@ -1,0 +1,296 @@
+package plugins
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/WaylonWalker/markata-go/pkg/models"
+)
+
+func TestContributionGraphPlugin_Name(t *testing.T) {
+	p := NewContributionGraphPlugin()
+	if got := p.Name(); got != "contribution_graph" {
+		t.Errorf("Name() = %q, want %q", got, "contribution_graph")
+	}
+}
+
+func TestContributionGraphPlugin_ProcessPost_NoContributionGraph(t *testing.T) {
+	p := NewContributionGraphPlugin()
+
+	post := &models.Post{
+		ArticleHTML: "<p>Hello world</p>",
+	}
+
+	err := p.processPost(post)
+	if err != nil {
+		t.Errorf("processPost() error = %v", err)
+	}
+
+	// HTML should be unchanged
+	if post.ArticleHTML != "<p>Hello world</p>" {
+		t.Errorf("HTML was modified when no contribution-graph blocks present")
+	}
+}
+
+func TestContributionGraphPlugin_ProcessPost_ValidGraph(t *testing.T) {
+	p := NewContributionGraphPlugin()
+
+	post := &models.Post{
+		ArticleHTML: `<p>Check out this contribution graph:</p>
+<pre><code class="language-contribution-graph">{
+  "data": [{"date": "2024-01-01", "value": 5}],
+  "options": {"domain": "year", "subDomain": "day"}
+}</code></pre>
+<p>Nice graph!</p>`,
+	}
+
+	err := p.processPost(post)
+	if err != nil {
+		t.Errorf("processPost() error = %v", err)
+	}
+
+	// Should contain a div element
+	if !strings.Contains(post.ArticleHTML, "<div id=") {
+		t.Error("Expected div element in output")
+	}
+
+	// Should contain Cal-Heatmap CDN script
+	if !strings.Contains(post.ArticleHTML, "cal-heatmap") {
+		t.Error("Expected Cal-Heatmap CDN script")
+	}
+
+	// Should have the container class
+	if !strings.Contains(post.ArticleHTML, `class="contribution-graph-container"`) {
+		t.Error("Expected contribution-graph-container class")
+	}
+
+	// Should have initialization script
+	if !strings.Contains(post.ArticleHTML, "new CalHeatmap()") {
+		t.Error("Expected CalHeatmap initialization script")
+	}
+}
+
+func TestContributionGraphPlugin_ProcessPost_InvalidJSON(t *testing.T) {
+	p := NewContributionGraphPlugin()
+
+	post := &models.Post{
+		ArticleHTML: `<pre><code class="language-contribution-graph">{ invalid json }</code></pre>`,
+	}
+
+	err := p.processPost(post)
+	if err != nil {
+		t.Errorf("processPost() error = %v", err)
+	}
+
+	// Should contain an error message
+	if !strings.Contains(post.ArticleHTML, "contribution-graph-error") {
+		t.Error("Expected error class for invalid JSON")
+	}
+	if !strings.Contains(post.ArticleHTML, "Invalid JSON") {
+		t.Error("Expected error message for invalid JSON")
+	}
+}
+
+func TestContributionGraphPlugin_ProcessPost_MultipleGraphs(t *testing.T) {
+	p := NewContributionGraphPlugin()
+
+	post := &models.Post{
+		ArticleHTML: `<pre><code class="language-contribution-graph">{"data": [], "options": {}}</code></pre>
+<p>And another:</p>
+<pre><code class="language-contribution-graph">{"data": [], "options": {"domain": "month"}}</code></pre>`,
+	}
+
+	err := p.processPost(post)
+	if err != nil {
+		t.Errorf("processPost() error = %v", err)
+	}
+
+	// Should have two div elements with different IDs
+	count := strings.Count(post.ArticleHTML, "<div id=")
+	if count != 2 {
+		t.Errorf("Expected 2 div elements, got %d", count)
+	}
+
+	// CDN should only be included once
+	cdnCount := strings.Count(post.ArticleHTML, "cal-heatmap.min.js")
+	if cdnCount != 1 {
+		t.Errorf("Expected 1 CDN script inclusion, got %d", cdnCount)
+	}
+}
+
+func TestContributionGraphPlugin_ProcessPost_SkipPost(t *testing.T) {
+	p := NewContributionGraphPlugin()
+
+	post := &models.Post{
+		Skip:        true,
+		ArticleHTML: `<pre><code class="language-contribution-graph">{"data": []}</code></pre>`,
+	}
+	originalHTML := post.ArticleHTML
+
+	err := p.processPost(post)
+	if err != nil {
+		t.Errorf("processPost() error = %v", err)
+	}
+
+	// HTML should be unchanged for skipped posts
+	if post.ArticleHTML != originalHTML {
+		t.Error("Skip post HTML was modified")
+	}
+}
+
+func TestContributionGraphPlugin_ProcessPost_EmptyHTML(t *testing.T) {
+	p := NewContributionGraphPlugin()
+
+	post := &models.Post{
+		ArticleHTML: "",
+	}
+
+	err := p.processPost(post)
+	if err != nil {
+		t.Errorf("processPost() error = %v", err)
+	}
+
+	if post.ArticleHTML != "" {
+		t.Error("Empty HTML was modified")
+	}
+}
+
+func TestContributionGraphPlugin_ProcessPost_Disabled(t *testing.T) {
+	p := NewContributionGraphPlugin()
+	p.SetConfig(models.ContributionGraphConfig{
+		Enabled: false,
+		CDNURL:  "https://cdn.jsdelivr.net/npm/cal-heatmap@4",
+	})
+
+	// Verify plugin is disabled via config
+	if p.Config().Enabled {
+		t.Error("Expected plugin to be disabled")
+	}
+}
+
+func TestContributionGraphPlugin_ProcessPost_CustomContainerClass(t *testing.T) {
+	p := NewContributionGraphPlugin()
+	p.SetConfig(models.ContributionGraphConfig{
+		Enabled:        true,
+		CDNURL:         "https://example.com/cal-heatmap",
+		ContainerClass: "my-custom-graph",
+		Theme:          "dark",
+	})
+
+	post := &models.Post{
+		ArticleHTML: `<pre><code class="language-contribution-graph">{"data": []}</code></pre>`,
+	}
+
+	err := p.processPost(post)
+	if err != nil {
+		t.Errorf("processPost() error = %v", err)
+	}
+
+	if !strings.Contains(post.ArticleHTML, `class="my-custom-graph"`) {
+		t.Error("Expected custom container class")
+	}
+	if !strings.Contains(post.ArticleHTML, "example.com/cal-heatmap") {
+		t.Error("Expected custom CDN URL")
+	}
+}
+
+func TestContributionGraphPlugin_ProcessPost_HTMLEntities(t *testing.T) {
+	p := NewContributionGraphPlugin()
+
+	// Goldmark encodes special characters, so we test that they get decoded
+	post := &models.Post{
+		ArticleHTML: `<pre><code class="language-contribution-graph">{&quot;data&quot;: [], &quot;options&quot;: {}}</code></pre>`,
+	}
+
+	err := p.processPost(post)
+	if err != nil {
+		t.Errorf("processPost() error = %v", err)
+	}
+
+	// Should process successfully (HTML entities decoded)
+	if strings.Contains(post.ArticleHTML, "contribution-graph-error") {
+		t.Error("Should handle HTML entities correctly")
+	}
+	if !strings.Contains(post.ArticleHTML, "<div id=") {
+		t.Error("Expected div element after HTML entity decoding")
+	}
+}
+
+func TestContributionGraphPlugin_ProcessPost_PreserveSurroundingContent(t *testing.T) {
+	p := NewContributionGraphPlugin()
+
+	post := &models.Post{
+		ArticleHTML: `<h1>Title</h1>
+<pre><code class="language-contribution-graph">{"data": []}</code></pre>
+<p>Footer content</p>`,
+	}
+
+	err := p.processPost(post)
+	if err != nil {
+		t.Errorf("processPost() error = %v", err)
+	}
+
+	// Should preserve surrounding content
+	if !strings.Contains(post.ArticleHTML, "<h1>Title</h1>") {
+		t.Error("Lost header content")
+	}
+	if !strings.Contains(post.ArticleHTML, "<p>Footer content</p>") {
+		t.Error("Lost footer content")
+	}
+}
+
+func TestContributionGraphPlugin_ProcessPost_WithOptions(t *testing.T) {
+	p := NewContributionGraphPlugin()
+
+	post := &models.Post{
+		ArticleHTML: `<pre><code class="language-contribution-graph">{
+  "data": [{"date": "2024-01-01", "value": 5}],
+  "options": {
+    "domain": "month",
+    "subDomain": "day",
+    "cellSize": 15,
+    "range": 12
+  }
+}</code></pre>`,
+	}
+
+	err := p.processPost(post)
+	if err != nil {
+		t.Errorf("processPost() error = %v", err)
+	}
+
+	// Should contain domain configuration
+	if !strings.Contains(post.ArticleHTML, "domain:") {
+		t.Error("Expected domain configuration in output")
+	}
+
+	// Should contain initialization with CalHeatmap
+	if !strings.Contains(post.ArticleHTML, "cal.paint") {
+		t.Error("Expected cal.paint call in output")
+	}
+}
+
+func TestContributionGraphPlugin_ProcessPost_DataParsing(t *testing.T) {
+	p := NewContributionGraphPlugin()
+
+	post := &models.Post{
+		ArticleHTML: `<pre><code class="language-contribution-graph">{
+  "data": [
+    {"date": "2024-01-01", "value": 5},
+    {"date": "2024-01-02", "value": 10},
+    {"date": "2024-01-03", "value": 3}
+  ],
+  "options": {}
+}</code></pre>`,
+	}
+
+	err := p.processPost(post)
+	if err != nil {
+		t.Errorf("processPost() error = %v", err)
+	}
+
+	// Should contain the data in the script
+	if !strings.Contains(post.ArticleHTML, "2024-01-01") {
+		t.Error("Expected data to be included in output")
+	}
+}

--- a/pkg/plugins/registry.go
+++ b/pkg/plugins/registry.go
@@ -58,6 +58,7 @@ func registerBuiltinPluginsLocked() {
 	pluginRegistry.constructors["glossary"] = func() lifecycle.Plugin { return NewGlossaryPlugin() }
 	pluginRegistry.constructors["md_video"] = func() lifecycle.Plugin { return NewMDVideoPlugin() }
 	pluginRegistry.constructors["chartjs"] = func() lifecycle.Plugin { return NewChartJSPlugin() }
+	pluginRegistry.constructors["contribution_graph"] = func() lifecycle.Plugin { return NewContributionGraphPlugin() }
 	pluginRegistry.constructors["one_line_link"] = func() lifecycle.Plugin { return NewOneLineLinkPlugin() }
 	pluginRegistry.constructors["wikilink_hover"] = func() lifecycle.Plugin { return NewWikilinkHoverPlugin() }
 	pluginRegistry.constructors["qrcode"] = func() lifecycle.Plugin { return NewQRCodePlugin() }

--- a/spec/spec/OPTIONAL_PLUGINS.md
+++ b/spec/spec/OPTIONAL_PLUGINS.md
@@ -9,18 +9,19 @@ This document specifies optional plugins that extend the static site generator w
 │                       OPTIONAL PLUGIN SET                           │
 ├─────────────────────────────────────────────────────────────────────┤
 │  CONTENT ENHANCEMENT                                                │
-│    ├─ glossary          Auto-link terms to definition posts        │
-│    ├─ mermaid           Render Mermaid diagrams                    │
-│    ├─ chartjs           Render Chart.js charts                     │
-│    ├─ csv_fence         Convert CSV code blocks to tables          │
-│    └─ md_video          Convert image syntax to video tags         │
+│    ├─ glossary            Auto-link terms to definition posts      │
+│    ├─ mermaid             Render Mermaid diagrams                  │
+│    ├─ chartjs             Render Chart.js charts                   │
+│    ├─ contribution_graph  GitHub-style calendar heatmaps           │
+│    ├─ csv_fence           Convert CSV code blocks to tables        │
+│    └─ md_video            Convert image syntax to video tags       │
 │                                                                      │
 │  LINK ENHANCEMENT                                                    │
-│    ├─ one_line_link     Rich previews for URLs on own line         │
-│    └─ wikilink_hover    Hover previews for wikilinks               │
+│    ├─ one_line_link       Rich previews for URLs on own line       │
+│    └─ wikilink_hover      Hover previews for wikilinks             │
 │                                                                      │
 │  OUTPUT GENERATION                                                   │
-│    └─ qrcode            Generate QR codes for posts                │
+│    └─ qrcode              Generate QR codes for posts              │
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -234,8 +235,6 @@ The plugin MUST implement:
 
 ### `chartjs`
 
-> **Note:** This plugin is planned but not yet implemented.
-
 **Stage:** `render` (late priority, after markdown conversion)
 
 **Purpose:** Convert Chart.js JSON blocks into rendered charts.
@@ -248,7 +247,7 @@ The plugin MUST implement:
 [markata-go.chartjs]
 enabled = true
 cdn_url = "https://cdn.jsdelivr.net/npm/chart.js"
-default_options = {}               # Default Chart.js options
+container_class = "chartjs-container"
 ```
 
 **Syntax:**
@@ -305,6 +304,126 @@ default_options = {}               # Default Chart.js options
 | `polarArea` | Polar area chart |
 | `bubble` | Bubble chart |
 | `scatter` | Scatter plot |
+
+**Interface requirements:**
+
+The plugin MUST implement:
+- `Plugin` - Basic plugin interface with `Name()` method
+- `ConfigurePlugin` - To read configuration
+- `RenderPlugin` - To process posts during the render stage
+- `PriorityPlugin` - To ensure late execution after markdown rendering
+
+---
+
+### `contribution_graph`
+
+**Stage:** `render` (late priority, after markdown conversion)
+
+**Purpose:** Generate GitHub-style calendar heatmaps showing post activity using Cal-Heatmap.
+
+**Dependencies:** None (client-side rendering via CDN)
+
+**Configuration:**
+
+```toml
+[markata-go.contribution_graph]
+enabled = true
+cdn_url = "https://cdn.jsdelivr.net/npm/cal-heatmap@4"
+container_class = "contribution-graph-container"
+theme = "light"                    # light, dark
+```
+
+**Configuration Fields:**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `true` | Whether the plugin is active |
+| `cdn_url` | string | `"https://cdn.jsdelivr.net/npm/cal-heatmap@4"` | URL for Cal-Heatmap library |
+| `container_class` | string | `"contribution-graph-container"` | CSS class for container div |
+| `theme` | string | `"light"` | Cal-Heatmap color theme |
+
+**Syntax:**
+
+````markdown
+```contribution-graph
+{
+  "data": [
+    {"date": "2024-01-01", "value": 5},
+    {"date": "2024-01-02", "value": 3},
+    {"date": "2024-01-03", "value": 8}
+  ],
+  "options": {
+    "domain": "year",
+    "subDomain": "day",
+    "cellSize": 12,
+    "range": 1
+  }
+}
+```
+````
+
+**Data Format:**
+
+The `data` array should contain objects with:
+- `date`: ISO date string (YYYY-MM-DD)
+- `value`: Numeric value for that date (affects cell color intensity)
+
+**Options:**
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `domain` | string | `"year"` | Time domain: "year", "month", "week", "day" |
+| `subDomain` | string | `"day"` | Sub-domain: "day", "hour", "minute" |
+| `cellSize` | number | `10` | Size of each cell in pixels |
+| `range` | number | `1` | Number of domain units to display |
+
+**Behavior:**
+
+1. Find all `<pre><code class="language-contribution-graph">` blocks
+2. Parse JSON content (data and options)
+3. Replace with div container and initialization script
+4. Inject Cal-Heatmap CSS and JS (once per page)
+
+**Output:**
+
+```html
+<div class="contribution-graph-container">
+  <div id="contribution-graph-1"></div>
+</div>
+
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/cal-heatmap@4/cal-heatmap.css">
+<script src="https://cdn.jsdelivr.net/npm/cal-heatmap@4/cal-heatmap.min.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const cal = new CalHeatmap();
+  cal.paint({
+    itemSelector: '#contribution-graph-1',
+    data: {
+      source: [{"date": "2024-01-01", "value": 5}, ...],
+      x: 'date',
+      y: 'value'
+    },
+    domain: { type: 'year' },
+    subDomain: { type: 'day' }
+  });
+});
+</script>
+```
+
+**Use Cases:**
+
+- Blog post publishing frequency visualization
+- GitHub-style contribution tracking
+- Habit tracking displays
+- Activity heatmaps for any date-based data
+
+**Interface requirements:**
+
+The plugin MUST implement:
+- `Plugin` - Basic plugin interface with `Name()` method
+- `ConfigurePlugin` - To read configuration
+- `RenderPlugin` - To process posts during the render stage
+- `PriorityPlugin` - To ensure late execution after markdown rendering
 
 ---
 


### PR DESCRIPTION
## Summary

Implements a contribution graph visualization plugin that generates GitHub-style calendar heatmaps showing post activity using the Cal-Heatmap library.

- Adds `contribution_graph` plugin following the existing ChartJSPlugin pattern
- Adds `ContributionGraphConfig` struct to models/config.go
- Registers the plugin in registry.go
- Creates comprehensive test suite (13 tests)
- Updates spec documentation in `spec/spec/OPTIONAL_PLUGINS.md`
- Creates user documentation in `docs/guides/analytics.md`
- Updates plugin reference in `docs/reference/plugins.md`

## Usage

```markdown
\`\`\`contribution-graph
{
  "data": [
    {"date": "2024-01-01", "value": 5},
    {"date": "2024-01-02", "value": 3}
  ],
  "options": {
    "domain": "year",
    "subDomain": "day",
    "cellSize": 12
  }
}
\`\`\`
```

## Configuration

```toml
[markata-go.contribution_graph]
enabled = true
cdn_url = "https://cdn.jsdelivr.net/npm/cal-heatmap@4"
container_class = "contribution-graph-container"
theme = "light"
```

Fixes #514