### PR TITLE
feat: add htmx-infinite pagination mode for infinite scroll

### DIFF
--- a/pkg/models/feed.go
+++ b/pkg/models/feed.go
@@ -10,6 +10,9 @@ const (
 	// PaginationHTMX uses HTMX for seamless AJAX-based page loading.
 	PaginationHTMX PaginationType = "htmx"
 
+	// PaginationHTMXInfinite uses HTMX for infinite scroll pagination.
+	PaginationHTMXInfinite PaginationType = "htmx-infinite"
+
 	// PaginationJS uses client-side JavaScript for pagination.
 	PaginationJS PaginationType = "js"
 )

--- a/pkg/models/feed_test.go
+++ b/pkg/models/feed_test.go
@@ -416,6 +416,7 @@ func TestFeedConfig_Paginate_PaginationType(t *testing.T) {
 	}{
 		{"manual explicit", PaginationManual, PaginationManual},
 		{"htmx explicit", PaginationHTMX, PaginationHTMX},
+		{"htmx-infinite explicit", PaginationHTMXInfinite, PaginationHTMXInfinite},
 		{"js explicit", PaginationJS, PaginationJS},
 		{"empty defaults to manual", "", PaginationManual},
 	}

--- a/pkg/themes/default/static/css/main.css
+++ b/pkg/themes/default/static/css/main.css
@@ -944,6 +944,59 @@ body:has(.background-decoration) div.feed {
   transition: opacity 0.2s;
 }
 
+/* Infinite Scroll Pagination */
+.pagination-infinite {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: var(--space-8) 0;
+  margin-top: var(--space-6);
+}
+
+.infinite-scroll-trigger {
+  height: 1px;
+  width: 100%;
+}
+
+.infinite-scroll-loading {
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+}
+
+.infinite-scroll-loading.htmx-request {
+  display: flex;
+}
+
+.loading-spinner {
+  width: 24px;
+  height: 24px;
+  border: 2px solid var(--color-border);
+  border-top-color: var(--color-primary);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.infinite-scroll-end {
+  padding: var(--space-4);
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  text-align: center;
+  border-top: 1px solid var(--color-border);
+  width: 100%;
+  max-width: 300px;
+}
+
 /* Utility Classes */
 .sr-only {
   position: absolute;

--- a/pkg/themes/default/static/js/infinite-scroll.js
+++ b/pkg/themes/default/static/js/infinite-scroll.js
@@ -1,0 +1,99 @@
+/**
+ * Infinite scroll pagination for markata-go
+ * Supports pagination_type: "htmx-infinite"
+ *
+ * This script works alongside HTMX to provide infinite scroll functionality.
+ * It updates the pagination trigger element after each page load to point
+ * to the next page, continuing until all pages are loaded.
+ */
+(function() {
+  'use strict';
+
+  // Initialize when DOM is ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initInfiniteScroll);
+  } else {
+    initInfiniteScroll();
+  }
+
+  // Expose for view transitions to re-initialize
+  window.initInfiniteScroll = initInfiniteScroll;
+
+  // Re-initialize after view transitions
+  window.addEventListener('view-transition-complete', initInfiniteScroll);
+
+  function initInfiniteScroll() {
+    const paginationContainer = document.getElementById('pagination-infinite');
+    if (!paginationContainer) return;
+
+    // Get initial state
+    let currentPage = parseInt(paginationContainer.dataset.currentPage, 10) || 1;
+    const totalPages = parseInt(paginationContainer.dataset.totalPages, 10) || 1;
+
+    // Listen for HTMX after-swap to update the trigger for the next page
+    document.body.addEventListener('htmx:afterSwap', function(event) {
+      // Only handle swaps into the posts list
+      if (!event.detail.target.classList.contains('posts-list')) return;
+
+      currentPage++;
+
+      // Check if there are more pages
+      if (currentPage >= totalPages) {
+        // No more pages - show end message
+        showEndMessage(paginationContainer);
+      } else {
+        // Update trigger for next page
+        updateTrigger(paginationContainer, currentPage, totalPages);
+      }
+    });
+  }
+
+  function updateTrigger(container, currentPage, totalPages) {
+    const trigger = container.querySelector('.infinite-scroll-trigger');
+    if (!trigger) return;
+
+    // Calculate the next page URL
+    // URLs follow the pattern: /feed/ for page 1, /feed/page/N/ for page N
+    const currentUrl = window.location.pathname;
+    const baseUrl = currentUrl.replace(/\/page\/\d+\/?$/, '').replace(/\/$/, '');
+    const nextPageNum = currentPage + 1;
+    const nextUrl = baseUrl + '/page/' + nextPageNum + '/';
+
+    // Update the trigger's HTMX attributes
+    trigger.setAttribute('hx-get', nextUrl);
+
+    // Re-process the element so HTMX picks up the new URL
+    if (window.htmx) {
+      htmx.process(trigger);
+    }
+
+    // Update data attributes
+    container.dataset.currentPage = currentPage;
+    container.dataset.nextUrl = nextUrl;
+    container.dataset.hasNext = (nextPageNum <= totalPages).toString();
+  }
+
+  function showEndMessage(container) {
+    // Replace loading indicator with end message
+    const loading = container.querySelector('.infinite-scroll-loading');
+    const trigger = container.querySelector('.infinite-scroll-trigger');
+
+    if (trigger) {
+      trigger.remove();
+    }
+
+    if (loading) {
+      loading.style.display = 'none';
+    }
+
+    // Check if end message already exists
+    if (!container.querySelector('.infinite-scroll-end')) {
+      const endMessage = document.createElement('div');
+      endMessage.className = 'infinite-scroll-end';
+      endMessage.innerHTML = '<span>You\'ve reached the end</span>';
+      container.appendChild(endMessage);
+    }
+
+    container.dataset.hasNext = 'false';
+  }
+})();

--- a/pkg/themes/default/templates/feed.html
+++ b/pkg/themes/default/templates/feed.html
@@ -4,8 +4,11 @@
 {% block description %}{{ feed.description | default:config.description | default:"" }}{% endblock %}
 
 {% block htmx %}
-{% if page.pagination_type == "htmx" %}
+{% if page.pagination_type == "htmx" or page.pagination_type == "htmx-infinite" %}
 <script src="https://unpkg.com/htmx.org@1.9.10" integrity="sha384-D1Kt99CQMDuVetoL1lrYwg5t+9QdHe7NLX/SoJYkXDFfX37iInKRy5xLSi8nO7UC" crossorigin="anonymous"></script>
+{% if page.pagination_type == "htmx-infinite" %}
+<script src="{{ 'js/infinite-scroll.js' | theme_asset }}" defer></script>
+{% endif %}
 {% elif page.pagination_type == "js" %}
 <script src="{{ 'js/pagination.js' | theme_asset }}" defer></script>
 {% endif %}

--- a/pkg/themes/default/templates/partials/pagination.html
+++ b/pkg/themes/default/templates/partials/pagination.html
@@ -1,7 +1,70 @@
 {# Pagination partial - auto-selects template based on pagination_type #}
 {# Ellipsis pagination: shows 1, ..., current-2 to current+2, ..., last #}
 {% if page.total_pages > 1 %}
-{% if page.pagination_type == "htmx" %}
+{% if page.pagination_type == "htmx-infinite" %}
+{# HTMX Infinite Scroll - auto-loads next page when scrolling near bottom #}
+<div class="pagination-infinite"
+     id="pagination-infinite"
+     data-next-url="{{ page.next_url }}"
+     data-has-next="{{ page.has_next }}"
+     data-current-page="{{ page.number }}"
+     data-total-pages="{{ page.total_pages }}">
+  {% if page.has_next %}
+  <div class="infinite-scroll-trigger"
+       hx-get="{{ page.next_url }}"
+       hx-trigger="revealed"
+       hx-select=".posts-list > *"
+       hx-target=".posts-list"
+       hx-swap="beforeend"
+       hx-indicator=".infinite-scroll-loading">
+  </div>
+  <div class="infinite-scroll-loading" aria-hidden="true">
+    <div class="loading-spinner"></div>
+    <span>Loading more posts...</span>
+  </div>
+  {% else %}
+  <div class="infinite-scroll-end">
+    <span>You've reached the end</span>
+  </div>
+  {% endif %}
+</div>
+<noscript>
+  {# Fallback to manual pagination when JS is disabled #}
+  <nav class="pagination" aria-label="Pagination">
+    {% if page.has_prev %}
+    <a href="{{ page.prev_url }}" class="pagination-prev" rel="prev">&laquo; Newer</a>
+    {% else %}
+    <span class="pagination-prev disabled">&laquo; Newer</span>
+    {% endif %}
+    <div class="pagination-pages">
+      {% for url in page.page_urls %}
+      {% with page_num=forloop.Counter %}
+      {% if page_num == 1 or page_num == page.total_pages or (page_num >= page.number|add:"-2" and page_num <= page.number|add:"2") %}
+        {% if page_num == page.total_pages and page.number < page.total_pages|add:"-3" %}
+        <span class="pagination-ellipsis" aria-hidden="true">...</span>
+        {% elif page_num > 1 and page_num == page.number|add:"-2" and page.number > 4 %}
+        <span class="pagination-ellipsis" aria-hidden="true">...</span>
+        {% endif %}
+        {% if page_num == page.number %}
+        <span class="pagination-page current" aria-current="page">{{ page_num }}</span>
+        {% else %}
+        <a href="{{ url }}" class="pagination-page">{{ page_num }}</a>
+        {% endif %}
+        {% if page_num == 1 and page.number > 4 %}
+        <span class="pagination-ellipsis" aria-hidden="true">...</span>
+        {% endif %}
+      {% endif %}
+      {% endwith %}
+      {% endfor %}
+    </div>
+    {% if page.has_next %}
+    <a href="{{ page.next_url }}" class="pagination-next" rel="next">Older &raquo;</a>
+    {% else %}
+    <span class="pagination-next disabled">Older &raquo;</span>
+    {% endif %}
+  </nav>
+</noscript>
+{% elif page.pagination_type == "htmx" %}
 {# HTMX Pagination - uses hx-* attributes for AJAX loading #}
 <nav id="pagination-nav" class="pagination pagination-htmx" aria-label="Pagination" hx-boost="true" hx-swap="outerHTML">
   {# Previous button #}

--- a/pkg/themes/default/templates/reader.html
+++ b/pkg/themes/default/templates/reader.html
@@ -6,8 +6,11 @@
 {% block body_class %}page-reader{% endblock %}
 
 {% block head_extra %}
-{% if pagination_type == "htmx" %}
+{% if pagination_type == "htmx" or pagination_type == "htmx-infinite" %}
 <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+{% if pagination_type == "htmx-infinite" %}
+<script src="{{ 'js/infinite-scroll.js' | theme_asset }}" defer></script>
+{% endif %}
 {% endif %}
 {% endblock %}
 

--- a/templates/feed.html
+++ b/templates/feed.html
@@ -4,8 +4,11 @@
 {% block description %}{{ feed.description | default:config.description | default:"" }}{% endblock %}
 
 {% block htmx %}
-{% if page.pagination_type == "htmx" %}
+{% if page.pagination_type == "htmx" or page.pagination_type == "htmx-infinite" %}
 <script src="https://unpkg.com/htmx.org@1.9.10" integrity="sha384-D1Kt99CQMDuVetoL1lrYwg5t+9QdHe7NLX/SoJYkXDFfX37iInKRy5xLSi8nO7UC" crossorigin="anonymous"></script>
+{% if page.pagination_type == "htmx-infinite" %}
+<script src="{{ 'js/infinite-scroll.js' | theme_asset }}" defer></script>
+{% endif %}
 {% elif page.pagination_type == "js" %}
 <script src="{{ 'js/pagination.js' | theme_asset }}" defer></script>
 {% endif %}

--- a/templates/partials/pagination.html
+++ b/templates/partials/pagination.html
@@ -1,6 +1,57 @@
 {# Pagination partial - auto-selects template based on pagination_type #}
 {% if page.total_pages > 1 %}
-{% if page.pagination_type == "htmx" %}
+{% if page.pagination_type == "htmx-infinite" %}
+{# HTMX Infinite Scroll - auto-loads next page when scrolling near bottom #}
+<div class="pagination-infinite"
+     id="pagination-infinite"
+     data-next-url="{{ page.next_url }}"
+     data-has-next="{{ page.has_next }}"
+     data-current-page="{{ page.number }}"
+     data-total-pages="{{ page.total_pages }}">
+  {% if page.has_next %}
+  <div class="infinite-scroll-trigger"
+       hx-get="{{ page.next_url }}"
+       hx-trigger="revealed"
+       hx-select=".posts-list > *"
+       hx-target=".posts-list"
+       hx-swap="beforeend"
+       hx-indicator=".infinite-scroll-loading">
+  </div>
+  <div class="infinite-scroll-loading" aria-hidden="true">
+    <div class="loading-spinner"></div>
+    <span>Loading more posts...</span>
+  </div>
+  {% else %}
+  <div class="infinite-scroll-end">
+    <span>You've reached the end</span>
+  </div>
+  {% endif %}
+</div>
+<noscript>
+  {# Fallback to manual pagination when JS is disabled #}
+  <nav class="pagination" aria-label="Pagination">
+    {% if page.has_prev %}
+    <a href="{{ page.prev_url }}" class="pagination-prev" rel="prev">&laquo; Newer</a>
+    {% else %}
+    <span class="pagination-prev disabled">&laquo; Newer</span>
+    {% endif %}
+    <div class="pagination-pages">
+      {% for url in page.page_urls %}
+      {% if forloop.Counter == page.number %}
+      <span class="pagination-page current" aria-current="page">{{ forloop.Counter }}</span>
+      {% else %}
+      <a href="{{ url }}" class="pagination-page">{{ forloop.Counter }}</a>
+      {% endif %}
+      {% endfor %}
+    </div>
+    {% if page.has_next %}
+    <a href="{{ page.next_url }}" class="pagination-next" rel="next">Older &raquo;</a>
+    {% else %}
+    <span class="pagination-next disabled">Older &raquo;</span>
+    {% endif %}
+  </nav>
+</noscript>
+{% elif page.pagination_type == "htmx" %}
 {# HTMX Pagination - uses hx-* attributes for AJAX loading #}
 <nav class="pagination pagination-htmx" aria-label="Pagination" hx-boost="true">
   {# Previous button #}

--- a/templates/reader.html
+++ b/templates/reader.html
@@ -7,8 +7,11 @@
 {% block body_class %}page-reader{% endblock %}
 
 {% block htmx %}
-{% if page.pagination_type == "htmx" %}
+{% if page.pagination_type == "htmx" or page.pagination_type == "htmx-infinite" %}
 <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+{% if page.pagination_type == "htmx-infinite" %}
+<script src="{{ 'js/infinite-scroll.js' | theme_asset }}" defer></script>
+{% endif %}
 {% elif page.pagination_type == "js" %}
 <script src="{{ 'js/pagination.js' | theme_asset }}" defer></script>
 {% endif %}


### PR DESCRIPTION
## Summary

Adds a new `htmx-infinite` pagination type that provides infinite scroll functionality for feeds, automatically loading the next page when users scroll near the bottom.

## Changes

- **New pagination type**: `htmx-infinite` alongside existing `manual`, `htmx`, and `js` options
- **Automatic loading**: Uses HTMX's `revealed` trigger to detect when the user scrolls to the bottom
- **Loading indicator**: Displays a spinner and "Loading more posts..." message during fetch
- **End state**: Shows "You've reached the end" when all pages are loaded
- **Fallback**: Includes `<noscript>` block with traditional pagination for users without JavaScript

## Configuration

```toml
[feeds.archive]
pagination_type = "htmx-infinite"
```

## Implementation Details

1. Added `PaginationHTMXInfinite` constant to `pkg/models/feed.go`
2. Updated pagination templates (`templates/partials/pagination.html` and `pkg/themes/default/templates/partials/pagination.html`)
3. Created `pkg/themes/default/static/js/infinite-scroll.js` to handle HTMX after-swap events and update the trigger URL for subsequent pages
4. Added CSS styles for loading spinner and end-of-content message in `main.css`
5. Updated `feed.html` and `reader.html` templates to include HTMX and the infinite scroll JS when needed
6. Added test case for the new pagination type

Closes #580