### PR TITLE
feat: add pagefind environment variable support

### DIFF
--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -109,6 +109,49 @@ func applyEnvOverride(config *models.Config, key, value string) {
 		}
 	case "feed_defaults_syndication_include_content", "feeds_defaults_syndication_include_content":
 		config.FeedDefaults.Syndication.IncludeContent = parseBool(value)
+	// Pagefind search settings
+	case "search_pagefind_auto_install":
+		if config.Extra == nil {
+			config.Extra = make(map[string]interface{})
+		}
+		if searchConfig, ok := config.Extra["search"].(models.SearchConfig); ok {
+			autoInstall := parseBool(value)
+			searchConfig.Pagefind.AutoInstall = &autoInstall
+			config.Extra["search"] = searchConfig
+		}
+	case "search_pagefind_cache_dir":
+		if config.Extra == nil {
+			config.Extra = make(map[string]interface{})
+		}
+		if searchConfig, ok := config.Extra["search"].(models.SearchConfig); ok {
+			searchConfig.Pagefind.CacheDir = value
+			config.Extra["search"] = searchConfig
+		}
+	case "search_pagefind_version":
+		if config.Extra == nil {
+			config.Extra = make(map[string]interface{})
+		}
+		if searchConfig, ok := config.Extra["search"].(models.SearchConfig); ok {
+			searchConfig.Pagefind.Version = value
+			config.Extra["search"] = searchConfig
+		}
+	case "search_pagefind_bundle_dir":
+		if config.Extra == nil {
+			config.Extra = make(map[string]interface{})
+		}
+		if searchConfig, ok := config.Extra["search"].(models.SearchConfig); ok {
+			searchConfig.Pagefind.BundleDir = value
+			config.Extra["search"] = searchConfig
+		}
+	case "search_pagefind_verbose":
+		if config.Extra == nil {
+			config.Extra = make(map[string]interface{})
+		}
+		if searchConfig, ok := config.Extra["search"].(models.SearchConfig); ok {
+			verbose := parseBool(value)
+			searchConfig.Pagefind.Verbose = &verbose
+			config.Extra["search"] = searchConfig
+		}
 	}
 }
 

--- a/pkg/config/env_pagefind_test.go
+++ b/pkg/config/env_pagefind_test.go
@@ -1,0 +1,168 @@
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/WaylonWalker/markata-go/pkg/models"
+)
+
+func TestApplyEnvOverrides_PagefindSettings(t *testing.T) {
+	tests := []struct {
+		name         string
+		envVars      map[string]string
+		expectedFunc func(*models.Config) bool
+	}{
+		{
+			name: "search_pagefind_auto_install true",
+			envVars: map[string]string{
+				"MARKATA_GO_SEARCH_PAGEFIND_AUTO_INSTALL": "true",
+			},
+			expectedFunc: func(c *models.Config) bool {
+				if c.Extra == nil {
+					return false
+				}
+				searchConfig, ok := c.Extra["search"].(models.SearchConfig)
+				if !ok {
+					return false
+				}
+				return searchConfig.Pagefind.AutoInstall != nil && *searchConfig.Pagefind.AutoInstall == true
+			},
+		},
+		{
+			name: "search_pagefind_auto_install false",
+			envVars: map[string]string{
+				"MARKATA_GO_SEARCH_PAGEFIND_AUTO_INSTALL": "false",
+			},
+			expectedFunc: func(c *models.Config) bool {
+				if c.Extra == nil {
+					return false
+				}
+				searchConfig, ok := c.Extra["search"].(models.SearchConfig)
+				if !ok {
+					return false
+				}
+				return searchConfig.Pagefind.AutoInstall != nil && *searchConfig.Pagefind.AutoInstall == false
+			},
+		},
+		{
+			name: "search_pagefind_cache_dir",
+			envVars: map[string]string{
+				"MARKATA_GO_SEARCH_PAGEFIND_CACHE_DIR": "/tmp/pagefind-cache",
+			},
+			expectedFunc: func(c *models.Config) bool {
+				if c.Extra == nil {
+					return false
+				}
+				searchConfig, ok := c.Extra["search"].(models.SearchConfig)
+				if !ok {
+					return false
+				}
+				return searchConfig.Pagefind.CacheDir == "/tmp/pagefind-cache"
+			},
+		},
+		{
+			name: "search_pagefind_version",
+			envVars: map[string]string{
+				"MARKATA_GO_SEARCH_PAGEFIND_VERSION": "v1.4.0",
+			},
+			expectedFunc: func(c *models.Config) bool {
+				if c.Extra == nil {
+					return false
+				}
+				searchConfig, ok := c.Extra["search"].(models.SearchConfig)
+				if !ok {
+					return false
+				}
+				return searchConfig.Pagefind.Version == "v1.4.0"
+			},
+		},
+		{
+			name: "search_pagefind_bundle_dir",
+			envVars: map[string]string{
+				"MARKATA_GO_SEARCH_PAGEFIND_BUNDLE_DIR": "_search",
+			},
+			expectedFunc: func(c *models.Config) bool {
+				if c.Extra == nil {
+					return false
+				}
+				searchConfig, ok := c.Extra["search"].(models.SearchConfig)
+				if !ok {
+					return false
+				}
+				return searchConfig.Pagefind.BundleDir == "_search"
+			},
+		},
+		{
+			name: "search_pagefind_verbose true",
+			envVars: map[string]string{
+				"MARKATA_GO_SEARCH_PAGEFIND_VERBOSE": "true",
+			},
+			expectedFunc: func(c *models.Config) bool {
+				if c.Extra == nil {
+					return false
+				}
+				searchConfig, ok := c.Extra["search"].(models.SearchConfig)
+				if !ok {
+					return false
+				}
+				return searchConfig.Pagefind.Verbose != nil && *searchConfig.Pagefind.Verbose == true
+			},
+		},
+		{
+			name: "multiple pagefind settings",
+			envVars: map[string]string{
+				"MARKATA_GO_SEARCH_PAGEFIND_AUTO_INSTALL": "true",
+				"MARKATA_GO_SEARCH_PAGEFIND_CACHE_DIR":    "/tmp/cache",
+				"MARKATA_GO_SEARCH_PAGEFIND_VERSION":      "v1.4.0",
+				"MARKATA_GO_SEARCH_PAGEFIND_VERBOSE":      "true",
+			},
+			expectedFunc: func(c *models.Config) bool {
+				if c.Extra == nil {
+					return false
+				}
+				searchConfig, ok := c.Extra["search"].(models.SearchConfig)
+				if !ok {
+					return false
+				}
+				return searchConfig.Pagefind.AutoInstall != nil && *searchConfig.Pagefind.AutoInstall == true &&
+					searchConfig.Pagefind.CacheDir == "/tmp/cache" &&
+					searchConfig.Pagefind.Version == "v1.4.0" &&
+					searchConfig.Pagefind.Verbose != nil && *searchConfig.Pagefind.Verbose == true
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set environment variables
+			for key, value := range tt.envVars {
+				os.Setenv(key, value)
+			}
+			defer func() {
+				// Clean up environment variables
+				for key := range tt.envVars {
+					os.Unsetenv(key)
+				}
+			}()
+
+			// Create a config with default search settings
+			config := &models.Config{
+				Extra: map[string]interface{}{
+					"search": models.NewSearchConfig(),
+				},
+			}
+
+			// Apply env overrides
+			err := ApplyEnvOverrides(config)
+			if err != nil {
+				t.Fatalf("ApplyEnvOverrides() error = %v", err)
+			}
+
+			// Check expected condition
+			if !tt.expectedFunc(config) {
+				t.Errorf("ApplyEnvOverrides() did not set expected values for %s", tt.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Add environment variable overrides for pagefind search configuration to enable
container-friendly configuration without modifying config files.

## Changes
- Extend `pkg/config/env.go` to support pagefind environment variables
- Add comprehensive test coverage in `pkg/config/env_pagefind_test.go`

## New Environment Variables
- `MARKATA_GO_SEARCH_PAGEFIND_AUTO_INSTALL` - Enable/disable auto-install (bool)
- `MARKATA_GO_SEARCH_PAGEFIND_CACHE_DIR` - Set cache directory (string)  
- `MARKATA_GO_SEARCH_PAGEFIND_VERSION` - Set pagefind version (string)
- `MARKATA_GO_SEARCH_PAGEFIND_BUNDLE_DIR` - Set output directory (string)
- `MARKATA_GO_SEARCH_PAGEFIND_VERBOSE` - Enable verbose output (bool)

## Use Case
This enables container deployments to configure pagefind settings via
environment variables while preserving existing file-based configuration:

```bash
# Enable auto-install and set cache directory for container
MARKATA_GO_SEARCH_PAGEFIND_AUTO_INSTALL=true \
MARKATA_GO_SEARCH_PAGEFIND_CACHE_DIR=/tmp/pagefind-cache \
markata-go build
```

In Kubernetes with emptyDir:
```yaml
env:
- name: MARKATA_GO_SEARCH_PAGEFIND_AUTO_INSTALL
  value: "true"
- name: MARKATA_GO_SEARCH_PAGEFIND_CACHE_DIR  
  value: "/tmp/pagefind-cache"
volumeMounts:
- name: pagefind-cache
  mountPath: /tmp/pagefind-cache
```

## Testing
- Added comprehensive unit tests covering all new environment variables
- Verified end-to-end functionality with real markata build
- Tests include boolean parsing, string values, and multiple settings combined

## Context
Resolves the limitation where pagefind auto-install fails in scratch containers
due to missing cache directories and the inability to modify config files at
runtime in containerized environments.