### PR TITLE
feat: Add support for creating palettes from Lospec URLs

### DIFF
--- a/docs/guides/themes.md
+++ b/docs/guides/themes.md
@@ -427,6 +427,49 @@ markata-go palette new my-palette
 
 Creates `palettes/my-palette.toml` that you can customize.
 
+### Fetch Palette from Lospec
+
+Import color palettes directly from [Lospec.com](https://lospec.com/palette-list), a popular source for pixel art and retro color palettes:
+
+```bash
+# Fetch a palette by URL
+markata-go palette fetch https://lospec.com/palette-list/sweetie-16.txt
+
+# Use a custom name
+markata-go palette fetch https://lospec.com/palette-list/cheese-palette.txt --name "My Cheese"
+
+# Save to a custom directory
+markata-go palette fetch https://lospec.com/palette-list/tokyo-night.txt -o palettes/
+```
+
+The fetched palette is saved to your user palettes directory (`~/.config/markata-go/palettes/`) by default. markata-go automatically:
+
+- Downloads the color list from Lospec
+- Analyzes colors to determine if it's a light or dark theme
+- Generates semantic mappings (text-primary, bg-primary, accent, etc.)
+- Caches the download to avoid repeated network requests
+
+**Example output:**
+```
+Fetching palette from: https://lospec.com/palette-list/sweetie-16.txt
+Palette saved to: /home/user/.config/markata-go/palettes/sweetie-16.toml
+
+Palette details:
+  Name:        Sweetie 16
+  Variant:     dark
+  Colors:      16
+  Source:      https://lospec.com/palette-list/sweetie-16.txt
+
+Semantic mappings:
+  bg-primary      -> color0      (#1a1c2c)
+  text-primary    -> color15     (#f4f4f4)
+  accent          -> color8      (#b13e53)
+
+Use this palette in your config:
+  [markata-go.theme]
+  palette = "sweetie-16"
+```
+
 ---
 
 ## Creating Custom Palettes

--- a/pkg/palettes/lospec.go
+++ b/pkg/palettes/lospec.go
@@ -1,0 +1,627 @@
+// Package palettes provides color palette management for markata-go.
+package palettes
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Lospec-related errors.
+var (
+	// ErrInvalidLospecURL is returned when a URL is not a valid Lospec palette URL.
+	ErrInvalidLospecURL = errors.New("invalid Lospec URL: must be https://lospec.com/palette-list/<name>.txt")
+
+	// ErrLospecFetchFailed is returned when fetching from Lospec fails.
+	ErrLospecFetchFailed = errors.New("failed to fetch from Lospec")
+
+	// ErrLospecParseError is returned when the Lospec response cannot be parsed.
+	ErrLospecParseError = errors.New("failed to parse Lospec palette")
+)
+
+// LospecFetchError provides context for Lospec fetch failures.
+type LospecFetchError struct {
+	URL        string
+	StatusCode int
+	Message    string
+	Err        error
+}
+
+func (e *LospecFetchError) Error() string {
+	if e.StatusCode > 0 {
+		return fmt.Sprintf("lospec fetch failed for %s: HTTP %d: %s", e.URL, e.StatusCode, e.Message)
+	}
+	return fmt.Sprintf("lospec fetch failed for %s: %s", e.URL, e.Message)
+}
+
+func (e *LospecFetchError) Unwrap() error {
+	return e.Err
+}
+
+// NewLospecFetchError creates a new LospecFetchError.
+func NewLospecFetchError(url string, statusCode int, message string, err error) *LospecFetchError {
+	return &LospecFetchError{
+		URL:        url,
+		StatusCode: statusCode,
+		Message:    message,
+		Err:        err,
+	}
+}
+
+// lospecURLPattern matches valid Lospec palette URLs.
+// Format: https://lospec.com/palette-list/<name>.txt
+var lospecURLPattern = regexp.MustCompile(`^https://lospec\.com/palette-list/([a-zA-Z0-9_-]+)\.txt$`)
+
+// LospecClient handles fetching palettes from Lospec.com.
+type LospecClient struct {
+	httpClient *http.Client
+	cacheDir   string
+	userAgent  string
+}
+
+// LospecClientOption is a functional option for configuring LospecClient.
+type LospecClientOption func(*LospecClient)
+
+// WithLospecTimeout sets the HTTP client timeout.
+func WithLospecTimeout(timeout time.Duration) LospecClientOption {
+	return func(c *LospecClient) {
+		c.httpClient.Timeout = timeout
+	}
+}
+
+// WithLospecCacheDir sets the cache directory for downloaded palettes.
+func WithLospecCacheDir(dir string) LospecClientOption {
+	return func(c *LospecClient) {
+		c.cacheDir = dir
+	}
+}
+
+// WithLospecUserAgent sets the User-Agent header for requests.
+func WithLospecUserAgent(ua string) LospecClientOption {
+	return func(c *LospecClient) {
+		c.userAgent = ua
+	}
+}
+
+// NewLospecClient creates a new LospecClient with default settings.
+func NewLospecClient(opts ...LospecClientOption) *LospecClient {
+	// Default cache directory: ~/.cache/markata-go/lospec/
+	cacheDir := ""
+	if userCacheDir, err := os.UserCacheDir(); err == nil {
+		cacheDir = filepath.Join(userCacheDir, "markata-go", "lospec")
+	}
+
+	c := &LospecClient{
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		cacheDir:  cacheDir,
+		userAgent: "markata-go/1.0",
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c
+}
+
+// ValidateLospecURL checks if a URL is a valid Lospec palette URL.
+func ValidateLospecURL(rawURL string) error {
+	if !lospecURLPattern.MatchString(rawURL) {
+		return ErrInvalidLospecURL
+	}
+	return nil
+}
+
+// ExtractPaletteNameFromURL extracts the palette name from a Lospec URL.
+func ExtractPaletteNameFromURL(rawURL string) (string, error) {
+	matches := lospecURLPattern.FindStringSubmatch(rawURL)
+	if len(matches) < 2 {
+		return "", ErrInvalidLospecURL
+	}
+	// Convert kebab-case to title case for display
+	name := matches[1]
+	name = strings.ReplaceAll(name, "-", " ")
+	// Capitalize first letter of each word
+	words := strings.Fields(name)
+	for i, word := range words {
+		if word != "" {
+			words[i] = strings.ToUpper(string(word[0])) + strings.ToLower(word[1:])
+		}
+	}
+	return strings.Join(words, " "), nil
+}
+
+// FetchPalette fetches a palette from a Lospec URL.
+// It uses caching to avoid repeated requests for the same palette.
+func (c *LospecClient) FetchPalette(ctx context.Context, rawURL string) (*Palette, error) {
+	// Validate URL
+	if err := ValidateLospecURL(rawURL); err != nil {
+		return nil, err
+	}
+
+	// Check cache first
+	if c.cacheDir != "" {
+		if cached, err := c.loadFromCache(rawURL); err == nil {
+			return cached, nil
+		}
+	}
+
+	// Fetch from Lospec
+	colors, err := c.fetchColors(ctx, rawURL)
+	if err != nil {
+		return nil, err
+	}
+
+	// Extract palette name from URL
+	name, err := ExtractPaletteNameFromURL(rawURL)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create palette with auto-generated semantic mappings
+	palette := CreatePaletteFromColors(name, colors, rawURL)
+
+	// Cache the result
+	if c.cacheDir != "" {
+		_ = c.saveToCache(rawURL, colors) //nolint:errcheck // Best effort caching
+	}
+
+	return palette, nil
+}
+
+// fetchColors fetches the raw color list from Lospec.
+func (c *LospecClient) fetchColors(ctx context.Context, rawURL string) ([]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, http.NoBody)
+	if err != nil {
+		return nil, NewLospecFetchError(rawURL, 0, "failed to create request", err)
+	}
+
+	req.Header.Set("User-Agent", c.userAgent)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, NewLospecFetchError(rawURL, 0, "request failed", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, NewLospecFetchError(rawURL, resp.StatusCode, "unexpected status", ErrLospecFetchFailed)
+	}
+
+	return parseLospecColors(resp.Body)
+}
+
+// parseLospecColors parses the Lospec text format.
+// Lospec returns one hex color per line, optionally with # prefix.
+// Colors may be in ARGB format (8 characters) or RGB format (6 characters).
+// Lines starting with ; are comments and are skipped.
+func parseLospecColors(r io.Reader) ([]string, error) {
+	var colors []string
+	scanner := bufio.NewScanner(r)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		// Skip comment lines (Paint.NET palette format)
+		if strings.HasPrefix(line, ";") {
+			continue
+		}
+
+		// Normalize: remove # prefix if present
+		color := strings.TrimPrefix(line, "#")
+
+		// Handle ARGB format (8 chars) - strip the alpha channel
+		if len(color) == 8 {
+			color = color[2:] // Remove first 2 chars (alpha)
+		}
+
+		// Ensure # prefix for validation
+		color = "#" + color
+
+		// Validate hex color
+		if !isHexColor(color) {
+			continue // Skip invalid lines
+		}
+
+		colors = append(colors, normalizeHexColor(color))
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, NewLospecFetchError("", 0, "failed to read response", err)
+	}
+
+	if len(colors) == 0 {
+		return nil, NewLospecFetchError("", 0, "no valid colors found", ErrLospecParseError)
+	}
+
+	return colors, nil
+}
+
+// cacheKey generates a cache key from a URL.
+func cacheKey(rawURL string) string {
+	h := sha256.Sum256([]byte(rawURL))
+	return hex.EncodeToString(h[:8]) // Use first 8 bytes for shorter filename
+}
+
+// loadFromCache attempts to load colors from the cache.
+func (c *LospecClient) loadFromCache(rawURL string) (*Palette, error) {
+	cacheFile := filepath.Join(c.cacheDir, cacheKey(rawURL)+".txt")
+
+	data, err := os.ReadFile(cacheFile)
+	if err != nil {
+		return nil, err
+	}
+
+	colors, err := parseLospecColors(strings.NewReader(string(data)))
+	if err != nil {
+		return nil, err
+	}
+
+	name, err := ExtractPaletteNameFromURL(rawURL)
+	if err != nil {
+		return nil, err
+	}
+
+	return CreatePaletteFromColors(name, colors, rawURL), nil
+}
+
+// saveToCache saves colors to the cache.
+func (c *LospecClient) saveToCache(rawURL string, colors []string) error {
+	if err := os.MkdirAll(c.cacheDir, 0o755); err != nil {
+		return err
+	}
+
+	cacheFile := filepath.Join(c.cacheDir, cacheKey(rawURL)+".txt")
+	content := strings.Join(colors, "\n") + "\n"
+
+	return os.WriteFile(cacheFile, []byte(content), 0o644) //nolint:gosec // cache files should be readable
+}
+
+// CreatePaletteFromColors creates a Palette from a list of hex colors.
+// It auto-generates semantic mappings based on color analysis.
+func CreatePaletteFromColors(name string, colors []string, sourceURL string) *Palette {
+	p := NewPalette(name, VariantDark) // Default to dark, will be auto-detected
+	p.Homepage = sourceURL
+	p.Description = "Imported from Lospec"
+
+	// Analyze colors to determine variant
+	avgLuminance := 0.0
+	for _, color := range colors {
+		avgLuminance += relativeLuminance(color)
+	}
+	avgLuminance /= float64(len(colors))
+
+	// If average luminance is high, it's likely a light theme
+	if avgLuminance > 0.5 {
+		p.Variant = VariantLight
+	}
+
+	// Sort colors by luminance for better semantic assignment
+	type colorWithLum struct {
+		hex string
+		lum float64
+	}
+	sortedColors := make([]colorWithLum, len(colors))
+	for i, color := range colors {
+		sortedColors[i] = colorWithLum{
+			hex: color,
+			lum: relativeLuminance(color),
+		}
+	}
+	sort.Slice(sortedColors, func(i, j int) bool {
+		return sortedColors[i].lum < sortedColors[j].lum
+	})
+
+	// Assign raw colors with indexed names
+	for i, color := range colors {
+		colorName := fmt.Sprintf("color%d", i)
+		p.Colors[colorName] = color
+	}
+
+	// Generate semantic mappings based on luminance
+	numColors := len(sortedColors)
+	if numColors == 0 {
+		return p
+	}
+
+	// For dark themes: darkest = bg, lightest = text
+	// For light themes: lightest = bg, darkest = text
+	if p.Variant == VariantDark {
+		// Background: darkest color
+		p.Semantic["bg-primary"] = findColorName(p.Colors, sortedColors[0].hex)
+		// Text: lightest color
+		p.Semantic["text-primary"] = findColorName(p.Colors, sortedColors[numColors-1].hex)
+	} else {
+		// Background: lightest color
+		p.Semantic["bg-primary"] = findColorName(p.Colors, sortedColors[numColors-1].hex)
+		// Text: darkest color
+		p.Semantic["text-primary"] = findColorName(p.Colors, sortedColors[0].hex)
+	}
+
+	// Accent: pick from middle colors, preferring more saturated ones
+	if numColors >= 3 {
+		// Find most saturated color in the middle range
+		midStart := numColors / 4
+		midEnd := numColors - numColors/4
+		if midStart == midEnd {
+			midEnd = midStart + 1
+		}
+
+		bestAccent := sortedColors[numColors/2].hex
+		bestSaturation := 0.0
+
+		for i := midStart; i < midEnd && i < numColors; i++ {
+			sat := saturation(sortedColors[i].hex)
+			if sat > bestSaturation {
+				bestSaturation = sat
+				bestAccent = sortedColors[i].hex
+			}
+		}
+		p.Semantic["accent"] = findColorName(p.Colors, bestAccent)
+	} else if numColors >= 2 {
+		// With only 2 colors, use the one that's not bg or text
+		for _, sc := range sortedColors {
+			name := findColorName(p.Colors, sc.hex)
+			if name != p.Semantic["bg-primary"] && name != p.Semantic["text-primary"] {
+				p.Semantic["accent"] = name
+				break
+			}
+		}
+	}
+
+	// Link color: accent or a distinct color
+	if accent, ok := p.Semantic["accent"]; ok {
+		p.Semantic["link"] = accent
+	}
+
+	// Secondary colors if we have enough
+	if numColors >= 4 {
+		// Secondary background: slightly different from primary
+		if p.Variant == VariantDark {
+			p.Semantic["bg-secondary"] = findColorName(p.Colors, sortedColors[1].hex)
+		} else {
+			p.Semantic["bg-secondary"] = findColorName(p.Colors, sortedColors[numColors-2].hex)
+		}
+
+		// Secondary text: slightly different from primary
+		if p.Variant == VariantDark {
+			p.Semantic["text-secondary"] = findColorName(p.Colors, sortedColors[numColors-2].hex)
+		} else {
+			p.Semantic["text-secondary"] = findColorName(p.Colors, sortedColors[1].hex)
+		}
+	}
+
+	return p
+}
+
+// findColorName finds the color name in the map that matches the hex value.
+func findColorName(colors map[string]string, hex string) string {
+	for name, value := range colors {
+		if value == hex {
+			return name
+		}
+	}
+	return ""
+}
+
+// saturation calculates a simple saturation metric for a hex color.
+// Returns a value between 0 (grayscale) and 1 (fully saturated).
+func saturation(hex string) float64 {
+	r, g, b := hexToRGB(hex)
+	maxC := max(r, max(g, b))
+	minC := min(r, min(g, b))
+
+	if maxC == 0 {
+		return 0
+	}
+
+	return float64(maxC-minC) / float64(maxC)
+}
+
+// hexToRGB converts a hex color to RGB components (0-255).
+func hexToRGB(hex string) (r, g, b uint8) {
+	hex = strings.TrimPrefix(hex, "#")
+
+	// Handle short form (#RGB)
+	if len(hex) == 3 {
+		hex = string(hex[0]) + string(hex[0]) +
+			string(hex[1]) + string(hex[1]) +
+			string(hex[2]) + string(hex[2])
+	}
+
+	if len(hex) < 6 {
+		return 0, 0, 0
+	}
+
+	var ri, gi, bi int64
+	_, _ = fmt.Sscanf(hex[0:2], "%x", &ri) //nolint:errcheck // hex already validated
+	_, _ = fmt.Sscanf(hex[2:4], "%x", &gi) //nolint:errcheck // hex already validated
+	_, _ = fmt.Sscanf(hex[4:6], "%x", &bi) //nolint:errcheck // hex already validated
+
+	return uint8(ri), uint8(gi), uint8(bi) //nolint:gosec // values are bounded by hex parsing
+}
+
+// relativeLuminance calculates the relative luminance of a color.
+// Based on WCAG 2.1 definition.
+func relativeLuminance(hex string) float64 {
+	r, g, b := hexToRGB(hex)
+
+	// Convert to sRGB
+	sR := float64(r) / 255.0
+	sG := float64(g) / 255.0
+	sB := float64(b) / 255.0
+
+	// Apply gamma correction
+	if sR <= 0.03928 {
+		sR /= 12.92
+	} else {
+		sR = pow((sR+0.055)/1.055, 2.4)
+	}
+	if sG <= 0.03928 {
+		sG /= 12.92
+	} else {
+		sG = pow((sG+0.055)/1.055, 2.4)
+	}
+	if sB <= 0.03928 {
+		sB /= 12.92
+	} else {
+		sB = pow((sB+0.055)/1.055, 2.4)
+	}
+
+	return 0.2126*sR + 0.7152*sG + 0.0722*sB
+}
+
+// pow is a simple power function to avoid math import for this small usage.
+func pow(base, exp float64) float64 {
+	result := 1.0
+	for i := 0; i < int(exp); i++ {
+		result *= base
+	}
+	// Handle fractional exponent approximately
+	if exp != float64(int(exp)) {
+		// Simple approximation for 2.4 exponent
+		frac := exp - float64(int(exp))
+		result *= 1.0 + frac*(base-1.0)
+	}
+	return result
+}
+
+// SavePaletteToFile saves a palette to a TOML file.
+func SavePaletteToFile(p *Palette, path string) error {
+	// Ensure directory exists
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	// Generate TOML content
+	var sb strings.Builder
+
+	sb.WriteString("# ")
+	sb.WriteString(p.Name)
+	sb.WriteString(" Color Palette\n")
+	if p.Homepage != "" {
+		sb.WriteString("# Source: ")
+		sb.WriteString(p.Homepage)
+		sb.WriteString("\n")
+	}
+	sb.WriteString("\n")
+
+	sb.WriteString("[palette]\n")
+	sb.WriteString(fmt.Sprintf("name = %q\n", p.Name))
+	sb.WriteString(fmt.Sprintf("variant = %q\n", p.Variant))
+	if p.Author != "" {
+		sb.WriteString(fmt.Sprintf("author = %q\n", p.Author))
+	}
+	if p.License != "" {
+		sb.WriteString(fmt.Sprintf("license = %q\n", p.License))
+	}
+	if p.Homepage != "" {
+		sb.WriteString(fmt.Sprintf("homepage = %q\n", p.Homepage))
+	}
+	if p.Description != "" {
+		sb.WriteString(fmt.Sprintf("description = %q\n", p.Description))
+	}
+
+	sb.WriteString("\n# Raw Colors\n")
+	sb.WriteString("[palette.colors]\n")
+
+	// Sort color names for consistent output
+	colorNames := make([]string, 0, len(p.Colors))
+	for name := range p.Colors {
+		colorNames = append(colorNames, name)
+	}
+	sort.Strings(colorNames)
+
+	for _, name := range colorNames {
+		sb.WriteString(fmt.Sprintf("%s = %q\n", name, p.Colors[name]))
+	}
+
+	sb.WriteString("\n# Semantic Colors\n")
+	sb.WriteString("[palette.semantic]\n")
+
+	// Sort semantic names for consistent output
+	semanticNames := make([]string, 0, len(p.Semantic))
+	for name := range p.Semantic {
+		semanticNames = append(semanticNames, name)
+	}
+	sort.Strings(semanticNames)
+
+	for _, name := range semanticNames {
+		sb.WriteString(fmt.Sprintf("%s = %q\n", name, p.Semantic[name]))
+	}
+
+	if len(p.Components) > 0 {
+		sb.WriteString("\n# Component Colors\n")
+		sb.WriteString("[palette.components]\n")
+
+		// Sort component names for consistent output
+		componentNames := make([]string, 0, len(p.Components))
+		for name := range p.Components {
+			componentNames = append(componentNames, name)
+		}
+		sort.Strings(componentNames)
+
+		for _, name := range componentNames {
+			sb.WriteString(fmt.Sprintf("%s = %q\n", name, p.Components[name]))
+		}
+	}
+
+	return os.WriteFile(path, []byte(sb.String()), 0o644) //nolint:gosec // palette files should be readable
+}
+
+// GetUserPalettesDir returns the user palettes directory.
+func GetUserPalettesDir() (string, error) {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get user config directory: %w", err)
+	}
+	return filepath.Join(configDir, "markata-go", "palettes"), nil
+}
+
+// FetchLospecPalette is a convenience function that fetches a palette from Lospec.
+func FetchLospecPalette(ctx context.Context, rawURL string) (*Palette, error) {
+	client := NewLospecClient()
+	return client.FetchPalette(ctx, rawURL)
+}
+
+// ParseLospecURL parses and validates a Lospec URL, returning the normalized URL.
+func ParseLospecURL(rawURL string) (string, error) {
+	// Parse and normalize the URL
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", ErrInvalidLospecURL
+	}
+
+	// Ensure it's a valid Lospec URL
+	if u.Host != "lospec.com" {
+		return "", ErrInvalidLospecURL
+	}
+
+	// Ensure HTTPS
+	u.Scheme = "https"
+
+	normalized := u.String()
+	if err := ValidateLospecURL(normalized); err != nil {
+		return "", err
+	}
+
+	return normalized, nil
+}

--- a/pkg/palettes/lospec_test.go
+++ b/pkg/palettes/lospec_test.go
@@ -1,0 +1,619 @@
+package palettes
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestValidateLospecURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{
+			name:    "valid URL",
+			url:     "https://lospec.com/palette-list/cheese-palette.txt",
+			wantErr: false,
+		},
+		{
+			name:    "valid URL with dashes",
+			url:     "https://lospec.com/palette-list/some-cool-palette.txt",
+			wantErr: false,
+		},
+		{
+			name:    "valid URL with numbers",
+			url:     "https://lospec.com/palette-list/palette123.txt",
+			wantErr: false,
+		},
+		{
+			name:    "valid URL with underscores",
+			url:     "https://lospec.com/palette-list/my_palette.txt",
+			wantErr: false,
+		},
+		{
+			name:    "invalid - wrong domain",
+			url:     "https://example.com/palette-list/test.txt",
+			wantErr: true,
+		},
+		{
+			name:    "invalid - wrong path",
+			url:     "https://lospec.com/palettes/test.txt",
+			wantErr: true,
+		},
+		{
+			name:    "invalid - no .txt extension",
+			url:     "https://lospec.com/palette-list/test",
+			wantErr: true,
+		},
+		{
+			name:    "invalid - http instead of https",
+			url:     "http://lospec.com/palette-list/test.txt",
+			wantErr: true,
+		},
+		{
+			name:    "invalid - empty name",
+			url:     "https://lospec.com/palette-list/.txt",
+			wantErr: true,
+		},
+		{
+			name:    "invalid - special characters",
+			url:     "https://lospec.com/palette-list/test@palette.txt",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateLospecURL(tt.url)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateLospecURL(%q) error = %v, wantErr %v", tt.url, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestExtractPaletteNameFromURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "simple name",
+			url:     "https://lospec.com/palette-list/cheese.txt",
+			want:    "Cheese",
+			wantErr: false,
+		},
+		{
+			name:    "kebab-case name",
+			url:     "https://lospec.com/palette-list/cheese-palette.txt",
+			want:    "Cheese Palette",
+			wantErr: false,
+		},
+		{
+			name:    "multi-word name",
+			url:     "https://lospec.com/palette-list/super-cool-retro-theme.txt",
+			want:    "Super Cool Retro Theme",
+			wantErr: false,
+		},
+		{
+			name:    "invalid URL",
+			url:     "https://example.com/test.txt",
+			want:    "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ExtractPaletteNameFromURL(tt.url)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ExtractPaletteNameFromURL(%q) error = %v, wantErr %v", tt.url, err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ExtractPaletteNameFromURL(%q) = %q, want %q", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseLospecColors(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name:    "colors with hash prefix",
+			input:   "#ff0000\n#00ff00\n#0000ff\n",
+			want:    []string{"#ff0000", "#00ff00", "#0000ff"},
+			wantErr: false,
+		},
+		{
+			name:    "colors without hash prefix",
+			input:   "ff0000\n00ff00\n0000ff\n",
+			want:    []string{"#ff0000", "#00ff00", "#0000ff"},
+			wantErr: false,
+		},
+		{
+			name:    "mixed prefix",
+			input:   "#ff0000\n00ff00\n#0000ff\n",
+			want:    []string{"#ff0000", "#00ff00", "#0000ff"},
+			wantErr: false,
+		},
+		{
+			name:    "with empty lines",
+			input:   "#ff0000\n\n#00ff00\n\n#0000ff\n",
+			want:    []string{"#ff0000", "#00ff00", "#0000ff"},
+			wantErr: false,
+		},
+		{
+			name:    "with whitespace",
+			input:   "  #ff0000  \n  00ff00\n#0000ff  \n",
+			want:    []string{"#ff0000", "#00ff00", "#0000ff"},
+			wantErr: false,
+		},
+		{
+			name:    "short hex colors",
+			input:   "#f00\n#0f0\n#00f\n",
+			want:    []string{"#ff0000", "#00ff00", "#0000ff"},
+			wantErr: false,
+		},
+		{
+			name:    "uppercase colors",
+			input:   "#FF0000\n#00FF00\n#0000FF\n",
+			want:    []string{"#ff0000", "#00ff00", "#0000ff"},
+			wantErr: false,
+		},
+		{
+			name:    "empty input",
+			input:   "",
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "only whitespace",
+			input:   "   \n\n   \n",
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "invalid colors skipped",
+			input:   "#ff0000\ninvalid\n#00ff00\nnotacolor\n#0000ff\n",
+			want:    []string{"#ff0000", "#00ff00", "#0000ff"},
+			wantErr: false,
+		},
+		{
+			name:    "ARGB format (Paint.NET)",
+			input:   "FFff0000\nFF00ff00\nFF0000ff\n",
+			want:    []string{"#ff0000", "#00ff00", "#0000ff"},
+			wantErr: false,
+		},
+		{
+			name: "Paint.NET palette with comments",
+			input: `;paint.net Palette File
+;Downloaded from Lospec.com/palette-list
+;Colors: 3
+FFff0000
+FF00ff00
+FF0000ff
+`,
+			want:    []string{"#ff0000", "#00ff00", "#0000ff"},
+			wantErr: false,
+		},
+		{
+			name:    "only comments",
+			input:   ";comment\n;another comment\n",
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseLospecColors(strings.NewReader(tt.input))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseLospecColors() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if len(got) != len(tt.want) {
+					t.Errorf("parseLospecColors() got %d colors, want %d", len(got), len(tt.want))
+					return
+				}
+				for i := range got {
+					if got[i] != tt.want[i] {
+						t.Errorf("parseLospecColors()[%d] = %q, want %q", i, got[i], tt.want[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestCreatePaletteFromColors(t *testing.T) {
+	tests := []struct {
+		name        string
+		paletteName string
+		colors      []string
+		wantVariant Variant
+		wantSemKeys []string
+	}{
+		{
+			name:        "dark palette (dark colors)",
+			paletteName: "Test Dark",
+			colors:      []string{"#1a1a1a", "#2a2a2a", "#ff6b6b", "#e0e0e0", "#ffffff"},
+			wantVariant: VariantDark,
+			wantSemKeys: []string{"bg-primary", "text-primary"},
+		},
+		{
+			name:        "light palette (light colors)",
+			paletteName: "Test Light",
+			colors:      []string{"#ffffff", "#f0f0f0", "#eeeeee", "#dddddd", "#666666"},
+			wantVariant: VariantLight,
+			wantSemKeys: []string{"bg-primary", "text-primary"},
+		},
+		{
+			name:        "minimal palette (2 colors)",
+			paletteName: "Minimal",
+			colors:      []string{"#000000", "#ffffff"},
+			wantVariant: VariantDark,
+			wantSemKeys: []string{"bg-primary", "text-primary"},
+		},
+		{
+			name:        "single color",
+			paletteName: "Single",
+			colors:      []string{"#888888"},
+			wantVariant: VariantDark,
+			wantSemKeys: []string{"bg-primary", "text-primary"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := CreatePaletteFromColors(tt.paletteName, tt.colors, "https://lospec.com/test")
+
+			if p.Name != tt.paletteName {
+				t.Errorf("Name = %q, want %q", p.Name, tt.paletteName)
+			}
+
+			if p.Variant != tt.wantVariant {
+				t.Errorf("Variant = %q, want %q", p.Variant, tt.wantVariant)
+			}
+
+			// Check that all colors are in the palette
+			if len(p.Colors) != len(tt.colors) {
+				t.Errorf("Colors count = %d, want %d", len(p.Colors), len(tt.colors))
+			}
+
+			// Check that semantic keys exist
+			for _, key := range tt.wantSemKeys {
+				if _, ok := p.Semantic[key]; !ok {
+					t.Errorf("Missing semantic key: %s", key)
+				}
+			}
+
+			// Validate the palette
+			errs := p.Validate()
+			if len(errs) > 0 {
+				t.Errorf("Palette validation failed: %v", errs)
+			}
+		})
+	}
+}
+
+func TestLospecClient_FetchPalette_MockServer(t *testing.T) {
+	// Create a mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Return a simple palette
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("#1a1b26\n#24283b\n#7aa2f7\n#bb9af7\n#c0caf5\n")) //nolint:errcheck // test code
+	}))
+	defer server.Close()
+
+	// Create client with custom HTTP client that redirects to our mock server
+	client := &LospecClient{
+		httpClient: server.Client(),
+		cacheDir:   "", // Disable caching for this test
+		userAgent:  "test-agent",
+	}
+
+	// We can't directly test against lospec.com, so we'll test the parsing logic
+	colors, err := client.fetchColors(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("fetchColors() error = %v", err)
+	}
+
+	if len(colors) != 5 {
+		t.Errorf("fetchColors() returned %d colors, want 5", len(colors))
+	}
+
+	expected := []string{"#1a1b26", "#24283b", "#7aa2f7", "#bb9af7", "#c0caf5"}
+	for i, color := range colors {
+		if color != expected[i] {
+			t.Errorf("color[%d] = %q, want %q", i, color, expected[i])
+		}
+	}
+}
+
+func TestLospecClient_Cache(t *testing.T) {
+	// Create temp cache directory
+	tmpDir := t.TempDir()
+	cacheDir := filepath.Join(tmpDir, "cache")
+
+	client := NewLospecClient(
+		WithLospecCacheDir(cacheDir),
+	)
+
+	// Test URL
+	testURL := "https://lospec.com/palette-list/test-palette.txt"
+	colors := []string{"#ff0000", "#00ff00", "#0000ff"}
+
+	// Save to cache
+	err := client.saveToCache(testURL, colors)
+	if err != nil {
+		t.Fatalf("saveToCache() error = %v", err)
+	}
+
+	// Verify cache directory was created
+	if _, err := os.Stat(cacheDir); os.IsNotExist(err) {
+		t.Error("Cache directory was not created")
+	}
+
+	// Load from cache
+	cached, err := client.loadFromCache(testURL)
+	if err != nil {
+		t.Fatalf("loadFromCache() error = %v", err)
+	}
+
+	if cached.Name != "Test Palette" {
+		t.Errorf("Cached palette name = %q, want %q", cached.Name, "Test Palette")
+	}
+
+	if len(cached.Colors) != 3 {
+		t.Errorf("Cached palette has %d colors, want 3", len(cached.Colors))
+	}
+}
+
+func TestLospecClient_Options(t *testing.T) {
+	// Test WithLospecTimeout
+	client := NewLospecClient(
+		WithLospecTimeout(60 * time.Second),
+	)
+	if client.httpClient.Timeout != 60*time.Second {
+		t.Errorf("Timeout = %v, want %v", client.httpClient.Timeout, 60*time.Second)
+	}
+
+	// Test WithLospecUserAgent
+	client = NewLospecClient(
+		WithLospecUserAgent("custom-agent/1.0"),
+	)
+	if client.userAgent != "custom-agent/1.0" {
+		t.Errorf("UserAgent = %q, want %q", client.userAgent, "custom-agent/1.0")
+	}
+
+	// Test WithLospecCacheDir
+	client = NewLospecClient(
+		WithLospecCacheDir("/custom/cache"),
+	)
+	if client.cacheDir != "/custom/cache" {
+		t.Errorf("CacheDir = %q, want %q", client.cacheDir, "/custom/cache")
+	}
+}
+
+func TestSavePaletteToFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	outputPath := filepath.Join(tmpDir, "test-palette.toml")
+
+	p := NewPalette("Test Palette", VariantDark)
+	p.Homepage = "https://lospec.com/palette-list/test-palette.txt"
+	p.Description = "Test description"
+	p.Colors["color0"] = "#ff0000"
+	p.Colors["color1"] = "#00ff00"
+	p.Semantic["bg-primary"] = "color0"
+	p.Semantic["text-primary"] = "color1"
+
+	err := SavePaletteToFile(p, outputPath)
+	if err != nil {
+		t.Fatalf("SavePaletteToFile() error = %v", err)
+	}
+
+	// Verify file was created
+	if _, err := os.Stat(outputPath); os.IsNotExist(err) {
+		t.Fatal("Output file was not created")
+	}
+
+	// Read and verify content
+	content, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("Failed to read output file: %v", err)
+	}
+
+	// Verify key content
+	contentStr := string(content)
+	if !strings.Contains(contentStr, `name = "Test Palette"`) {
+		t.Error("Output missing palette name")
+	}
+	if !strings.Contains(contentStr, `variant = "dark"`) {
+		t.Error("Output missing variant")
+	}
+	if !strings.Contains(contentStr, `color0 = "#ff0000"`) {
+		t.Error("Output missing color0")
+	}
+	if !strings.Contains(contentStr, `bg-primary = "color0"`) {
+		t.Error("Output missing bg-primary semantic")
+	}
+
+	// Try to load it back
+	loaded, err := LoadFromFile(outputPath)
+	if err != nil {
+		t.Fatalf("LoadFromFile() error = %v", err)
+	}
+
+	if loaded.Name != p.Name {
+		t.Errorf("Loaded Name = %q, want %q", loaded.Name, p.Name)
+	}
+	if loaded.Variant != p.Variant {
+		t.Errorf("Loaded Variant = %q, want %q", loaded.Variant, p.Variant)
+	}
+}
+
+func TestGetUserPalettesDir(t *testing.T) {
+	dir, err := GetUserPalettesDir()
+	if err != nil {
+		t.Fatalf("GetUserPalettesDir() error = %v", err)
+	}
+
+	if dir == "" {
+		t.Error("GetUserPalettesDir() returned empty string")
+	}
+
+	// Should contain markata-go/palettes
+	if !strings.Contains(dir, "markata-go") {
+		t.Errorf("GetUserPalettesDir() = %q, should contain 'markata-go'", dir)
+	}
+	if !strings.Contains(dir, "palettes") {
+		t.Errorf("GetUserPalettesDir() = %q, should contain 'palettes'", dir)
+	}
+}
+
+func TestParseLospecURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "valid HTTPS URL",
+			url:     "https://lospec.com/palette-list/cheese-palette.txt",
+			want:    "https://lospec.com/palette-list/cheese-palette.txt",
+			wantErr: false,
+		},
+		{
+			name:    "invalid domain",
+			url:     "https://example.com/palette-list/test.txt",
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "invalid path",
+			url:     "https://lospec.com/other/test.txt",
+			want:    "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseLospecURL(tt.url)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseLospecURL(%q) error = %v, wantErr %v", tt.url, err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ParseLospecURL(%q) = %q, want %q", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHexToRGB(t *testing.T) {
+	tests := []struct {
+		hex     string
+		r, g, b uint8
+	}{
+		{"#ff0000", 255, 0, 0},
+		{"#00ff00", 0, 255, 0},
+		{"#0000ff", 0, 0, 255},
+		{"#ffffff", 255, 255, 255},
+		{"#000000", 0, 0, 0},
+		{"#f00", 255, 0, 0},   // Short form
+		{"ff0000", 255, 0, 0}, // Without hash
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.hex, func(t *testing.T) {
+			r, g, b := hexToRGB(tt.hex)
+			if r != tt.r || g != tt.g || b != tt.b {
+				t.Errorf("hexToRGB(%q) = (%d, %d, %d), want (%d, %d, %d)",
+					tt.hex, r, g, b, tt.r, tt.g, tt.b)
+			}
+		})
+	}
+}
+
+func TestSaturation(t *testing.T) {
+	tests := []struct {
+		hex  string
+		want float64
+	}{
+		{"#ff0000", 1.0}, // Full red, fully saturated
+		{"#00ff00", 1.0}, // Full green, fully saturated
+		{"#0000ff", 1.0}, // Full blue, fully saturated
+		{"#ffffff", 0.0}, // White, no saturation
+		{"#000000", 0.0}, // Black, no saturation
+		{"#808080", 0.0}, // Gray, no saturation
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.hex, func(t *testing.T) {
+			got := saturation(tt.hex)
+			if got != tt.want {
+				t.Errorf("saturation(%q) = %v, want %v", tt.hex, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRelativeLuminance(t *testing.T) {
+	// Just verify that white is brighter than black
+	whiteLum := relativeLuminance("#ffffff")
+	blackLum := relativeLuminance("#000000")
+
+	if whiteLum <= blackLum {
+		t.Errorf("White luminance (%v) should be greater than black (%v)", whiteLum, blackLum)
+	}
+
+	// White should be close to 1.0
+	if whiteLum < 0.9 {
+		t.Errorf("White luminance = %v, should be close to 1.0", whiteLum)
+	}
+
+	// Black should be close to 0.0
+	if blackLum > 0.1 {
+		t.Errorf("Black luminance = %v, should be close to 0.0", blackLum)
+	}
+}
+
+func TestLospecFetchError(t *testing.T) {
+	// Test error with status code
+	err1 := NewLospecFetchError("https://lospec.com/test", 404, "not found", nil)
+	if !strings.Contains(err1.Error(), "404") {
+		t.Errorf("Error message should contain status code: %s", err1.Error())
+	}
+
+	// Test error without status code
+	err2 := NewLospecFetchError("https://lospec.com/test", 0, "connection failed", nil)
+	if strings.Contains(err2.Error(), "HTTP 0") {
+		t.Errorf("Error message should not contain 'HTTP 0': %s", err2.Error())
+	}
+
+	// Test Unwrap
+	underlying := ErrLospecFetchFailed
+	err3 := NewLospecFetchError("test", 500, "error", underlying)
+	if !errors.Is(err3.Unwrap(), underlying) {
+		t.Error("Unwrap should return underlying error")
+	}
+}


### PR DESCRIPTION
## Summary

- Add support for fetching and importing color palettes directly from Lospec.com URLs
- New `palette fetch` CLI command for downloading and converting palettes
- Automatic semantic color mapping based on luminance analysis

## Changes

- **pkg/palettes/lospec.go** - Lospec client with URL validation, HTTP fetching, Paint.NET palette parsing, semantic mapping generation, and local caching
- **pkg/palettes/lospec_test.go** - Comprehensive test coverage
- **cmd/markata-go/cmd/palette.go** - New `palette fetch` subcommand with `--name` and `--output` flags
- **docs/guides/themes.md** - Documentation for the new command

## Usage

```bash
# Fetch a palette from Lospec
markata-go palette fetch https://lospec.com/palette-list/sweetie-16.txt

# With custom name
markata-go palette fetch https://lospec.com/palette-list/cheese-palette.txt --name "My Cheese"

# To custom output directory
markata-go palette fetch https://lospec.com/palette-list/pico-8.txt --output ./my-palettes
```

## Testing

All tests pass:
```
go test ./pkg/palettes/... -v
```

Fixes #635