### PR TITLE
fix: rename tags variable to tag_list in tags listing page

### DIFF
--- a/pkg/plugins/tags_listing.go
+++ b/pkg/plugins/tags_listing.go
@@ -202,7 +202,7 @@ func (p *TagsListingPlugin) renderTagsPage(config *lifecycle.Config, tagsConfig 
 	}
 
 	ctx := templates.NewContext(syntheticPost, "", modelsConfig)
-	ctx.Extra["tags"] = tagInfos
+	ctx.Extra["tag_list"] = tagInfos
 	ctx.Extra["total_tags"] = len(tagInfos)
 
 	// Render template

--- a/pkg/themes/default/templates/tags.html
+++ b/pkg/themes/default/templates/tags.html
@@ -11,9 +11,9 @@
     <p class="tags-count">{{ total_tags }} tag{{ total_tags|pluralize }} found</p>
   </header>
 
-  {% if tags %}
+  {% if tag_list %}
   <div class="tags-cloud">
-    {% for tag in tags %}
+    {% for tag in tag_list %}
     <a href="{{ tag.Href }}" class="tag-item" data-count="{{ tag.Count }}">
       <span class="tag-name">{{ tag.Name }}</span>
       <span class="tag-count">({{ tag.Count }})</span>
@@ -30,7 +30,7 @@
         </tr>
       </thead>
       <tbody>
-        {% for tag in tags %}
+        {% for tag in tag_list %}
         <tr>
           <td><a href="{{ tag.Href }}">{{ tag.Name }}</a></td>
           <td class="count">{{ tag.Count }}</td>


### PR DESCRIPTION
## Summary
- Fixes variable name collision in the tags listing page template context
- Renames `tags` to `tag_list` to avoid collision with post's empty tags array

## Problem
The `/tags/` page shows "No tags found" despite having the correct `total_tags` count because:
1. The synthetic post created for the tags page has no tags (empty array)
2. `ToPongo2()` sets `ctx["tags"]` from the post's tags before processing Extra values
3. Extra values don't override existing keys, so `ctx.Extra["tags"]` (the actual tag list) is ignored

## Solution
Rename the variable from `tags` to `tag_list` to avoid the collision. This is the safer option that doesn't risk breaking templates relying on `tags` being the post's tags.

## Changes
- `pkg/plugins/tags_listing.go`: `ctx.Extra["tags"]` -> `ctx.Extra["tag_list"]`
- `pkg/themes/default/templates/tags.html`: Updated all `tags` references to `tag_list`

Fixes #639