### PR TITLE
fix: deterministic feed updated timestamps

### DIFF
--- a/docs/guides/feeds.md
+++ b/docs/guides/feeds.md
@@ -210,6 +210,15 @@ orphan_threshold = 3          # Merge last page if <= N items
 pagination_type = "manual"    # Pagination strategy
 ```
 
+## Feed Timestamps
+
+Feed timestamps are deterministic and based on content, not build time:
+
+- Atom `<updated>` and RSS `<lastBuildDate>` use the most recent post date in the feed.
+- If no posts have dates, these fields are omitted.
+
+This avoids no-change incremental builds rewriting feeds.
+
 ### Pagination Types
 
 | Type | Description | Use Case |

--- a/pkg/plugins/feeds_timestamp_test.go
+++ b/pkg/plugins/feeds_timestamp_test.go
@@ -1,0 +1,112 @@
+package plugins
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
+	"github.com/WaylonWalker/markata-go/pkg/models"
+)
+
+func TestGenerateAtom_UpdatedDeterministic(t *testing.T) {
+	config := lifecycle.NewConfig()
+	config.Extra = map[string]interface{}{"url": "https://example.com"}
+
+	old := time.Date(2023, 1, 1, 10, 0, 0, 0, time.UTC)
+	newer := time.Date(2024, 2, 2, 12, 0, 0, 0, time.UTC)
+
+	feed := &lifecycle.Feed{
+		Name:  "test",
+		Title: "Test Feed",
+		Path:  "test",
+		Posts: []*models.Post{
+			{Slug: "old", Href: "/old/", Date: &old},
+			{Slug: "new", Href: "/new/", Date: &newer},
+		},
+	}
+
+	atom, err := GenerateAtom(feed, config)
+	if err != nil {
+		t.Fatalf("GenerateAtom error: %v", err)
+	}
+
+	if !strings.Contains(atom, "<updated>2024-02-02T12:00:00Z</updated>") {
+		t.Fatalf("expected updated to use latest post date, got:\n%s", atom)
+	}
+}
+
+func TestGenerateRSS_LastBuildDateDeterministic(t *testing.T) {
+	config := lifecycle.NewConfig()
+	config.Extra = map[string]interface{}{"url": "https://example.com"}
+
+	old := time.Date(2023, 1, 1, 10, 0, 0, 0, time.UTC)
+	newer := time.Date(2024, 2, 2, 12, 0, 0, 0, time.UTC)
+
+	feed := &lifecycle.Feed{
+		Name:  "test",
+		Title: "Test Feed",
+		Path:  "test",
+		Posts: []*models.Post{
+			{Slug: "old", Href: "/old/", Date: &old},
+			{Slug: "new", Href: "/new/", Date: &newer},
+		},
+	}
+
+	rss, err := GenerateRSS(feed, config)
+	if err != nil {
+		t.Fatalf("GenerateRSS error: %v", err)
+	}
+
+	if !strings.Contains(rss, "<lastBuildDate>Fri, 02 Feb 2024 12:00:00 +0000</lastBuildDate>") {
+		t.Fatalf("expected lastBuildDate to use latest post date, got:\n%s", rss)
+	}
+}
+
+func TestGenerateAtom_UpdatedOmittedWhenNoDates(t *testing.T) {
+	config := lifecycle.NewConfig()
+	config.Extra = map[string]interface{}{"url": "https://example.com"}
+
+	feed := &lifecycle.Feed{
+		Name:  "test",
+		Title: "Test Feed",
+		Path:  "test",
+		Posts: []*models.Post{
+			{Slug: "one", Href: "/one/"},
+			{Slug: "two", Href: "/two/"},
+		},
+	}
+
+	atom, err := GenerateAtom(feed, config)
+	if err != nil {
+		t.Fatalf("GenerateAtom error: %v", err)
+	}
+
+	if strings.Contains(atom, "<updated>") {
+		t.Fatalf("expected updated to be omitted when no dates, got:\n%s", atom)
+	}
+}
+
+func TestGenerateRSS_LastBuildDateOmittedWhenNoDates(t *testing.T) {
+	config := lifecycle.NewConfig()
+	config.Extra = map[string]interface{}{"url": "https://example.com"}
+
+	feed := &lifecycle.Feed{
+		Name:  "test",
+		Title: "Test Feed",
+		Path:  "test",
+		Posts: []*models.Post{
+			{Slug: "one", Href: "/one/"},
+			{Slug: "two", Href: "/two/"},
+		},
+	}
+
+	rss, err := GenerateRSS(feed, config)
+	if err != nil {
+		t.Fatalf("GenerateRSS error: %v", err)
+	}
+
+	if strings.Contains(rss, "<lastBuildDate>") {
+		t.Fatalf("expected lastBuildDate to be omitted when no dates, got:\n%s", rss)
+	}
+}

--- a/pkg/plugins/rss.go
+++ b/pkg/plugins/rss.go
@@ -83,9 +83,19 @@ func GenerateRSS(feed *lifecycle.Feed, config *lifecycle.Config) (string, error)
 		},
 	}
 
-	// Set last build date
-	if len(feed.Posts) > 0 {
-		rss.Channel.LastBuildDate = time.Now().Format(time.RFC1123Z)
+	// Set last build date based on most recent post date (deterministic)
+	var latest *time.Time
+	for _, post := range feed.Posts {
+		if post.Date == nil {
+			continue
+		}
+		if latest == nil || post.Date.After(*latest) {
+			t := *post.Date
+			latest = &t
+		}
+	}
+	if latest != nil {
+		rss.Channel.LastBuildDate = latest.Format(time.RFC1123Z)
 	}
 
 	// Add items

--- a/spec/spec/FEEDS.md
+++ b/spec/spec/FEEDS.md
@@ -104,6 +104,15 @@ sitemap = "sitemap.xml"            # Template for sitemap
 | `pagination` | Pagination | Pagination info |
 | `formats` | FeedFormats | Enabled output formats (html, rss, atom, json, markdown, text, sitemap) |
 
+### Feed Timestamps
+
+Feed timestamps are deterministic and based on content, not build time:
+
+- **Atom `<updated>`** and **RSS `<lastBuildDate>`** use the most recent post date in the feed.
+- If no posts have dates, these fields are omitted or left empty (no build-time fallback).
+
+This ensures no-change incremental builds produce identical feed outputs.
+
 ### Pagination Object
 
 | Field | Type | Description |


### PR DESCRIPTION
## Summary

Make Atom/RSS feed timestamps deterministic by using the most recent post date in the feed instead of build time. Omits timestamps when no post dates are present to avoid no-change rebuild diffs.

## Changes

- Atom `<updated>` uses latest post date; omitted if no dates
- RSS `<lastBuildDate>` uses latest post date; omitted if no dates
- Add tests for deterministic behavior
- Update feed spec and guide

## Tests

- `go test ./...`

Refs #532