### PR TITLE
perf: cache link href extraction for incremental builds

### DIFF
--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -1344,6 +1344,10 @@ include_index = false  # Include index page in inlinks (default: false)
 6. Populates `Inlinks` and `Outlinks` on each post
 7. Stores all links in cache for use by other plugins
 
+**Performance:**
+- Caches href extraction per post using a hash of `ArticleHTML`
+- Reuses cached hrefs on unchanged posts, while still rebuilding link objects
+
 **Post fields set:**
 | Field | Type | Description |
 |-------|------|-------------|

--- a/spec/spec/DEFAULT_PLUGINS.md
+++ b/spec/spec/DEFAULT_PLUGINS.md
@@ -851,11 +851,10 @@ include_index = false          # Exclude index page from inlinks by default
 5. Exclude self-links from both inlinks and outlinks
 
 **Caching:**
-Results are cached per-post based on hash of:
-- Plugin file
-- Post slug
-- Post title  
-- Post content
+Per-post href extraction is cached using a hash of `article_html`. If the hash
+matches on a subsequent build, the plugin reuses cached hrefs instead of
+re-parsing HTML. Link objects are still rebuilt each run to keep target
+resolution and inlinks/outlinks consistent.
 
 **Hook behavior:**
 


### PR DESCRIPTION
## Summary

Cache link href extraction per post using ArticleHTML hash to reduce repeated parsing on incremental builds. Link objects are still rebuilt each run to keep inlinks/outlinks correct as posts change.

## Changes

- Add cached href storage to build cache (`pkg/buildcache/cache.go`)
- Use cached hrefs in link collector (`pkg/plugins/link_collector.go`)
- Update spec/docs (`spec/spec/DEFAULT_PLUGINS.md`, `docs/reference/plugins.md`)
- Add tests for cache behavior (`pkg/plugins/link_collector_test.go`)

## Tests

- `go test ./...`

Refs #530