### PR TITLE
feat(websub): advertise hub discovery links

### DIFF
--- a/cmd/markata-go/cmd/benchmark.go
+++ b/cmd/markata-go/cmd/benchmark.go
@@ -400,6 +400,7 @@ func createBenchmarkManager(cfgPath, workDir string) (*lifecycle.Manager, error)
 	lcConfig.Extra["nav"] = cfg.Nav
 	lcConfig.Extra["footer"] = cfg.Footer
 	lcConfig.Extra["post_formats"] = cfg.PostFormats
+	lcConfig.Extra["websub"] = cfg.WebSub
 	lcConfig.Extra["well_known"] = cfg.WellKnown
 	lcConfig.Extra["theme"] = map[string]interface{}{
 		"name":       cfg.Theme.Name,

--- a/cmd/markata-go/cmd/core.go
+++ b/cmd/markata-go/cmd/core.go
@@ -63,6 +63,7 @@ func createManager(cfgPath string) (*lifecycle.Manager, error) {
 	lcConfig.Extra["nav"] = cfg.Nav
 	lcConfig.Extra["footer"] = cfg.Footer
 	lcConfig.Extra["post_formats"] = cfg.PostFormats
+	lcConfig.Extra["websub"] = cfg.WebSub
 	lcConfig.Extra["well_known"] = cfg.WellKnown
 	lcConfig.Extra["seo"] = cfg.SEO
 	lcConfig.Extra["search"] = cfg.Search

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -468,6 +468,25 @@ When enabled, this adds the following link tag to your site's `<head>`:
 - [webmention.io](https://webmention.io/) - Free hosted webmention service
 - [Bridgy](https://brid.gy/) - Connects social media interactions to webmentions
 
+### WebSub Settings (`[markata-go.websub]`)
+
+[WebSub](https://www.w3.org/TR/websub/) enables near-real-time feed delivery by advertising hub URLs. When enabled, markata-go adds discovery links to HTML pages and RSS/Atom feeds.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `false` | Enable WebSub discovery links |
+| `hubs` | array | `[]` | List of WebSub hub URLs |
+
+```toml
+[markata-go.websub]
+enabled = true
+hubs = ["https://hub.example.com/"]
+```
+
+**Output:**
+- HTML `<head>` includes `<link rel="hub" href="...">` for each hub
+- RSS/Atom feeds include `rel="hub"` and `rel="self"` links
+
 ### Head Configuration (`[markata-go.head]`)
 
 The head configuration allows you to customize elements in the HTML `<head>` section, including custom meta tags, links, scripts, and feed alternate links.

--- a/docs/guides/feeds.md
+++ b/docs/guides/feeds.md
@@ -989,6 +989,18 @@ Add `<link>` tags in your base template for feed autodiscovery:
 </head>
 ```
 
+### WebSub Discovery
+
+If you enable WebSub, markata-go also emits hub discovery links:
+
+```html
+<head>
+  <link rel="hub" href="https://hub.example.com/">
+</head>
+```
+
+RSS/Atom feeds include `rel="hub"` and `rel="self"` links when WebSub is enabled.
+
 ## Configuration Reference
 
 ### Feed Config Fields

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -25,5 +25,6 @@ func DefaultConfig() *models.Config {
 			},
 		},
 		WellKnown: models.NewWellKnownConfig(),
+		WebSub:    models.NewWebSubConfig(),
 	}
 }

--- a/pkg/config/merge.go
+++ b/pkg/config/merge.go
@@ -75,6 +75,9 @@ func MergeConfigs(base, override *models.Config) *models.Config {
 	// PostFormats - merge if override has any formats enabled
 	result.PostFormats = mergePostFormatsConfig(base.PostFormats, override.PostFormats)
 
+	// WebSub - merge
+	result.WebSub = mergeWebSubConfig(base.WebSub, override.WebSub)
+
 	// WellKnown - merge
 	result.WellKnown = mergeWellKnownConfig(base.WellKnown, override.WellKnown)
 
@@ -263,6 +266,20 @@ func mergePostFormatsConfig(base, override models.PostFormatsConfig) models.Post
 	}
 	if override.OG {
 		result.OG = true
+	}
+
+	return result
+}
+
+// mergeWebSubConfig merges WebSubConfig values.
+func mergeWebSubConfig(base, override models.WebSubConfig) models.WebSubConfig {
+	result := base
+
+	if override.Enabled != nil {
+		result.Enabled = override.Enabled
+	}
+	if override.Hubs != nil {
+		result.Hubs = append([]string{}, override.Hubs...)
 	}
 
 	return result

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -30,6 +30,7 @@ type configSource interface {
 	getTags() tagsConverter
 	getEncryption() encryptionConverter
 	getTagAggregator() tagAggregatorConverter
+	getWebSub() webSubConverter
 }
 
 // baseConfigData holds the basic config fields that are directly assignable.
@@ -123,6 +124,10 @@ type tagAggregatorConverter interface {
 	toTagAggregatorConfig() models.TagAggregatorConfig
 }
 
+type webSubConverter interface {
+	toWebSubConfig() models.WebSubConfig
+}
+
 // buildConfig constructs a models.Config from a configSource.
 // This helper eliminates code duplication across TOML, YAML, and JSON config converters.
 func buildConfig(src configSource) *models.Config {
@@ -209,6 +214,9 @@ func buildConfig(src configSource) *models.Config {
 	// Convert TagAggregator config
 	config.TagAggregator = src.getTagAggregator().toTagAggregatorConfig()
 
+	// Convert WebSub config
+	config.WebSub = src.getWebSub().toWebSubConfig()
+
 	return config
 }
 
@@ -253,7 +261,7 @@ func ParseTOML(data []byte) (*models.Config, error) {
 			"default_templates": true, "auto_feeds": true, "head": true,
 			"content_templates": true, "footer_layout": true, "search": true,
 			"plugins": true, "thoughts": true, "wikilinks": true, "tags": true,
-			"tag_aggregator": true,
+			"tag_aggregator": true, "websub": true,
 		}
 
 		// Copy unknown sections to Extra
@@ -330,6 +338,7 @@ type tomlConfig struct {
 	Tags          tomlTagsConfig          `toml:"tags"`
 	Encryption    tomlEncryptionConfig    `toml:"encryption"`
 	TagAggregator tomlTagAggregatorConfig `toml:"tag_aggregator"`
+	WebSub        tomlWebSubConfig        `toml:"websub"`
 	UnknownFields map[string]any          `toml:"-"`
 }
 
@@ -544,6 +553,26 @@ func (t *tomlTagAggregatorConfig) toTagAggregatorConfig() models.TagAggregatorCo
 		config.Enabled = defaults.Enabled
 	}
 
+	return config
+}
+
+type tomlWebSubConfig struct {
+	Enabled *bool    `toml:"enabled"`
+	Hubs    []string `toml:"hubs"`
+}
+
+func (w *tomlWebSubConfig) toWebSubConfig() models.WebSubConfig {
+	defaults := models.NewWebSubConfig()
+	config := models.WebSubConfig{
+		Enabled: w.Enabled,
+		Hubs:    w.Hubs,
+	}
+	if config.Enabled == nil {
+		config.Enabled = defaults.Enabled
+	}
+	if config.Hubs == nil {
+		config.Hubs = defaults.Hubs
+	}
 	return config
 }
 
@@ -1134,6 +1163,7 @@ func (c *tomlConfig) getBlogroll() blogrollConverter           { return &c.Blogr
 func (c *tomlConfig) getTags() tagsConverter                   { return &c.Tags }
 func (c *tomlConfig) getEncryption() encryptionConverter       { return &c.Encryption }
 func (c *tomlConfig) getTagAggregator() tagAggregatorConverter { return &c.TagAggregator }
+func (c *tomlConfig) getWebSub() webSubConverter               { return &c.WebSub }
 
 func (c *tomlConfig) toConfig() *models.Config {
 	return buildConfig(c)
@@ -1308,6 +1338,7 @@ type yamlConfig struct {
 	Tags          yamlTagsConfig          `yaml:"tags"`
 	Encryption    yamlEncryptionConfig    `yaml:"encryption"`
 	TagAggregator yamlTagAggregatorConfig `yaml:"tag_aggregator"`
+	WebSub        yamlWebSubConfig        `yaml:"websub"`
 }
 
 type yamlNavItem struct {
@@ -1487,6 +1518,26 @@ func (t *yamlTagAggregatorConfig) toTagAggregatorConfig() models.TagAggregatorCo
 		config.Enabled = defaults.Enabled
 	}
 
+	return config
+}
+
+type yamlWebSubConfig struct {
+	Enabled *bool    `yaml:"enabled"`
+	Hubs    []string `yaml:"hubs"`
+}
+
+func (w *yamlWebSubConfig) toWebSubConfig() models.WebSubConfig {
+	defaults := models.NewWebSubConfig()
+	config := models.WebSubConfig{
+		Enabled: w.Enabled,
+		Hubs:    w.Hubs,
+	}
+	if config.Enabled == nil {
+		config.Enabled = defaults.Enabled
+	}
+	if config.Hubs == nil {
+		config.Hubs = defaults.Hubs
+	}
 	return config
 }
 
@@ -2163,6 +2214,7 @@ func (c *yamlConfig) getBlogroll() blogrollConverter           { return &c.Blogr
 func (c *yamlConfig) getTags() tagsConverter                   { return &c.Tags }
 func (c *yamlConfig) getEncryption() encryptionConverter       { return &c.Encryption }
 func (c *yamlConfig) getTagAggregator() tagAggregatorConverter { return &c.TagAggregator }
+func (c *yamlConfig) getWebSub() webSubConverter               { return &c.WebSub }
 
 func (c *yamlConfig) toConfig() *models.Config {
 	return buildConfig(c)
@@ -2275,6 +2327,7 @@ type jsonConfig struct {
 	Tags          jsonTagsConfig          `json:"tags"`
 	Encryption    jsonEncryptionConfig    `json:"encryption"`
 	TagAggregator jsonTagAggregatorConfig `json:"tag_aggregator"`
+	WebSub        jsonWebSubConfig        `json:"websub"`
 }
 
 type jsonNavItem struct {
@@ -2454,6 +2507,26 @@ func (t *jsonTagAggregatorConfig) toTagAggregatorConfig() models.TagAggregatorCo
 		config.Enabled = defaults.Enabled
 	}
 
+	return config
+}
+
+type jsonWebSubConfig struct {
+	Enabled *bool    `json:"enabled"`
+	Hubs    []string `json:"hubs"`
+}
+
+func (w *jsonWebSubConfig) toWebSubConfig() models.WebSubConfig {
+	defaults := models.NewWebSubConfig()
+	config := models.WebSubConfig{
+		Enabled: w.Enabled,
+		Hubs:    w.Hubs,
+	}
+	if config.Enabled == nil {
+		config.Enabled = defaults.Enabled
+	}
+	if config.Hubs == nil {
+		config.Hubs = defaults.Hubs
+	}
 	return config
 }
 
@@ -3130,6 +3203,7 @@ func (c *jsonConfig) getBlogroll() blogrollConverter           { return &c.Blogr
 func (c *jsonConfig) getTags() tagsConverter                   { return &c.Tags }
 func (c *jsonConfig) getEncryption() encryptionConverter       { return &c.Encryption }
 func (c *jsonConfig) getTagAggregator() tagAggregatorConverter { return &c.TagAggregator }
+func (c *jsonConfig) getWebSub() webSubConverter               { return &c.WebSub }
 
 func (c *jsonConfig) toConfig() *models.Config {
 	return buildConfig(c)

--- a/pkg/config/parser_test.go
+++ b/pkg/config/parser_test.go
@@ -68,6 +68,29 @@ keybase_username = "alice"
 	}
 }
 
+func TestParseTOML_WebSub(t *testing.T) {
+	data := []byte(`
+[markata-go]
+title = "Test Site"
+
+[markata-go.websub]
+enabled = true
+hubs = ["https://hub.example.com/"]
+`)
+
+	config, err := ParseTOML(data)
+	if err != nil {
+		t.Fatalf("ParseTOML() error = %v", err)
+	}
+
+	if config.WebSub.Enabled == nil || *config.WebSub.Enabled != true {
+		t.Fatalf("WebSub.Enabled = %v, want true", config.WebSub.Enabled)
+	}
+	if len(config.WebSub.Hubs) != 1 || config.WebSub.Hubs[0] != "https://hub.example.com/" {
+		t.Fatalf("WebSub.Hubs = %v, want hub list", config.WebSub.Hubs)
+	}
+}
+
 func TestParseTOML_InvalidSyntax(t *testing.T) {
 	data := []byte(`invalid toml {{{{ syntax`)
 

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -344,6 +344,9 @@ type Config struct {
 	// Webmention configures Webmention endpoint for receiving mentions
 	Webmention WebmentionConfig `json:"webmention" yaml:"webmention" toml:"webmention"`
 
+	// WebSub configures WebSub discovery links for feeds
+	WebSub WebSubConfig `json:"websub" yaml:"websub" toml:"websub"`
+
 	// Components configures layout components (nav, footer, sidebar)
 	Components ComponentsConfig `json:"components" yaml:"components" toml:"components"`
 
@@ -1289,6 +1292,39 @@ func NewWebmentionConfig() WebmentionConfig {
 		Enabled:  false,
 		Endpoint: "",
 	}
+}
+
+// WebSubConfig configures WebSub discovery links for feeds.
+// See https://www.w3.org/TR/websub/ for the specification.
+type WebSubConfig struct {
+	// Enabled controls whether WebSub discovery links are included (default: false)
+	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty" toml:"enabled,omitempty"`
+
+	// Hubs is the list of WebSub hub URLs to advertise
+	Hubs []string `json:"hubs,omitempty" yaml:"hubs,omitempty" toml:"hubs,omitempty"`
+}
+
+// NewWebSubConfig creates a new WebSubConfig with default values.
+func NewWebSubConfig() WebSubConfig {
+	enabled := false
+	return WebSubConfig{
+		Enabled: &enabled,
+		Hubs:    []string{},
+	}
+}
+
+// IsEnabled returns whether WebSub discovery links are enabled.
+// Defaults to false if not explicitly set.
+func (w WebSubConfig) IsEnabled() bool {
+	if w.Enabled == nil {
+		return false
+	}
+	return *w.Enabled
+}
+
+// HubsList returns a copy of configured hub URLs.
+func (w WebSubConfig) HubsList() []string {
+	return append([]string{}, w.Hubs...)
 }
 
 // WebMentionsConfig configures the webmentions plugin for sending outgoing mentions.
@@ -2263,6 +2299,7 @@ func NewConfig() *Config {
 		SEO:              NewSEOConfig(),
 		IndieAuth:        NewIndieAuthConfig(),
 		Webmention:       NewWebmentionConfig(),
+		WebSub:           NewWebSubConfig(),
 		Components:       NewComponentsConfig(),
 		Search:           NewSearchConfig(),
 		Layout:           NewLayoutConfig(),

--- a/pkg/plugins/atom.go
+++ b/pkg/plugins/atom.go
@@ -95,6 +95,10 @@ func GenerateAtom(feed *lifecycle.Feed, config *lifecycle.Config) (string, error
 		Entries: make([]AtomEntry, 0, len(feed.Posts)),
 	}
 
+	for _, hub := range getWebSubHubs(config) {
+		atomFeed.Links = append(atomFeed.Links, AtomFeedLink{Href: hub, Rel: "hub"})
+	}
+
 	if updatedTime != nil {
 		atomFeed.Updated = updatedTime.Format(time.RFC3339)
 	}

--- a/pkg/plugins/templates.go
+++ b/pkg/plugins/templates.go
@@ -650,6 +650,11 @@ func toModelsConfigUncached(config *lifecycle.Config) *models.Config {
 		modelsConfig.PostFormats = postFormats
 	}
 
+	// Copy WebSub config if available
+	if websub, ok := config.Extra["websub"].(models.WebSubConfig); ok {
+		modelsConfig.WebSub = websub
+	}
+
 	// Copy Head config if available
 	if head, ok := config.Extra["head"].(models.HeadConfig); ok {
 		modelsConfig.Head = head

--- a/pkg/plugins/websub.go
+++ b/pkg/plugins/websub.go
@@ -1,0 +1,34 @@
+package plugins
+
+import (
+	"strings"
+
+	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
+	"github.com/WaylonWalker/markata-go/pkg/models"
+)
+
+func getWebSubConfig(config *lifecycle.Config) models.WebSubConfig {
+	if config != nil && config.Extra != nil {
+		if ws, ok := config.Extra["websub"].(models.WebSubConfig); ok {
+			return ws
+		}
+	}
+	return models.NewWebSubConfig()
+}
+
+func getWebSubHubs(config *lifecycle.Config) []string {
+	websub := getWebSubConfig(config)
+	if !websub.IsEnabled() {
+		return nil
+	}
+
+	hubs := make([]string, 0, len(websub.Hubs))
+	for _, hub := range websub.Hubs {
+		trimmed := strings.TrimSpace(hub)
+		if trimmed == "" {
+			continue
+		}
+		hubs = append(hubs, trimmed)
+	}
+	return hubs
+}

--- a/pkg/plugins/websub_discovery_test.go
+++ b/pkg/plugins/websub_discovery_test.go
@@ -1,0 +1,63 @@
+package plugins
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
+	"github.com/WaylonWalker/markata-go/pkg/models"
+)
+
+func TestGenerateRSS_WebSubDiscovery(t *testing.T) {
+	config := &lifecycle.Config{
+		Extra: map[string]interface{}{
+			"url": "https://example.com",
+			"websub": models.WebSubConfig{
+				Enabled: webSubBoolPtr(true),
+				Hubs:    []string{"https://hub.example.com/"},
+			},
+		},
+	}
+	feed := &lifecycle.Feed{Path: "blog", Posts: []*models.Post{}}
+
+	rss, err := GenerateRSS(feed, config)
+	if err != nil {
+		t.Fatalf("GenerateRSS() error = %v", err)
+	}
+
+	if !strings.Contains(rss, "rel=\"hub\"") {
+		t.Fatalf("expected rel=\"hub\" in RSS output")
+	}
+	if !strings.Contains(rss, "https://hub.example.com/") {
+		t.Fatalf("expected hub URL in RSS output")
+	}
+}
+
+func TestGenerateAtom_WebSubDiscovery(t *testing.T) {
+	config := &lifecycle.Config{
+		Extra: map[string]interface{}{
+			"url": "https://example.com",
+			"websub": models.WebSubConfig{
+				Enabled: webSubBoolPtr(true),
+				Hubs:    []string{"https://hub.example.com/"},
+			},
+		},
+	}
+	feed := &lifecycle.Feed{Path: "blog", Posts: []*models.Post{}}
+
+	atom, err := GenerateAtom(feed, config)
+	if err != nil {
+		t.Fatalf("GenerateAtom() error = %v", err)
+	}
+
+	if !strings.Contains(atom, "rel=\"hub\"") {
+		t.Fatalf("expected rel=\"hub\" in Atom output")
+	}
+	if !strings.Contains(atom, "https://hub.example.com/") {
+		t.Fatalf("expected hub URL in Atom output")
+	}
+}
+
+func webSubBoolPtr(value bool) *bool {
+	return &value
+}

--- a/pkg/templates/context.go
+++ b/pkg/templates/context.go
@@ -236,6 +236,9 @@ func configToMap(c *models.Config) map[string]interface{} {
 	// Convert search to map
 	searchMap := searchToMap(&c.Search)
 
+	// Convert WebSub to map
+	webSubMap := webSubToMap(&c.WebSub)
+
 	// Convert layout to map
 	layoutMap := layoutToMap(&c.Layout)
 
@@ -268,6 +271,7 @@ func configToMap(c *models.Config) map[string]interface{} {
 		"post_formats":  postFormatsMap,
 		"head":          headMap,
 		"search":        searchMap,
+		"websub":        webSubMap,
 		"layout":        layoutMap,
 		"sidebar":       sidebarMap,
 		"toc":           tocMap,
@@ -389,6 +393,23 @@ func postFormatsToMap(p *models.PostFormatsConfig) map[string]interface{} {
 		"markdown": p.Markdown,
 		"text":     p.Text,
 		"og":       p.OG,
+	}
+}
+
+// webSubToMap converts a WebSubConfig to a map for template access.
+func webSubToMap(w *models.WebSubConfig) map[string]interface{} {
+	if w == nil {
+		return nil
+	}
+
+	enabled := false
+	if w.Enabled != nil {
+		enabled = *w.Enabled
+	}
+
+	return map[string]interface{}{
+		"enabled": enabled,
+		"hubs":    append([]string{}, w.Hubs...),
 	}
 }
 

--- a/pkg/themes/default/templates/base.html
+++ b/pkg/themes/default/templates/base.html
@@ -81,6 +81,12 @@
   {% endif %}
 
   <!-- RSS/Atom/JSON Feeds -->
+  {% if config.websub.enabled and config.websub.hubs %}
+  <!-- WebSub Hubs -->
+  {% for hub in config.websub.hubs %}
+  <link rel="hub" href="{{ hub }}">
+  {% endfor %}
+  {% endif %}
   {% if config.head.alternate_feeds %}
   {% for feed in config.head.alternate_feeds %}
   <link rel="alternate" type="{{ feed.mime_type }}" title="{{ feed.title }}" href="{{ feed.href }}">

--- a/spec/spec/CONFIG.md
+++ b/spec/spec/CONFIG.md
@@ -752,6 +752,25 @@ This section controls auto-generated `.well-known` endpoints derived from site m
 
 ---
 
+### WebSub (`[my-ssg.websub]`)
+
+```toml
+[my-ssg.websub]
+enabled = true
+hubs = ["https://hub.example.com/"]
+```
+
+When enabled, markata-go emits WebSub discovery links:
+
+- HTML pages include `<link rel="hub" href="...">` for each hub
+- RSS/Atom feeds include `rel="hub"` and `rel="self"` links
+
+**Defaults:**
+- `enabled` defaults to `false`
+- `hubs` defaults to an empty list
+
+---
+
 ## See Also
 
 - [SPEC.md](./SPEC.md) - Core specification

--- a/spec/spec/FEEDS.md
+++ b/spec/spec/FEEDS.md
@@ -113,6 +113,15 @@ Feed timestamps are deterministic and based on content, not build time:
 
 This ensures no-change incremental builds produce identical feed outputs.
 
+### WebSub Discovery
+
+When WebSub is enabled, feed outputs include discovery links so hubs and subscribers can find the feed endpoint:
+
+- RSS includes `<atom:link rel="self">` plus one `<atom:link rel="hub">` per configured hub.
+- Atom includes `<link rel="self">` plus one `<link rel="hub">` per configured hub.
+
+HTML pages include `<link rel="hub">` tags in the `<head>` for each hub.
+
 ### Pagination Object
 
 | Field | Type | Description |

--- a/templates/base.html
+++ b/templates/base.html
@@ -83,6 +83,12 @@
   {% endif %}
 
   <!-- RSS/Atom/JSON Feeds -->
+  {% if config.websub.enabled and config.websub.hubs %}
+  <!-- WebSub Hubs -->
+  {% for hub in config.websub.hubs %}
+  <link rel="hub" href="{{ hub }}">
+  {% endfor %}
+  {% endif %}
   {% if config.head.alternate_feeds %}
   {% for feed in config.head.alternate_feeds %}
   <link rel="alternate" type="{{ feed.mime_type }}" title="{{ feed.title }}" href="{{ feed.href }}">


### PR DESCRIPTION
## Summary

Add WebSub (PubSubHubbub) discovery links for real-time feed updates. This is a replacement for PR #657 which had merge conflicts.

- Add `WebSubConfig` with `enabled` and `hubs` fields
- Add config parsing for TOML, YAML, and JSON formats  
- Add merge logic for WebSub configuration
- Add `<link rel="hub">` tags to HTML head (base.html templates)
- Add `rel="hub"` links to RSS and Atom feeds
- Update docs and spec with WebSub configuration

## Configuration

```toml
[markata-go.websub]
enabled = true
hubs = ["https://hub.example.com/"]
```

## Output

**HTML head:**
```html
<link rel="hub" href="https://hub.example.com/">
```

**RSS/Atom feeds:**
- RSS includes `<atom:link rel="hub" href="...">`
- Atom includes `<link rel="hub" href="...">`

Fixes #652
Supersedes #657