### PR TITLE
feat: add Atom, Markdown, and Text formats to tag feeds

### DIFF
--- a/pkg/plugins/auto_feeds.go
+++ b/pkg/plugins/auto_feeds.go
@@ -541,16 +541,22 @@ func getAutoFeedsConfig(config *lifecycle.Config) AutoFeedsConfig {
 			Enabled:    true, // Tag feeds enabled by default
 			SlugPrefix: defaultTagsPrefix,
 			Formats: models.FeedFormats{
-				HTML: true,
-				RSS:  true,
+				HTML:     true,
+				RSS:      true,
+				Atom:     true,
+				Markdown: true,
+				Text:     true,
 			},
 		},
 		Categories: AutoFeedTypeConfig{
 			Enabled:    false,
 			SlugPrefix: defaultCategoriesPrefix,
 			Formats: models.FeedFormats{
-				HTML: true,
-				RSS:  true,
+				HTML:     true,
+				RSS:      true,
+				Atom:     true,
+				Markdown: true,
+				Text:     true,
 			},
 		},
 		Archives: AutoArchiveConfig{
@@ -559,8 +565,11 @@ func getAutoFeedsConfig(config *lifecycle.Config) AutoFeedsConfig {
 			YearlyFeeds:  true,
 			MonthlyFeeds: false,
 			Formats: models.FeedFormats{
-				HTML: true,
-				RSS:  false,
+				HTML:     true,
+				RSS:      false,
+				Atom:     false,
+				Markdown: true,
+				Text:     true,
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

- Adds Atom, Markdown, and Text feed formats to auto-generated tag feeds
- Also adds these formats to category feeds and archive feeds for consistency
- Tag and category feeds now match the format support of regular post feeds

## Changes

Updated the default formats in `getAutoFeedsConfig()` in `pkg/plugins/auto_feeds.go`:

- **Tags**: Added `Atom: true`, `Markdown: true`, `Text: true`
- **Categories**: Added `Atom: true`, `Markdown: true`, `Text: true`
- **Archives**: Added `Atom: false`, `Markdown: true`, `Text: true` (RSS/Atom disabled for archives as before)

## Testing

All existing tests pass including the full `TestAutoFeeds*` test suite.

Fixes #617