### PR TITLE
feat(theme): add theme-aware browser default styles

### DIFF
--- a/pkg/themes/default/static/css/main.css
+++ b/pkg/themes/default/static/css/main.css
@@ -10,6 +10,160 @@
   margin: 0;
 }
 
+/* Prevent font scaling in landscape on mobile */
+html {
+  -webkit-text-size-adjust: 100%;
+}
+
+/* Inherit fonts for form elements */
+input, button, textarea, select {
+  font: inherit;
+}
+
+/* ==========================================================================
+   Theme-aware Browser Defaults
+   ========================================================================== */
+
+/* accent-color: Theme native form controls (checkboxes, radios, range, progress) */
+:root {
+  accent-color: var(--color-primary);
+}
+
+/* caret-color: Theme the text cursor in inputs */
+input,
+textarea,
+[contenteditable="true"] {
+  caret-color: var(--color-primary);
+}
+
+/* ::marker: Theme list bullet/number colors */
+::marker {
+  color: var(--color-text-muted);
+}
+
+/* ==========================================================================
+   Form Elements Base Styling
+   ========================================================================== */
+
+input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="file"]):not([type="submit"]):not([type="button"]):not([type="reset"]),
+select,
+textarea {
+  color: var(--color-text);
+  background-color: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius, 0.375rem);
+  padding: var(--space-2, 0.5rem) var(--space-3, 0.75rem);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="file"]):not([type="submit"]):not([type="button"]):not([type="reset"]):focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary) 20%, transparent);
+}
+
+/* Placeholder text */
+::placeholder {
+  color: var(--color-text-muted);
+  opacity: 0.7;
+}
+
+/* Button base styling */
+button,
+input[type="submit"],
+input[type="button"],
+input[type="reset"] {
+  cursor: pointer;
+  color: var(--color-text);
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius, 0.375rem);
+  padding: var(--space-2, 0.5rem) var(--space-4, 1rem);
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+
+button:hover,
+input[type="submit"]:hover,
+input[type="button"]:hover,
+input[type="reset"]:hover {
+  background-color: var(--color-background);
+  border-color: var(--color-primary);
+}
+
+button:focus-visible,
+input[type="submit"]:focus-visible,
+input[type="button"]:focus-visible,
+input[type="reset"]:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+/* Disabled form elements */
+input:disabled,
+select:disabled,
+textarea:disabled,
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* File input button */
+::file-selector-button {
+  font: inherit;
+  color: var(--color-text);
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius, 0.375rem);
+  padding: var(--space-2, 0.5rem) var(--space-4, 1rem);
+  margin-right: var(--space-3, 0.75rem);
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+
+::file-selector-button:hover {
+  background-color: var(--color-background);
+  border-color: var(--color-primary);
+}
+
+/* Search input cancel button */
+input[type="search"]::-webkit-search-cancel-button {
+  -webkit-appearance: none;
+  height: 1em;
+  width: 1em;
+  border-radius: 50%;
+  background-color: var(--color-text-muted);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+input[type="search"]:focus::-webkit-search-cancel-button,
+input[type="search"]:not(:placeholder-shown)::-webkit-search-cancel-button {
+  opacity: 0.6;
+}
+
+input[type="search"]::-webkit-search-cancel-button:hover {
+  opacity: 1;
+}
+
+/* Dialog backdrop (for future use) */
+::backdrop {
+  background-color: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+}
+
+/* High contrast mode overrides */
+@media (prefers-contrast: more) {
+  input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="file"]),
+  select,
+  textarea,
+  button {
+    border-width: 2px;
+  }
+}
+
 /* Base */
 html {
   font-size: 16px;


### PR DESCRIPTION
## Summary

Add comprehensive theming for browser default elements to ensure visual consistency across all palettes.

## Changes

Added to `pkg/themes/default/static/css/main.css`:

### Theme-aware Browser Defaults
- **`accent-color`**: Theme native checkboxes, radios, range inputs, progress bars
- **`caret-color`**: Theme text cursor in inputs/textareas
- **`::marker`**: Theme list bullet/number colors with muted text color
- **`::placeholder`**: Theme input placeholder text

### Form Element Base Styling
- **Inputs/Select/Textarea**: Base styling with theme colors, borders, focus states
- **Buttons**: Consistent button styling with hover/focus states
- **`::file-selector-button`**: Theme file input buttons
- **`::-webkit-search-cancel-button`**: Theme search clear buttons
- **Disabled states**: Consistent disabled appearance

### Other Improvements
- **`::backdrop`**: Prepare for future dialog/modal support
- **Font inheritance**: Form elements inherit font from body
- **Mobile**: Prevent font scaling in landscape orientation
- **High contrast mode**: Increase border widths for visibility

## Before/After

Before: Form elements use browser defaults (blue accents, system fonts)
After: Form elements match the active palette's colors

## Testing

- Builds successfully
- CSS is valid
- Works with all existing palettes