### PR TITLE
fix: deterministic reader ordering

### DIFF
--- a/docs/guides/blogroll.md
+++ b/docs/guides/blogroll.md
@@ -326,6 +326,12 @@ The reader page shows the latest posts from all feeds in reverse chronological o
 - Links to the original article
 - Pagination navigation (when more than one page)
 
+**Deterministic ordering:**
+1. Most recent publish/update date first
+2. Feed URL (ascending)
+3. Entry ID (ascending)
+4. Title (ascending)
+
 ## Custom Templates
 
 Create custom templates for full control over the appearance.

--- a/pkg/plugins/blogroll_determinism_test.go
+++ b/pkg/plugins/blogroll_determinism_test.go
@@ -1,0 +1,37 @@
+package plugins
+
+import (
+	"testing"
+	"time"
+
+	"github.com/WaylonWalker/markata-go/pkg/models"
+)
+
+func TestCompareEntries_DeterministicTieBreakers(t *testing.T) {
+	baseTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	a := &models.ExternalEntry{FeedURL: "https://b.example.com/rss", ID: "b", Title: "B", Published: &baseTime}
+	b := &models.ExternalEntry{FeedURL: "https://a.example.com/rss", ID: "a", Title: "A", Published: &baseTime}
+
+	if compareEntries(a, b) {
+		t.Fatalf("expected feed URL tie-breaker to sort ascending")
+	}
+	if !compareEntries(b, a) {
+		t.Fatalf("expected feed URL tie-breaker to sort ascending")
+	}
+}
+
+func TestLatestEntryDate_UsesLatestPublishedOrUpdated(t *testing.T) {
+	older := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	newer := time.Date(2024, 2, 1, 12, 0, 0, 0, time.UTC)
+
+	entries := []*models.ExternalEntry{
+		{Published: &older},
+		{Updated: &newer},
+	}
+
+	latest := latestEntryDate(entries)
+	if latest == nil || !latest.Equal(newer) {
+		t.Fatalf("expected latest date %v, got %v", newer, latest)
+	}
+}

--- a/spec/spec/FEEDS.md
+++ b/spec/spec/FEEDS.md
@@ -463,7 +463,7 @@ RSS feed for feed readers.
     <link>{{ config.url }}{{ feed.href }}</link>
     <description>{{ feed.description }}</description>
     <language>{{ config.lang | default('en') }}</language>
-    <lastBuildDate>{{ now | rss_date }}</lastBuildDate>
+    <lastBuildDate>{{ feed.updated | rss_date }}</lastBuildDate>
     <atom:link href="{{ config.url }}{{ feed.href }}rss.xml" rel="self" type="application/rss+xml"/>
 
     {% for post in feed.posts[:20] %}
@@ -497,7 +497,7 @@ Atom feed (RFC 4287).
   <link href="{{ config.url }}{{ feed.href }}" rel="alternate"/>
   <link href="{{ config.url }}{{ feed.href }}atom.xml" rel="self"/>
   <id>{{ config.url }}{{ feed.href }}</id>
-  <updated>{{ now | atom_date }}</updated>
+  <updated>{{ feed.updated | atom_date }}</updated>
 
   {% for post in feed.posts[:20] %}
   <entry>


### PR DESCRIPTION
## Summary

Make reader/blogroll output deterministic by using a stable entry sort with tie-breakers and exposing a deterministic updated timestamp based on latest entry date.

## Changes

- Stable sort entries (date desc, feed URL, entry ID, title)
- Reader template context includes `updated` from latest entry date
- Add tests for deterministic ordering helpers
- Update blogroll docs and feed spec

## Tests

- `go test ./...`

Refs #536