### PR TITLE
fix: resolve keyboard shortcuts race condition

### DIFF
--- a/pkg/themes/default/templates/base.html
+++ b/pkg/themes/default/templates/base.html
@@ -180,39 +180,36 @@
       document.body.appendChild(mentionScript);
     }
 
-    // Keyboard Shortcuts Registry - load the core registry first
+    // Keyboard Shortcuts Registry - load the core registry first, then load dependent scripts
     const shortcutsRegistryScript = document.createElement('script');
     shortcutsRegistryScript.src = '{{ 'js/shortcuts-registry.js' | theme_asset }}';
-    shortcutsRegistryScript.defer = true;
+    // Use onload to ensure registry is fully loaded before dependent scripts
+    shortcutsRegistryScript.onload = function() {
+      // Keyboard Shortcuts - load search and core shortcuts
+      if (document.querySelector('#pagefind-search, #shortcuts-modal, [type="search"]')) {
+        const shortcutsScript = document.createElement('script');
+        shortcutsScript.src = '{{ 'js/search-shortcuts.js' | theme_asset }}';
+        document.body.appendChild(shortcutsScript);
+      }
+
+      // Scrolling Shortcuts - always available
+      const scrollingScript = document.createElement('script');
+      scrollingScript.src = '{{ 'js/scrolling-shortcuts.js' | theme_asset }}';
+      document.body.appendChild(scrollingScript);
+
+      // Navigation Shortcuts - load if post cards exist
+      if (document.querySelector('.card, [data-card]')) {
+        const navigationScript = document.createElement('script');
+        navigationScript.src = '{{ 'js/navigation-shortcuts.js' | theme_asset }}';
+        document.body.appendChild(navigationScript);
+      }
+
+      // History Shortcuts - always available (go back/forward)
+      const historyScript = document.createElement('script');
+      historyScript.src = '{{ 'js/history-shortcuts.js' | theme_asset }}';
+      document.body.appendChild(historyScript);
+    };
     document.body.appendChild(shortcutsRegistryScript);
-
-    // Keyboard Shortcuts - load search and core shortcuts
-    if (document.querySelector('#pagefind-search, #shortcuts-modal, [type="search"]')) {
-      const shortcutsScript = document.createElement('script');
-      shortcutsScript.src = '{{ 'js/search-shortcuts.js' | theme_asset }}';
-      shortcutsScript.defer = true;
-      document.body.appendChild(shortcutsScript);
-    }
-
-    // Scrolling Shortcuts - always available
-    const scrollingScript = document.createElement('script');
-    scrollingScript.src = '{{ 'js/scrolling-shortcuts.js' | theme_asset }}';
-    scrollingScript.defer = true;
-    document.body.appendChild(scrollingScript);
-
-     // Navigation Shortcuts - load if post cards exist
-    if (document.querySelector('.card, [data-card]')) {
-      const navigationScript = document.createElement('script');
-      navigationScript.src = '{{ 'js/navigation-shortcuts.js' | theme_asset }}';
-      navigationScript.defer = true;
-      document.body.appendChild(navigationScript);
-    }
-
-    // History Shortcuts - always available (go back/forward)
-    const historyScript = document.createElement('script');
-    historyScript.src = '{{ 'js/history-shortcuts.js' | theme_asset }}';
-    historyScript.defer = true;
-    document.body.appendChild(historyScript);
 
     // Pagination (JS mode) - only load if JS pagination element exists
     if (document.querySelector('.pagination-js')) {


### PR DESCRIPTION
## Summary
- Fixes race condition where keyboard shortcuts fail to register on the archive page
- Uses `onload` callback on the shortcuts registry script to ensure it's fully loaded before dependent scripts are added
- Removes unnecessary `defer` attributes from dynamically loaded scripts (since they're loaded in sequence via callbacks)

## Root Cause
All shortcut scripts were being loaded with `defer=true` simultaneously. With `defer`, the browser determines execution order, which doesn't guarantee the registry loads before scripts that depend on it.

## Solution
Chain-load dependent scripts inside the registry script's `onload` callback, ensuring the registry is fully available before any script attempts to use `window.shortcutsRegistry`.

Fixes #619