### PR TITLE
feat(footer): display theme name in built with statement

### DIFF
--- a/pkg/themes/default/templates/components/footer.html
+++ b/pkg/themes/default/templates/components/footer.html
@@ -26,7 +26,7 @@
         {% endif %}
 
         {% if footer.show_copyright %}
-        <p class="footer-copyright">&copy; {{ "now" | date:"2006" }} {{ config.author | default:config.title | default:"" }}. Built with <a href="https://github.com/WaylonWalker/markata-go">markata-go</a>.</p>
+        <p class="footer-copyright">&copy; {{ "now" | date:"2006" }} {{ config.author | default:config.title | default:"" }}. Built with <a href="https://github.com/WaylonWalker/markata-go">markata-go</a> using {{ config.theme.name | default:"default" }} theme.</p>
         {% endif %}
     </div>
 </footer>

--- a/templates/components/footer.html
+++ b/templates/components/footer.html
@@ -25,7 +25,7 @@
 
         <div class="footer-bottom">
             {% if footer.show_copyright %}
-            <p class="footer-copyright">&copy; {{ "now" | date:"2006" }} {{ config.author | default:"" }}. Built with <a href="https://github.com/WaylonWalker/markata-go">markata-go</a>.</p>
+            <p class="footer-copyright">&copy; {{ "now" | date:"2006" }} {{ config.author | default:"" }}. Built with <a href="https://github.com/WaylonWalker/markata-go">markata-go</a> using {{ config.theme.name | default:"default" }} theme.</p>
             {% endif %}
             <p class="footer-shortcuts-hint">Press <kbd>?</kbd> for keyboard shortcuts</p>
         </div>


### PR DESCRIPTION
## Summary

- Add the current theme name to the footer's "Built with" text
- Falls back to "default" if no theme name is configured
- Updates both base template and default theme template

Closes #587