### PR TITLE
feat: add mark, keys, container, emoji extensions and fix Extra template access

### DIFF
--- a/pkg/plugins/containers.go
+++ b/pkg/plugins/containers.go
@@ -1,0 +1,277 @@
+// Package plugins provides lifecycle plugins for markata-go.
+package plugins
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/renderer/html"
+	"github.com/yuin/goldmark/text"
+	"github.com/yuin/goldmark/util"
+)
+
+// KindContainer is the AST node kind for container elements.
+var KindContainer = ast.NewNodeKind("Container")
+
+// Container is an AST node representing a container block (::: class).
+type Container struct {
+	ast.BaseBlock
+	// Classes holds the CSS classes for this container
+	Classes []string
+	// ContainerID holds the optional ID for this container
+	ContainerID string
+	// ExtraAttrs holds additional attributes
+	ExtraAttrs map[string]string
+}
+
+// Kind returns the kind of this node.
+func (n *Container) Kind() ast.NodeKind {
+	return KindContainer
+}
+
+// Dump dumps the node for debugging.
+func (n *Container) Dump(source []byte, level int) {
+	attrs := map[string]string{
+		"Classes": strings.Join(n.Classes, " "),
+	}
+	if n.ContainerID != "" {
+		attrs["ID"] = n.ContainerID
+	}
+	ast.DumpHelper(n, source, level, attrs, nil)
+}
+
+// NewContainer creates a new Container node.
+func NewContainer(classes []string, id string, attrs map[string]string) *Container {
+	return &Container{
+		Classes:     classes,
+		ContainerID: id,
+		ExtraAttrs:  attrs,
+	}
+}
+
+// containerRegex matches container opening syntax:
+// ::: class1 class2 {#id .extra-class key=value}
+// Group 1: classes (space-separated)
+// Group 2: optional attribute block
+var containerRegex = regexp.MustCompile(`^:::\s*(\S.*?)?\s*(?:\{([^}]*)\})?\s*$`)
+
+// containerParser parses ::: container syntax.
+type containerParser struct{}
+
+// newContainerParser creates a new container parser.
+func newContainerParser() parser.BlockParser {
+	return &containerParser{}
+}
+
+// Trigger returns the trigger bytes for this parser.
+func (p *containerParser) Trigger() []byte {
+	return []byte{':'}
+}
+
+// Open is called when a new block starts.
+func (p *containerParser) Open(_ ast.Node, reader text.Reader, _ parser.Context) (ast.Node, parser.State) {
+	line, segment := reader.PeekLine()
+	lineStr := string(line)
+
+	// Check for opening :::
+	if !strings.HasPrefix(lineStr, ":::") {
+		return nil, parser.NoChildren
+	}
+
+	// Check for closing ::: (just ":::" with optional whitespace)
+	trimmed := strings.TrimSpace(lineStr)
+	if trimmed == ":::" {
+		// This is a closing tag, not an opening
+		return nil, parser.NoChildren
+	}
+
+	// Parse the opening line
+	matches := containerRegex.FindStringSubmatch(lineStr)
+	if matches == nil {
+		return nil, parser.NoChildren
+	}
+
+	// Extract classes
+	var classes []string
+	if matches[1] != "" {
+		// Split by whitespace
+		classes = append(classes, strings.Fields(matches[1])...)
+	}
+
+	// Extract attributes from {#id .class key=value} block
+	var id string
+	attrs := make(map[string]string)
+
+	if matches[2] != "" {
+		attrStr := matches[2]
+		for _, part := range strings.Fields(attrStr) {
+			if strings.HasPrefix(part, "#") {
+				id = part[1:]
+			} else if strings.HasPrefix(part, ".") {
+				classes = append(classes, part[1:])
+			} else if idx := strings.Index(part, "="); idx > 0 {
+				key := part[:idx]
+				value := strings.Trim(part[idx+1:], `"'`)
+				attrs[key] = value
+			}
+		}
+	}
+
+	// Create the container node
+	node := NewContainer(classes, id, attrs)
+
+	// Advance past the opening line
+	reader.Advance(segment.Len() - 1)
+	// Find the newline
+	for {
+		line, _ := reader.PeekLine()
+		if len(line) == 0 {
+			break
+		}
+		if line[0] == '\n' {
+			reader.Advance(1)
+			break
+		}
+		reader.Advance(1)
+	}
+
+	return node, parser.HasChildren
+}
+
+// Continue is called for each subsequent line.
+func (p *containerParser) Continue(_ ast.Node, reader text.Reader, _ parser.Context) parser.State {
+	line, segment := reader.PeekLine()
+	lineStr := strings.TrimSpace(string(line))
+
+	// Check for closing :::
+	if lineStr == ":::" {
+		reader.Advance(segment.Len())
+		return parser.Close
+	}
+
+	return parser.Continue | parser.HasChildren
+}
+
+// Close is called when the block ends.
+func (p *containerParser) Close(_ ast.Node, _ text.Reader, _ parser.Context) {
+	// Nothing special to do
+}
+
+// CanInterruptParagraph returns true if this parser can interrupt a paragraph.
+func (p *containerParser) CanInterruptParagraph() bool {
+	return true
+}
+
+// CanAcceptIndentedLine returns true if this parser can accept an indented line.
+func (p *containerParser) CanAcceptIndentedLine() bool {
+	return false
+}
+
+// containerHTMLRenderer renders Container nodes to HTML.
+type containerHTMLRenderer struct {
+	html.Config
+}
+
+// newContainerHTMLRenderer creates a new container HTML renderer.
+func newContainerHTMLRenderer() renderer.NodeRenderer {
+	return &containerHTMLRenderer{
+		Config: html.NewConfig(),
+	}
+}
+
+// RegisterFuncs registers the render functions.
+func (r *containerHTMLRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
+	reg.Register(KindContainer, r.renderContainer)
+}
+
+// renderContainer renders a Container node to HTML.
+//
+//nolint:errcheck // WriteString errors are handled at a higher level in goldmark
+func (r *containerHTMLRenderer) renderContainer(w util.BufWriter, _ []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
+	container, ok := n.(*Container)
+	if !ok {
+		return ast.WalkContinue, nil
+	}
+
+	if entering {
+		_, _ = w.WriteString("<div")
+
+		// Add ID if present
+		if container.ContainerID != "" {
+			_, _ = w.WriteString(` id="`)
+			_, _ = w.WriteString(escapeHTMLAttr(container.ContainerID))
+			_, _ = w.WriteString(`"`)
+		}
+
+		// Add classes if present
+		if len(container.Classes) > 0 {
+			_, _ = w.WriteString(` class="`)
+			for i, class := range container.Classes {
+				if i > 0 {
+					_, _ = w.WriteString(" ")
+				}
+				_, _ = w.WriteString(escapeHTMLAttr(class))
+			}
+			_, _ = w.WriteString(`"`)
+		}
+
+		// Add other attributes
+		for key, value := range container.ExtraAttrs {
+			_, _ = w.WriteString(` `)
+			_, _ = w.WriteString(escapeHTMLAttr(key))
+			_, _ = w.WriteString(`="`)
+			_, _ = w.WriteString(escapeHTMLAttr(value))
+			_, _ = w.WriteString(`"`)
+		}
+
+		_, _ = w.WriteString(">\n")
+	} else {
+		_, _ = w.WriteString("</div>\n")
+	}
+
+	return ast.WalkContinue, nil
+}
+
+// escapeHTMLAttr escapes a string for use in an HTML attribute.
+func escapeHTMLAttr(s string) string {
+	var b strings.Builder
+	for _, c := range s {
+		switch c {
+		case '<':
+			b.WriteString("&lt;")
+		case '>':
+			b.WriteString("&gt;")
+		case '&':
+			b.WriteString("&amp;")
+		case '"':
+			b.WriteString("&quot;")
+		case '\'':
+			b.WriteString("&#39;")
+		default:
+			b.WriteRune(c)
+		}
+	}
+	return b.String()
+}
+
+// ContainerExtension is a goldmark extension for container syntax.
+type ContainerExtension struct{}
+
+// Extend adds the container parser and renderer to goldmark.
+func (e *ContainerExtension) Extend(m goldmark.Markdown) {
+	m.Parser().AddOptions(
+		parser.WithBlockParsers(
+			// Lower priority than admonitions so !!! takes precedence
+			util.Prioritized(newContainerParser(), 800),
+		),
+	)
+	m.Renderer().AddOptions(
+		renderer.WithNodeRenderers(
+			util.Prioritized(newContainerHTMLRenderer(), 500),
+		),
+	)
+}

--- a/pkg/plugins/keys.go
+++ b/pkg/plugins/keys.go
@@ -1,0 +1,280 @@
+// Package plugins provides lifecycle plugins for markata-go.
+package plugins
+
+import (
+	"strings"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/renderer/html"
+	"github.com/yuin/goldmark/text"
+	"github.com/yuin/goldmark/util"
+)
+
+// KindKeys is the AST node kind for keyboard key elements.
+var KindKeys = ast.NewNodeKind("Keys")
+
+// Keys is an AST node representing keyboard keys (++Ctrl+Alt+Del++).
+type Keys struct {
+	ast.BaseInline
+	// KeySequence holds the individual keys (e.g., ["Ctrl", "Alt", "Del"])
+	KeySequence []string
+}
+
+// Kind returns the kind of this node.
+func (n *Keys) Kind() ast.NodeKind {
+	return KindKeys
+}
+
+// Dump dumps the node for debugging.
+func (n *Keys) Dump(source []byte, level int) {
+	ast.DumpHelper(n, source, level, map[string]string{
+		"Keys": strings.Join(n.KeySequence, "+"),
+	}, nil)
+}
+
+// NewKeys creates a new Keys node.
+func NewKeys(keys []string) *Keys {
+	return &Keys{
+		KeySequence: keys,
+	}
+}
+
+// keysParser parses ++Key+Key++ syntax for keyboard keys.
+type keysParser struct{}
+
+// newKeysParser creates a new keys parser.
+func newKeysParser() parser.InlineParser {
+	return &keysParser{}
+}
+
+// Trigger returns the trigger bytes for this parser.
+func (p *keysParser) Trigger() []byte {
+	return []byte{'+'}
+}
+
+// Parse parses the ++Key+Key++ syntax.
+func (p *keysParser) Parse(_ ast.Node, block text.Reader, _ parser.Context) ast.Node {
+	line, _ := block.PeekLine()
+
+	// Must start with ++
+	if len(line) < 4 || line[0] != '+' || line[1] != '+' {
+		return nil
+	}
+
+	// Find the closing ++
+	// Start after the opening ++
+	content := line[2:]
+	endIdx := -1
+
+	for i := 0; i < len(content)-1; i++ {
+		if content[i] == '+' && content[i+1] == '+' {
+			// Make sure this isn't a key separator (single +)
+			// Check that we have content before this
+			if i > 0 {
+				endIdx = i
+				break
+			}
+		}
+	}
+
+	if endIdx == -1 {
+		return nil
+	}
+
+	// Extract the key sequence
+	keyStr := string(content[:endIdx])
+	if keyStr == "" {
+		return nil
+	}
+
+	// Split by + to get individual keys
+	keys := splitKeys(keyStr)
+	if len(keys) == 0 {
+		return nil
+	}
+
+	// Total length consumed: ++ + content + ++
+	totalLen := 2 + endIdx + 2
+	block.Advance(totalLen)
+
+	return NewKeys(keys)
+}
+
+// splitKeys splits a key string by + while handling edge cases.
+// e.g., "Ctrl+Alt+Del" -> ["Ctrl", "Alt", "Del"]
+// e.g., "Ctrl++" -> ["Ctrl", "+"] (plus key)
+func splitKeys(s string) []string {
+	var keys []string
+	var current strings.Builder
+
+	i := 0
+	for i < len(s) {
+		if s[i] == '+' {
+			// Check if this is a plus key (at the end or followed by another +)
+			if current.Len() == 0 {
+				// Empty before +, this might be a + key at the start
+				// But that's unusual, skip
+				i++
+				continue
+			}
+
+			// We have content, this + is a separator
+			keys = append(keys, current.String())
+			current.Reset()
+			i++
+		} else {
+			current.WriteByte(s[i])
+			i++
+		}
+	}
+
+	// Don't forget the last key
+	if current.Len() > 0 {
+		keys = append(keys, current.String())
+	}
+
+	return keys
+}
+
+// keysHTMLRenderer renders Keys nodes to HTML.
+type keysHTMLRenderer struct {
+	html.Config
+}
+
+// newKeysHTMLRenderer creates a new keys HTML renderer.
+func newKeysHTMLRenderer() renderer.NodeRenderer {
+	return &keysHTMLRenderer{
+		Config: html.NewConfig(),
+	}
+}
+
+// RegisterFuncs registers the render functions.
+func (r *keysHTMLRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
+	reg.Register(KindKeys, r.renderKeys)
+}
+
+// keyClassMap maps common key names to CSS class suffixes.
+var keyClassMap = map[string]string{
+	"ctrl":        "ctrl",
+	"control":     "ctrl",
+	"alt":         "alt",
+	"shift":       "shift",
+	"meta":        "meta",
+	"cmd":         "meta",
+	"command":     "meta",
+	"win":         "win",
+	"windows":     "win",
+	"super":       "win",
+	"enter":       "enter",
+	"return":      "enter",
+	"tab":         "tab",
+	"space":       "space",
+	"backspace":   "backspace",
+	"delete":      "delete",
+	"del":         "delete",
+	"escape":      "escape",
+	"esc":         "escape",
+	"up":          "up",
+	"down":        "down",
+	"left":        "left",
+	"right":       "right",
+	"home":        "home",
+	"end":         "end",
+	"pageup":      "page-up",
+	"pagedown":    "page-down",
+	"insert":      "insert",
+	"caps":        "caps-lock",
+	"capslock":    "caps-lock",
+	"num":         "num-lock",
+	"numlock":     "num-lock",
+	"scroll":      "scroll-lock",
+	"print":       "print-screen",
+	"printscreen": "print-screen",
+	"pause":       "pause",
+	"break":       "break",
+	"f1":          "f1",
+	"f2":          "f2",
+	"f3":          "f3",
+	"f4":          "f4",
+	"f5":          "f5",
+	"f6":          "f6",
+	"f7":          "f7",
+	"f8":          "f8",
+	"f9":          "f9",
+	"f10":         "f10",
+	"f11":         "f11",
+	"f12":         "f12",
+}
+
+// renderKeys renders a Keys node to HTML.
+//
+//nolint:errcheck // WriteString errors are handled at a higher level in goldmark
+func (r *keysHTMLRenderer) renderKeys(w util.BufWriter, _ []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
+	if !entering {
+		return ast.WalkContinue, nil
+	}
+
+	keys, ok := n.(*Keys)
+	if !ok {
+		return ast.WalkContinue, nil
+	}
+
+	_, _ = w.WriteString(`<span class="keys">`)
+
+	for i, key := range keys.KeySequence {
+		if i > 0 {
+			_, _ = w.WriteString(`<span class="key-separator">+</span>`)
+		}
+
+		// Determine CSS class for this key
+		class := "kbd"
+		if keyClass, ok := keyClassMap[strings.ToLower(key)]; ok {
+			class = "kbd key-" + keyClass
+		}
+
+		_, _ = w.WriteString(`<kbd class="`)
+		_, _ = w.WriteString(class)
+		_, _ = w.WriteString(`">`)
+		// HTML escape the key name
+		for _, c := range key {
+			switch c {
+			case '<':
+				_, _ = w.WriteString("&lt;")
+			case '>':
+				_, _ = w.WriteString("&gt;")
+			case '&':
+				_, _ = w.WriteString("&amp;")
+			case '"':
+				_, _ = w.WriteString("&quot;")
+			default:
+				_, _ = w.WriteRune(c)
+			}
+		}
+		_, _ = w.WriteString(`</kbd>`)
+	}
+
+	_, _ = w.WriteString(`</span>`)
+
+	return ast.WalkContinue, nil
+}
+
+// KeysExtension is a goldmark extension for keyboard keys syntax.
+type KeysExtension struct{}
+
+// Extend adds the keys parser and renderer to goldmark.
+func (e *KeysExtension) Extend(m goldmark.Markdown) {
+	m.Parser().AddOptions(
+		parser.WithInlineParsers(
+			// Higher priority than mark to handle ++ before =
+			util.Prioritized(newKeysParser(), 400),
+		),
+	)
+	m.Renderer().AddOptions(
+		renderer.WithNodeRenderers(
+			util.Prioritized(newKeysHTMLRenderer(), 500),
+		),
+	)
+}

--- a/pkg/plugins/mark.go
+++ b/pkg/plugins/mark.go
@@ -1,0 +1,151 @@
+// Package plugins provides lifecycle plugins for markata-go.
+package plugins
+
+import (
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/renderer/html"
+	"github.com/yuin/goldmark/text"
+	"github.com/yuin/goldmark/util"
+)
+
+// KindMark is the AST node kind for mark (highlight) elements.
+var KindMark = ast.NewNodeKind("Mark")
+
+// Mark is an AST node representing highlighted text (==text==).
+type Mark struct {
+	ast.BaseInline
+}
+
+// Kind returns the kind of this node.
+func (n *Mark) Kind() ast.NodeKind {
+	return KindMark
+}
+
+// Dump dumps the node for debugging.
+func (n *Mark) Dump(source []byte, level int) {
+	ast.DumpHelper(n, source, level, nil, nil)
+}
+
+// NewMark creates a new Mark node.
+func NewMark() *Mark {
+	return &Mark{}
+}
+
+// markParser parses ==text== syntax for highlighted text.
+// This uses a simple greedy approach: find == opening, then find == closing.
+type markParser struct{}
+
+// newMarkParser creates a new mark parser.
+func newMarkParser() parser.InlineParser {
+	return &markParser{}
+}
+
+// Trigger returns the trigger bytes for this parser.
+func (p *markParser) Trigger() []byte {
+	return []byte{'='}
+}
+
+// Parse parses the ==text== syntax.
+func (p *markParser) Parse(_ ast.Node, block text.Reader, _ parser.Context) ast.Node {
+	line, segment := block.PeekLine()
+
+	// Must start with ==
+	if len(line) < 4 || line[0] != '=' || line[1] != '=' {
+		return nil
+	}
+
+	// Don't match === (could be other syntax or just decoration)
+	if len(line) > 2 && line[2] == '=' {
+		return nil
+	}
+
+	// Find the closing ==
+	// Start searching after the opening ==
+	content := line[2:]
+	closeIdx := -1
+
+	for i := 0; i < len(content)-1; i++ {
+		if content[i] == '=' && content[i+1] == '=' {
+			// Found closing ==, but make sure we have content
+			if i > 0 {
+				closeIdx = i
+				break
+			}
+		}
+	}
+
+	if closeIdx == -1 {
+		return nil
+	}
+
+	// Extract the content between == and ==
+	markedContent := content[:closeIdx]
+	if len(markedContent) == 0 {
+		return nil
+	}
+
+	// Create the mark node
+	mark := NewMark()
+
+	// Add the content as a text child
+	// The content segment starts at: segment.Start + 2 (after opening ==)
+	// and ends at: segment.Start + 2 + closeIdx
+	contentSegment := text.NewSegment(segment.Start+2, segment.Start+2+closeIdx)
+	textNode := ast.NewTextSegment(contentSegment)
+	mark.AppendChild(mark, textNode)
+
+	// Advance past the entire ==content== (opening + content + closing)
+	totalLen := 2 + closeIdx + 2
+	block.Advance(totalLen)
+
+	return mark
+}
+
+// markHTMLRenderer renders Mark nodes to HTML.
+type markHTMLRenderer struct {
+	html.Config
+}
+
+// newMarkHTMLRenderer creates a new mark HTML renderer.
+func newMarkHTMLRenderer() renderer.NodeRenderer {
+	return &markHTMLRenderer{
+		Config: html.NewConfig(),
+	}
+}
+
+// RegisterFuncs registers the render functions.
+func (r *markHTMLRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
+	reg.Register(KindMark, r.renderMark)
+}
+
+// renderMark renders a Mark node to HTML.
+//
+//nolint:errcheck // WriteString errors are handled at a higher level in goldmark
+func (r *markHTMLRenderer) renderMark(w util.BufWriter, _ []byte, _ ast.Node, entering bool) (ast.WalkStatus, error) {
+	if entering {
+		_, _ = w.WriteString("<mark>")
+	} else {
+		_, _ = w.WriteString("</mark>")
+	}
+	return ast.WalkContinue, nil
+}
+
+// MarkExtension is a goldmark extension for mark (highlight) syntax.
+type MarkExtension struct{}
+
+// Extend adds the mark parser and renderer to goldmark.
+func (e *MarkExtension) Extend(m goldmark.Markdown) {
+	m.Parser().AddOptions(
+		parser.WithInlineParsers(
+			util.Prioritized(newMarkParser(), 500),
+		),
+	)
+	m.Renderer().AddOptions(
+		renderer.WithNodeRenderers(
+			util.Prioritized(newMarkHTMLRenderer(), 500),
+		),
+	)
+}

--- a/pkg/plugins/render_markdown.go
+++ b/pkg/plugins/render_markdown.go
@@ -13,6 +13,7 @@ import (
 	"github.com/WaylonWalker/markata-go/pkg/models"
 	"github.com/WaylonWalker/markata-go/pkg/palettes"
 	"github.com/yuin/goldmark"
+	emoji "github.com/yuin/goldmark-emoji"
 	highlighting "github.com/yuin/goldmark-highlighting/v2"
 	"github.com/yuin/goldmark/extension"
 	"github.com/yuin/goldmark/parser"
@@ -84,6 +85,14 @@ func createMarkdownRenderer(chromaTheme string, lineNumbers bool) goldmark.Markd
 			highlighting.NewHighlighting(highlightOpts...),
 			// Custom admonition extension
 			&AdmonitionExtension{},
+			// Mark extension for ==highlighted text==
+			&MarkExtension{},
+			// Keys extension for ++Ctrl+Alt+Del++
+			&KeysExtension{},
+			// Container extension for ::: class
+			&ContainerExtension{},
+			// Emoji extension for :smile: syntax
+			emoji.Emoji,
 		),
 		goldmark.WithParserOptions(
 			parser.WithAutoHeadingID(),

--- a/pkg/templates/context.go
+++ b/pkg/templates/context.go
@@ -147,24 +147,30 @@ func postToMapUncached(p *models.Post) map[string]interface{} {
 
 	// Add extra fields
 	if p.Extra != nil {
+		// Also expose Extra as a nested map for template access like post.Extra.key
+		extraMap := make(map[string]interface{})
 		for k, v := range p.Extra {
-			// Don't override existing keys
+			extraMap[k] = v
+			// Don't override existing keys (flatten to top level for backwards compat)
 			if _, exists := m[k]; !exists {
 				// Special handling for structured_data
 				if k == "structured_data" {
 					if sd, ok := v.(*models.StructuredData); ok {
 						m[k] = structuredDataToMap(sd)
+						extraMap[k] = structuredDataToMap(sd)
 						continue
 					}
 				}
 				// Special handling for toc entries (from toc plugin)
 				if k == "toc" {
 					m[k] = tocEntriesToMaps(v)
+					extraMap[k] = tocEntriesToMaps(v)
 					continue
 				}
 				m[k] = v
 			}
 		}
+		m["Extra"] = extraMap
 	}
 
 	return m

--- a/pkg/themes/default/static/css/admonitions.css
+++ b/pkg/themes/default/static/css/admonitions.css
@@ -112,12 +112,6 @@
   --admonition-icon: "#";
 }
 
-.admonition.seealso {
-  --admonition-color: var(--admonition-seealso-border, #8b5cf6);
-  --admonition-bg: var(--admonition-seealso-bg, #f5f3ff);
-  --admonition-icon: "->";
-}
-
 /* Aside - Sidebar/Marginal Note (Tufte-style) */
 /* Asides are positioned in the margin of the article, outside the main content flow */
 
@@ -194,6 +188,90 @@ aside.admonition.aside .admonition-title::before {
 @media (prefers-color-scheme: dark) {
   aside.admonition.aside {
     --admonition-bg: #1f2937;
+  }
+}
+
+/* VSplit - Side-by-side comparison layout */
+/* Parent vsplit contains child vsplits arranged in columns */
+
+.admonition.vsplit {
+  --admonition-color: var(--admonition-vsplit-border, #6b7280);
+  --admonition-bg: transparent;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0;
+  padding: 0;
+  margin: var(--space-4) 0;
+  border-left: none;
+  background: transparent;
+}
+
+/* On larger screens, arrange child vsplits side by side */
+@media (min-width: 768px) {
+  .admonition.vsplit {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+/* VSplit title spans full width */
+.admonition.vsplit > .admonition-title {
+  grid-column: 1 / -1;
+  margin: 0 var(--space-4) var(--space-2);
+  padding-bottom: var(--space-2);
+  border-bottom: 2px solid var(--color-border, #e5e7eb);
+}
+
+/* Nested vsplits (the actual split columns) */
+/* These should NOT be grids - only the parent is a grid */
+.admonition.vsplit > .admonition.vsplit {
+  display: block;
+  margin: 0;
+  padding: var(--space-4);
+  border: none;
+  border-top: 2px solid var(--color-border, #e5e7eb);
+  background: var(--color-surface, #f9fafb);
+}
+
+/* On larger screens, use vertical divider instead of horizontal */
+@media (min-width: 768px) {
+  .admonition.vsplit > .admonition.vsplit {
+    border-top: none;
+  }
+
+  /* First child - right border */
+  .admonition.vsplit > .admonition.vsplit:first-of-type {
+    border-right: 2px solid var(--color-border, #e5e7eb);
+  }
+
+  /* Last child - left border (if more than 2) */
+  .admonition.vsplit > .admonition.vsplit:last-of-type {
+    border-left: none;
+  }
+}
+
+/* On mobile, stack with top borders */
+@media (max-width: 767px) {
+  .admonition.vsplit > .admonition.vsplit:first-of-type {
+    border-top: none;
+  }
+}
+
+/* Nested vsplit title */
+.admonition.vsplit > .admonition.vsplit > .admonition-title {
+  margin-bottom: var(--space-2);
+  padding-bottom: var(--space-1);
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+}
+
+/* Remove icon from vsplit titles */
+.admonition.vsplit .admonition-title::before {
+  content: none;
+}
+
+/* Dark mode for vsplit */
+@media (prefers-color-scheme: dark) {
+  .admonition.vsplit > .admonition.vsplit {
+    background: var(--color-surface, #1f2937);
   }
 }
 

--- a/pkg/themes/default/static/css/components.css
+++ b/pkg/themes/default/static/css/components.css
@@ -1651,3 +1651,243 @@ article.kb-highlighted {
     display: none !important;
   }
 }
+
+/* ==========================================================================
+   Mark (Highlight) Styles
+
+   Styles for ==highlighted text== syntax rendered as <mark> elements.
+   ========================================================================== */
+
+mark {
+  background-color: var(--color-mark-bg, #fff3cd);
+  color: var(--color-mark-text, inherit);
+  padding: 0.125em 0.25em;
+  border-radius: 0.125em;
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  mark {
+    background-color: var(--color-mark-bg, #5c4d1f);
+    color: var(--color-mark-text, #ffd700);
+  }
+}
+
+/* ==========================================================================
+   Keyboard Keys Styles
+
+   Styles for ++Key+Key++ syntax rendered as <kbd> elements.
+   ========================================================================== */
+
+.keys {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.125em;
+}
+
+.key-separator {
+  color: var(--color-text-muted);
+  font-size: 0.875em;
+  margin: 0 0.125em;
+}
+
+kbd,
+kbd.kbd {
+  display: inline-block;
+  padding: 0.15em 0.4em;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.875em;
+  line-height: 1.4;
+  color: var(--color-text);
+  background-color: var(--color-surface, #f5f5f5);
+  border: 1px solid var(--color-border, #ccc);
+  border-radius: 0.25em;
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1), 0 2px 0 0 var(--color-background, #fff) inset;
+  white-space: nowrap;
+}
+
+/* Modifier keys get a slightly different style */
+kbd.key-ctrl,
+kbd.key-alt,
+kbd.key-shift,
+kbd.key-meta,
+kbd.key-win {
+  font-weight: 600;
+  background-color: var(--color-kbd-modifier-bg, #e8e8e8);
+}
+
+/* Function keys */
+kbd.key-f1, kbd.key-f2, kbd.key-f3, kbd.key-f4,
+kbd.key-f5, kbd.key-f6, kbd.key-f7, kbd.key-f8,
+kbd.key-f9, kbd.key-f10, kbd.key-f11, kbd.key-f12 {
+  min-width: 2em;
+  text-align: center;
+}
+
+/* Navigation keys */
+kbd.key-up, kbd.key-down, kbd.key-left, kbd.key-right,
+kbd.key-home, kbd.key-end, kbd.key-page-up, kbd.key-page-down {
+  min-width: 1.5em;
+  text-align: center;
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  kbd,
+  kbd.kbd {
+    background-color: var(--color-surface, #2d2d2d);
+    border-color: var(--color-border, #555);
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.3), 0 2px 0 0 var(--color-background, #1a1a1a) inset;
+  }
+
+  kbd.key-ctrl,
+  kbd.key-alt,
+  kbd.key-shift,
+  kbd.key-meta,
+  kbd.key-win {
+    background-color: var(--color-kbd-modifier-bg, #3d3d3d);
+  }
+}
+
+/* High contrast mode */
+@media (prefers-contrast: more) {
+  kbd,
+  kbd.kbd {
+    border-width: 2px;
+    border-color: var(--color-text);
+  }
+}
+
+/* ==========================================================================
+   Container Styles
+
+   Styles for ::: container syntax rendered as <div> elements.
+   ========================================================================== */
+
+/* Generic container - no default styling, just classes */
+div[class]:not([class=""]) {
+  /* Container divs get their styling from their classes */
+}
+
+/* Common container patterns */
+.container {
+  padding: 1rem;
+  margin: 1rem 0;
+}
+
+/* Warning container */
+.warning {
+  padding: 1rem;
+  margin: 1rem 0;
+  background-color: var(--color-warning-bg, #fff3cd);
+  border-left: 4px solid var(--color-warning-border, #ffc107);
+  border-radius: 0.25rem;
+}
+
+/* Info container */
+.info {
+  padding: 1rem;
+  margin: 1rem 0;
+  background-color: var(--color-info-bg, #cff4fc);
+  border-left: 4px solid var(--color-info-border, #0dcaf0);
+  border-radius: 0.25rem;
+}
+
+/* Success container */
+.success {
+  padding: 1rem;
+  margin: 1rem 0;
+  background-color: var(--color-success-bg, #d1e7dd);
+  border-left: 4px solid var(--color-success-border, #198754);
+  border-radius: 0.25rem;
+}
+
+/* Error/Danger container */
+.error,
+.danger {
+  padding: 1rem;
+  margin: 1rem 0;
+  background-color: var(--color-danger-bg, #f8d7da);
+  border-left: 4px solid var(--color-danger-border, #dc3545);
+  border-radius: 0.25rem;
+}
+
+/* Note container */
+.note {
+  padding: 1rem;
+  margin: 1rem 0;
+  background-color: var(--color-note-bg, #e7e9eb);
+  border-left: 4px solid var(--color-note-border, #6c757d);
+  border-radius: 0.25rem;
+}
+
+/* Dark mode for containers */
+@media (prefers-color-scheme: dark) {
+  .warning {
+    background-color: var(--color-warning-bg, #332d1a);
+  }
+
+  .info {
+    background-color: var(--color-info-bg, #1a2e33);
+  }
+
+  .success {
+    background-color: var(--color-success-bg, #1a2e22);
+  }
+
+  .error,
+  .danger {
+    background-color: var(--color-danger-bg, #331a1d);
+  }
+
+  .note {
+    background-color: var(--color-note-bg, #2d2d2d);
+  }
+}
+
+/* Columns container - side by side layout */
+.columns {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin: 1rem 0;
+}
+
+.columns > * {
+  flex: 1;
+  min-width: 200px;
+}
+
+@media (max-width: 640px) {
+  .columns {
+    flex-direction: column;
+  }
+
+  .columns > * {
+    min-width: auto;
+  }
+}
+
+/* Center container */
+.center {
+  text-align: center;
+}
+
+/* Right-align container */
+.right {
+  text-align: right;
+}
+
+/* Hidden container (for conditional content) */
+.hidden {
+  display: none;
+}
+
+/* Print styles */
+@media print {
+  .no-print,
+  .hidden-print {
+    display: none !important;
+  }
+}

--- a/pkg/themes/default/templates/base.html
+++ b/pkg/themes/default/templates/base.html
@@ -10,15 +10,31 @@
   {% endblock %}
 
   {% block head %}
-  <!-- Theme CSS -->
+  <!-- Core Theme CSS (always loaded) -->
   <link rel="stylesheet" href="{{ 'css/variables.css' | theme_asset }}">
   <link rel="stylesheet" href="{{ 'css/main.css' | theme_asset }}">
   <link rel="stylesheet" href="{{ 'css/components.css' | theme_asset }}">
-  <link rel="stylesheet" href="{{ 'css/admonitions.css' | theme_asset }}">
-  <link rel="stylesheet" href="{{ 'css/code.css' | theme_asset }}">
+
+  <!-- Conditional CSS: Cards (only on feed/index pages where cards are displayed) -->
+  {% if feed or page %}
   <link rel="stylesheet" href="{{ 'css/cards.css' | theme_asset }}">
-  <link rel="stylesheet" href="{{ 'css/webmentions.css' | theme_asset }}">
+  {% endif %}
+
+  <!-- Conditional CSS: Admonitions (only when post uses admonitions) -->
+  {% if post.Extra.needs_admonitions_css %}
+  <link rel="stylesheet" href="{{ 'css/admonitions.css' | theme_asset }}">
+  {% endif %}
+
+  <!-- Conditional CSS: Code highlighting (only when post has code blocks) -->
+  {% if post.Extra.needs_code_css %}
+  <link rel="stylesheet" href="{{ 'css/code.css' | theme_asset }}">
   <link rel="stylesheet" href="/css/chroma.css">
+  {% endif %}
+
+  <!-- Conditional CSS: Webmentions (only when webmentions enabled and post may have mentions) -->
+  {% if config.Webmention.Enabled %}
+  <link rel="stylesheet" href="{{ 'css/webmentions.css' | theme_asset }}">
+  {% endif %}
 
   <!-- Palette Switcher CSS (when enabled) -->
   {% if config.theme.switcher.enabled %}

--- a/themes/default/static/css/admonitions.css
+++ b/themes/default/static/css/admonitions.css
@@ -191,6 +191,90 @@ aside.admonition.aside .admonition-title::before {
   }
 }
 
+/* VSplit - Side-by-side comparison layout */
+/* Parent vsplit contains child vsplits arranged in columns */
+
+.admonition.vsplit {
+  --admonition-color: var(--admonition-vsplit-border, #6b7280);
+  --admonition-bg: transparent;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0;
+  padding: 0;
+  margin: var(--space-4) 0;
+  border-left: none;
+  background: transparent;
+}
+
+/* On larger screens, arrange child vsplits side by side */
+@media (min-width: 768px) {
+  .admonition.vsplit {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+/* VSplit title spans full width */
+.admonition.vsplit > .admonition-title {
+  grid-column: 1 / -1;
+  margin: 0 var(--space-4) var(--space-2);
+  padding-bottom: var(--space-2);
+  border-bottom: 2px solid var(--color-border, #e5e7eb);
+}
+
+/* Nested vsplits (the actual split columns) */
+/* These should NOT be grids - only the parent is a grid */
+.admonition.vsplit > .admonition.vsplit {
+  display: block;
+  margin: 0;
+  padding: var(--space-4);
+  border: none;
+  border-top: 2px solid var(--color-border, #e5e7eb);
+  background: var(--color-surface, #f9fafb);
+}
+
+/* On larger screens, use vertical divider instead of horizontal */
+@media (min-width: 768px) {
+  .admonition.vsplit > .admonition.vsplit {
+    border-top: none;
+  }
+
+  /* First child - right border */
+  .admonition.vsplit > .admonition.vsplit:first-of-type {
+    border-right: 2px solid var(--color-border, #e5e7eb);
+  }
+
+  /* Last child - left border (if more than 2) */
+  .admonition.vsplit > .admonition.vsplit:last-of-type {
+    border-left: none;
+  }
+}
+
+/* On mobile, stack with top borders */
+@media (max-width: 767px) {
+  .admonition.vsplit > .admonition.vsplit:first-of-type {
+    border-top: none;
+  }
+}
+
+/* Nested vsplit title */
+.admonition.vsplit > .admonition.vsplit > .admonition-title {
+  margin-bottom: var(--space-2);
+  padding-bottom: var(--space-1);
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+}
+
+/* Remove icon from vsplit titles */
+.admonition.vsplit .admonition-title::before {
+  content: none;
+}
+
+/* Dark mode for vsplit */
+@media (prefers-color-scheme: dark) {
+  .admonition.vsplit > .admonition.vsplit {
+    background: var(--color-surface, #1f2937);
+  }
+}
+
 /* Collapsible admonitions use <details>/<summary> */
 details.admonition {
   border-left: 4px solid var(--admonition-color, var(--color-primary));

--- a/themes/default/static/css/components.css
+++ b/themes/default/static/css/components.css
@@ -1322,6 +1322,133 @@
    @mention links in content.
    ========================================================================== */
 
+/* ==========================================================================
+   Keyboard Navigation Styles
+
+   Styles for keyboard-navigated elements including post highlighting
+   and toast notifications.
+   ========================================================================== */
+
+/* Highlighted post in feed when using keyboard navigation (j/k) */
+.kb-highlighted {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+  border-radius: 4px;
+  background-color: color-mix(in srgb, var(--color-primary) 10%, transparent);
+  transition: outline-color 0.15s ease, background-color 0.15s ease;
+}
+
+/* Ensure highlighted cards are visible */
+.card.kb-highlighted,
+.post-card.kb-highlighted,
+article.kb-highlighted {
+  outline-offset: 4px;
+}
+
+/* Toast notification for keyboard actions (e.g., URL copied) */
+.kb-toast {
+  position: fixed;
+  bottom: 2rem;
+  left: 50%;
+  transform: translateX(-50%) translateY(1rem);
+  padding: 0.75rem 1.5rem;
+  background-color: var(--color-surface);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  font-size: 0.875rem;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s;
+  z-index: 10000;
+}
+
+.kb-toast--visible {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(0);
+}
+
+/* Shortcuts modal section styling */
+.shortcuts-section {
+  margin-bottom: 1.5rem;
+}
+
+.shortcuts-section:last-child {
+  margin-bottom: 0;
+}
+
+.shortcuts-section-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+  margin: 0 0 0.5rem 0;
+  padding-bottom: 0.25rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+/* Compact table for shortcuts in sectioned modal */
+.shortcuts-section .shortcuts-table {
+  margin-bottom: 0;
+}
+
+.shortcuts-section .shortcuts-table td {
+  padding: 0.25rem 0.5rem;
+}
+
+.shortcuts-section .shortcuts-table td:first-child {
+  padding-left: 0;
+  white-space: nowrap;
+}
+
+/* Respect reduced motion preference */
+@media (prefers-reduced-motion: reduce) {
+  .kb-highlighted {
+    transition: none;
+  }
+
+  .kb-toast {
+    transition: opacity 0.1s ease, visibility 0.1s;
+    transform: translateX(-50%);
+  }
+
+  .kb-toast--visible {
+    transform: translateX(-50%);
+  }
+}
+
+/* High contrast mode support */
+@media (prefers-contrast: more) {
+  .kb-highlighted {
+    outline-width: 3px;
+    outline-color: var(--color-text);
+  }
+
+  .kb-toast {
+    border-width: 2px;
+    border-color: var(--color-text);
+  }
+}
+
+/* Print styles - hide keyboard-related elements */
+@media print {
+  .kb-highlighted {
+    outline: none;
+    background-color: transparent;
+  }
+
+  .kb-toast {
+    display: none !important;
+  }
+}
+
+/* ==========================================================================
+   End Keyboard Navigation Styles
+   ========================================================================== */
+
 /* Base card styling */
 .mention-card {
   position: absolute;
@@ -1521,6 +1648,246 @@
 /* Print styles - hide hover cards */
 @media print {
   .mention-card {
+    display: none !important;
+  }
+}
+
+/* ==========================================================================
+   Mark (Highlight) Styles
+
+   Styles for ==highlighted text== syntax rendered as <mark> elements.
+   ========================================================================== */
+
+mark {
+  background-color: var(--color-mark-bg, #fff3cd);
+  color: var(--color-mark-text, inherit);
+  padding: 0.125em 0.25em;
+  border-radius: 0.125em;
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  mark {
+    background-color: var(--color-mark-bg, #5c4d1f);
+    color: var(--color-mark-text, #ffd700);
+  }
+}
+
+/* ==========================================================================
+   Keyboard Keys Styles
+
+   Styles for ++Key+Key++ syntax rendered as <kbd> elements.
+   ========================================================================== */
+
+.keys {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.125em;
+}
+
+.key-separator {
+  color: var(--color-text-muted);
+  font-size: 0.875em;
+  margin: 0 0.125em;
+}
+
+kbd,
+kbd.kbd {
+  display: inline-block;
+  padding: 0.15em 0.4em;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.875em;
+  line-height: 1.4;
+  color: var(--color-text);
+  background-color: var(--color-surface, #f5f5f5);
+  border: 1px solid var(--color-border, #ccc);
+  border-radius: 0.25em;
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1), 0 2px 0 0 var(--color-background, #fff) inset;
+  white-space: nowrap;
+}
+
+/* Modifier keys get a slightly different style */
+kbd.key-ctrl,
+kbd.key-alt,
+kbd.key-shift,
+kbd.key-meta,
+kbd.key-win {
+  font-weight: 600;
+  background-color: var(--color-kbd-modifier-bg, #e8e8e8);
+}
+
+/* Function keys */
+kbd.key-f1, kbd.key-f2, kbd.key-f3, kbd.key-f4,
+kbd.key-f5, kbd.key-f6, kbd.key-f7, kbd.key-f8,
+kbd.key-f9, kbd.key-f10, kbd.key-f11, kbd.key-f12 {
+  min-width: 2em;
+  text-align: center;
+}
+
+/* Navigation keys */
+kbd.key-up, kbd.key-down, kbd.key-left, kbd.key-right,
+kbd.key-home, kbd.key-end, kbd.key-page-up, kbd.key-page-down {
+  min-width: 1.5em;
+  text-align: center;
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  kbd,
+  kbd.kbd {
+    background-color: var(--color-surface, #2d2d2d);
+    border-color: var(--color-border, #555);
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.3), 0 2px 0 0 var(--color-background, #1a1a1a) inset;
+  }
+
+  kbd.key-ctrl,
+  kbd.key-alt,
+  kbd.key-shift,
+  kbd.key-meta,
+  kbd.key-win {
+    background-color: var(--color-kbd-modifier-bg, #3d3d3d);
+  }
+}
+
+/* High contrast mode */
+@media (prefers-contrast: more) {
+  kbd,
+  kbd.kbd {
+    border-width: 2px;
+    border-color: var(--color-text);
+  }
+}
+
+/* ==========================================================================
+   Container Styles
+
+   Styles for ::: container syntax rendered as <div> elements.
+   ========================================================================== */
+
+/* Generic container - no default styling, just classes */
+div[class]:not([class=""]) {
+  /* Container divs get their styling from their classes */
+}
+
+/* Common container patterns */
+.container {
+  padding: 1rem;
+  margin: 1rem 0;
+}
+
+/* Warning container */
+.warning {
+  padding: 1rem;
+  margin: 1rem 0;
+  background-color: var(--color-warning-bg, #fff3cd);
+  border-left: 4px solid var(--color-warning-border, #ffc107);
+  border-radius: 0.25rem;
+}
+
+/* Info container */
+.info {
+  padding: 1rem;
+  margin: 1rem 0;
+  background-color: var(--color-info-bg, #cff4fc);
+  border-left: 4px solid var(--color-info-border, #0dcaf0);
+  border-radius: 0.25rem;
+}
+
+/* Success container */
+.success {
+  padding: 1rem;
+  margin: 1rem 0;
+  background-color: var(--color-success-bg, #d1e7dd);
+  border-left: 4px solid var(--color-success-border, #198754);
+  border-radius: 0.25rem;
+}
+
+/* Error/Danger container */
+.error,
+.danger {
+  padding: 1rem;
+  margin: 1rem 0;
+  background-color: var(--color-danger-bg, #f8d7da);
+  border-left: 4px solid var(--color-danger-border, #dc3545);
+  border-radius: 0.25rem;
+}
+
+/* Note container */
+.note {
+  padding: 1rem;
+  margin: 1rem 0;
+  background-color: var(--color-note-bg, #e7e9eb);
+  border-left: 4px solid var(--color-note-border, #6c757d);
+  border-radius: 0.25rem;
+}
+
+/* Dark mode for containers */
+@media (prefers-color-scheme: dark) {
+  .warning {
+    background-color: var(--color-warning-bg, #332d1a);
+  }
+
+  .info {
+    background-color: var(--color-info-bg, #1a2e33);
+  }
+
+  .success {
+    background-color: var(--color-success-bg, #1a2e22);
+  }
+
+  .error,
+  .danger {
+    background-color: var(--color-danger-bg, #331a1d);
+  }
+
+  .note {
+    background-color: var(--color-note-bg, #2d2d2d);
+  }
+}
+
+/* Columns container - side by side layout */
+.columns {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin: 1rem 0;
+}
+
+.columns > * {
+  flex: 1;
+  min-width: 200px;
+}
+
+@media (max-width: 640px) {
+  .columns {
+    flex-direction: column;
+  }
+
+  .columns > * {
+    min-width: auto;
+  }
+}
+
+/* Center container */
+.center {
+  text-align: center;
+}
+
+/* Right-align container */
+.right {
+  text-align: right;
+}
+
+/* Hidden container (for conditional content) */
+.hidden {
+  display: none;
+}
+
+/* Print styles */
+@media print {
+  .no-print,
+  .hidden-print {
     display: none !important;
   }
 }


### PR DESCRIPTION
## Summary

- Add mark extension for `==highlighted text==` syntax
- Add keys extension for `++Ctrl+Alt+Del++` keyboard shortcuts
- Add container extension for `::: class` fenced divs
- Add emoji support via goldmark-emoji (`:joy:`, `:rocket:`, etc.)
- Fix `post.Extra` template access by exposing Extra as nested map
- Add vsplit CSS for side-by-side admonition layouts
- Add conditional CSS loading for admonitions and code blocks
- Sync theme files between `themes/` and `pkg/themes/`

## New Markdown Syntax

| Extension | Input | Output |
|-----------|-------|--------|
| Mark | `==highlighted==` | `<mark>highlighted</mark>` |
| Keys | `++Ctrl+Alt+Del++` | `<span class="keys"><kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>Del</kbd></span>` |
| Containers | `::: warning` | `<div class="warning">` |
| Emoji | `:joy:` `:rocket:` | Unicode emoji characters |

## Bug Fix

The template conditional `{% if post.Extra.needs_admonitions_css %}` wasn't working because `post.Extra` was being flattened into the post map rather than exposed as a nested object. This PR adds `Extra` as both flattened keys (for backwards compatibility) and as a nested map for template access.

## CSS Improvements

- Added vsplit styles for side-by-side comparison layouts
- Added mark/highlight styles with light/dark mode support
- Added keyboard key styles with modifier key highlighting
- Added container styles (warning, info, success, error, note)
- CSS is now conditionally loaded based on content detection

## Related Issues

- Refs #539 (duplicate theme directories)
- Related to #544 (nested admonition code blocks - known limitation)

## Testing

- All existing tests pass
- Manually verified on test site with sample page
- Verified mark, keys, containers, and emoji render correctly
- Verified conditional CSS loading works