### PR TITLE
fix: consistent pagination button styling across pages

### DIFF
--- a/pkg/themes/default/templates/reader.html
+++ b/pkg/themes/default/templates/reader.html
@@ -5,12 +5,14 @@
 
 {% block body_class %}page-reader{% endblock %}
 
-{% block head_extra %}
-{% if pagination_type == "htmx" or pagination_type == "htmx-infinite" %}
+{% block htmx %}
+{% if page.pagination_type == "htmx" or page.pagination_type == "htmx-infinite" %}
 <script src="https://unpkg.com/htmx.org@1.9.10"></script>
-{% if pagination_type == "htmx-infinite" %}
+{% if page.pagination_type == "htmx-infinite" %}
 <script src="{{ 'js/infinite-scroll.js' | theme_asset }}" defer></script>
 {% endif %}
+{% elif page.pagination_type == "js" %}
+<script src="{{ 'js/pagination.js' | theme_asset }}" defer></script>
 {% endif %}
 {% endblock %}
 
@@ -25,11 +27,7 @@
     <a href="/blogroll/">View Blogroll</a>
   </nav>
 
-  {% if pagination_type == "htmx" %}
-  <div id="reader-content">
-  {% endif %}
-
-  <ul class="reader-entries">
+  <ul class="reader-entries posts-list">
     {% for entry in entries %}
     <li class="reader-entry">
       <article class="reader-entry-article{% if entry.image_url %} has-image{% endif %}">
@@ -57,46 +55,6 @@
     {% endfor %}
   </ul>
 
-  {# Pagination Navigation #}
-  {% if page.total_pages > 1 %}
-  <nav class="pagination" aria-label="Page navigation">
-    {% if page.has_prev %}
-      {% if pagination_type == "htmx" %}
-      <a href="{{ page.prev_url }}" hx-get="{{ page.prev_url }}partial/" hx-target="#reader-content" hx-swap="innerHTML">&laquo; Previous</a>
-      {% else %}
-      <a href="{{ page.prev_url }}">&laquo; Previous</a>
-      {% endif %}
-    {% else %}
-    <span class="pagination-disabled">&laquo; Previous</span>
-    {% endif %}
-
-    {% for url in page.page_urls %}
-    {% set page_num = forloop.Counter %}
-    {% if page_num == page.number %}
-    <span class="pagination-current">{{ page_num }}</span>
-    {% else %}
-      {% if pagination_type == "htmx" %}
-      <a href="{{ url }}" hx-get="{{ url }}partial/" hx-target="#reader-content" hx-swap="innerHTML">{{ page_num }}</a>
-      {% else %}
-      <a href="{{ url }}">{{ page_num }}</a>
-      {% endif %}
-    {% endif %}
-    {% endfor %}
-
-    {% if page.has_next %}
-      {% if pagination_type == "htmx" %}
-      <a href="{{ page.next_url }}" hx-get="{{ page.next_url }}partial/" hx-target="#reader-content" hx-swap="innerHTML">Next &raquo;</a>
-      {% else %}
-      <a href="{{ page.next_url }}">Next &raquo;</a>
-      {% endif %}
-    {% else %}
-    <span class="pagination-disabled">Next &raquo;</span>
-    {% endif %}
-  </nav>
-  {% endif %}
-
-  {% if pagination_type == "htmx" %}
-  </div>
-  {% endif %}
+  {% include "partials/pagination.html" %}
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary

- Replaces inline pagination HTML in reader template with shared `partials/pagination.html` partial
- Updates template block from `head_extra` to `htmx` for consistency with other templates
- Adds `posts-list` class to reader entries for proper HTMX targeting

## Problem

The reader page (`/reader/`) had custom inline pagination HTML that used different CSS classes than the shared pagination partial:
- `pagination-disabled` instead of `pagination-prev disabled` / `pagination-next disabled`
- `pagination-current` instead of `pagination-page current`
- Links without `pagination-prev`, `pagination-next`, `pagination-page` classes

These classes had no CSS styling defined, causing visual inconsistency with the archive page which uses the shared pagination partial.

## Solution

Use the shared `partials/pagination.html` partial in the reader template, ensuring consistent styling with all other paginated pages (archive, feeds, etc.).

Fixes #622