### PR TITLE
fix(pagination): correct active button state on navigation

### DIFF
--- a/pkg/themes/default/static/js/view-transitions.js
+++ b/pkg/themes/default/static/js/view-transitions.js
@@ -118,8 +118,9 @@
    * Navigate to a URL with view transition
    */
   async function navigateWithTransition(url) {
-    // Fetch new page content
-    const response = await fetch(url);
+    // Fetch new page content with cache bypass to ensure fresh content
+    // This prevents stale content (e.g., wrong pagination active state) after navigation
+    const response = await fetch(url, { cache: 'no-store' });
 
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}: ${response.statusText}`);


### PR DESCRIPTION
## Summary

- Bypass browser cache when fetching pages via view transitions
- This ensures fresh content is always rendered, fixing the pagination active button issue

## Problem

When navigating between pages in manual feed pagination (e.g., /archive/page/2/), the active button didn't update correctly. Button 1 stayed highlighted even after clicking page 2. After refresh, the correct page became active.

## Root Cause

The view transitions feature uses `fetch()` to load new pages, but without cache control headers. Browsers may serve cached responses, causing stale content (including the wrong active pagination button) to be displayed.

## Solution

Added `{ cache: 'no-store' }` option to the fetch call in `view-transitions.js` to ensure fresh content is always fetched during navigation.

Fixes #574