### PR TITLE
fix: correct pagefind-ui asset paths in templates

### DIFF
--- a/pkg/plugins/blogroll.go
+++ b/pkg/plugins/blogroll.go
@@ -1362,9 +1362,10 @@ func (p *BlogrollPlugin) extractSearchConfig(extra, result map[string]interface{
 	}
 
 	// Convert pagefind config
+	// Use the actual pagefind bundle directory (defaults to _pagefind), not the blogroll output dir
 	bundleDir := search.Pagefind.BundleDir
 	if bundleDir == "" {
-		bundleDir = blogrollBundleDir
+		bundleDir = defaultBundleDir
 	}
 
 	result["search"] = map[string]interface{}{


### PR DESCRIPTION
## Summary

- Fixes 404 errors for Pagefind search UI assets on the reader page
- The blogroll plugin was incorrectly defaulting `bundle_dir` to `"blogroll"` instead of `"_pagefind"`, causing the template to generate incorrect paths like `/blogroll/pagefind-ui.css` instead of `/_pagefind/pagefind-ui.css`

## Root Cause

In `pkg/plugins/blogroll.go`, the `extractSearchConfig` function was using `blogrollBundleDir` ("blogroll") as the default value for `pagefind.bundle_dir` when it should use `defaultBundleDir` ("_pagefind") - the actual location where pagefind generates its UI assets.

Fixes #620