### PR TITLE
refactor: share diagnostic logic between LSP and lint

### DIFF
--- a/pkg/diagnostics/diagnostics.go
+++ b/pkg/diagnostics/diagnostics.go
@@ -1,0 +1,501 @@
+package diagnostics
+
+import (
+	"bufio"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Severity indicates the severity of a diagnostic issue.
+type Severity int
+
+const (
+	SeverityError Severity = iota
+	SeverityWarning
+	SeverityInfo
+)
+
+func (s Severity) String() string {
+	switch s {
+	case SeverityError:
+		return "error"
+	case SeverityWarning:
+		return "warning"
+	case SeverityInfo:
+		return "info"
+	default:
+		return "unknown"
+	}
+}
+
+// Range represents a position range in a document.
+type Range struct {
+	StartLine int // 0-based line number
+	StartCol  int // 0-based column (character offset)
+	EndLine   int // 0-based line number
+	EndCol    int // 0-based column
+}
+
+// Issue represents a diagnostic issue found in a file.
+type Issue struct {
+	File     string   // File path
+	Range    Range    // Position in the file
+	Code     string   // Issue code (e.g., "duplicate-key", "broken-wikilink")
+	Severity Severity // Severity level
+	Message  string   // Human-readable message
+	Fixable  bool     // Whether this issue can be automatically fixed
+}
+
+// Resolver provides lookup functionality for wikilinks and mentions.
+// This interface allows the diagnostics package to check if references exist
+// without directly depending on the LSP index or any specific implementation.
+type Resolver interface {
+	// ResolveSlug returns true if a post with the given slug exists.
+	ResolveSlug(slug string) bool
+	// ResolveHandle returns true if a mention handle exists in the blogroll.
+	ResolveHandle(handle string) bool
+}
+
+// Check runs all diagnostic checks on the content and returns any issues found.
+// The resolver is optional; if nil, wikilink and mention checks are skipped.
+func Check(filePath, content string, resolver Resolver) []Issue {
+	var issues []Issue
+
+	// Extract frontmatter for YAML-specific checks
+	frontmatter, body, hasFrontmatter := extractFrontmatter(content)
+
+	if hasFrontmatter {
+		issues = append(issues, checkDuplicateKeys(filePath, frontmatter)...)
+		issues = append(issues, checkDateFormats(filePath, frontmatter)...)
+	}
+
+	// Body checks
+	issues = append(issues, checkImageLinks(filePath, body, hasFrontmatter, frontmatter)...)
+	issues = append(issues, checkProtocollessURLs(filePath, content)...)
+	issues = append(issues, checkH1Headings(filePath, body, hasFrontmatter, frontmatter)...)
+	issues = append(issues, checkAdmonitionFencedCode(filePath, body, hasFrontmatter, frontmatter)...)
+
+	// Reference checks (require resolver)
+	if resolver != nil {
+		issues = append(issues, checkWikilinks(filePath, body, hasFrontmatter, frontmatter, resolver)...)
+		issues = append(issues, checkMentions(filePath, body, hasFrontmatter, frontmatter, resolver)...)
+	}
+
+	return issues
+}
+
+// extractFrontmatter extracts frontmatter from content.
+func extractFrontmatter(content string) (frontmatter, body string, hasFrontmatter bool) {
+	if !strings.HasPrefix(content, "---") {
+		return "", content, false
+	}
+
+	parts := strings.SplitN(content[3:], "---", 2)
+	if len(parts) < 2 {
+		return "", content, false
+	}
+
+	return parts[0], parts[1], true
+}
+
+// checkDuplicateKeys finds duplicate YAML keys in frontmatter.
+func checkDuplicateKeys(filePath, frontmatter string) []Issue {
+	var issues []Issue
+	seen := make(map[string]int) // key -> first line number
+	scanner := bufio.NewScanner(strings.NewReader(frontmatter))
+	lineNum := 1 // Start at 1 (after the opening ---)
+
+	// Regex to match top-level YAML keys (not indented)
+	keyRegex := regexp.MustCompile(`^([a-zA-Z_][a-zA-Z0-9_]*)\s*:`)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		lineNum++
+
+		if match := keyRegex.FindStringSubmatch(line); match != nil {
+			key := match[1]
+			if firstLine, exists := seen[key]; exists {
+				issues = append(issues, Issue{
+					File: filePath,
+					Range: Range{
+						StartLine: lineNum - 1, // 0-based
+						StartCol:  0,
+						EndLine:   lineNum - 1,
+						EndCol:    len(line),
+					},
+					Code:     "duplicate-key",
+					Severity: SeverityError,
+					Message:  fmt.Sprintf("duplicate key '%s' (first occurrence at line %d)", key, firstLine),
+					Fixable:  true,
+				})
+			} else {
+				seen[key] = lineNum
+			}
+		}
+	}
+
+	return issues
+}
+
+// checkDateFormats validates date formats in frontmatter.
+func checkDateFormats(filePath, frontmatter string) []Issue {
+	var issues []Issue
+	scanner := bufio.NewScanner(strings.NewReader(frontmatter))
+	lineNum := 1
+
+	// Regex to match date-like fields
+	dateKeyRegex := regexp.MustCompile(`^(date|published_date|created|modified|updated)\s*:\s*(.+)$`)
+
+	// Common invalid date patterns
+	invalidDatePatterns := []struct {
+		pattern *regexp.Regexp
+		desc    string
+	}{
+		{regexp.MustCompile(`\d{4}-\d{1,2}-\d{1,2}T\d{2}:\d{2}:\d{2}`), "single-digit month/day"},
+		{regexp.MustCompile(`\d{4}/\d{2}/\d{2}`), "slash separator"},
+	}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		lineNum++
+
+		if match := dateKeyRegex.FindStringSubmatch(line); match != nil {
+			key := match[1]
+			value := strings.TrimSpace(match[2])
+			value = strings.Trim(value, "\"'")
+
+			// Try to parse as valid ISO 8601
+			_, err := time.Parse(time.RFC3339, value)
+			if err != nil {
+				// Try other valid formats
+				_, err2 := time.Parse("2006-01-02", value)
+				if err2 != nil {
+					// Check for specific invalid patterns
+					for _, p := range invalidDatePatterns {
+						if p.pattern.MatchString(value) {
+							issues = append(issues, Issue{
+								File: filePath,
+								Range: Range{
+									StartLine: lineNum - 1,
+									StartCol:  0,
+									EndLine:   lineNum - 1,
+									EndCol:    len(line),
+								},
+								Code:     "invalid-date",
+								Severity: SeverityWarning,
+								Message:  fmt.Sprintf("invalid date format for '%s': %s (%s)", key, value, p.desc),
+								Fixable:  true,
+							})
+							break
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return issues
+}
+
+// checkImageLinks finds malformed image links.
+func checkImageLinks(filePath, body string, hasFrontmatter bool, frontmatter string) []Issue {
+	var issues []Issue
+
+	// Regex for image links without alt text: ![](url)
+	noAltRegex := regexp.MustCompile(`!\[\]\(([^)]+)\)`)
+
+	// Calculate line offset for body
+	lineOffset := 0
+	if hasFrontmatter {
+		lineOffset = strings.Count(frontmatter, "\n") + 2 // +2 for both --- lines
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(body))
+	lineNum := 0
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		lineNum++
+
+		if matches := noAltRegex.FindAllStringSubmatchIndex(line, -1); matches != nil {
+			for _, match := range matches {
+				issues = append(issues, Issue{
+					File: filePath,
+					Range: Range{
+						StartLine: lineNum + lineOffset - 1,
+						StartCol:  match[0],
+						EndLine:   lineNum + lineOffset - 1,
+						EndCol:    match[1],
+					},
+					Code:     "missing-alt-text",
+					Severity: SeverityWarning,
+					Message:  "image link missing alt text",
+					Fixable:  true,
+				})
+			}
+		}
+	}
+
+	return issues
+}
+
+// checkProtocollessURLs finds protocol-less URLs.
+func checkProtocollessURLs(filePath, content string) []Issue {
+	var issues []Issue
+
+	// Regex for protocol-less URLs: //example.com
+	protocollessRegex := regexp.MustCompile(`[^:]//[a-zA-Z0-9][a-zA-Z0-9.-]+\.[a-zA-Z]{2,}`)
+
+	scanner := bufio.NewScanner(strings.NewReader(content))
+	lineNum := 0
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		lineNum++
+
+		if matches := protocollessRegex.FindAllStringIndex(line, -1); matches != nil {
+			for _, match := range matches {
+				issues = append(issues, Issue{
+					File: filePath,
+					Range: Range{
+						StartLine: lineNum - 1,
+						StartCol:  match[0] + 1, // +1 to skip the non-colon char
+						EndLine:   lineNum - 1,
+						EndCol:    match[1],
+					},
+					Code:     "protocol-less-url",
+					Severity: SeverityWarning,
+					Message:  "protocol-less URL found (should use https://)",
+					Fixable:  true,
+				})
+			}
+		}
+	}
+
+	return issues
+}
+
+// checkH1Headings finds H1 headings in markdown content.
+func checkH1Headings(filePath, body string, hasFrontmatter bool, frontmatter string) []Issue {
+	var issues []Issue
+
+	lineOffset := 0
+	if hasFrontmatter {
+		lineOffset = strings.Count(frontmatter, "\n") + 1
+		body = strings.TrimPrefix(body, "\n")
+	}
+
+	inCodeBlock := false
+	scanner := bufio.NewScanner(strings.NewReader(body))
+	lineNum := 0
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		lineNum++
+
+		trimmedLine := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmedLine, "```") || strings.HasPrefix(trimmedLine, "~~~") {
+			inCodeBlock = !inCodeBlock
+			continue
+		}
+
+		if inCodeBlock {
+			continue
+		}
+
+		if strings.HasPrefix(line, "# ") || line == "#" {
+			issues = append(issues, Issue{
+				File: filePath,
+				Range: Range{
+					StartLine: lineNum + lineOffset - 1,
+					StartCol:  0,
+					EndLine:   lineNum + lineOffset - 1,
+					EndCol:    len(line),
+				},
+				Code:     "h1-in-content",
+				Severity: SeverityWarning,
+				Message:  "H1 heading found in content. Templates already add an H1 from frontmatter title. Use H2 (##) or deeper instead.",
+				Fixable:  false,
+			})
+		}
+	}
+
+	return issues
+}
+
+// checkAdmonitionFencedCode detects fenced code blocks inside admonitions
+// that don't have a blank line before them.
+func checkAdmonitionFencedCode(filePath, body string, hasFrontmatter bool, frontmatter string) []Issue {
+	var issues []Issue
+
+	lineOffset := 0
+	if hasFrontmatter {
+		lineOffset = strings.Count(frontmatter, "\n") + 1
+		body = strings.TrimPrefix(body, "\n")
+	}
+
+	lines := strings.Split(body, "\n")
+
+	admonitionRegex := regexp.MustCompile(`^(\s*)!!!\s+\w+`)
+	fencedCodeRegex := regexp.MustCompile(`^\s*` + "```")
+
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+		lineNum := i + 1 + lineOffset
+
+		if match := admonitionRegex.FindStringSubmatch(line); match != nil {
+			admonitionIndent := len(match[1])
+
+			if i+1 < len(lines) {
+				nextLine := lines[i+1]
+				trimmedNext := strings.TrimLeft(nextLine, " \t")
+				nextIndent := len(nextLine) - len(trimmedNext)
+
+				if nextIndent > admonitionIndent && fencedCodeRegex.MatchString(nextLine) {
+					issues = append(issues, Issue{
+						File: filePath,
+						Range: Range{
+							StartLine: lineNum - 1,
+							StartCol:  0,
+							EndLine:   lineNum - 1,
+							EndCol:    len(line),
+						},
+						Code:     "admonition-fenced-code",
+						Severity: SeverityWarning,
+						Message:  "fenced code block immediately follows admonition without blank line - this may not render correctly due to goldmark limitation",
+						Fixable:  true,
+					})
+				}
+			}
+		}
+	}
+
+	return issues
+}
+
+// wikilinkRegex matches [[slug]] and [[slug|display text]] patterns.
+var wikilinkRegex = regexp.MustCompile(`\[\[([^\]|]+)(?:\|([^\]]+))?\]\]`)
+
+// checkWikilinks finds broken wikilinks in content.
+func checkWikilinks(filePath, body string, hasFrontmatter bool, frontmatter string, resolver Resolver) []Issue {
+	var issues []Issue
+
+	lineOffset := 0
+	if hasFrontmatter {
+		lineOffset = strings.Count(frontmatter, "\n") + 2 // +2 for both --- lines
+	}
+
+	lines := strings.Split(body, "\n")
+	inCodeBlock := false
+	codeBlockPattern := regexp.MustCompile("^```|^~~~")
+
+	for lineNum, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if codeBlockPattern.MatchString(trimmed) {
+			inCodeBlock = !inCodeBlock
+			continue
+		}
+		if inCodeBlock {
+			continue
+		}
+
+		matches := wikilinkRegex.FindAllStringSubmatchIndex(line, -1)
+		for _, match := range matches {
+			if len(match) < 4 {
+				continue
+			}
+
+			slugStart := match[2]
+			slugEnd := match[3]
+			slug := strings.TrimSpace(line[slugStart:slugEnd])
+
+			if !resolver.ResolveSlug(slug) {
+				issues = append(issues, Issue{
+					File: filePath,
+					Range: Range{
+						StartLine: lineNum + lineOffset,
+						StartCol:  match[0],
+						EndLine:   lineNum + lineOffset,
+						EndCol:    match[1],
+					},
+					Code:     "broken-wikilink",
+					Severity: SeverityWarning,
+					Message:  fmt.Sprintf("broken wikilink: target post %q not found", slug),
+					Fixable:  false,
+				})
+			}
+		}
+	}
+
+	return issues
+}
+
+// mentionRegex matches @handle patterns.
+var mentionRegex = regexp.MustCompile(`@([a-zA-Z][a-zA-Z0-9_.-]*)`)
+
+// checkMentions finds unknown mentions in content.
+func checkMentions(filePath, body string, hasFrontmatter bool, frontmatter string, resolver Resolver) []Issue {
+	var issues []Issue
+
+	lineOffset := 0
+	if hasFrontmatter {
+		lineOffset = strings.Count(frontmatter, "\n") + 2
+	}
+
+	lines := strings.Split(body, "\n")
+	inCodeBlock := false
+	codeBlockPattern := regexp.MustCompile("^```|^~~~")
+
+	for lineNum, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if codeBlockPattern.MatchString(trimmed) {
+			inCodeBlock = !inCodeBlock
+			continue
+		}
+		if inCodeBlock {
+			continue
+		}
+
+		matches := mentionRegex.FindAllStringSubmatchIndex(line, -1)
+		for _, match := range matches {
+			if len(match) < 4 {
+				continue
+			}
+
+			start := match[0]
+			// Validate that @ is at a valid boundary
+			if start > 0 {
+				prevChar := line[start-1]
+				if (prevChar >= 'a' && prevChar <= 'z') ||
+					(prevChar >= 'A' && prevChar <= 'Z') ||
+					(prevChar >= '0' && prevChar <= '9') || prevChar == '_' || prevChar == '@' {
+					continue // Skip email addresses and @@mentions
+				}
+			}
+
+			handleStart := match[2]
+			handleEnd := match[3]
+			handle := strings.ToLower(line[handleStart:handleEnd])
+
+			if !resolver.ResolveHandle(handle) {
+				issues = append(issues, Issue{
+					File: filePath,
+					Range: Range{
+						StartLine: lineNum + lineOffset,
+						StartCol:  match[0],
+						EndLine:   lineNum + lineOffset,
+						EndCol:    match[1],
+					},
+					Code:     "unknown-mention",
+					Severity: SeverityWarning,
+					Message:  fmt.Sprintf("unknown mention: @%s not found in blogroll", handle),
+					Fixable:  false,
+				})
+			}
+		}
+	}
+
+	return issues
+}

--- a/pkg/diagnostics/diagnostics_test.go
+++ b/pkg/diagnostics/diagnostics_test.go
@@ -1,0 +1,485 @@
+package diagnostics
+
+import (
+	"testing"
+)
+
+// mockResolver implements Resolver for testing.
+type mockResolver struct {
+	slugs   map[string]bool
+	handles map[string]bool
+}
+
+func (m *mockResolver) ResolveSlug(slug string) bool {
+	if m.slugs == nil {
+		return false
+	}
+	return m.slugs[slug]
+}
+
+func (m *mockResolver) ResolveHandle(handle string) bool {
+	if m.handles == nil {
+		return false
+	}
+	return m.handles[handle]
+}
+
+func TestCheck_DuplicateKeys(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		wantLen int
+	}{
+		{
+			name: "no duplicates",
+			content: `---
+title: Test
+date: 2024-01-01
+---
+Content`,
+			wantLen: 0,
+		},
+		{
+			name: "duplicate key",
+			content: `---
+title: First
+date: 2024-01-01
+title: Second
+---
+Content`,
+			wantLen: 1,
+		},
+		{
+			name: "multiple duplicate keys",
+			content: `---
+title: First
+date: 2024-01-01
+title: Second
+tags: [a, b]
+tags: [c, d]
+---
+Content`,
+			wantLen: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issues := Check("test.md", tt.content, nil)
+
+			var dupIssues []Issue
+			for _, issue := range issues {
+				if issue.Code == "duplicate-key" {
+					dupIssues = append(dupIssues, issue)
+				}
+			}
+
+			if len(dupIssues) != tt.wantLen {
+				t.Errorf("got %d duplicate-key issues, want %d", len(dupIssues), tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestCheck_InvalidDateFormats(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		wantLen int
+	}{
+		{
+			name: "valid ISO date",
+			content: `---
+date: 2024-01-15
+---`,
+			wantLen: 0,
+		},
+		{
+			name: "valid RFC3339 date",
+			content: `---
+date: 2024-01-15T10:30:00Z
+---`,
+			wantLen: 0,
+		},
+		{
+			name: "single digit month",
+			content: `---
+date: 2020-1-15T00:00:00
+---`,
+			wantLen: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issues := Check("test.md", tt.content, nil)
+
+			var dateIssues []Issue
+			for _, issue := range issues {
+				if issue.Code == "invalid-date" {
+					dateIssues = append(dateIssues, issue)
+				}
+			}
+
+			if len(dateIssues) != tt.wantLen {
+				t.Errorf("got %d invalid-date issues, want %d", len(dateIssues), tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestCheck_MissingAltText(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		wantLen int
+	}{
+		{
+			name: "image with alt text",
+			content: `---
+title: Test
+---
+![Alt text](image.png)`,
+			wantLen: 0,
+		},
+		{
+			name: "image without alt text",
+			content: `---
+title: Test
+---
+![](image.png)`,
+			wantLen: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issues := Check("test.md", tt.content, nil)
+
+			var altIssues []Issue
+			for _, issue := range issues {
+				if issue.Code == "missing-alt-text" {
+					altIssues = append(altIssues, issue)
+				}
+			}
+
+			if len(altIssues) != tt.wantLen {
+				t.Errorf("got %d missing-alt-text issues, want %d", len(altIssues), tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestCheck_ProtocollessURLs(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		wantLen int
+	}{
+		{
+			name: "proper https URL",
+			content: `---
+title: Test
+---
+[Link](https://example.com)`,
+			wantLen: 0,
+		},
+		{
+			name: "protocol-less URL",
+			content: `---
+title: Test
+---
+[Link](//example.com/path)`,
+			wantLen: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issues := Check("test.md", tt.content, nil)
+
+			var urlIssues []Issue
+			for _, issue := range issues {
+				if issue.Code == "protocol-less-url" {
+					urlIssues = append(urlIssues, issue)
+				}
+			}
+
+			if len(urlIssues) != tt.wantLen {
+				t.Errorf("got %d protocol-less-url issues, want %d", len(urlIssues), tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestCheck_H1Headings(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		wantLen int
+	}{
+		{
+			name: "H2 heading OK",
+			content: `---
+title: Test
+---
+## This is fine`,
+			wantLen: 0,
+		},
+		{
+			name: "H1 heading warning",
+			content: `---
+title: Test
+---
+# This is bad`,
+			wantLen: 1,
+		},
+		{
+			name: "H1 in code block OK",
+			content: `---
+title: Test
+---
+` + "```markdown" + `
+# This is in code block
+` + "```",
+			wantLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issues := Check("test.md", tt.content, nil)
+
+			var h1Issues []Issue
+			for _, issue := range issues {
+				if issue.Code == "h1-in-content" {
+					h1Issues = append(h1Issues, issue)
+				}
+			}
+
+			if len(h1Issues) != tt.wantLen {
+				t.Errorf("got %d h1-in-content issues, want %d", len(h1Issues), tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestCheck_BrokenWikilinks(t *testing.T) {
+	resolver := &mockResolver{
+		slugs: map[string]bool{
+			"existing-post": true,
+		},
+	}
+
+	tests := []struct {
+		name     string
+		content  string
+		wantLen  int
+		resolver Resolver
+	}{
+		{
+			name: "valid wikilink",
+			content: `---
+title: Test
+---
+Check out [[existing-post]]`,
+			wantLen:  0,
+			resolver: resolver,
+		},
+		{
+			name: "broken wikilink",
+			content: `---
+title: Test
+---
+Check out [[nonexistent-post]]`,
+			wantLen:  1,
+			resolver: resolver,
+		},
+		{
+			name: "no resolver skips check",
+			content: `---
+title: Test
+---
+Check out [[nonexistent-post]]`,
+			wantLen:  0,
+			resolver: nil,
+		},
+		{
+			name: "wikilink in code block OK",
+			content: `---
+title: Test
+---
+` + "```" + `
+[[broken-in-code]]
+` + "```",
+			wantLen:  0,
+			resolver: resolver,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issues := Check("test.md", tt.content, tt.resolver)
+
+			var wikiIssues []Issue
+			for _, issue := range issues {
+				if issue.Code == "broken-wikilink" {
+					wikiIssues = append(wikiIssues, issue)
+				}
+			}
+
+			if len(wikiIssues) != tt.wantLen {
+				t.Errorf("got %d broken-wikilink issues, want %d", len(wikiIssues), tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestCheck_UnknownMentions(t *testing.T) {
+	resolver := &mockResolver{
+		handles: map[string]bool{
+			"knownuser": true,
+		},
+	}
+
+	tests := []struct {
+		name     string
+		content  string
+		wantLen  int
+		resolver Resolver
+	}{
+		{
+			name: "valid mention",
+			content: `---
+title: Test
+---
+Thanks @knownuser!`,
+			wantLen:  0,
+			resolver: resolver,
+		},
+		{
+			name: "unknown mention",
+			content: `---
+title: Test
+---
+Thanks @unknownuser!`,
+			wantLen:  1,
+			resolver: resolver,
+		},
+		{
+			name: "no resolver skips check",
+			content: `---
+title: Test
+---
+Thanks @unknownuser!`,
+			wantLen:  0,
+			resolver: nil,
+		},
+		{
+			name: "email not a mention",
+			content: `---
+title: Test
+---
+Contact me at user@example.com`,
+			wantLen:  0,
+			resolver: resolver,
+		},
+		{
+			name: "mention in code block OK",
+			content: `---
+title: Test
+---
+` + "```" + `
+@unknownuser
+` + "```",
+			wantLen:  0,
+			resolver: resolver,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issues := Check("test.md", tt.content, tt.resolver)
+
+			var mentionIssues []Issue
+			for _, issue := range issues {
+				if issue.Code == "unknown-mention" {
+					mentionIssues = append(mentionIssues, issue)
+				}
+			}
+
+			if len(mentionIssues) != tt.wantLen {
+				t.Errorf("got %d unknown-mention issues, want %d", len(mentionIssues), tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestCheck_AdmonitionFencedCode(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		wantLen int
+	}{
+		{
+			name: "admonition with blank line before code OK",
+			content: `---
+title: Test
+---
+!!! note
+
+    ` + "```python" + `
+    print("hello")
+    ` + "```",
+			wantLen: 0,
+		},
+		{
+			name: "admonition without blank line warning",
+			content: `---
+title: Test
+---
+!!! note
+    ` + "```python" + `
+    print("hello")
+    ` + "```",
+			wantLen: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issues := Check("test.md", tt.content, nil)
+
+			var admonIssues []Issue
+			for _, issue := range issues {
+				if issue.Code == "admonition-fenced-code" {
+					admonIssues = append(admonIssues, issue)
+				}
+			}
+
+			if len(admonIssues) != tt.wantLen {
+				t.Errorf("got %d admonition-fenced-code issues, want %d", len(admonIssues), tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestSeverity_String(t *testing.T) {
+	tests := []struct {
+		severity Severity
+		want     string
+	}{
+		{SeverityError, "error"},
+		{SeverityWarning, "warning"},
+		{SeverityInfo, "info"},
+		{Severity(99), "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.severity.String(); got != tt.want {
+				t.Errorf("Severity.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/diagnostics/doc.go
+++ b/pkg/diagnostics/doc.go
@@ -1,0 +1,27 @@
+// Package diagnostics provides shared diagnostic checks for markdown files.
+//
+// This package contains diagnostic rules that are used by both the LSP server
+// and the CLI lint command to ensure consistent issue reporting across tools.
+//
+// # Diagnostic Types
+//
+// The package detects the following issues:
+//   - broken-wikilink: Wikilinks pointing to non-existent posts
+//   - unknown-mention: Mentions (@handle) not found in blogroll
+//   - h1-in-content: H1 headings in content (templates add H1 from title)
+//   - duplicate-key: Duplicate YAML keys in frontmatter
+//   - invalid-date: Invalid date formats (non-ISO 8601)
+//   - missing-alt-text: Images without alt text
+//   - protocol-less-url: URLs without protocol (//example.com)
+//   - admonition-fenced-code: Fenced code blocks in admonitions without blank line
+//
+// # Usage
+//
+// The main entry point is the Check function which runs all diagnostic checks:
+//
+//	issues := diagnostics.Check(filePath, content, nil)
+//
+// For wikilink and mention checking, provide a Resolver:
+//
+//	issues := diagnostics.Check(filePath, content, resolver)
+package diagnostics


### PR DESCRIPTION
Creates a shared pkg/diagnostics/ package. Both LSP and lint CLI now report the same set of diagnostic issues consistently. Fixes #607