### PR TITLE
feat(templates): add feed sidebar prev/next navigation for post pages

### DIFF
--- a/pkg/themes/default/templates/components/doc_sidebar.html
+++ b/pkg/themes/default/templates/components/doc_sidebar.html
@@ -4,21 +4,22 @@
 {# Requires: post.Extra.toc ([]TocEntry) from toc plugin #}
 
 {% with sidebar = config.components.doc_sidebar %}
-{% if sidebar.enabled and post.Extra.toc %}
+{# Only show sidebar if enabled and we have TOC entries #}
+{% if sidebar.enabled and post.Extra.toc and post.Extra.toc|length > 0 %}
 <aside class="doc-sidebar doc-sidebar--{{ sidebar.position | default:'right' }}" style="width: {{ sidebar.width | default:'250px' }}" aria-label="Table of Contents">
     <nav class="toc">
         <h2 class="toc-title">On this page</h2>
         <ul class="toc-list">
             {% for entry in post.Extra.toc %}
-            {% if entry.Level >= sidebar.min_depth and entry.Level <= sidebar.max_depth %}
-            <li class="toc-item toc-item--level-{{ entry.Level }}">
-                <a href="#{{ entry.ID }}" class="toc-link">{{ entry.Text }}</a>
-                {% if entry.Children %}
+            {% if entry.level >= sidebar.min_depth and entry.level <= sidebar.max_depth %}
+            <li class="toc-item toc-item--level-{{ entry.level }}">
+                <a href="#{{ entry.id }}" class="toc-link">{{ entry.text }}</a>
+                {% if entry.children %}
                 <ul class="toc-list toc-list--nested">
-                    {% for child in entry.Children %}
-                    {% if child.Level >= sidebar.min_depth and child.Level <= sidebar.max_depth %}
-                    <li class="toc-item toc-item--level-{{ child.Level }}">
-                        <a href="#{{ child.ID }}" class="toc-link">{{ child.Text }}</a>
+                    {% for child in entry.children %}
+                    {% if child.level >= sidebar.min_depth and child.level <= sidebar.max_depth %}
+                    <li class="toc-item toc-item--level-{{ child.level }}">
+                        <a href="#{{ child.id }}" class="toc-link">{{ child.text }}</a>
                     </li>
                     {% endif %}
                     {% endfor %}

--- a/pkg/themes/default/templates/components/feed_sidebar.html
+++ b/pkg/themes/default/templates/components/feed_sidebar.html
@@ -2,20 +2,36 @@
 {# Usage: {% include "components/feed_sidebar.html" %} #}
 {# Shows navigation links for posts in the same feed/series #}
 {# Requires: config.components.feed_sidebar (FeedSidebarConfig) #}
+{# Optional: sidebar_posts, sidebar_feed - injected by templates plugin for post pages #}
 
 {% with sidebar = config.components.feed_sidebar %}
-{% if sidebar.enabled %}
+{# Only show sidebar if enabled AND we have posts to display #}
+{# sidebar_posts is injected when the current post belongs to a configured feed #}
+{% if sidebar.enabled and (sidebar_posts or feed.posts or posts) %}
 <aside class="feed-sidebar feed-sidebar--{{ sidebar.position | default:'left' }}" style="width: {{ sidebar.width | default:'250px' }}" aria-label="Feed navigation">
     <nav class="feed-nav">
         {% if sidebar.title %}
         <h2 class="feed-nav-title">{{ sidebar.title }}</h2>
+        {% elif sidebar_feed.title %}
+        <h2 class="feed-nav-title">{{ sidebar_feed.title }}</h2>
         {% elif feed.title %}
         <h2 class="feed-nav-title">{{ feed.title }}</h2>
         {% else %}
         <h2 class="feed-nav-title">In this series</h2>
         {% endif %}
 
-        {% if feed.posts %}
+        {# Priority: sidebar_posts (injected for post pages) > feed.posts (feed pages) > posts (generic) #}
+        {% if sidebar_posts %}
+        <ul class="feed-nav-list">
+            {% for p in sidebar_posts %}
+            <li class="feed-nav-item{% if post.slug == p.slug %} feed-nav-item--active{% endif %}">
+                <a href="{{ p.href }}" class="feed-nav-link">
+                    {{ p.title | default:p.slug }}
+                </a>
+            </li>
+            {% endfor %}
+        </ul>
+        {% elif feed.posts %}
         <ul class="feed-nav-list">
             {% for p in feed.posts %}
             <li class="feed-nav-item{% if post.slug == p.slug %} feed-nav-item--active{% endif %}">
@@ -35,8 +51,6 @@
             </li>
             {% endfor %}
         </ul>
-        {% else %}
-        <p class="feed-nav-empty">No posts in this series.</p>
         {% endif %}
     </nav>
 </aside>

--- a/pkg/themes/default/templates/post.html
+++ b/pkg/themes/default/templates/post.html
@@ -97,7 +97,13 @@
   {% include "partials/webmentions.html" %}
 </article>
 
-{% if post.prev or post.next %}
+{# Use sidebar prev/next if available (for feed-based navigation), otherwise fall back to post.prev/post.next #}
+{% if sidebar_prev or sidebar_next %}
+<nav class="post-nav">
+  {% if sidebar_prev %}<a href="{{ sidebar_prev.href }}" class="prev">{{ sidebar_prev.title }}</a>{% endif %}
+  {% if sidebar_next %}<a href="{{ sidebar_next.href }}" class="next">{{ sidebar_next.title }}</a>{% endif %}
+</nav>
+{% elif post.prev or post.next %}
 <nav class="post-nav">
   {% if post.prev %}<a href="{{ post.prev.href }}" class="prev">{{ post.prev.title }}</a>{% endif %}
   {% if post.next %}<a href="{{ post.next.href }}" class="next">{{ post.next.title }}</a>{% endif %}


### PR DESCRIPTION
## Summary
- Inject sidebar posts and prev/next navigation when a post belongs to a configured feed
- Enables series-style navigation for collections like daily notes
- Posts in the same feed (tag) can now navigate with prev/next within that series

## How It Works

When rendering a post that belongs to a feed configured in `feed_sidebar.feeds` (e.g., `tags/daily-note`):

1. **`sidebar_posts`** - All posts in that feed, available for the sidebar list
2. **`sidebar_prev`** / **`sidebar_next`** - Adjacent posts within the feed for navigation
3. **`sidebar_feed`** - Feed config for title display

## Configuration

```toml
[markata-go.components.feed_sidebar]
enabled = true
position = "left"
width = "250px"
title = "Daily Notes"
feeds = ["tags/daily-note", "tags/tutorial"]
```

## Template Context

Templates now receive:
- `{{ sidebar_posts }}` - List of posts in the feed
- `{{ sidebar_prev }}` - Previous post in series (newer)
- `{{ sidebar_next }}` - Next post in series (older)
- `{{ sidebar_feed }}` - Feed configuration

## Files Changed
- `pkg/plugins/templates.go` - Add `getFeedSidebarPosts()` and `getSidebarPrevNext()` functions
- `pkg/themes/default/templates/components/feed_sidebar.html` - Support injected sidebar_posts
- `pkg/themes/default/templates/components/doc_sidebar.html` - Minor cleanup
- `pkg/themes/default/templates/post.html` - Integration