### PR TITLE
fix: remove duplicate extends directive in feed.html

### DIFF
--- a/templates/feed.html
+++ b/templates/feed.html
@@ -1,7 +1,5 @@
 {% extends "base.html" %}
 
-{% extends "base.html" %}
-
 {% block title %}{{ feed.title | default:config.title | default:"Posts" }}{% endblock %}
 {% block description %}{{ feed.description | default:config.description | default:"" }}{% endblock %}
 


### PR DESCRIPTION
## Summary

- Removes duplicate `{% extends "base.html" %}` directive from `templates/feed.html`

## Problem

The `templates/feed.html` file had the `{% extends "base.html" %}` directive on both lines 1 and 3, which is invalid Jinja2/pongo2 template syntax.

## Solution

Removed the duplicate extends directive on line 3, keeping only the one on line 1.

## Testing

- All tests pass (`go test ./...`)
- Build succeeds (`go build ./cmd/markata-go`)

Fixes #541