### PR TITLE
fix: add page-specific title and description to templates

### DIFF
--- a/templates/feed.html
+++ b/templates/feed.html
@@ -1,5 +1,8 @@
 {% extends "base.html" %}
 
+{% block title %}{{ feed.title | default:config.title | default:'My Site' }}{% endblock %}
+{% block description %}{{ feed.description | default:config.description | default:'' }}{% endblock %}
+
 {% block htmx %}
 {% if page.pagination_type == "htmx" %}
 <script src="https://unpkg.com/htmx.org@1.9.10" integrity="sha384-D1Kt99CQMDuVetoL1lrYwg5t+9QdHe7NLX/SoJYkXDFfX37iInKRy5xLSi8nO7UC" crossorigin="anonymous"></script>

--- a/templates/layouts/bare.html
+++ b/templates/layouts/bare.html
@@ -1,6 +1,9 @@
 {# Bare Layout - Minimal layout with content only #}
 {% extends "base.html" %}
 
+{% block title %}{{ post.title | default:config.title | default:'My Site' }}{% endblock %}
+{% block description %}{{ post.description | default:config.description | default:'' }}{% endblock %}
+
 {% block body_class %}layout layout--bare{% endblock %}
 
 {% block header %}

--- a/templates/layouts/blog.html
+++ b/templates/layouts/blog.html
@@ -1,6 +1,9 @@
 {# Blog Layout - Single-column layout optimized for reading #}
 {% extends "base.html" %}
 
+{% block title %}{{ post.title | default:config.title | default:'My Site' }}{% endblock %}
+{% block description %}{{ post.description | default:config.description | default:'' }}{% endblock %}
+
 {% block body_class %}layout layout--blog{% endblock %}
 
 {% block header %}

--- a/templates/layouts/docs.html
+++ b/templates/layouts/docs.html
@@ -1,6 +1,9 @@
 {# Documentation Layout - 3-panel layout with sidebar, content, and TOC #}
 {% extends "base.html" %}
 
+{% block title %}{{ post.title | default:config.title | default:'My Site' }}{% endblock %}
+{% block description %}{{ post.description | default:config.description | default:'' }}{% endblock %}
+
 {% block body_class %}layout layout--docs{% endblock %}
 
 {% block header %}

--- a/templates/layouts/landing.html
+++ b/templates/layouts/landing.html
@@ -1,6 +1,9 @@
 {# Landing Layout - Full-width layout for marketing pages #}
 {% extends "base.html" %}
 
+{% block title %}{{ post.title | default:config.title | default:'My Site' }}{% endblock %}
+{% block description %}{{ post.description | default:config.description | default:'' }}{% endblock %}
+
 {% block body_class %}layout layout--landing{% endblock %}
 
 {% block header %}

--- a/templates/post.html
+++ b/templates/post.html
@@ -1,5 +1,8 @@
 {% extends "base.html" %}
 
+{% block title %}{{ post.title | default:config.title | default:'My Site' }}{% endblock %}
+{% block description %}{{ post.description | default:config.description | default:'' }}{% endblock %}
+
 {% block content %}
 <div class="content-wrapper{% if config.components.doc_sidebar.enabled and post.toc %} content-wrapper--with-sidebar content-wrapper--sidebar-{{ config.components.doc_sidebar.position | default:'right' }}{% endif %}">
     <article data-pagefind-body>

--- a/themes/default/templates/feed.html
+++ b/themes/default/templates/feed.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% block title %}{{ feed.title | default:config.title | default:'Posts' }}{% endblock %}
+{% block description %}{{ feed.description | default:config.description | default:'' }}{% endblock %}
 
 {% block htmx %}
 {% if page.pagination_type == "htmx" %}


### PR DESCRIPTION
## Summary

Fixes Lighthouse SEO critical failures for missing `<title>` element and meta description.

- Templates now override title/description blocks with page-specific values
- Posts use `post.title` and `post.description`
- Feeds use `feed.title` and `feed.description`
- Falls back to site config values when page-specific values are missing

## Changes

- `templates/post.html` - Add title/description blocks
- `templates/feed.html` - Add title/description blocks
- `templates/layouts/blog.html` - Add title/description blocks
- `templates/layouts/docs.html` - Add title/description blocks  
- `templates/layouts/landing.html` - Add title/description blocks
- `templates/layouts/bare.html` - Add title/description blocks
- `themes/default/templates/feed.html` - Add missing description block

Fixes #524