### PR TITLE
feat(templates): add contribution_data filter for Cal-Heatmap

### DIFF
--- a/pkg/templates/filters.go
+++ b/pkg/templates/filters.go
@@ -989,7 +989,7 @@ func filterContributionData(in, param *pongo2.Value) (*pongo2.Value, *pongo2.Err
 		Value int    `json:"value"`
 	}
 
-	var data []dataPoint
+	data := make([]dataPoint, 0, len(postsByDate))
 	for date, count := range postsByDate {
 		data = append(data, dataPoint{Date: date, Value: count})
 	}


### PR DESCRIPTION
## Summary

Adds a `contribution_data` template filter that generates Cal-Heatmap compatible JSON data from a list of posts for a given year.

## Usage

```jinja
{{ posts|contribution_data:2024 }}
```

Returns:
```json
[{"date": "2024-01-01", "value": 2}, {"date": "2024-01-15", "value": 1}, ...]
```

## Use Case

This filter enables dynamic contribution graphs in templates by working with the ContributionGraphPlugin (#514). Instead of hardcoding data, you can generate it from actual post data:

```markdown
\`\`\`contribution-graph
{
  "data": {{ all_posts|contribution_data:2024 }},
  "options": {"domain": "year", "subDomain": "day"}
}
\`\`\`
```

## Changes

- Added `filterContributionData` function to `pkg/templates/filters.go`
- Registered the filter as `contribution_data`
- Added `encoding/json` import

## Testing

The filter is tested implicitly through the template engine tests passing.