### PR TITLE
fix(blogroll): add Atom-style icon/logo fallback for RSS feed images

### DIFF
--- a/pkg/blogroll/updater.go
+++ b/pkg/blogroll/updater.go
@@ -327,9 +327,15 @@ func parseRSSFeedMetadata(content string, metadata *Metadata) {
 		metadata.FeedAuthor = stripCDATA(author)
 	}
 
-	// Extract image
+	// Extract image (try multiple sources)
 	if imgURL := extractNestedXMLTag(channel, "image", "url"); imgURL != "" {
 		metadata.FeedImageURL = stripCDATA(imgURL)
+	} else if icon := extractXMLTag(channel, "icon"); icon != "" {
+		// Fallback to Atom-style icon tag (some feeds mix formats)
+		metadata.FeedImageURL = stripCDATA(icon)
+	} else if logo := extractXMLTag(channel, "logo"); logo != "" {
+		// Fallback to Atom-style logo tag
+		metadata.FeedImageURL = stripCDATA(logo)
 	}
 
 	// Extract lastBuildDate or pubDate


### PR DESCRIPTION
## Summary

Enhances RSS feed image extraction with fallback support for Atom-style icon/logo tags, fixing issue #601.

## Problem

RSS feeds currently only extract images from `<channel><image><url>` tags. Many feeds (especially those mixing RSS and Atom formats) use Atom-style `<icon>` or `<logo>` tags instead, resulting in missing avatars on the blogroll page.

## Solution

Added cascading fallback mechanism to RSS feed parsing:
1. First tries standard RSS `<image><url>` tag
2. Falls back to Atom-style `<icon>` tag if RSS image not found  
3. Falls back to Atom-style `<logo>` tag if neither are found

This mirrors the existing Atom feed parsing logic (lines 287-291), ensuring consistent behavior across feed types.

## Changes

**File Modified:** `pkg/blogroll/updater.go` (lines 330-339)

**Before:**
```go
// Extract image
if imgURL := extractNestedXMLTag(channel, "image", "url"); imgURL != "" {
    metadata.FeedImageURL = stripCDATA(imgURL)
}
```

**After:**
```go
// Extract image (try multiple sources)
if imgURL := extractNestedXMLTag(channel, "image", "url"); imgURL != "" {
    metadata.FeedImageURL = stripCDATA(imgURL)
} else if icon := extractXMLTag(channel, "icon"); icon != "" {
    // Fallback to Atom-style icon tag (some feeds mix formats)
    metadata.FeedImageURL = stripCDATA(icon)
} else if logo := extractXMLTag(channel, "logo"); logo != "" {
    // Fallback to Atom-style logo tag
    metadata.FeedImageURL = stripCDATA(logo)
}
```

## Testing

- ✅ Go build successful
- ✅ Code compiles without errors
- ✅ Follows existing code patterns from Atom parser

Closes #601