### PR TITLE
fix(blogroll): add avatar rendering with image/placeholder fallback

### DIFF
--- a/pkg/themes/default/static/css/components.css
+++ b/pkg/themes/default/static/css/components.css
@@ -1066,12 +1066,47 @@
   gap: 1rem;
 }
 
+/* Blogroll card with avatar layout */
 .blogroll-card {
   background-color: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: 8px;
-  padding: 1rem 1.25rem;
+  padding: 1rem;
   transition: border-color 0.2s, box-shadow 0.2s;
+  display: flex;
+  gap: 0.875rem;
+  align-items: flex-start;
+}
+
+.blogroll-card-avatar {
+  width: 56px;
+  height: 56px;
+  border-radius: 8px;
+  object-fit: cover;
+  flex-shrink: 0;
+  background: var(--color-border);
+  border: 2px solid var(--color-border);
+}
+
+.blogroll-card-avatar-placeholder {
+  width: 56px;
+  height: 56px;
+  border-radius: 8px;
+  flex-shrink: 0;
+  background: linear-gradient(135deg, var(--color-primary), #8b5cf6);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  border: 2px solid transparent;
+}
+
+.blogroll-card-content {
+  flex: 1;
+  min-width: 0;
 }
 
 .blogroll-card:hover {
@@ -1143,6 +1178,16 @@
 
   .blogroll-grid {
     grid-template-columns: 1fr;
+  }
+
+  .blogroll-card {
+    flex-direction: column;
+  }
+
+  .blogroll-card-avatar,
+  .blogroll-card-avatar-placeholder {
+    width: 100%;
+    height: 120px;
   }
 }
 

--- a/templates/blogroll.html
+++ b/templates/blogroll.html
@@ -24,22 +24,31 @@
     <div class="blogroll-grid">
       {% for feed in category.feeds %}
       <article class="blogroll-card">
-        <h3 class="blogroll-card-title">
-          {% if feed.site_url %}
-          <a href="{{ feed.site_url }}" target="_blank" rel="noopener">{{ feed.title }}</a>
-          {% else %}
-          {{ feed.title }}
-          {% endif %}
-        </h3>
-        {% if feed.description %}
-        <p class="blogroll-card-description">{{ feed.description | truncatewords:25 }}</p>
+        {% if feed.image_url %}
+        <img src="{{ feed.image_url }}" alt="{{ feed.title }}" class="blogroll-card-avatar" loading="lazy">
+        {% else %}
+        <div class="blogroll-card-avatar-placeholder" aria-hidden="true">
+          {{ feed.title|default:'?'|first|upper }}
+        </div>
         {% endif %}
-        <footer class="blogroll-card-meta">
-          <span class="blogroll-card-count">{{ feed.entry_count }} posts</span>
-          {% if feed.feed_url %}
-          <a href="{{ feed.feed_url }}" class="blogroll-card-feed" title="RSS Feed">RSS</a>
+        <div class="blogroll-card-content">
+          <h3 class="blogroll-card-title">
+            {% if feed.site_url %}
+            <a href="{{ feed.site_url }}" target="_blank" rel="noopener">{{ feed.title }}</a>
+            {% else %}
+            {{ feed.title }}
+            {% endif %}
+          </h3>
+          {% if feed.description %}
+          <p class="blogroll-card-description">{{ feed.description | truncatewords:25 }}</p>
           {% endif %}
-        </footer>
+          <footer class="blogroll-card-meta">
+            <span class="blogroll-card-count">{{ feed.entry_count }} posts</span>
+            {% if feed.feed_url %}
+            <a href="{{ feed.feed_url }}" class="blogroll-card-feed" title="RSS Feed">RSS</a>
+            {% endif %}
+          </footer>
+        </div>
       </article>
       {% endfor %}
     </div>


### PR DESCRIPTION
## Summary

Implements avatar rendering on the blogroll page with image/placeholder fallback, fixing issue #599.

## Problem

The blogroll page does not display feed avatars/images, even though:
- The data model `ExternalFeed` has an `ImageURL` field
- The config supports `image_url` for feeds
- The blogroll plugin populates this field
- The data is passed to the template

The template simply wasn't rendering the avatars, creating a poor visual experience.

## Solution

**Template Changes** (`templates/blogroll.html`):
- Added conditional avatar rendering using `feed.image_url`
- Added gradient placeholder with first letter of feed title as fallback
- Restructured card layout with flexbox for proper avatar/content alignment
- Added accessibility attributes (`aria-hidden`, `loading="lazy"`)

**CSS Changes** (`pkg/themes/default/static/css/components.css`):
- Updated `.blogroll-card` to use flexbox layout
- Added `.blogroll-card-avatar` for feed images (56x56px, rounded corners)
- Added `.blogroll-card-avatar-placeholder` with gradient background
- Added `.blogroll-card-content` wrapper for text content
- Added responsive mobile styles (stacks avatars vertically)

## Visual Design

**Desktop:**
- Avatar: 56px × 56px (rounded square)
- Layout: Horizontal flexbox (avatar | content)
- Placeholder: Gradient background (primary → purple) with uppercase letter

**Mobile:**
- Avatar: 100% width × 120px height
- Layout: Vertical stack (avatar above content)

## Files Changed

1. `templates/blogroll.html` - Add avatar rendering
2. `pkg/themes/default/static/css/components.css` - Add avatar styles

## Testing

- ✅ Go build successful
- ✅ Template compiles correctly
- ✅ Follows patterns from webmentions and reader templates

Closes #599