### PR TITLE
perf: reduce incremental overhead for feeds and assets

### DIFF
--- a/cmd/markata-go/cmd/core.go
+++ b/cmd/markata-go/cmd/core.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/WaylonWalker/markata-go/pkg/config"
 	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
@@ -162,6 +163,7 @@ func runBuild(m *lifecycle.Manager) (*BuildResult, error) {
 	}
 
 	for _, stage := range stages {
+		stageStart := time.Now()
 		if verbose {
 			fmt.Printf("  [%s] running...\n", stage)
 		}
@@ -169,6 +171,7 @@ func runBuild(m *lifecycle.Manager) (*BuildResult, error) {
 			return nil, fmt.Errorf("stage %s: %w", stage, err)
 		}
 		if verbose {
+			fmt.Printf("  [%s] done in %s\n", stage, time.Since(stageStart).Truncate(100*time.Microsecond))
 			switch stage {
 			case lifecycle.StageGlob:
 				fmt.Printf("  [%s] discovered %d files\n", stage, len(m.Files()))

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -115,6 +115,8 @@ The build command executes the full 9-stage lifecycle:
 8. **Write** - Output files to disk
 9. **Cleanup** - Release resources
 
+When `--verbose` is enabled, build output includes per-stage timing to highlight slow stages.
+
 ---
 
 ### serve

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -3043,6 +3043,9 @@ user_agent = "markata-go/1.0 (WebMention)"
 3. For each post, matches webmentions to the post's URL (with various URL format normalizations)
 4. Attaches matched webmentions to `post.Extra["webmentions"]`
 
+**Incremental builds:**
+When build cache is enabled, the plugin skips re-attaching webmentions if no posts are scheduled to rebuild.
+
 **Fetching webmentions:**
 The plugin loads from cache during builds. To fetch fresh webmentions from webmention.io:
 

--- a/pkg/plugins/auto_feeds.go
+++ b/pkg/plugins/auto_feeds.go
@@ -234,6 +234,7 @@ func (p *AutoFeedsPlugin) Load(m *lifecycle.Manager) error {
 func (p *AutoFeedsPlugin) Collect(m *lifecycle.Manager) error {
 	posts := m.Posts()
 	config := m.Config()
+	filterCache := newFeedFilterCache(posts)
 
 	autoConfig := getAutoFeedsConfig(config)
 
@@ -284,10 +285,11 @@ func (p *AutoFeedsPlugin) Collect(m *lifecycle.Manager) error {
 		fc.ApplyDefaults(feedDefaults)
 
 		// Filter posts for this feed
-		filteredPosts, err := filterPosts(posts, fc.Filter, fc.IncludePrivate)
+		filteredPosts, err := filterCache.FilterPosts(fc.Filter, fc.IncludePrivate)
 		if err != nil {
 			return fmt.Errorf("auto feed %q: %w", fc.Slug, err)
 		}
+		filteredPosts = cloneFeedPosts(filteredPosts)
 
 		// Sort posts by date, newest first
 		sortPosts(filteredPosts, "date", true)

--- a/pkg/plugins/palette_css.go
+++ b/pkg/plugins/palette_css.go
@@ -70,11 +70,19 @@ func (p *PaletteCSSPlugin) Write(m *lifecycle.Manager) error {
 
 	// Write to output directory
 	cssDir := filepath.Join(outputDir, "css")
+	cssPath := filepath.Join(cssDir, "variables.css")
+	if existing, err := os.ReadFile(cssPath); err == nil {
+		if bytes.Equal(existing, []byte(css)) {
+			log.Printf("[palette_css] CSS unchanged, skipping write")
+			return nil
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("reading existing palette CSS: %w", err)
+	}
+
 	if err := os.MkdirAll(cssDir, 0o755); err != nil {
 		return fmt.Errorf("creating css directory: %w", err)
 	}
-
-	cssPath := filepath.Join(cssDir, "variables.css")
 	//nolint:gosec // G306: variables.css is a public CSS file, 0644 is appropriate
 	if err := os.WriteFile(cssPath, []byte(css), 0o644); err != nil {
 		return fmt.Errorf("writing palette CSS: %w", err)

--- a/spec/spec/DEFAULT_PLUGINS.md
+++ b/spec/spec/DEFAULT_PLUGINS.md
@@ -1064,6 +1064,9 @@ For each feed, for each enabled format:
 2. Render with feed context
 3. Write to output path
 
+**Performance notes:**
+- Feed filtering results may be reused across feeds that share identical filter expressions and privacy settings within a single build.
+
 **Output paths:**
 | Format | Path Pattern |
 |--------|--------------|


### PR DESCRIPTION
## Summary

Reduce incremental build overhead by short‑circuiting work when inputs are unchanged and reusing feed filter results per build. Adds verbose per‑stage timing to help profiling.

## Changes

- Reuse parsed feed filters and cached results per build; sort on copy to avoid cross‑feed mutation
  - `pkg/plugins/feeds.go`
  - `pkg/plugins/auto_feeds.go`
- Skip palette CSS writes when output content is unchanged (`pkg/plugins/palette_css.go`)
- Skip webmentions attachment when no posts rebuild (`pkg/plugins/webmentions_fetch.go`)
- Add verbose stage timing (`cmd/markata-go/cmd/core.go`)
- Update docs/spec (`docs/reference/cli.md`, `docs/reference/plugins.md`, `spec/spec/DEFAULT_PLUGINS.md`)

## Tests

- `go test ./...`

Refs #528