### PR TITLE
fix: use 0644 permissions for public-facing HTML files

### DIFF
--- a/pkg/plugins/blogroll.go
+++ b/pkg/plugins/blogroll.go
@@ -955,7 +955,7 @@ func (p *BlogrollPlugin) writeBlogrollPage(m *lifecycle.Manager, outputDir strin
 
 	// Write the file
 	outputFile := filepath.Join(blogrollDir, "index.html")
-	return os.WriteFile(outputFile, []byte(content), 0o600)
+	return os.WriteFile(outputFile, []byte(content), 0o644) //nolint:gosec // G306: Public-facing HTML needs 644 permissions
 }
 
 // writeReaderPage generates the paginated /reader pages.
@@ -1049,7 +1049,7 @@ func (p *BlogrollPlugin) writeReaderPageFile(m *lifecycle.Manager, readerDir str
 	}
 
 	// Write the full page
-	if err := os.WriteFile(outputFile, []byte(content), 0o600); err != nil {
+	if err := os.WriteFile(outputFile, []byte(content), 0o644); err != nil { //nolint:gosec // G306: Public-facing HTML needs 644 permissions
 		return err
 	}
 
@@ -1061,7 +1061,7 @@ func (p *BlogrollPlugin) writeReaderPageFile(m *lifecycle.Manager, readerDir str
 
 		partialContent := p.renderReaderPartial(page.Entries, page)
 		partialFile := filepath.Join(partialDir, "index.html")
-		if err := os.WriteFile(partialFile, []byte(partialContent), 0o600); err != nil {
+		if err := os.WriteFile(partialFile, []byte(partialContent), 0o644); err != nil { //nolint:gosec // G306: Public-facing HTML needs 644 permissions
 			return err
 		}
 	}

--- a/pkg/plugins/error_pages.go
+++ b/pkg/plugins/error_pages.go
@@ -172,7 +172,7 @@ func (p *ErrorPagesPlugin) generate404Page(_ *lifecycle.Manager, cfg *models.Con
 		return fmt.Errorf("creating output directory for 404 page: %w", err)
 	}
 
-	if err := os.WriteFile(outputPath, []byte(html), 0o600); err != nil {
+	if err := os.WriteFile(outputPath, []byte(html), 0o644); err != nil { //nolint:gosec // G306: Public-facing HTML needs 644 permissions
 		return fmt.Errorf("writing 404.html: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

- Changes file permissions for public-facing HTML files from `0o600` to `0o644` to prevent 403 errors in multi-container deployments
- Adds `nolint:gosec` directives to suppress false-positive G306 warnings for intentionally world-readable files

### Files changed:
- `pkg/plugins/blogroll.go` - Blogroll index, reader pages, and reader partials
- `pkg/plugins/error_pages.go` - 404 HTML page

### Files intentionally unchanged (internal/cache):
- `pkg/plugins/blogroll.go:864` - Cache file (stays 0o600)
- `pkg/plugins/error_pages.go:116` - JSON index (stays 0o600)

Fixes #621