### PR TITLE
fix: ensure RSS XSL stylesheet loads on page transitions

### DIFF
--- a/pkg/themes/default/static/js/view-transitions.js
+++ b/pkg/themes/default/static/js/view-transitions.js
@@ -86,6 +86,9 @@
     // Skip links with rel=external
     if (link.rel && link.rel.includes('external')) return false;
 
+    // Skip XML files (RSS, Atom, sitemap) - they need native browser handling for XSL stylesheets
+    if (url.pathname.endsWith('.xml')) return false;
+
     // Skip TOC links (they have their own smooth scroll handling)
     if (link.classList.contains('toc-link')) return false;
 


### PR DESCRIPTION
## Summary

- Exclude XML files (.xml) from view transitions so RSS/Atom feed XSL stylesheets load properly

## Problem

When navigating from a blog post to an RSS feed page, the XSL stylesheet didn't load until a hard refresh. This was caused by the view transitions JavaScript intercepting the navigation and parsing the XML content as HTML, which breaks the `<?xml-stylesheet?>` processing instruction.

## Solution

Add a check in `shouldTransition()` to skip any URL ending in `.xml`. This allows the browser to handle XML files natively, which properly processes the XSL stylesheet reference.

Fixes #614