### PR TITLE
feat: add tags listing page with privacy controls

### DIFF
--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -383,6 +383,9 @@ type Config struct {
 	// Shortcuts configures user-defined keyboard shortcuts
 	Shortcuts ShortcutsConfig `json:"shortcuts" yaml:"shortcuts" toml:"shortcuts"`
 
+	// Tags configures the tags listing page at /tags
+	Tags TagsConfig `json:"tags" yaml:"tags" toml:"tags"`
+
 	// TemplatePresets defines named template preset configurations
 	// Each preset specifies templates for all output formats
 	TemplatePresets map[string]TemplatePreset `json:"template_presets,omitempty" yaml:"template_presets,omitempty" toml:"template_presets,omitempty"`
@@ -1855,6 +1858,79 @@ func (e *ErrorPagesConfig) Is404Enabled() bool {
 	return *e.Enable404
 }
 
+// TagsConfig configures the tags listing page at /tags.
+// The tags listing page shows all available tags with post counts and links to tag pages.
+type TagsConfig struct {
+	// Enabled controls whether the tags listing page is generated (default: true)
+	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty" toml:"enabled,omitempty"`
+
+	// Blacklist is a list of tag names to completely exclude from the tags listing.
+	// These tags will not appear on the /tags page and won't be visible publicly.
+	// Example: ["draft", "wip", "internal"]
+	Blacklist []string `json:"blacklist,omitempty" yaml:"blacklist,omitempty" toml:"blacklist,omitempty"`
+
+	// Private is a list of tag names that exist but should be hidden from the listing.
+	// Posts with these tags are still accessible via direct URL, but the tags
+	// won't appear on the /tags overview page.
+	// Example: ["personal", "unlisted"]
+	Private []string `json:"private,omitempty" yaml:"private,omitempty" toml:"private,omitempty"`
+
+	// Title is the title for the tags listing page (default: "Tags")
+	Title string `json:"title,omitempty" yaml:"title,omitempty" toml:"title,omitempty"`
+
+	// Description is the description for the tags listing page
+	Description string `json:"description,omitempty" yaml:"description,omitempty" toml:"description,omitempty"`
+
+	// Template is the template file to use (default: "tags.html")
+	Template string `json:"template,omitempty" yaml:"template,omitempty" toml:"template,omitempty"`
+
+	// SlugPrefix is the URL prefix for the tags listing (default: "tags")
+	SlugPrefix string `json:"slug_prefix,omitempty" yaml:"slug_prefix,omitempty" toml:"slug_prefix,omitempty"`
+}
+
+// NewTagsConfig creates a new TagsConfig with default values.
+func NewTagsConfig() TagsConfig {
+	enabled := true
+	return TagsConfig{
+		Enabled:     &enabled,
+		Blacklist:   []string{},
+		Private:     []string{},
+		Title:       "Tags",
+		Description: "",
+		Template:    "tags.html",
+		SlugPrefix:  "tags",
+	}
+}
+
+// IsEnabled returns whether the tags listing page is enabled.
+// Defaults to true if not explicitly set.
+func (t *TagsConfig) IsEnabled() bool {
+	if t.Enabled == nil {
+		return true
+	}
+	return *t.Enabled
+}
+
+// IsBlacklisted returns whether a tag is in the blacklist.
+func (t *TagsConfig) IsBlacklisted(tag string) bool {
+	for _, b := range t.Blacklist {
+		if b == tag {
+			return true
+		}
+	}
+	return false
+}
+
+// IsPrivate returns whether a tag is in the private list.
+func (t *TagsConfig) IsPrivate(tag string) bool {
+	for _, p := range t.Private {
+		if p == tag {
+			return true
+		}
+	}
+	return false
+}
+
 // CSSBundleConfig configures css_bundle plugin for combining CSS files.
 type CSSBundleConfig struct {
 	// Enabled controls whether CSS bundling is active (default: false)
@@ -1979,6 +2055,7 @@ func NewConfig() *Config {
 		ResourceHints:    NewResourceHintsConfig(),
 		Encryption:       NewEncryptionConfig(),
 		Shortcuts:        NewShortcutsConfig(),
+		Tags:             NewTagsConfig(),
 	}
 }
 

--- a/pkg/plugins/registry.go
+++ b/pkg/plugins/registry.go
@@ -88,6 +88,7 @@ func registerBuiltinPluginsLocked() {
 	pluginRegistry.constructors["critical_css"] = func() lifecycle.Plugin { return NewCriticalCSSPlugin() }
 	pluginRegistry.constructors["css_purge"] = func() lifecycle.Plugin { return NewCSSPurgePlugin() }
 	pluginRegistry.constructors["css_minify"] = func() lifecycle.Plugin { return NewCSSMinifyPlugin() }
+	pluginRegistry.constructors["tags_listing"] = func() lifecycle.Plugin { return NewTagsListingPlugin() }
 }
 
 // RegisterPluginConstructor registers a plugin constructor with the given name.
@@ -185,8 +186,9 @@ func DefaultPlugins() []lifecycle.Plugin {
 		NewCSSBundlePlugin(),    // Bundle CSS files (runs after CSS generators)
 		NewPublishFeedsPlugin(),
 		NewPublishHTMLPlugin(),
-		NewRedirectsPlugin(),  // Generate redirect pages
-		NewErrorPagesPlugin(), // Generate static 404 page
+		NewRedirectsPlugin(),   // Generate redirect pages
+		NewErrorPagesPlugin(),  // Generate static 404 page
+		NewTagsListingPlugin(), // Generate /tags listing page
 		// NewResourceHintsPlugin(), // Inject resource hints (after HTML written) // DISABLED: Performance issue on large sites
 		NewSitemapPlugin(),
 

--- a/pkg/plugins/tags_listing.go
+++ b/pkg/plugins/tags_listing.go
@@ -1,0 +1,274 @@
+// Package plugins provides lifecycle plugins for markata-go.
+package plugins
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+
+	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
+	"github.com/WaylonWalker/markata-go/pkg/models"
+	"github.com/WaylonWalker/markata-go/pkg/templates"
+)
+
+// TagInfo represents information about a single tag for the tags listing page.
+type TagInfo struct {
+	// Name is the display name of the tag
+	Name string
+
+	// Slug is the URL-safe slug of the tag
+	Slug string
+
+	// Count is the number of posts with this tag
+	Count int
+
+	// Href is the URL to the tag page
+	Href string
+}
+
+// TagsListingPlugin generates a tags listing page at /tags showing all available tags.
+// It supports blacklist and private tag configurations to control tag visibility.
+type TagsListingPlugin struct {
+	engineMu    sync.RWMutex
+	engineCache map[string]*templates.Engine
+}
+
+// NewTagsListingPlugin creates a new TagsListingPlugin.
+func NewTagsListingPlugin() *TagsListingPlugin {
+	return &TagsListingPlugin{
+		engineCache: make(map[string]*templates.Engine),
+	}
+}
+
+// Name returns the unique name of the plugin.
+func (p *TagsListingPlugin) Name() string {
+	return "tags_listing"
+}
+
+// Priority returns the plugin's priority for a given stage.
+func (p *TagsListingPlugin) Priority(stage lifecycle.Stage) int {
+	switch stage {
+	case lifecycle.StageWrite:
+		// Run after publish_feeds so tag pages exist
+		return lifecycle.PriorityLate
+	default:
+		return lifecycle.PriorityDefault
+	}
+}
+
+// getOrCreateEngine returns a cached template engine, or creates one if not cached.
+func (p *TagsListingPlugin) getOrCreateEngine(templatesDir, themeName string) (*templates.Engine, error) {
+	cacheKey := templatesDir + ":" + themeName
+
+	// Fast path: check cache with read lock
+	p.engineMu.RLock()
+	if engine, ok := p.engineCache[cacheKey]; ok {
+		p.engineMu.RUnlock()
+		return engine, nil
+	}
+	p.engineMu.RUnlock()
+
+	// Slow path: create engine with write lock
+	p.engineMu.Lock()
+	defer p.engineMu.Unlock()
+
+	// Double-check after acquiring write lock
+	if engine, ok := p.engineCache[cacheKey]; ok {
+		return engine, nil
+	}
+
+	engine, err := templates.NewEngineWithTheme(templatesDir, themeName)
+	if err != nil {
+		return nil, err
+	}
+
+	p.engineCache[cacheKey] = engine
+	return engine, nil
+}
+
+// Write generates the tags listing page.
+func (p *TagsListingPlugin) Write(m *lifecycle.Manager) error {
+	config := m.Config()
+
+	// Get tags config
+	tagsConfig := getTagsConfig(config)
+	if !tagsConfig.IsEnabled() {
+		return nil
+	}
+
+	// Collect and filter tags
+	tagInfos := p.collectTags(m.Posts(), &tagsConfig)
+	if len(tagInfos) == 0 {
+		log.Printf("[tags_listing] No tags found, skipping tags listing page")
+		return nil
+	}
+
+	// Sort tags alphabetically
+	sort.Slice(tagInfos, func(i, j int) bool {
+		return tagInfos[i].Name < tagInfos[j].Name
+	})
+
+	// Generate the tags listing page
+	return p.renderTagsPage(config, &tagsConfig, tagInfos)
+}
+
+// collectTags gathers all visible tags from posts with their counts.
+func (p *TagsListingPlugin) collectTags(posts []*models.Post, tagsConfig *models.TagsConfig) []TagInfo {
+	tagCounts := make(map[string]int)
+
+	for _, post := range posts {
+		// Skip draft/unpublished/private posts
+		if post.Draft || !post.Published || post.Private || post.Skip {
+			continue
+		}
+
+		for _, tag := range post.Tags {
+			// Skip blacklisted tags
+			if tagsConfig.IsBlacklisted(tag) {
+				continue
+			}
+			tagCounts[tag]++
+		}
+	}
+
+	// Filter out private tags and build TagInfo list
+	slugPrefix := tagsConfig.SlugPrefix
+	if slugPrefix == "" {
+		slugPrefix = "tags"
+	}
+
+	tagInfos := make([]TagInfo, 0, len(tagCounts))
+	for tag, count := range tagCounts {
+		// Skip private tags from listing
+		if tagsConfig.IsPrivate(tag) {
+			continue
+		}
+
+		slug := models.Slugify(tag)
+		tagInfos = append(tagInfos, TagInfo{
+			Name:  tag,
+			Slug:  slug,
+			Count: count,
+			Href:  "/" + slugPrefix + "/" + slug + "/",
+		})
+	}
+
+	return tagInfos
+}
+
+// renderTagsPage renders and writes the tags listing HTML page.
+func (p *TagsListingPlugin) renderTagsPage(config *lifecycle.Config, tagsConfig *models.TagsConfig, tagInfos []TagInfo) error {
+	slugPrefix := tagsConfig.SlugPrefix
+	if slugPrefix == "" {
+		slugPrefix = "tags"
+	}
+
+	// Create output directory
+	outputDir := config.OutputDir
+	tagsDir := filepath.Join(outputDir, slugPrefix)
+	if err := os.MkdirAll(tagsDir, 0o755); err != nil {
+		return fmt.Errorf("creating tags directory: %w", err)
+	}
+
+	// Get template engine
+	engine, err := p.createTemplateEngine(config)
+	if err != nil {
+		return err
+	}
+
+	// Determine template to use
+	templateName := tagsConfig.Template
+	if templateName == "" {
+		templateName = "tags.html"
+	}
+
+	// Check if template exists
+	if !engine.TemplateExists(templateName) {
+		log.Printf("[tags_listing] Warning: template %q not found, skipping tags listing page", templateName)
+		return nil
+	}
+
+	// Build context for template - create a synthetic post for the tags page
+	modelsConfig := ToModelsConfig(config)
+	title := tagsConfig.Title
+	description := tagsConfig.Description
+	syntheticPost := &models.Post{
+		Slug:        tagsConfig.SlugPrefix,
+		Title:       &title,
+		Description: &description,
+	}
+
+	ctx := templates.NewContext(syntheticPost, "", modelsConfig)
+	ctx.Extra["tags"] = tagInfos
+	ctx.Extra["total_tags"] = len(tagInfos)
+
+	// Render template
+	html, err := engine.Render(templateName, ctx)
+	if err != nil {
+		return fmt.Errorf("rendering tags template: %w", err)
+	}
+
+	// Write output file
+	outputPath := filepath.Join(tagsDir, "index.html")
+	//nolint:gosec // G306: Output files need 0644 for web serving
+	if err := os.WriteFile(outputPath, []byte(html), 0o644); err != nil {
+		return fmt.Errorf("writing tags listing page: %w", err)
+	}
+
+	log.Printf("[tags_listing] Generated /tags/ with %d tags", len(tagInfos))
+
+	return nil
+}
+
+// createTemplateEngine creates or retrieves a cached template engine.
+func (p *TagsListingPlugin) createTemplateEngine(config *lifecycle.Config) (*templates.Engine, error) {
+	templatesDir := PluginNameTemplates
+	if extra, ok := config.Extra["templates_dir"].(string); ok && extra != "" {
+		templatesDir = extra
+	}
+
+	themeName := getThemeName(config)
+
+	return p.getOrCreateEngine(templatesDir, themeName)
+}
+
+// getThemeName extracts the theme name from config.
+func getThemeName(config *lifecycle.Config) string {
+	if config.Extra == nil {
+		return ThemeDefault
+	}
+
+	if theme, ok := config.Extra["theme"].(models.ThemeConfig); ok && theme.Name != "" {
+		return theme.Name
+	}
+	if theme, ok := config.Extra["theme"].(map[string]interface{}); ok {
+		if name, ok := theme["name"].(string); ok && name != "" {
+			return name
+		}
+	}
+	if name, ok := config.Extra["theme"].(string); ok && name != "" {
+		return name
+	}
+
+	return ThemeDefault
+}
+
+// getTagsConfig retrieves tags configuration from the manager config.
+func getTagsConfig(config *lifecycle.Config) models.TagsConfig {
+	// Use ToModelsConfig to get the properly converted config
+	modelsConfig := ToModelsConfig(config)
+	if modelsConfig != nil {
+		return modelsConfig.Tags
+	}
+	return models.NewTagsConfig()
+}
+
+// Ensure TagsListingPlugin implements the required interfaces.
+var (
+	_ lifecycle.Plugin         = (*TagsListingPlugin)(nil)
+	_ lifecycle.WritePlugin    = (*TagsListingPlugin)(nil)
+	_ lifecycle.PriorityPlugin = (*TagsListingPlugin)(nil)
+)

--- a/pkg/plugins/templates.go
+++ b/pkg/plugins/templates.go
@@ -660,6 +660,13 @@ func toModelsConfigUncached(config *lifecycle.Config) *models.Config {
 		modelsConfig.Theme = theme
 	}
 
+	// Copy Tags config if available
+	if tags, ok := config.Extra["tags"].(models.TagsConfig); ok {
+		modelsConfig.Tags = tags
+	} else {
+		modelsConfig.Tags = models.NewTagsConfig()
+	}
+
 	// Copy the entire Extra map so templates can access dynamic plugin config
 	// (e.g., glightbox_enabled, glightbox_options set by image_zoom plugin)
 	if config.Extra != nil {

--- a/pkg/themes/default/templates/tags.html
+++ b/pkg/themes/default/templates/tags.html
@@ -1,0 +1,175 @@
+{% extends "base.html" %}
+
+{% block title %}{{ title | default:"Tags" }}{% endblock %}
+{% block description %}{{ description | default:config.description | default:"" }}{% endblock %}
+
+{% block content %}
+<div class="tags-listing">
+  <header class="tags-header">
+    <h1>{{ title | default:"Tags" }}</h1>
+    {% if description %}<p class="tags-description">{{ description }}</p>{% endif %}
+    <p class="tags-count">{{ total_tags }} tag{{ total_tags|pluralize }} found</p>
+  </header>
+
+  {% if tags %}
+  <div class="tags-cloud">
+    {% for tag in tags %}
+    <a href="{{ tag.Href }}" class="tag-item" data-count="{{ tag.Count }}">
+      <span class="tag-name">{{ tag.Name }}</span>
+      <span class="tag-count">({{ tag.Count }})</span>
+    </a>
+    {% endfor %}
+  </div>
+
+  <div class="tags-list">
+    <table class="tags-table">
+      <thead>
+        <tr>
+          <th>Tag</th>
+          <th>Posts</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for tag in tags %}
+        <tr>
+          <td><a href="{{ tag.Href }}">{{ tag.Name }}</a></td>
+          <td class="count">{{ tag.Count }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% else %}
+  <p class="no-tags">No tags found.</p>
+  {% endif %}
+</div>
+
+<style>
+.tags-listing {
+  max-width: var(--content-width, 800px);
+  margin: 0 auto;
+  padding: var(--spacing-lg, 2rem);
+}
+
+.tags-header {
+  margin-bottom: var(--spacing-xl, 3rem);
+  text-align: center;
+}
+
+.tags-header h1 {
+  margin-bottom: var(--spacing-sm, 0.5rem);
+}
+
+.tags-description {
+  color: var(--color-text-muted, #666);
+  margin-bottom: var(--spacing-sm, 0.5rem);
+}
+
+.tags-count {
+  color: var(--color-text-muted, #666);
+  font-size: 0.9em;
+}
+
+.tags-cloud {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm, 0.5rem);
+  justify-content: center;
+  margin-bottom: var(--spacing-xl, 3rem);
+  padding: var(--spacing-lg, 2rem);
+  background: var(--color-surface, #f5f5f5);
+  border-radius: var(--radius-lg, 0.5rem);
+}
+
+.tag-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: var(--spacing-xs, 0.25rem) var(--spacing-sm, 0.5rem);
+  background: var(--color-background, #fff);
+  border: 1px solid var(--color-border, #ddd);
+  border-radius: var(--radius-md, 0.25rem);
+  text-decoration: none;
+  color: var(--color-text, #333);
+  transition: all 0.2s ease;
+}
+
+.tag-item:hover {
+  background: var(--color-primary, #007bff);
+  border-color: var(--color-primary, #007bff);
+  color: var(--color-background, #fff);
+  transform: translateY(-2px);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.tag-name {
+  font-weight: 500;
+}
+
+.tag-count {
+  font-size: 0.85em;
+  opacity: 0.7;
+}
+
+.tags-list {
+  margin-top: var(--spacing-xl, 3rem);
+}
+
+.tags-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.tags-table th,
+.tags-table td {
+  padding: var(--spacing-sm, 0.5rem) var(--spacing-md, 1rem);
+  text-align: left;
+  border-bottom: 1px solid var(--color-border, #ddd);
+}
+
+.tags-table th {
+  font-weight: 600;
+  background: var(--color-surface, #f5f5f5);
+}
+
+.tags-table td.count {
+  text-align: center;
+  color: var(--color-text-muted, #666);
+}
+
+.tags-table tbody tr:hover {
+  background: var(--color-surface, #f5f5f5);
+}
+
+.tags-table a {
+  color: var(--color-primary, #007bff);
+  text-decoration: none;
+}
+
+.tags-table a:hover {
+  text-decoration: underline;
+}
+
+.no-tags {
+  text-align: center;
+  color: var(--color-text-muted, #666);
+  font-style: italic;
+}
+
+/* Responsive */
+@media (max-width: 600px) {
+  .tags-listing {
+    padding: var(--spacing-md, 1rem);
+  }
+
+  .tags-cloud {
+    padding: var(--spacing-md, 1rem);
+  }
+
+  .tags-table th,
+  .tags-table td {
+    padding: var(--spacing-xs, 0.25rem) var(--spacing-sm, 0.5rem);
+  }
+}
+</style>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Adds `/tags` page showing all available tags with post counts and links to tag pages
- Supports blacklist configuration to completely exclude certain tags
- Supports private configuration to hide tags from the listing while keeping their pages accessible
- Includes responsive CSS styling with cloud and table views

## Configuration
```toml
[markata-go.tags]
enabled = true
title = "Tags"
description = "Browse all topics"
template = "tags.html"
slug_prefix = "tags"
blacklist = ["draft", "wip"]
private = ["personal", "unlisted"]
```

## Files Changed
- `pkg/models/config.go` - Added `TagsConfig` struct with fields and helper methods
- `pkg/config/parser.go` - Added TOML/YAML/JSON parsing support for tags config
- `pkg/plugins/tags_listing.go` - New plugin that generates the tags listing page
- `pkg/plugins/registry.go` - Registered the `tags_listing` plugin
- `pkg/plugins/templates.go` - Added Tags config to `ToModelsConfig` function
- `pkg/themes/default/templates/tags.html` - New template for the tags page

Fixes #612