### PR TITLE
fix(lsp): initialize diagnostics array instead of nil slice

### DIFF
--- a/pkg/lsp/diagnostics.go
+++ b/pkg/lsp/diagnostics.go
@@ -19,7 +19,7 @@ func (s *Server) publishDiagnostics(uri, content string) error {
 
 // computeDiagnostics computes diagnostics for a document.
 func (s *Server) computeDiagnostics(_, content string) []Diagnostic {
-	var diagnostics []Diagnostic
+	diagnostics := []Diagnostic{}
 
 	// Find all wikilinks and check if they resolve
 	lines := strings.Split(content, "\n")


### PR DESCRIPTION
## Summary

Fixes #605 - Initializes the diagnostics array in `computeDiagnostics()` to prevent nil slice serialization that crashes Neovim 0.11+.

## Problem

The `computeDiagnostics()` function returns an uninitialized `nil` slice when no diagnostics are found. When JSON marshaled, Go serializes nil slices as `null`, which violates the LSP specification. Neovim 0.11+ crashes when it tries to get the length of a nil value in the diagnostic handler.

## Solution

Changed the initialization from:
```go
var diagnostics []Diagnostic
```

To:
```go
diagnostics := []Diagnostic{}
```

This ensures an empty array `[]` is serialized instead of `null`, complying with LSP spec and preventing client-side errors.

## Testing

- [x] Fix verified with manual testing in Neovim
- [x] LSP protocol compliance verified against spec
- [x] Go tests pass
- [x] Code formatting verified

## Related Issue

Closes #605