### PR TITLE
feat(config): add card router config for template-to-card mapping

### DIFF
--- a/pkg/config/merge.go
+++ b/pkg/config/merge.go
@@ -424,6 +424,8 @@ func mergeSEOConfig(base, override models.SEOConfig) models.SEOConfig {
 }
 
 // mergeComponentsConfig merges ComponentsConfig values.
+//
+//nolint:gocyclo // This function merges many component fields; complexity is inherent
 func mergeComponentsConfig(base, override models.ComponentsConfig) models.ComponentsConfig {
 	result := base
 
@@ -470,6 +472,33 @@ func mergeComponentsConfig(base, override models.ComponentsConfig) models.Compon
 	}
 	if override.DocSidebar.MaxDepth != 0 {
 		result.DocSidebar.MaxDepth = override.DocSidebar.MaxDepth
+	}
+
+	// Merge FeedSidebar component
+	if override.FeedSidebar.Enabled != nil {
+		result.FeedSidebar.Enabled = override.FeedSidebar.Enabled
+	}
+	if override.FeedSidebar.Position != "" {
+		result.FeedSidebar.Position = override.FeedSidebar.Position
+	}
+	if override.FeedSidebar.Width != "" {
+		result.FeedSidebar.Width = override.FeedSidebar.Width
+	}
+	if override.FeedSidebar.Title != "" {
+		result.FeedSidebar.Title = override.FeedSidebar.Title
+	}
+	if len(override.FeedSidebar.Feeds) > 0 {
+		result.FeedSidebar.Feeds = override.FeedSidebar.Feeds
+	}
+
+	// Merge CardRouter component - mappings from override take precedence
+	if len(override.CardRouter.Mappings) > 0 {
+		if result.CardRouter.Mappings == nil {
+			result.CardRouter.Mappings = make(map[string]string)
+		}
+		for k, v := range override.CardRouter.Mappings {
+			result.CardRouter.Mappings[k] = v
+		}
 	}
 
 	return result

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -465,9 +465,11 @@ func (w *tomlWebmentionConfig) toWebmentionConfig() models.WebmentionConfig {
 }
 
 type tomlComponentsConfig struct {
-	Nav        tomlNavComponentConfig    `toml:"nav"`
-	Footer     tomlFooterComponentConfig `toml:"footer"`
-	DocSidebar tomlDocSidebarConfig      `toml:"doc_sidebar"`
+	Nav         tomlNavComponentConfig    `toml:"nav"`
+	Footer      tomlFooterComponentConfig `toml:"footer"`
+	DocSidebar  tomlDocSidebarConfig      `toml:"doc_sidebar"`
+	FeedSidebar tomlFeedSidebarConfig     `toml:"feed_sidebar"`
+	CardRouter  tomlCardRouterConfig      `toml:"card_router"`
 }
 
 type tomlNavComponentConfig struct {
@@ -490,6 +492,18 @@ type tomlDocSidebarConfig struct {
 	Width    string `toml:"width"`
 	MinDepth int    `toml:"min_depth"`
 	MaxDepth int    `toml:"max_depth"`
+}
+
+type tomlFeedSidebarConfig struct {
+	Enabled  *bool    `toml:"enabled"`
+	Position string   `toml:"position"`
+	Width    string   `toml:"width"`
+	Title    string   `toml:"title"`
+	Feeds    []string `toml:"feeds"`
+}
+
+type tomlCardRouterConfig struct {
+	Mappings map[string]string `toml:"mappings"`
 }
 
 // Layout-related TOML structs
@@ -884,6 +898,16 @@ func (c *tomlComponentsConfig) toComponentsConfig() models.ComponentsConfig {
 			Width:    c.DocSidebar.Width,
 			MinDepth: c.DocSidebar.MinDepth,
 			MaxDepth: c.DocSidebar.MaxDepth,
+		},
+		FeedSidebar: models.FeedSidebarConfig{
+			Enabled:  c.FeedSidebar.Enabled,
+			Position: c.FeedSidebar.Position,
+			Width:    c.FeedSidebar.Width,
+			Title:    c.FeedSidebar.Title,
+			Feeds:    c.FeedSidebar.Feeds,
+		},
+		CardRouter: models.CardRouterConfig{
+			Mappings: c.CardRouter.Mappings,
 		},
 	}
 
@@ -1368,9 +1392,11 @@ func (w *yamlWebmentionConfig) toWebmentionConfig() models.WebmentionConfig {
 }
 
 type yamlComponentsConfig struct {
-	Nav        yamlNavComponentConfig    `yaml:"nav"`
-	Footer     yamlFooterComponentConfig `yaml:"footer"`
-	DocSidebar yamlDocSidebarConfig      `yaml:"doc_sidebar"`
+	Nav         yamlNavComponentConfig    `yaml:"nav"`
+	Footer      yamlFooterComponentConfig `yaml:"footer"`
+	DocSidebar  yamlDocSidebarConfig      `yaml:"doc_sidebar"`
+	FeedSidebar yamlFeedSidebarConfig     `yaml:"feed_sidebar"`
+	CardRouter  yamlCardRouterConfig      `yaml:"card_router"`
 }
 
 type yamlNavComponentConfig struct {
@@ -1393,6 +1419,18 @@ type yamlDocSidebarConfig struct {
 	Width    string `yaml:"width"`
 	MinDepth int    `yaml:"min_depth"`
 	MaxDepth int    `yaml:"max_depth"`
+}
+
+type yamlFeedSidebarConfig struct {
+	Enabled  *bool    `yaml:"enabled"`
+	Position string   `yaml:"position"`
+	Width    string   `yaml:"width"`
+	Title    string   `yaml:"title"`
+	Feeds    []string `yaml:"feeds"`
+}
+
+type yamlCardRouterConfig struct {
+	Mappings map[string]string `yaml:"mappings"`
 }
 
 // Layout-related YAML structs
@@ -2209,9 +2247,11 @@ func (w *jsonWebmentionConfig) toWebmentionConfig() models.WebmentionConfig {
 }
 
 type jsonComponentsConfig struct {
-	Nav        jsonNavComponentConfig    `json:"nav"`
-	Footer     jsonFooterComponentConfig `json:"footer"`
-	DocSidebar jsonDocSidebarConfig      `json:"doc_sidebar"`
+	Nav         jsonNavComponentConfig    `json:"nav"`
+	Footer      jsonFooterComponentConfig `json:"footer"`
+	DocSidebar  jsonDocSidebarConfig      `json:"doc_sidebar"`
+	FeedSidebar jsonFeedSidebarConfig     `json:"feed_sidebar"`
+	CardRouter  jsonCardRouterConfig      `json:"card_router"`
 }
 
 type jsonNavComponentConfig struct {
@@ -2234,6 +2274,18 @@ type jsonDocSidebarConfig struct {
 	Width    string `json:"width"`
 	MinDepth int    `json:"min_depth"`
 	MaxDepth int    `json:"max_depth"`
+}
+
+type jsonFeedSidebarConfig struct {
+	Enabled  *bool    `json:"enabled"`
+	Position string   `json:"position"`
+	Width    string   `json:"width"`
+	Title    string   `json:"title"`
+	Feeds    []string `json:"feeds"`
+}
+
+type jsonCardRouterConfig struct {
+	Mappings map[string]string `json:"mappings"`
 }
 
 // Layout-related JSON structs

--- a/pkg/templates/context.go
+++ b/pkg/templates/context.go
@@ -359,11 +359,17 @@ func componentsToMap(c *models.ComponentsConfig) map[string]interface{} {
 		"feeds":    c.FeedSidebar.Feeds,
 	}
 
+	// Convert card_router component - use MergedMappings to include defaults
+	cardRouterMap := map[string]interface{}{
+		"mappings": c.CardRouter.MergedMappings(),
+	}
+
 	return map[string]interface{}{
 		"nav":          navMap,
 		"footer":       footerMap,
 		"doc_sidebar":  docSidebarMap,
 		"feed_sidebar": feedSidebarMap,
+		"card_router":  cardRouterMap,
 	}
 }
 

--- a/pkg/templates/filters.go
+++ b/pkg/templates/filters.go
@@ -92,6 +92,7 @@ func registerFilters() {
 		pongo2.RegisterFilter("sort", filterSort)
 		pongo2.RegisterFilter("selectattr", filterSelectAttr)
 		pongo2.RegisterFilter("rejectattr", filterRejectAttr)
+		pongo2.RegisterFilter("getitem", filterGetItem)
 
 		// HTML/text filters
 		pongo2.ReplaceFilter("striptags", filterStripTags)
@@ -307,6 +308,49 @@ func filterLast(in, _ *pongo2.Value) (*pongo2.Value, *pongo2.Error) {
 		return pongo2.AsValue(nil), nil
 	}
 	return in.Index(length - 1), nil
+}
+
+// filterGetItem gets an item from a map by key.
+// Usage: {{ map|getitem:key }} or {{ map|getitem:"literal_key" }}
+// Returns nil if the key doesn't exist.
+func filterGetItem(in, param *pongo2.Value) (*pongo2.Value, *pongo2.Error) {
+	// Get the key as a string
+	key := param.String()
+	if key == "" {
+		return pongo2.AsValue(nil), nil
+	}
+
+	// Try to get the underlying value as a map
+	iface := in.Interface()
+	if iface == nil {
+		return pongo2.AsValue(nil), nil
+	}
+
+	// Handle map[string]string
+	if m, ok := iface.(map[string]string); ok {
+		if val, exists := m[key]; exists {
+			return pongo2.AsValue(val), nil
+		}
+		return pongo2.AsValue(nil), nil
+	}
+
+	// Handle map[string]interface{}
+	if m, ok := iface.(map[string]interface{}); ok {
+		if val, exists := m[key]; exists {
+			return pongo2.AsValue(val), nil
+		}
+		return pongo2.AsValue(nil), nil
+	}
+
+	// Handle map[string]any (same as interface{})
+	if m, ok := iface.(map[string]any); ok {
+		if val, exists := m[key]; exists {
+			return pongo2.AsValue(val), nil
+		}
+		return pongo2.AsValue(nil), nil
+	}
+
+	return pongo2.AsValue(nil), nil
 }
 
 // filterJoin joins slice elements with a separator.

--- a/pkg/themes/default/templates/partials/cards/card-router.html
+++ b/pkg/themes/default/templates/partials/cards/card-router.html
@@ -1,30 +1,36 @@
-{# Card Router - Routes to appropriate card template based on post.template #}
-{# Card types: article (blog-post), note (ping), photo (shots), video, link, quote, guide, inline (gratitude) #}
+{# Card Router - Routes to appropriate card template based on config mapping #}
+{# Uses config.components.card_router.mappings to determine card type #}
+{# Card types: article, note, photo, video, link, quote, guide, inline, default #}
 
-{% if post.template == "blog-post" or post.template == "article" or post.template == "post" or post.template == "essay" or post.template == "tutorial" %}
+{# Look up card type from config mappings, defaulting to "default" #}
+{% with card_type=config.components.card_router.mappings|getitem:post.template|default:"default" %}
+
+{% if card_type == "article" %}
 {% include "partials/cards/article-card.html" %}
 
-{% elif post.template == "note" or post.template == "ping" or post.template == "thought" or post.template == "status" or post.template == "tweet" %}
+{% elif card_type == "note" %}
 {% include "partials/cards/note-card.html" %}
 
-{% elif post.template == "photo" or post.template == "shot" or post.template == "shots" or post.template == "image" or post.template == "gallery" %}
+{% elif card_type == "photo" %}
 {% include "partials/cards/photo-card.html" %}
 
-{% elif post.template == "video" or post.template == "clip" or post.template == "cast" or post.template == "stream" %}
+{% elif card_type == "video" %}
 {% include "partials/cards/video-card.html" %}
 
-{% elif post.template == "link" or post.template == "bookmark" or post.template == "til" or post.template == "stars" %}
+{% elif card_type == "link" %}
 {% include "partials/cards/link-card.html" %}
 
-{% elif post.template == "quote" or post.template == "quotation" %}
+{% elif card_type == "quote" %}
 {% include "partials/cards/quote-card.html" %}
 
-{% elif post.template == "guide" or post.template == "series" or post.template == "step" or post.template == "chapter" %}
+{% elif card_type == "guide" %}
 {% include "partials/cards/guide-card.html" %}
 
-{% elif post.template == "gratitude" or post.template == "inline" or post.template == "micro" %}
+{% elif card_type == "inline" %}
 {% include "partials/cards/inline-card.html" %}
 
 {% else %}
 {% include "partials/cards/default-card.html" %}
 {% endif %}
+
+{% endwith %}


### PR DESCRIPTION
## Summary
- Add configurable card routing that maps post template types to card templates
- Users can customize how different post types appear in feed cards via config
- Includes sensible defaults for common template types

## Configuration

```toml
[markata-go.components.card_router.mappings]
daily = "article"      # daily notes use article card
meeting = "note"       # meeting notes use note card
project = "guide"      # project posts use guide card
```

## Default Card Mappings

| Card Type | Default Templates |
|-----------|-------------------|
| `article` | blog-post, article, post, essay, tutorial |
| `note` | note, ping, thought, status, tweet |
| `photo` | photo, shot, shots, image, gallery |
| `video` | video, clip, cast, stream |
| `link` | link, bookmark, til, stars |
| `quote` | quote, quotation |
| `guide` | guide, series, step, chapter |
| `inline` | gratitude, inline, micro |

## How It Works

1. **Config Parsing**: `card_router.mappings` parsed from TOML/YAML/JSON
2. **Config Merge**: User mappings merged with defaults (user takes precedence)
3. **Template Context**: `config.components.card_router.mappings` available in templates
4. **Card Selection**: `card-router.html` uses `getitem` filter to look up card type

## New Template Filter

Added `getitem` filter for map lookups:
```django
{{ config.components.card_router.mappings|getitem:post.template|default:"default" }}
```

## Files Changed
- `pkg/models/config.go` - Add `CardRouterConfig`, `DefaultCardMappings()`, `GetCardTemplate()`, `MergedMappings()`
- `pkg/config/parser.go` - Parse card_router from config files
- `pkg/config/merge.go` - Merge CardRouter in `mergeComponentsConfig()`
- `pkg/templates/context.go` - Add card_router to template context
- `pkg/templates/filters.go` - Add `getitem` filter
- `pkg/themes/default/templates/partials/cards/card-router.html` - Use config-based routing