### PR TITLE
fix(hotkeys): ensure modal renders by moving include before script check

### DIFF
--- a/pkg/themes/default/static/css/components.css
+++ b/pkg/themes/default/static/css/components.css
@@ -1395,8 +1395,9 @@ article.kb-highlighted {
    transition: opacity 0.2s ease, visibility 0.2s ease;
 }
 
-/* Modal is visible when not aria-hidden */
-.shortcuts-modal:not([aria-hidden="true"]) {
+/* Modal is visible when not aria-hidden or when --open class is added */
+.shortcuts-modal:not([aria-hidden="true"]),
+.shortcuts-modal.shortcuts-modal--open {
    opacity: 1;
    visibility: visible;
 }

--- a/pkg/themes/default/templates/base.html
+++ b/pkg/themes/default/templates/base.html
@@ -158,6 +158,9 @@
   {% block htmx %}{% endblock %}
   {% block scripts %}{% endblock %}
 
+  {# Shortcuts Modal - must be before conditional script loading so #shortcuts-modal exists when checked #}
+  {% include "partials/shortcuts-modal.html" %}
+
   <!-- Conditional Script Loading: Only load when needed -->
   <script>
     // Wikilink Hover Tooltips - only load if wikilinks with data-title exist
@@ -256,6 +259,5 @@
   {% endif %}
 
    {% include "partials/background-scripts.html" %}
-   {% include "partials/shortcuts-modal.html" %}
 </body>
 </html>


### PR DESCRIPTION
## Summary

Fixes #573 - The keyboard shortcuts modal was not rendering when pressing `?`.

## Root Causes

1. **Template Load Order Issue**: The `shortcuts-modal.html` template was included **after** the conditional script loader that checks for `#shortcuts-modal`. Since the script runs synchronously during page load, the element didn't exist in the DOM yet.

2. **CSS/JS Mismatch**: The CSS used `aria-hidden` attribute for visibility control, but the JavaScript also adds/removes a `shortcuts-modal--open` class.

## Changes

### `pkg/themes/default/templates/base.html`
- Moved `{% include "partials/shortcuts-modal.html" %}` to **before** the conditional script loading section
- Added explanatory comment about why the order matters

### `pkg/themes/default/static/css/components.css`
- Added CSS rule for `.shortcuts-modal--open` class alongside the existing `aria-hidden` selector
- Ensures modal visibility works with both the JS class toggle and aria-hidden attribute

## Testing

- [x] `just lint` passes
- [x] `just test` passes
- Modal now renders when pressing `?`
- Escape key closes the modal
- Toggle button works correctly