### PR TITLE
fix: clean up hover cards and keyboard shortcuts after view transitions

### DIFF
--- a/pkg/themes/default/static/js/view-transitions.js
+++ b/pkg/themes/default/static/js/view-transitions.js
@@ -213,8 +213,16 @@
       window.initTooltips();
     }
 
+    if (window.initMentionCards && typeof window.initMentionCards === 'function') {
+      window.initMentionCards();
+    }
+
     if (window.initPagination && typeof window.initPagination === 'function') {
       window.initPagination();
+    }
+
+    if (window.initNavigationShortcuts && typeof window.initNavigationShortcuts === 'function') {
+      window.initNavigationShortcuts();
     }
 
     // Re-attach event listeners


### PR DESCRIPTION
## Summary

Fixes two critical issues with view transitions:
1. **Hover cards staying open** - Wikilink tooltips and mention cards would remain visible after navigating to a new page
2. **Keyboard shortcuts not working** - j/k/o/Enter shortcuts stopped working after view transitions

## Root Cause

When using view transitions for client-side navigation:
- The entire DOM is replaced with new page content
- JavaScript state (`selectedCard`, `currentCard`, `tooltip`) still references old DOM nodes
- Scripts never re-initialized to attach to new DOM elements
- Event listeners were lost or pointing to stale elements

## Changes

### `tooltips.js`
- Added `cleanup()` function to remove orphaned tooltips and prevent duplicate listeners
- Added `boundLinks` WeakSet to track which elements have listeners
- Call `removeTooltip()` before creating new ones
- Exposed `window.initTooltips` and added `view-transition-complete` listener

### `mention-cards.js`
- Added `cleanup()` function to clear timers, remove cards, reset state
- Added `boundMentions` WeakSet to track bound elements
- Added `cardDelegationSetup` flag to prevent duplicate document listeners
- Exposed `window.initMentionCards` and added `view-transition-complete` listener

### `navigation-shortcuts.js`
- Added `cleanup()` function to clear timers, reset key states, remove highlights
- Added `state.initialized` and `state.jkRegistered` flags to prevent duplicate registrations
- Refresh `state.cards = getCards()` in handlers to handle DOM changes
- Check `!state.selectedCard.parentNode` to detect stale references
- Exposed `window.initNavigationShortcuts` and added `view-transition-complete` listener

### `view-transitions.js`
- Added calls to `window.initMentionCards()` and `window.initNavigationShortcuts()` in `reinitializeScripts()`

## Testing

1. Navigate from home to archive page using view transitions
2. Verify hover tooltips appear and disappear correctly
3. Verify mention cards appear and disappear correctly
4. Press `j` to navigate cards - should work correctly
5. Press `k` to go back - should work correctly
6. Press `o` to open a card - should work correctly

All interactive features now properly clean up stale state and re-attach to new DOM elements after each navigation.