### PR TITLE
feat: add configurable keyboard shortcuts from config

### DIFF
--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -380,6 +380,9 @@ type Config struct {
 	// Encryption configures content encryption for private posts
 	Encryption EncryptionConfig `json:"encryption" yaml:"encryption" toml:"encryption"`
 
+	// Shortcuts configures user-defined keyboard shortcuts
+	Shortcuts ShortcutsConfig `json:"shortcuts" yaml:"shortcuts" toml:"shortcuts"`
+
 	// TemplatePresets defines named template preset configurations
 	// Each preset specifies templates for all output formats
 	TemplatePresets map[string]TemplatePreset `json:"template_presets,omitempty" yaml:"template_presets,omitempty" toml:"template_presets,omitempty"`
@@ -1751,6 +1754,27 @@ func NewEncryptionConfig() EncryptionConfig {
 	}
 }
 
+// ShortcutsConfig configures user-defined keyboard shortcuts.
+// Shortcuts are organized by group (e.g., "navigation") and map key sequences to URLs.
+type ShortcutsConfig struct {
+	// Navigation contains shortcuts for navigating to specific pages.
+	// Keys are key sequences (e.g., "g t"), values are destination URLs.
+	// Example: {"g t": "/tags/", "g a": "/about/"}
+	Navigation map[string]string `json:"navigation,omitempty" yaml:"navigation,omitempty" toml:"navigation,omitempty"`
+}
+
+// NewShortcutsConfig creates a new ShortcutsConfig with default values.
+func NewShortcutsConfig() ShortcutsConfig {
+	return ShortcutsConfig{
+		Navigation: make(map[string]string),
+	}
+}
+
+// HasCustomShortcuts returns true if any custom shortcuts are defined.
+func (s *ShortcutsConfig) HasCustomShortcuts() bool {
+	return len(s.Navigation) > 0
+}
+
 // ContentTemplateConfig defines a single content template.
 type ContentTemplateConfig struct {
 	// Name is the template identifier (e.g., "post", "page", "docs")
@@ -1954,6 +1978,7 @@ func NewConfig() *Config {
 		ErrorPages:       NewErrorPagesConfig(),
 		ResourceHints:    NewResourceHintsConfig(),
 		Encryption:       NewEncryptionConfig(),
+		Shortcuts:        NewShortcutsConfig(),
 	}
 }
 

--- a/pkg/themes/default/static/js/custom-shortcuts.js
+++ b/pkg/themes/default/static/js/custom-shortcuts.js
@@ -1,0 +1,172 @@
+/**
+ * Custom Shortcuts Module for markata-go
+ *
+ * Registers user-defined keyboard shortcuts from markata.toml configuration.
+ * Supports key sequences like "g t" for navigation to specific pages.
+ *
+ * Configuration in markata.toml:
+ *   [shortcuts.navigation]
+ *   "g t" = "/tags/"
+ *   "g a" = "/about/"
+ */
+
+(function() {
+  'use strict';
+
+  // Wait for registry to be available
+  function waitForRegistry(callback, attempts) {
+    attempts = attempts || 0;
+    if (window.shortcutsRegistry) {
+      callback();
+    } else if (attempts < 50) {
+      setTimeout(function() {
+        waitForRegistry(callback, attempts + 1);
+      }, 10);
+    }
+  }
+
+  var state = {
+    pendingKeys: [],
+    lastKeyTime: 0,
+    keySequenceTimeout: 500 // ms
+  };
+
+  /**
+   * Parse a key sequence string into an array of keys
+   * @param {string} sequence - e.g., "g t" or "Shift+G"
+   * @returns {Array<string>} Array of individual keys
+   */
+  function parseKeySequence(sequence) {
+    return sequence.trim().split(/\s+/);
+  }
+
+  /**
+   * Navigate to a URL
+   * @param {string} url - The destination URL
+   */
+  function navigateTo(url) {
+    window.location.href = url;
+  }
+
+  /**
+   * Get description for a custom shortcut
+   * @param {string} url - The destination URL
+   * @returns {string} Human-readable description
+   */
+  function getDescription(url) {
+    // Extract a meaningful name from the URL
+    var path = url.replace(/^\/+|\/+$/g, '');
+    if (!path) {
+      return 'Go to home';
+    }
+    // Capitalize first letter
+    var name = path.split('/').pop();
+    name = name.charAt(0).toUpperCase() + name.slice(1);
+    return 'Go to ' + name;
+  }
+
+  /**
+   * Initialize custom shortcuts from window.customShortcuts
+   */
+  function init() {
+    if (!window.customShortcuts || !window.customShortcuts.navigation) {
+      return;
+    }
+
+    var navigation = window.customShortcuts.navigation;
+    var shortcuts = [];
+
+    // Parse all shortcuts and group by first key
+    for (var sequence in navigation) {
+      if (navigation.hasOwnProperty(sequence)) {
+        var url = navigation[sequence];
+        var keys = parseKeySequence(sequence);
+        shortcuts.push({
+          keys: keys,
+          url: url,
+          description: getDescription(url)
+        });
+      }
+    }
+
+    if (shortcuts.length === 0) {
+      return;
+    }
+
+    // Register each custom shortcut with the registry for display in help modal
+    shortcuts.forEach(function(shortcut) {
+      var displayKey = shortcut.keys.join(' ');
+      window.shortcutsRegistry.register({
+        key: displayKey,
+        modifiers: [],
+        description: shortcut.description,
+        group: 'custom navigation',
+        // Handler is a no-op since we handle it via keydown listener for sequences
+        handler: function() {},
+        priority: 5
+      });
+    });
+
+    // Handle key sequences via keydown listener
+    document.addEventListener('keydown', function(e) {
+      if (window.shortcutsRegistry.areDisabled()) return;
+      if (window.shortcutsRegistry.isInputElement(e.target)) return;
+
+      var now = Date.now();
+      var timeSinceLastKey = now - state.lastKeyTime;
+
+      // Reset sequence if too much time passed
+      if (timeSinceLastKey > state.keySequenceTimeout) {
+        state.pendingKeys = [];
+      }
+
+      // Add current key to sequence
+      state.pendingKeys.push(e.key);
+      state.lastKeyTime = now;
+
+      // Check if current sequence matches any shortcut
+      var currentSequence = state.pendingKeys.join(' ');
+
+      for (var i = 0; i < shortcuts.length; i++) {
+        var shortcut = shortcuts[i];
+        var targetSequence = shortcut.keys.join(' ');
+
+        if (currentSequence === targetSequence) {
+          // Full match - navigate
+          e.preventDefault();
+          navigateTo(shortcut.url);
+          state.pendingKeys = [];
+          state.lastKeyTime = 0;
+          return;
+        }
+
+        // Check if current sequence is a prefix of this shortcut
+        if (targetSequence.indexOf(currentSequence) === 0) {
+          // Partial match - wait for more keys
+          e.preventDefault();
+          return;
+        }
+      }
+
+      // No match found - reset if no partial matches
+      var hasPartialMatch = shortcuts.some(function(shortcut) {
+        var targetSequence = shortcut.keys.join(' ');
+        return targetSequence.indexOf(currentSequence) === 0;
+      });
+
+      if (!hasPartialMatch) {
+        state.pendingKeys = [];
+        state.lastKeyTime = 0;
+      }
+    });
+  }
+
+  // Initialize when registry is available
+  waitForRegistry(function() {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', init);
+    } else {
+      init();
+    }
+  });
+})();

--- a/pkg/themes/default/templates/base.html
+++ b/pkg/themes/default/templates/base.html
@@ -164,6 +164,15 @@
 
   <!-- Conditional Script Loading: Only load when needed -->
   <script>
+    // Custom Navigation Shortcuts from config
+    {% if config.shortcuts and config.shortcuts.navigation %}
+    window.customShortcuts = {
+      navigation: {
+        {% for key, url in config.shortcuts.navigation.items() %}"{{ key }}": "{{ url }}"{% if not loop.last %}, {% endif %}{% endfor %}
+      }
+    };
+    {% endif %}
+
     // Wikilink Hover Tooltips - only load if wikilinks with data-title exist
     if (document.querySelector('.wikilink[data-title]')) {
       const script = document.createElement('script');
@@ -211,6 +220,12 @@
     };
     document.body.appendChild(shortcutsRegistryScript);
 
+    // Custom Shortcuts - load if custom shortcuts are defined in config
+      {% if config.shortcuts and config.shortcuts.navigation %}
+      const customShortcutsScript = document.createElement('script');
+      customShortcutsScript.src = '{{ 'js/custom-shortcuts.js' | theme_asset }}';
+      document.body.appendChild(customShortcutsScript);
+      {% endif %}
     // Pagination (JS mode) - only load if JS pagination element exists
     if (document.querySelector('.pagination-js')) {
       const paginationScript = document.createElement('script');

--- a/pkg/themes/default/templates/partials/shortcuts-modal.html
+++ b/pkg/themes/default/templates/partials/shortcuts-modal.html
@@ -137,6 +137,23 @@
                     </tbody>
                 </table>
             </section>
+
+            {# Custom Navigation Section (from config) #}
+            {% if config.shortcuts and config.shortcuts.navigation %}
+            <section class="shortcuts-section">
+                <h3 class="shortcuts-section-title">Custom Navigation</h3>
+                <table class="shortcuts-table">
+                    <tbody>
+                        {% for key, url in config.shortcuts.navigation.items() %}
+                        <tr>
+                            <td>{% for k in key.split(' ') %}<kbd>{{ k }}</kbd>{% if not loop.last %} {% endif %}{% endfor %}</td>
+                            <td>Go to {{ url }}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </section>
+            {% endif %}
         </div>
 
         <footer class="shortcuts-modal-footer">


### PR DESCRIPTION
## Summary

- Adds support for user-configurable keyboard shortcuts in `markata.toml`
- Custom shortcuts automatically integrate with the shortcuts registry
- Custom shortcuts appear in the keyboard shortcuts help modal (press `?`)

## Configuration

Users can define custom navigation shortcuts in their `markata.toml`:

```toml
[shortcuts.navigation]
"g t" = "/tags/"
"g a" = "/about/"
"g p" = "/projects/"
```

## Changes

- **pkg/models/config.go**: Added `ShortcutsConfig` type with `Navigation` map for key-to-URL mappings
- **pkg/themes/default/templates/base.html**: Render `window.customShortcuts` from config and conditionally load custom shortcuts script
- **pkg/themes/default/templates/partials/shortcuts-modal.html**: Display custom navigation shortcuts in help modal
- **pkg/themes/default/static/js/custom-shortcuts.js**: New JavaScript module that registers custom shortcuts with the shortcuts registry

## How It Works

1. Config parsing reads `[shortcuts.navigation]` section with key sequences as keys and URLs as values
2. Template renders shortcuts config as `window.customShortcuts` JavaScript object
3. `custom-shortcuts.js` registers shortcuts with the existing registry for help modal display
4. Key sequences (e.g., "g t") are handled via keydown listener with timeout between keys

Fixes #611