### PR TITLE
docs: clarify viewport_width/viewport_height are reserved for future use

### DIFF
--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -1498,10 +1498,20 @@ type CriticalCSSConfig struct {
 	// Enabled controls whether critical CSS optimization is active (default: false)
 	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty" toml:"enabled,omitempty"`
 
-	// ViewportWidth is the simulated viewport width for determining above-the-fold content (default: 1300)
+	// ViewportWidth is reserved for future viewport-based critical CSS detection.
+	// NOTE: Currently NOT implemented. The critical CSS extractor uses a selector-based
+	// approach (see ExtraSelectors/ExcludeSelectors) rather than viewport simulation.
+	// True viewport-based detection would require a headless browser.
+	// This field is retained for configuration compatibility and future enhancement.
+	// Default: 1300
 	ViewportWidth int `json:"viewport_width,omitempty" yaml:"viewport_width,omitempty" toml:"viewport_width,omitempty"`
 
-	// ViewportHeight is the simulated viewport height for determining above-the-fold content (default: 900)
+	// ViewportHeight is reserved for future viewport-based critical CSS detection.
+	// NOTE: Currently NOT implemented. The critical CSS extractor uses a selector-based
+	// approach (see ExtraSelectors/ExcludeSelectors) rather than viewport simulation.
+	// True viewport-based detection would require a headless browser.
+	// This field is retained for configuration compatibility and future enhancement.
+	// Default: 900
 	ViewportHeight int `json:"viewport_height,omitempty" yaml:"viewport_height,omitempty" toml:"viewport_height,omitempty"`
 
 	// Minify controls whether to minify the critical CSS output (default: true)
@@ -1525,6 +1535,8 @@ type CriticalCSSConfig struct {
 }
 
 // NewCriticalCSSConfig creates a new CriticalCSSConfig with default values.
+// Note: ViewportWidth and ViewportHeight are set for future compatibility but
+// are not currently used by the selector-based critical CSS extractor.
 func NewCriticalCSSConfig() CriticalCSSConfig {
 	enabled := false
 	minify := true

--- a/pkg/plugins/critical_css.go
+++ b/pkg/plugins/critical_css.go
@@ -51,6 +51,9 @@ func (p *CriticalCSSPlugin) Configure(m *lifecycle.Manager) error {
 	}
 
 	// Use defaults if not configured
+	// NOTE: ViewportWidth and ViewportHeight are stored for configuration compatibility
+	// but are NOT currently used. The extractor uses a selector-based approach, not
+	// viewport simulation. See issue #570 for discussion of future implementation.
 	if p.config.ViewportWidth == 0 {
 		p.config.ViewportWidth = 1300
 	}


### PR DESCRIPTION
## Summary

- Clarifies that `viewport_width` and `viewport_height` config options in critical_css are **not currently implemented**
- Documents that the current implementation uses a selector-based approach, not viewport simulation
- Retains fields for configuration compatibility and potential future enhancement

## Problem

The `critical_css` configuration includes `viewport_width` and `viewport_height` options that appeared to control viewport simulation for determining above-the-fold content. However, these values were never actually used - the current implementation uses a purely selector-based approach.

This caused user confusion as the options implied functionality that didn't exist.

## Solution

Updated documentation to clearly indicate:
- These fields are reserved for future viewport-based critical CSS detection
- Currently NOT implemented - uses selector-based approach instead
- True viewport-based detection would require a headless browser
- Fields retained for configuration compatibility

Fixes #570