### PR TITLE
fix: make feed pagination ordering deterministic

### DIFF
--- a/pkg/plugins/auto_feeds.go
+++ b/pkg/plugins/auto_feeds.go
@@ -98,136 +98,187 @@ func (p *AutoFeedsPlugin) Load(m *lifecycle.Manager) error {
 
 	autoConfig := getAutoFeedsConfig(config)
 
-	// Helper to create string pointer
-	strPtr := func(s string) *string { return &s }
-
 	// Pre-register tag feed synthetic posts
 	if autoConfig.Tags.Enabled {
-		prefix := autoConfig.Tags.SlugPrefix
-		if prefix == "" {
-			prefix = defaultTagsPrefix
-		}
-
-		// Collect all unique tags
-		tags := make(map[string]bool)
-		for _, post := range posts {
-			for _, tag := range post.Tags {
-				tags[tag] = true
-			}
-		}
-
-		// Register synthetic post for each tag
-		for tag := range tags {
-			slug := prefix + "/" + slugify(tag)
-			syntheticPost := &models.Post{
-				Slug:        slug,
-				Title:       strPtr(fmt.Sprintf("Posts tagged: %s", tag)),
-				Description: strPtr(fmt.Sprintf("All posts with the tag %q", tag)),
-				Href:        "/" + slug + "/",
-				Published:   true,
-				Skip:        true,
-				// Add aliases so [[ python ]] resolves to tags/python
-				Extra: map[string]interface{}{
-					"aliases": []interface{}{tag, slugify(tag)},
-				},
-			}
-			m.AddPost(syntheticPost)
-		}
+		p.registerTagSyntheticPosts(m, posts, autoConfig.Tags)
 	}
 
 	// Pre-register category feed synthetic posts
 	if autoConfig.Categories.Enabled {
-		prefix := autoConfig.Categories.SlugPrefix
-		if prefix == "" {
-			prefix = defaultCategoriesPrefix
-		}
-
-		// Collect all unique categories
-		categories := make(map[string]bool)
-		for _, post := range posts {
-			if cat, ok := post.Extra["category"].(string); ok && cat != "" {
-				categories[cat] = true
-			}
-		}
-
-		// Register synthetic post for each category
-		for cat := range categories {
-			slug := prefix + "/" + slugify(cat)
-			syntheticPost := &models.Post{
-				Slug:        slug,
-				Title:       strPtr(fmt.Sprintf("Category: %s", cat)),
-				Description: strPtr(fmt.Sprintf("All posts in the %q category", cat)),
-				Href:        "/" + slug + "/",
-				Published:   true,
-				Skip:        true,
-				// Add aliases so [[ Technology ]] resolves to categories/technology
-				Extra: map[string]interface{}{
-					"aliases": []interface{}{cat, slugify(cat)},
-				},
-			}
-			m.AddPost(syntheticPost)
-		}
+		p.registerCategorySyntheticPosts(m, posts, autoConfig.Categories)
 	}
 
 	// Pre-register archive feed synthetic posts
 	if autoConfig.Archives.Enabled {
-		prefix := autoConfig.Archives.SlugPrefix
-		if prefix == "" {
-			prefix = defaultArchivePrefix
-		}
-
-		// Collect all unique year/month combinations
-		years := make(map[int]bool)
-		yearMonths := make(map[string]bool)
-
-		for _, post := range posts {
-			if post.Date != nil {
-				year := post.Date.Year()
-				month := post.Date.Month()
-				years[year] = true
-				yearMonths[fmt.Sprintf("%04d/%02d", year, month)] = true
-			}
-		}
-
-		// Register synthetic posts for yearly archives
-		if autoConfig.Archives.YearlyFeeds {
-			for year := range years {
-				slug := fmt.Sprintf("%s/%04d", prefix, year)
-				syntheticPost := &models.Post{
-					Slug:        slug,
-					Title:       strPtr(fmt.Sprintf("Archive: %d", year)),
-					Description: strPtr(fmt.Sprintf("All posts from %d", year)),
-					Href:        "/" + slug + "/",
-					Published:   true,
-					Skip:        true,
-				}
-				m.AddPost(syntheticPost)
-			}
-		}
-
-		// Register synthetic posts for monthly archives
-		if autoConfig.Archives.MonthlyFeeds {
-			for ym := range yearMonths {
-				var year, month int
-				//nolint:errcheck // best-effort parsing
-				fmt.Sscanf(ym, "%d/%d", &year, &month)
-
-				slug := fmt.Sprintf("%s/%s", prefix, ym)
-				monthName := time.Month(month).String()
-				syntheticPost := &models.Post{
-					Slug:        slug,
-					Title:       strPtr(fmt.Sprintf("Archive: %s %d", monthName, year)),
-					Description: strPtr(fmt.Sprintf("All posts from %s %d", monthName, year)),
-					Href:        "/" + slug + "/",
-					Published:   true,
-					Skip:        true,
-				}
-				m.AddPost(syntheticPost)
-			}
-		}
+		p.registerArchiveSyntheticPosts(m, posts, autoConfig.Archives)
 	}
 
 	return nil
+}
+
+// autoFeedsStrPtr returns a pointer to the given string.
+func autoFeedsStrPtr(s string) *string { return &s }
+
+// registerTagSyntheticPosts creates synthetic posts for tag feeds.
+func (p *AutoFeedsPlugin) registerTagSyntheticPosts(m *lifecycle.Manager, posts []*models.Post, config AutoFeedTypeConfig) {
+	prefix := config.SlugPrefix
+	if prefix == "" {
+		prefix = defaultTagsPrefix
+	}
+
+	// Collect all unique tags
+	tagsMap := make(map[string]bool)
+	for _, post := range posts {
+		for _, tag := range post.Tags {
+			tagsMap[tag] = true
+		}
+	}
+
+	// Sort tags for deterministic ordering
+	tags := make([]string, 0, len(tagsMap))
+	for tag := range tagsMap {
+		tags = append(tags, tag)
+	}
+	sort.Strings(tags)
+
+	// Register synthetic post for each tag
+	for _, tag := range tags {
+		slug := prefix + "/" + slugify(tag)
+		syntheticPost := &models.Post{
+			Slug:        slug,
+			Title:       autoFeedsStrPtr(fmt.Sprintf("Posts tagged: %s", tag)),
+			Description: autoFeedsStrPtr(fmt.Sprintf("All posts with the tag %q", tag)),
+			Href:        "/" + slug + "/",
+			Published:   true,
+			Skip:        true,
+			// Add aliases so [[ python ]] resolves to tags/python
+			Extra: map[string]interface{}{
+				"aliases": []interface{}{tag, slugify(tag)},
+			},
+		}
+		m.AddPost(syntheticPost)
+	}
+}
+
+// registerCategorySyntheticPosts creates synthetic posts for category feeds.
+func (p *AutoFeedsPlugin) registerCategorySyntheticPosts(m *lifecycle.Manager, posts []*models.Post, config AutoFeedTypeConfig) {
+	prefix := config.SlugPrefix
+	if prefix == "" {
+		prefix = defaultCategoriesPrefix
+	}
+
+	// Collect all unique categories
+	categoriesMap := make(map[string]bool)
+	for _, post := range posts {
+		if cat, ok := post.Extra["category"].(string); ok && cat != "" {
+			categoriesMap[cat] = true
+		}
+	}
+
+	// Sort categories for deterministic ordering
+	categories := make([]string, 0, len(categoriesMap))
+	for cat := range categoriesMap {
+		categories = append(categories, cat)
+	}
+	sort.Strings(categories)
+
+	// Register synthetic post for each category
+	for _, cat := range categories {
+		slug := prefix + "/" + slugify(cat)
+		syntheticPost := &models.Post{
+			Slug:        slug,
+			Title:       autoFeedsStrPtr(fmt.Sprintf("Category: %s", cat)),
+			Description: autoFeedsStrPtr(fmt.Sprintf("All posts in the %q category", cat)),
+			Href:        "/" + slug + "/",
+			Published:   true,
+			Skip:        true,
+			// Add aliases so [[ Technology ]] resolves to categories/technology
+			Extra: map[string]interface{}{
+				"aliases": []interface{}{cat, slugify(cat)},
+			},
+		}
+		m.AddPost(syntheticPost)
+	}
+}
+
+// registerArchiveSyntheticPosts creates synthetic posts for archive feeds.
+func (p *AutoFeedsPlugin) registerArchiveSyntheticPosts(m *lifecycle.Manager, posts []*models.Post, config AutoArchiveConfig) {
+	prefix := config.SlugPrefix
+	if prefix == "" {
+		prefix = defaultArchivePrefix
+	}
+
+	// Collect all unique year/month combinations
+	yearsMap := make(map[int]bool)
+	yearMonthsMap := make(map[string]bool)
+
+	for _, post := range posts {
+		if post.Date != nil {
+			year := post.Date.Year()
+			month := post.Date.Month()
+			yearsMap[year] = true
+			yearMonthsMap[fmt.Sprintf("%04d/%02d", year, month)] = true
+		}
+	}
+
+	// Register synthetic posts for yearly archives
+	if config.YearlyFeeds {
+		p.registerYearlyArchivePosts(m, yearsMap, prefix)
+	}
+
+	// Register synthetic posts for monthly archives
+	if config.MonthlyFeeds {
+		p.registerMonthlyArchivePosts(m, yearMonthsMap, prefix)
+	}
+}
+
+// registerYearlyArchivePosts creates synthetic posts for yearly archive feeds.
+func (p *AutoFeedsPlugin) registerYearlyArchivePosts(m *lifecycle.Manager, yearsMap map[int]bool, prefix string) {
+	years := make([]int, 0, len(yearsMap))
+	for year := range yearsMap {
+		years = append(years, year)
+	}
+	sort.Ints(years)
+
+	for _, year := range years {
+		slug := fmt.Sprintf("%s/%04d", prefix, year)
+		syntheticPost := &models.Post{
+			Slug:        slug,
+			Title:       autoFeedsStrPtr(fmt.Sprintf("Archive: %d", year)),
+			Description: autoFeedsStrPtr(fmt.Sprintf("All posts from %d", year)),
+			Href:        "/" + slug + "/",
+			Published:   true,
+			Skip:        true,
+		}
+		m.AddPost(syntheticPost)
+	}
+}
+
+// registerMonthlyArchivePosts creates synthetic posts for monthly archive feeds.
+func (p *AutoFeedsPlugin) registerMonthlyArchivePosts(m *lifecycle.Manager, yearMonthsMap map[string]bool, prefix string) {
+	yearMonths := make([]string, 0, len(yearMonthsMap))
+	for ym := range yearMonthsMap {
+		yearMonths = append(yearMonths, ym)
+	}
+	sort.Strings(yearMonths)
+
+	for _, ym := range yearMonths {
+		var year, month int
+		//nolint:errcheck // best-effort parsing
+		fmt.Sscanf(ym, "%d/%d", &year, &month)
+
+		slug := fmt.Sprintf("%s/%s", prefix, ym)
+		monthName := time.Month(month).String()
+		syntheticPost := &models.Post{
+			Slug:        slug,
+			Title:       autoFeedsStrPtr(fmt.Sprintf("Archive: %s %d", monthName, year)),
+			Description: autoFeedsStrPtr(fmt.Sprintf("All posts from %s %d", monthName, year)),
+			Href:        "/" + slug + "/",
+			Published:   true,
+			Skip:        true,
+		}
+		m.AddPost(syntheticPost)
+	}
 }
 
 // Collect generates automatic feeds for tags, categories, and date archives.

--- a/pkg/plugins/feeds.go
+++ b/pkg/plugins/feeds.go
@@ -237,12 +237,19 @@ func cloneFeedPosts(posts []*models.Post) []*models.Post {
 }
 
 // sortPosts sorts posts by the specified field.
+// When primary sort values are equal, uses Path as a secondary sort key
+// to ensure deterministic ordering across builds.
 func sortPosts(posts []*models.Post, field string, reverse bool) {
 	sort.SliceStable(posts, func(i, j int) bool {
 		vi := getFieldValue(posts[i], field)
 		vj := getFieldValue(posts[j], field)
 
 		cmp := compareFieldValues(vi, vj)
+
+		// Use path as tie-breaker for deterministic ordering
+		if cmp == 0 {
+			cmp = strings.Compare(posts[i].Path, posts[j].Path)
+		}
 
 		if reverse {
 			return cmp > 0

--- a/pkg/services/post_service.go
+++ b/pkg/services/post_service.go
@@ -189,6 +189,12 @@ func sortPosts(posts []*models.Post, field string, order SortOrder) {
 		default:
 			return false
 		}
+
+		// Use path as tie-breaker for deterministic ordering
+		if cmp == 0 && field != "path" {
+			cmp = strings.Compare(posts[i].Path, posts[j].Path)
+		}
+
 		if order == SortDesc {
 			return cmp > 0
 		}


### PR DESCRIPTION
## Summary

- Add secondary sort key (path) as tie-breaker when primary sort values are equal
- Sort tag, category, and archive feeds alphabetically before iteration
- Convert maps to sorted slices before iterating to avoid non-deterministic ordering

## Problem

Feed pagination pages had non-deterministic tag ordering. Tags appeared in different order between builds due to:
1. Go map iteration being non-deterministic
2. Missing secondary sort key when primary keys (like dates) are equal

## Changes

- `pkg/plugins/feeds.go`: Add path as tie-breaker in `sortPosts()` for deterministic ordering
- `pkg/plugins/auto_feeds.go`: Sort tags, categories, years, and year-months before iterating to ensure deterministic synthetic post registration
- `pkg/services/post_service.go`: Add path as tie-breaker in `sortPosts()` for API consistency

## Testing

- All existing tests pass (`go test ./...`)
- Build succeeds (`go build ./cmd/markata-go`)

Fixes #542