### PR TITLE
feat(templates): add Microformats2 h-entry/h-feed markup

### DIFF
--- a/docs/guides/templates.md
+++ b/docs/guides/templates.md
@@ -946,6 +946,83 @@ If a specified template doesn't exist, markata-go falls back to:
 
 ---
 
+## Microformats2 Support
+
+markata-go's default templates include [Microformats2](https://microformats.org/wiki/microformats2) markup for better interoperability with IndieWeb tools and feed readers.
+
+### h-entry on Posts
+
+Single post pages include `h-entry` markup on the `<article>` element:
+
+```html
+<article class="post h-entry">
+  <a class="u-url" href="https://example.com/my-post/" hidden></a>
+  <header>
+    <h1 class="p-name">Post Title</h1>
+    <time class="dt-published" datetime="2024-01-15T00:00:00Z">January 15, 2024</time>
+    <span class="p-author h-card" hidden>
+      <a class="u-url p-name" href="https://example.com">Author Name</a>
+    </span>
+  </header>
+  <div class="post-content e-content">
+    <!-- rendered content -->
+  </div>
+  <div class="tags">
+    <a class="p-category" href="/tags/topic/">topic</a>
+  </div>
+</article>
+```
+
+**Properties used:**
+- `h-entry` - Entry/post container
+- `p-name` - Post title
+- `u-url` - Canonical permalink
+- `dt-published` - Publication date
+- `e-content` - Entry content (HTML)
+- `p-summary` - Post description/excerpt
+- `p-category` - Tags/categories
+- `p-author h-card` - Author information
+
+### h-feed on Listings
+
+Feed and listing pages include `h-feed` markup:
+
+```html
+<div class="feed h-feed">
+  <h1 class="p-name">Blog Posts</h1>
+  <p class="p-summary">All blog posts</p>
+  <span class="p-author h-card" hidden>
+    <a class="u-url p-name" href="https://example.com">Site Author</a>
+  </span>
+
+  <!-- Each card is an h-entry -->
+  <article class="card h-entry">...</article>
+</div>
+```
+
+### Card Types
+
+All card templates include appropriate microformat classes:
+
+| Card Type | Key Classes |
+|-----------|-------------|
+| article-card | `h-entry`, `p-name`, `u-url`, `p-summary`, `dt-published`, `p-category` |
+| note-card | `h-entry`, `p-content`, `dt-published` |
+| photo-card | `h-entry`, `u-photo`, `u-video`, `p-name`, `p-summary` |
+| video-card | `h-entry`, `u-photo` (thumbnail), `p-name`, `p-summary` |
+| link-card | `h-entry`, `u-bookmark-of`, `p-name`, `p-summary` |
+| quote-card | `h-entry`, `e-content`, `h-cite` |
+| guide-card | `h-entry`, `p-name`, `u-url`, `p-summary` |
+| inline-card | `h-entry`, `e-content` |
+
+### Validation
+
+Test your microformats with:
+- [IndieWebify.me](https://indiewebify.me/) - Validate h-entry markup
+- [Pin13](https://pin13.net/mf2/) - Parse and view microformats
+
+---
+
 ## Tips and Best Practices
 
 1. **Always use `|safe` for HTML content** - When outputting rendered HTML (like `body` or `post.ArticleHTML`), use the `safe` filter to prevent double-escaping.

--- a/pkg/themes/default/templates/feed.html
+++ b/pkg/themes/default/templates/feed.html
@@ -15,12 +15,18 @@
 {% endblock %}
 
 {% block content %}
-<div class="feed">
+<div class="feed h-feed">
   {% if feed.title %}
   <header class="feed-header">
-    <h1>{{ feed.title }}</h1>
-    {% if feed.description %}<p>{{ feed.description }}</p>{% endif %}
+    <h1 class="p-name">{{ feed.title }}</h1>
+    {% if feed.description %}<p class="p-summary">{{ feed.description }}</p>{% endif %}
   </header>
+  {% endif %}
+  {# Author h-card for the feed (representative) #}
+  {% if config.author %}
+  <span class="p-author h-card" hidden>
+    <a class="u-url p-name" href="{{ config.url }}">{{ config.author }}</a>
+  </span>
   {% endif %}
 
   <div class="posts posts-list" id="posts-list">

--- a/pkg/themes/default/templates/partials/cards/article-card.html
+++ b/pkg/themes/default/templates/partials/cards/article-card.html
@@ -1,24 +1,24 @@
 {# Article Card - High prominence for blog posts, tutorials, essays #}
 {# Large title, excerpt, tags, reading time, generous padding #}
-<article class="card card-article">
+<article class="card card-article h-entry">
   <header class="card-header">
-    <h2 class="card-title"><a href="{{ post.href }}">{{ post.title | default:post.slug }}</a></h2>
+    <h2 class="card-title p-name"><a class="u-url" href="{{ post.href }}">{{ post.title | default:post.slug }}</a></h2>
   </header>
 
-  <div class="card-excerpt">
+  <div class="card-excerpt p-summary">
     {{ post.article_html | excerpt | safe }}
   </div>
 
   <footer class="card-meta">
     {% if post.date %}
-    <time datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
     {% endif %}
     {% if post.reading_time %}<span class="reading-time">{{ post.reading_time }} min read</span>{% endif %}
     {% include "partials/webmention-counts.html" %}
     {% if post.tags %}
     <div class="card-tags">
       {% for tag in post.tags %}
-      <span class="tag">{{ tag }}</span>
+      <span class="tag p-category">{{ tag }}</span>
       {% endfor %}
     </div>
     {% endif %}

--- a/pkg/themes/default/templates/partials/cards/default-card.html
+++ b/pkg/themes/default/templates/partials/cards/default-card.html
@@ -1,15 +1,15 @@
 {# Default Card - Fallback for unmapped templateKey values #}
 {# Basic card layout similar to original card.html #}
-<article class="card card-default">
-  <h2 class="card-title"><a href="{{ post.href }}">{{ post.title | default:post.slug }}</a></h2>
+<article class="card card-default h-entry">
+  <h2 class="card-title p-name"><a class="u-url" href="{{ post.href }}">{{ post.title | default:post.slug }}</a></h2>
 
   {% if post.description %}
-  <p class="card-description">{{ post.description }}</p>
+  <p class="card-description p-summary">{{ post.description }}</p>
   {% endif %}
 
   <footer class="card-meta">
     {% if post.date %}
-    <time datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
     {% endif %}
     {% if post.reading_time %}<span class="reading-time">{{ post.reading_time }} min</span>{% endif %}
     {% include "partials/webmention-counts.html" %}

--- a/pkg/themes/default/templates/partials/cards/guide-card.html
+++ b/pkg/themes/default/templates/partials/cards/guide-card.html
@@ -1,20 +1,20 @@
 {# Guide Card - Step/chapter indicator for guides, series, tutorials #}
 {# Shows step number (from forloop.counter), title, description #}
-<article class="card card-guide">
+<article class="card card-guide h-entry">
   <div class="card-step-indicator">
     <span class="step-number">{{ forloop.counter | default:"1" }}</span>
   </div>
 
   <div class="card-body">
-    <h3 class="card-title"><a href="{{ post.href }}">{{ post.title | default:post.slug }}</a></h3>
+    <h3 class="card-title p-name"><a class="u-url" href="{{ post.href }}">{{ post.title | default:post.slug }}</a></h3>
 
     {% if post.description %}
-    <p class="card-description">{{ post.description | truncatechars:200 }}</p>
+    <p class="card-description p-summary">{{ post.description | truncatechars:200 }}</p>
     {% endif %}
 
     <footer class="card-meta">
       {% if post.date %}
-      <time datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+      <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
       {% endif %}
       {% if post.reading_time %}<span class="reading-time">{{ post.reading_time }} min</span>{% endif %}
     </footer>

--- a/pkg/themes/default/templates/partials/cards/inline-card.html
+++ b/pkg/themes/default/templates/partials/cards/inline-card.html
@@ -1,13 +1,14 @@
 {# Inline Card - Full rendered content for gratitude, micro posts #}
 {# Minimal wrapper, displays full article_html content #}
-<article class="card card-inline">
-  <div class="card-content">
+<article class="card card-inline h-entry">
+  <a class="u-url" href="{{ post.href }}" hidden></a>
+  <div class="card-content e-content">
     {{ post.article_html | safe }}
   </div>
 
   <footer class="card-meta">
     {% if post.date %}
-    <time datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
     {% endif %}
     <a href="{{ post.href }}" class="card-permalink">Permalink</a>
   </footer>

--- a/pkg/themes/default/templates/partials/cards/link-card.html
+++ b/pkg/themes/default/templates/partials/cards/link-card.html
@@ -1,34 +1,36 @@
 {# Link Card - URL preview style for links, bookmarks, TIL posts #}
 {# Shows domain, title, description in preview card style #}
-<article class="card card-link">
-  <a href="{{ post.href }}" class="card-link-wrapper">
+<article class="card card-link h-entry">
+  <a href="{{ post.href }}" class="card-link-wrapper u-url">
     {% if post.image %}
     <div class="card-link-image">
-      <img src="{{ post.image }}" alt="" loading="lazy">
+      <img src="{{ post.image }}" alt="" class="u-photo" loading="lazy">
     </div>
     {% endif %}
 
     <div class="card-link-content">
       {% if post.url %}
       <span class="card-domain">{{ post.url | default:post.href }}</span>
+      {# Mark external URL as bookmark-of for IndieWeb #}
+      <data class="u-bookmark-of" value="{{ post.url }}" hidden></data>
       {% endif %}
 
-      <h3 class="card-title">{{ post.title | default:post.slug }}</h3>
+      <h3 class="card-title p-name">{{ post.title | default:post.slug }}</h3>
 
       {% if post.description %}
-      <p class="card-description">{{ post.description | truncatechars:120 }}</p>
+      <p class="card-description p-summary">{{ post.description | truncatechars:120 }}</p>
       {% endif %}
     </div>
   </a>
 
   <footer class="card-meta">
     {% if post.date %}
-    <time datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
     {% endif %}
     {% if post.tags %}
     <div class="card-tags">
       {% for tag in post.tags %}
-      <span class="tag">{{ tag }}</span>
+      <span class="tag p-category">{{ tag }}</span>
       {% endfor %}
     </div>
     {% endif %}

--- a/pkg/themes/default/templates/partials/cards/note-card.html
+++ b/pkg/themes/default/templates/partials/cards/note-card.html
@@ -1,17 +1,18 @@
 {# Note Card - Low prominence for pings, thoughts, status updates #}
 {# Minimal styling, left border accent, no title shown #}
-<article class="card card-note">
+<article class="card card-note h-entry">
+  <a class="u-url" href="{{ post.href }}" hidden></a>
   <div class="card-content">
     {% if post.description %}
-    <p class="card-text">{{ post.description }}</p>
+    <p class="card-text p-content">{{ post.description }}</p>
     {% elif post.article_html %}
-    <div class="card-text">{{ post.article_html | striptags | truncatechars:200 }}</div>
+    <div class="card-text p-content">{{ post.article_html | striptags | truncatechars:200 }}</div>
     {% endif %}
   </div>
 
   <footer class="card-meta">
     {% if post.date %}
-    <time datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
     {% endif %}
     {% include "partials/webmention-counts.html" %}
     <a href="{{ post.href }}" class="card-link">View</a>

--- a/pkg/themes/default/templates/partials/cards/photo-card.html
+++ b/pkg/themes/default/templates/partials/cards/photo-card.html
@@ -1,16 +1,16 @@
 {# Photo Card - Image/video prominent for shots, photos, gallery posts #}
 {# Large media with aspect-ratio, caption/description below #}
 {# Auto-detects video files by extension: .mp4, .webm, .mov, .m4v, .ogv #}
-<article class="card card-photo">
+<article class="card card-photo h-entry">
   {% if post.image %}
-  <a href="{{ post.href }}" class="card-image-link">
+  <a href="{{ post.href }}" class="card-image-link u-url">
     {% with post.image|lower as img_lower %}
     {% if img_lower|endswith:".mp4" or img_lower|endswith:".webm" or img_lower|endswith:".mov" or img_lower|endswith:".m4v" or img_lower|endswith:".ogv" %}
-    <video class="card-image" autoplay muted loop playsinline>
+    <video class="card-image u-video" autoplay muted loop playsinline>
       <source src="{{ post.image }}" type="video/{% if img_lower|endswith:".mp4" or img_lower|endswith:".m4v" %}mp4{% elif img_lower|endswith:".webm" %}webm{% elif img_lower|endswith:".mov" %}quicktime{% else %}ogg{% endif %}">
     </video>
     {% else %}
-    <img src="{{ post.image }}" alt="{{ post.title | default:post.description | default:'Photo' }}" class="card-image" loading="lazy">
+    <img src="{{ post.image }}" alt="{{ post.title | default:post.description | default:'Photo' }}" class="card-image u-photo" loading="lazy">
     {% endif %}
     {% endwith %}
   </a>
@@ -18,16 +18,16 @@
 
   <div class="card-body">
     {% if post.title %}
-    <h3 class="card-title"><a href="{{ post.href }}">{{ post.title }}</a></h3>
+    <h3 class="card-title p-name"><a href="{{ post.href }}">{{ post.title }}</a></h3>
     {% endif %}
 
     {% if post.description %}
-    <p class="card-caption">{{ post.description }}</p>
+    <p class="card-caption p-summary">{{ post.description }}</p>
     {% endif %}
 
     <footer class="card-meta">
       {% if post.date %}
-      <time datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+      <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
       {% endif %}
     </footer>
   </div>

--- a/pkg/themes/default/templates/partials/cards/quote-card.html
+++ b/pkg/themes/default/templates/partials/cards/quote-card.html
@@ -1,7 +1,8 @@
 {# Quote Card - Blockquote styling for quotes, quotations #}
 {# Large quote with source attribution #}
-<article class="card card-quote">
-  <blockquote class="card-blockquote">
+<article class="card card-quote h-entry">
+  <a class="u-url" href="{{ post.href }}" hidden></a>
+  <blockquote class="card-blockquote e-content">
     {% if post.quote %}
     <p>{{ post.quote }}</p>
     {% elif post.description %}
@@ -13,18 +14,18 @@
 
   <footer class="card-attribution">
     {% if post.source or post.author %}
-    <cite>
-      {% if post.author %}<span class="quote-author">{{ post.author }}</span>{% endif %}
-      {% if post.source %}<span class="quote-source">{{ post.source }}</span>{% endif %}
+    <cite class="h-cite">
+      {% if post.author %}<span class="quote-author p-author">{{ post.author }}</span>{% endif %}
+      {% if post.source %}<span class="quote-source p-name">{{ post.source }}</span>{% endif %}
     </cite>
     {% endif %}
 
     {% if post.title %}
-    <a href="{{ post.href }}" class="card-title-link">{{ post.title }}</a>
+    <a href="{{ post.href }}" class="card-title-link p-name">{{ post.title }}</a>
     {% endif %}
 
     {% if post.date %}
-    <time datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
     {% endif %}
   </footer>
 </article>

--- a/pkg/themes/default/templates/partials/cards/video-card.html
+++ b/pkg/themes/default/templates/partials/cards/video-card.html
@@ -1,10 +1,10 @@
 {# Video Card - Video/thumbnail prominent for video, clip, stream posts #}
 {# Video thumbnail with play indicator, title below #}
-<article class="card card-video">
+<article class="card card-video h-entry">
   {% if post.image or post.thumbnail %}
-  <a href="{{ post.href }}" class="card-video-link">
+  <a href="{{ post.href }}" class="card-video-link u-url">
     <div class="card-video-container">
-      <img src="{{ post.image | default:post.thumbnail }}" alt="{{ post.title | default:'Video thumbnail' }}" class="card-thumbnail" loading="lazy">
+      <img src="{{ post.image | default:post.thumbnail }}" alt="{{ post.title | default:'Video thumbnail' }}" class="card-thumbnail u-photo" loading="lazy">
       <div class="card-play-icon">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="48" height="48">
           <path d="M8 5v14l11-7z"/>
@@ -16,16 +16,16 @@
 
   <div class="card-body">
     {% if post.title %}
-    <h3 class="card-title"><a href="{{ post.href }}">{{ post.title }}</a></h3>
+    <h3 class="card-title p-name"><a href="{{ post.href }}">{{ post.title }}</a></h3>
     {% endif %}
 
     {% if post.description %}
-    <p class="card-description">{{ post.description | truncatechars:150 }}</p>
+    <p class="card-description p-summary">{{ post.description | truncatechars:150 }}</p>
     {% endif %}
 
     <footer class="card-meta">
       {% if post.date %}
-      <time datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+      <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
       {% endif %}
       {% if post.duration %}<span class="duration">{{ post.duration }}</span>{% endif %}
     </footer>

--- a/pkg/themes/default/templates/post.html
+++ b/pkg/themes/default/templates/post.html
@@ -56,21 +56,30 @@
 {% endblock %}
 
 {% block content %}
-<article class="post" data-pagefind-body>
+<article class="post h-entry" data-pagefind-body>
+  {# Hidden canonical URL for microformats parsers #}
+  <a class="u-url" href="{{ config.url }}{{ post.href }}" hidden></a>
+
   <header class="post-header">
-    <h1 data-pagefind-meta="title">{{ post.title }}</h1>
+    <h1 class="p-name" data-pagefind-meta="title">{{ post.title }}</h1>
     {% if post.description %}
-    <p class="post-description visually-hidden" data-pagefind-meta="excerpt">{{ post.description }}</p>
+    <p class="post-description p-summary visually-hidden" data-pagefind-meta="excerpt">{{ post.description }}</p>
     {% endif %}
     {% if post.date or post.reading_time %}
     <div class="post-meta">
-      {% if post.date %}<time datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>{% endif %}
+      {% if post.date %}<time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>{% endif %}
       {% if post.reading_time %}<span>{{ post.reading_time }} min read</span>{% endif %}
     </div>
     {% endif %}
+    {# Author h-card (representative) #}
+    {% if config.author %}
+    <span class="p-author h-card" hidden>
+      <a class="u-url p-name" href="{{ config.url }}">{{ config.author }}</a>
+    </span>
+    {% endif %}
   </header>
 
-  <div class="post-content{% if post.css_class %} {{ post.css_class }}{% endif %}">
+  <div class="post-content e-content{% if post.css_class %} {{ post.css_class }}{% endif %}">
     {{ body | safe }}
   </div>
 
@@ -78,7 +87,7 @@
   <footer class="post-footer">
     <div class="tags">
       {% for tag in post.tags %}
-      <a href="/tags/{{ tag | slugify }}/" class="tag" data-pagefind-filter="tag">{{ tag }}</a>
+      <a href="/tags/{{ tag | slugify }}/" class="tag p-category" data-pagefind-filter="tag">{{ tag }}</a>
       {% endfor %}
     </div>
   </footer>

--- a/spec/spec/TEMPLATES.md
+++ b/spec/spec/TEMPLATES.md
@@ -765,6 +765,64 @@ template_engine_compat:
 
 ---
 
+## Microformats2 Semantic Markup
+
+Default templates include Microformats2 classes for IndieWeb compatibility.
+
+### Post Pages (h-entry)
+
+Single post templates MUST include `h-entry` markup:
+
+```html
+<article class="post h-entry">
+  <a class="u-url" href="{{ config.url }}{{ post.href }}" hidden></a>
+  <h1 class="p-name">{{ post.title }}</h1>
+  <time class="dt-published" datetime="{{ post.date | atom_date }}">...</time>
+  <div class="post-content e-content">{{ body | safe }}</div>
+  {% for tag in post.tags %}
+  <a class="p-category" href="/tags/{{ tag | slugify }}/">{{ tag }}</a>
+  {% endfor %}
+  <span class="p-author h-card" hidden>
+    <a class="u-url p-name" href="{{ config.url }}">{{ config.author }}</a>
+  </span>
+</article>
+```
+
+### Feed Pages (h-feed)
+
+Feed/listing templates MUST include `h-feed` markup:
+
+```html
+<div class="feed h-feed">
+  <h1 class="p-name">{{ feed.title }}</h1>
+  <p class="p-summary">{{ feed.description }}</p>
+  <span class="p-author h-card" hidden>
+    <a class="u-url p-name" href="{{ config.url }}">{{ config.author }}</a>
+  </span>
+  {% for post in posts %}
+  <article class="card h-entry">...</article>
+  {% endfor %}
+</div>
+```
+
+### Required Microformat Classes
+
+| Class | Element | Description |
+|-------|---------|-------------|
+| `h-entry` | article | Entry container |
+| `p-name` | h1/h2 | Entry title |
+| `u-url` | a | Canonical permalink |
+| `dt-published` | time | Publication datetime |
+| `e-content` | div | Entry content (HTML) |
+| `p-summary` | p | Entry summary/excerpt |
+| `p-category` | a/span | Tags/categories |
+| `p-author h-card` | span | Author information |
+| `h-feed` | div | Feed container |
+| `u-photo` | img | Photo content |
+| `u-video` | video | Video content |
+
+---
+
 ## See Also
 
 - [SPEC.md](./SPEC.md) - Full specification

--- a/templates/feed.html
+++ b/templates/feed.html
@@ -15,11 +15,11 @@
 {% endblock %}
 
 {% block content %}
-<div class="feed{% if feed.type == 'guide' %} feed--guide{% elif feed.type == 'series' %} feed--series{% endif %}">
+<div class="feed h-feed{% if feed.type == 'guide' %} feed--guide{% elif feed.type == 'series' %} feed--series{% endif %}">
   <header class="feed-header">
-    <h1>{{ feed.title | default:"Posts" }}</h1>
+    <h1 class="p-name">{{ feed.title | default:"Posts" }}</h1>
     {% if feed.description %}
-    <p>{{ feed.description }}</p>
+    <p class="p-summary">{{ feed.description }}</p>
     {% endif %}
     {% if feed.type == "guide" or feed.type == "series" %}
     <div class="feed-meta">
@@ -27,6 +27,12 @@
     </div>
     {% endif %}
   </header>
+  {# Author h-card for the feed (representative) #}
+  {% if config.author %}
+  <span class="p-author h-card" hidden>
+    <a class="u-url p-name" href="{{ config.url }}">{{ config.author }}</a>
+  </span>
+  {% endif %}
 
   <div class="posts posts-list" id="posts-list">
     {% if page.pagination_type == "js" %}

--- a/templates/partials/cards/article-card.html
+++ b/templates/partials/cards/article-card.html
@@ -1,24 +1,24 @@
 {# Article Card - High prominence for blog posts, tutorials, essays #}
 {# Large title, excerpt, tags, reading time, generous padding #}
-<article class="card card-article">
+<article class="card card-article h-entry">
   <header class="card-header">
-    <h2 class="card-title"><a href="{{ post.href }}">{{ post.title | default:post.slug }}</a></h2>
+    <h2 class="card-title p-name"><a class="u-url" href="{{ post.href }}">{{ post.title | default:post.slug }}</a></h2>
   </header>
 
-  <div class="card-excerpt">
+  <div class="card-excerpt p-summary">
     {{ post.article_html | excerpt | safe }}
   </div>
 
   <footer class="card-meta">
     {% if post.date %}
-    <time datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
     {% endif %}
     {% if post.reading_time %}<span class="reading-time">{{ post.reading_time }} min read</span>{% endif %}
     {% include "partials/webmention-counts.html" %}
     {% if post.tags %}
     <div class="card-tags">
       {% for tag in post.tags %}
-      <span class="tag">{{ tag }}</span>
+      <span class="tag p-category">{{ tag }}</span>
       {% endfor %}
     </div>
     {% endif %}

--- a/templates/partials/cards/default-card.html
+++ b/templates/partials/cards/default-card.html
@@ -1,15 +1,15 @@
 {# Default Card - Fallback for unmapped templateKey values #}
 {# Basic card layout similar to original card.html #}
-<article class="card card-default">
-  <h2 class="card-title"><a href="{{ post.href }}">{{ post.title | default:post.slug }}</a></h2>
+<article class="card card-default h-entry">
+  <h2 class="card-title p-name"><a class="u-url" href="{{ post.href }}">{{ post.title | default:post.slug }}</a></h2>
 
   {% if post.description %}
-  <p class="card-description">{{ post.description }}</p>
+  <p class="card-description p-summary">{{ post.description }}</p>
   {% endif %}
 
   <footer class="card-meta">
     {% if post.date %}
-    <time datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
     {% endif %}
     {% if post.reading_time %}<span class="reading-time">{{ post.reading_time }} min</span>{% endif %}
     {% include "partials/webmention-counts.html" %}

--- a/templates/partials/cards/guide-card.html
+++ b/templates/partials/cards/guide-card.html
@@ -1,20 +1,20 @@
 {# Guide Card - Step/chapter indicator for guides, series, tutorials #}
 {# Shows step number (from forloop.counter), title, description #}
-<article class="card card-guide">
+<article class="card card-guide h-entry">
   <div class="card-step-indicator">
     <span class="step-number">{{ forloop.counter | default:"1" }}</span>
   </div>
 
   <div class="card-body">
-    <h3 class="card-title"><a href="{{ post.href }}">{{ post.title | default:post.slug }}</a></h3>
+    <h3 class="card-title p-name"><a class="u-url" href="{{ post.href }}">{{ post.title | default:post.slug }}</a></h3>
 
     {% if post.description %}
-    <p class="card-description">{{ post.description | truncatechars:200 }}</p>
+    <p class="card-description p-summary">{{ post.description | truncatechars:200 }}</p>
     {% endif %}
 
     <footer class="card-meta">
       {% if post.date %}
-      <time datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+      <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
       {% endif %}
       {% if post.reading_time %}<span class="reading-time">{{ post.reading_time }} min</span>{% endif %}
     </footer>

--- a/templates/partials/cards/inline-card.html
+++ b/templates/partials/cards/inline-card.html
@@ -1,13 +1,14 @@
 {# Inline Card - Full rendered content for gratitude, micro posts #}
 {# Minimal wrapper, displays full article_html content #}
-<article class="card card-inline">
-  <div class="card-content">
+<article class="card card-inline h-entry">
+  <a class="u-url" href="{{ post.href }}" hidden></a>
+  <div class="card-content e-content">
     {{ post.article_html | safe }}
   </div>
 
   <footer class="card-meta">
     {% if post.date %}
-    <time datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
     {% endif %}
     <a href="{{ post.href }}" class="card-permalink">Permalink</a>
   </footer>

--- a/templates/partials/cards/link-card.html
+++ b/templates/partials/cards/link-card.html
@@ -1,34 +1,36 @@
 {# Link Card - URL preview style for links, bookmarks, TIL posts #}
 {# Shows domain, title, description in preview card style #}
-<article class="card card-link">
-  <a href="{{ post.href }}" class="card-link-wrapper">
+<article class="card card-link h-entry">
+  <a href="{{ post.href }}" class="card-link-wrapper u-url">
     {% if post.image %}
     <div class="card-link-image">
-      <img src="{{ post.image }}" alt="" loading="lazy">
+      <img src="{{ post.image }}" alt="" class="u-photo" loading="lazy">
     </div>
     {% endif %}
 
     <div class="card-link-content">
       {% if post.url %}
       <span class="card-domain">{{ post.url | default:post.href }}</span>
+      {# Mark external URL as bookmark-of for IndieWeb #}
+      <data class="u-bookmark-of" value="{{ post.url }}" hidden></data>
       {% endif %}
 
-      <h3 class="card-title">{{ post.title | default:post.slug }}</h3>
+      <h3 class="card-title p-name">{{ post.title | default:post.slug }}</h3>
 
       {% if post.description %}
-      <p class="card-description">{{ post.description | truncatechars:120 }}</p>
+      <p class="card-description p-summary">{{ post.description | truncatechars:120 }}</p>
       {% endif %}
     </div>
   </a>
 
   <footer class="card-meta">
     {% if post.date %}
-    <time datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
     {% endif %}
     {% if post.tags %}
     <div class="card-tags">
       {% for tag in post.tags %}
-      <span class="tag">{{ tag }}</span>
+      <span class="tag p-category">{{ tag }}</span>
       {% endfor %}
     </div>
     {% endif %}

--- a/templates/partials/cards/note-card.html
+++ b/templates/partials/cards/note-card.html
@@ -1,17 +1,18 @@
 {# Note Card - Low prominence for pings, thoughts, status updates #}
 {# Minimal styling, left border accent, no title shown #}
-<article class="card card-note">
+<article class="card card-note h-entry">
+  <a class="u-url" href="{{ post.href }}" hidden></a>
   <div class="card-content">
     {% if post.description %}
-    <p class="card-text">{{ post.description }}</p>
+    <p class="card-text p-content">{{ post.description }}</p>
     {% elif post.article_html %}
-    <div class="card-text">{{ post.article_html | striptags | truncatechars:200 }}</div>
+    <div class="card-text p-content">{{ post.article_html | striptags | truncatechars:200 }}</div>
     {% endif %}
   </div>
 
   <footer class="card-meta">
     {% if post.date %}
-    <time datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
     {% endif %}
     {% include "partials/webmention-counts.html" %}
     <a href="{{ post.href }}" class="card-link">View</a>

--- a/templates/partials/cards/photo-card.html
+++ b/templates/partials/cards/photo-card.html
@@ -1,16 +1,16 @@
 {# Photo Card - Image/video prominent for shots, photos, gallery posts #}
 {# Large media with aspect-ratio, caption/description below #}
 {# Auto-detects video files by extension: .mp4, .webm, .mov, .m4v, .ogv #}
-<article class="card card-photo">
+<article class="card card-photo h-entry">
   {% if post.image %}
-  <a href="{{ post.href }}" class="card-image-link">
+  <a href="{{ post.href }}" class="card-image-link u-url">
     {% with post.image|lower as img_lower %}
     {% if img_lower|endswith:".mp4" or img_lower|endswith:".webm" or img_lower|endswith:".mov" or img_lower|endswith:".m4v" or img_lower|endswith:".ogv" %}
-    <video class="card-image" autoplay muted loop playsinline>
+    <video class="card-image u-video" autoplay muted loop playsinline>
       <source src="{{ post.image }}" type="video/{% if img_lower|endswith:".mp4" or img_lower|endswith:".m4v" %}mp4{% elif img_lower|endswith:".webm" %}webm{% elif img_lower|endswith:".mov" %}quicktime{% else %}ogg{% endif %}">
     </video>
     {% else %}
-    <img src="{{ post.image }}" alt="{{ post.title | default:post.description | default:'Photo' }}" class="card-image" loading="lazy">
+    <img src="{{ post.image }}" alt="{{ post.title | default:post.description | default:'Photo' }}" class="card-image u-photo" loading="lazy">
     {% endif %}
     {% endwith %}
   </a>
@@ -18,16 +18,16 @@
 
   <div class="card-body">
     {% if post.title %}
-    <h3 class="card-title"><a href="{{ post.href }}">{{ post.title }}</a></h3>
+    <h3 class="card-title p-name"><a href="{{ post.href }}">{{ post.title }}</a></h3>
     {% endif %}
 
     {% if post.description %}
-    <p class="card-caption">{{ post.description }}</p>
+    <p class="card-caption p-summary">{{ post.description }}</p>
     {% endif %}
 
     <footer class="card-meta">
       {% if post.date %}
-      <time datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+      <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
       {% endif %}
     </footer>
   </div>

--- a/templates/partials/cards/quote-card.html
+++ b/templates/partials/cards/quote-card.html
@@ -1,7 +1,8 @@
 {# Quote Card - Blockquote styling for quotes, quotations #}
 {# Large quote with source attribution #}
-<article class="card card-quote">
-  <blockquote class="card-blockquote">
+<article class="card card-quote h-entry">
+  <a class="u-url" href="{{ post.href }}" hidden></a>
+  <blockquote class="card-blockquote e-content">
     {% if post.quote %}
     <p>{{ post.quote }}</p>
     {% elif post.description %}
@@ -13,18 +14,18 @@
 
   <footer class="card-attribution">
     {% if post.source or post.author %}
-    <cite>
-      {% if post.author %}<span class="quote-author">{{ post.author }}</span>{% endif %}
-      {% if post.source %}<span class="quote-source">{{ post.source }}</span>{% endif %}
+    <cite class="h-cite">
+      {% if post.author %}<span class="quote-author p-author">{{ post.author }}</span>{% endif %}
+      {% if post.source %}<span class="quote-source p-name">{{ post.source }}</span>{% endif %}
     </cite>
     {% endif %}
 
     {% if post.title %}
-    <a href="{{ post.href }}" class="card-title-link">{{ post.title }}</a>
+    <a href="{{ post.href }}" class="card-title-link p-name">{{ post.title }}</a>
     {% endif %}
 
     {% if post.date %}
-    <time datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
     {% endif %}
   </footer>
 </article>

--- a/templates/partials/cards/video-card.html
+++ b/templates/partials/cards/video-card.html
@@ -1,10 +1,10 @@
 {# Video Card - Video/thumbnail prominent for video, clip, stream posts #}
 {# Video thumbnail with play indicator, title below #}
-<article class="card card-video">
+<article class="card card-video h-entry">
   {% if post.image or post.thumbnail %}
-  <a href="{{ post.href }}" class="card-video-link">
+  <a href="{{ post.href }}" class="card-video-link u-url">
     <div class="card-video-container">
-      <img src="{{ post.image | default:post.thumbnail }}" alt="{{ post.title | default:'Video thumbnail' }}" class="card-thumbnail" loading="lazy">
+      <img src="{{ post.image | default:post.thumbnail }}" alt="{{ post.title | default:'Video thumbnail' }}" class="card-thumbnail u-photo" loading="lazy">
       <div class="card-play-icon">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="48" height="48">
           <path d="M8 5v14l11-7z"/>
@@ -16,16 +16,16 @@
 
   <div class="card-body">
     {% if post.title %}
-    <h3 class="card-title"><a href="{{ post.href }}">{{ post.title }}</a></h3>
+    <h3 class="card-title p-name"><a href="{{ post.href }}">{{ post.title }}</a></h3>
     {% endif %}
 
     {% if post.description %}
-    <p class="card-description">{{ post.description | truncatechars:150 }}</p>
+    <p class="card-description p-summary">{{ post.description | truncatechars:150 }}</p>
     {% endif %}
 
     <footer class="card-meta">
       {% if post.date %}
-      <time datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+      <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
       {% endif %}
       {% if post.duration %}<span class="duration">{{ post.duration }}</span>{% endif %}
     </footer>

--- a/templates/post.html
+++ b/templates/post.html
@@ -1,19 +1,70 @@
 {% extends "base.html" %}
-{% extends "base.html" %}
 
-{% block title %}{{ post.title }} | {{ config.title | default:"My Site" }}{% endblock %}
-{% block description %}{{ post.description | default:"" }}{% endblock %}
+{% block title %}{{ post.title }} | {{ config.title | default:'My Site' }}{% endblock %}
+{% block description %}{{ post.description | default:'' }}{% endblock %}
 
-{% block title %}{{ post.title | default:config.title | default:'My Site' }}{% endblock %}
-{% block description %}{{ post.description | default:config.description | default:'' }}{% endblock %}
+{% block meta %}
+{{ block.Super() }}
+{# Canonical URL for SEO #}
+<link rel="canonical" href="{{ config.url }}{{ post.href }}">
+
+{# Alternate format links #}
+{% if config.post_formats.markdown %}
+<link rel="alternate" type="text/markdown" title="Markdown Source" href="/{{ post.slug }}.md">
+{% endif %}
+{% if config.post_formats.text %}
+<link rel="alternate" type="text/plain" title="Plain Text" href="/{{ post.slug }}.txt">
+{% endif %}
+{% if config.post_formats.og %}
+<link rel="alternate" type="text/html" title="Social Card" href="{{ post.href }}og/">
+{% endif %}
+
+{# Structured Data: JSON-LD #}
+{% if post.structured_data.jsonld %}
+<script type="application/ld+json">
+{{ post.structured_data.jsonld | safe }}
+</script>
+{% endif %}
+
+{# Structured Data: OpenGraph meta tags #}
+{% if post.structured_data.opengraph %}
+{% for meta in post.structured_data.opengraph %}
+<meta property="{{ meta.property }}" content="{{ meta.content }}">
+{% endfor %}
+{% else %}
+{# Fallback to basic OG tags if no structured data #}
+<meta property="og:title" content="{{ post.title }}">
+<meta property="og:type" content="article">
+<meta property="og:url" content="{{ config.url }}{{ post.href }}">
+{% if post.description %}
+<meta property="og:description" content="{{ post.description }}">
+{% endif %}
+{% if post.date %}
+<meta property="article:published_time" content="{{ post.date | atom_date }}">
+{% endif %}
+{% if config.post_formats.og %}
+<meta property="og:image" content="{{ config.url }}{{ post.href }}og/">
+{% endif %}
+{% endif %}
+
+{# Structured Data: Twitter Card meta tags #}
+{% if post.structured_data.twitter %}
+{% for meta in post.structured_data.twitter %}
+<meta name="{{ meta.name }}" content="{{ meta.content }}">
+{% endfor %}
+{% endif %}
+{% endblock %}
 
 {% block content %}
 <div class="content-wrapper{% if config.components.doc_sidebar.enabled and post.toc %} content-wrapper--with-sidebar content-wrapper--sidebar-{{ config.components.doc_sidebar.position | default:'right' }}{% endif %}">
-    <article data-pagefind-body>
-        <header>
-            <h1 data-pagefind-meta="title">{{ post.title }}</h1>
+    <article class="post h-entry" data-pagefind-body>
+        {# Hidden canonical URL for microformats parsers #}
+        <a class="u-url" href="{{ config.url }}{{ post.href }}" hidden></a>
+
+        <header class="post-header">
+            <h1 class="p-name" data-pagefind-meta="title">{{ post.title }}</h1>
             {% if post.description %}
-            <p class="visually-hidden" data-pagefind-meta="excerpt">{{ post.description | striptags }}</p>
+            <p class="post-description p-summary visually-hidden" data-pagefind-meta="excerpt">{{ post.description | striptags }}</p>
             {% endif %}
             {# Pagefind image metadata for search thumbnails #}
             {% if post.cover_image %}
@@ -25,13 +76,22 @@
             {% elif config.seo.default_image %}
             <meta data-pagefind-meta="image[content]" content="{{ config.seo.default_image }}">
             {% endif %}
-            {% if post.date %}
-            <time datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+            {% if post.date or post.reading_time %}
+            <div class="post-meta">
+                {% if post.date %}<time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>{% endif %}
+                {% if post.reading_time %}<span>{{ post.reading_time }} min read</span>{% endif %}
+            </div>
+            {% endif %}
+            {# Author h-card (representative) #}
+            {% if config.author %}
+            <span class="p-author h-card" hidden>
+                <a class="u-url p-name" href="{{ config.url }}">{{ config.author }}</a>
+            </span>
             {% endif %}
             {% if post.tags %}
             <div class="tags">
                 {% for tag in post.tags %}
-                <a href="/tags/{{ tag | slugify }}/">{{ tag }}</a>
+                <a href="/tags/{{ tag | slugify }}/" class="tag p-category">{{ tag }}</a>
                 {% endfor %}
             </div>
             {% endif %}
@@ -47,7 +107,8 @@
             </div>
             {% endif %}
         </header>
-        <div class="post-content{% if post.css_class %} {{ post.css_class }}{% endif %}">
+
+        <div class="post-content e-content{% if post.css_class %} {{ post.css_class }}{% endif %}">
             {{ body | safe }}
         </div>
 


### PR DESCRIPTION
## Summary

Add semantic IndieWeb microformat classes to default templates for better interoperability with IndieWeb tools and feed readers.

## Changes

### Post pages (h-entry)
- Add `h-entry` to article elements
- Add `p-name` to titles, `u-url` for permalinks
- Add `dt-published` to time elements
- Add `e-content` to post content divs
- Add `p-author h-card` for author attribution
- Add `p-category` to tag links

### Feed pages (h-feed)
- Add `h-feed` to feed containers
- Add `p-name` and `p-summary` to feed headers
- Add `p-author h-card` for feed author

### Card templates (all 9 types)
- `article-card`: `h-entry`, `p-name`, `u-url`, `p-summary`, `dt-published`, `p-category`
- `note-card`: `h-entry`, `p-content`, `dt-published`
- `photo-card`: `h-entry`, `u-photo`, `u-video`, `p-name`, `p-summary`
- `video-card`: `h-entry`, `u-photo` (thumbnail), `p-name`, `p-summary`
- `link-card`: `h-entry`, `u-bookmark-of`, `p-name`, `p-summary`
- `quote-card`: `h-entry`, `e-content`, `h-cite`
- `guide-card`: `h-entry`, `p-name`, `u-url`, `p-summary`
- `inline-card`: `h-entry`, `e-content`
- `default-card`: `h-entry`, `p-name`, `u-url`, `p-summary`

### Documentation
- Add Microformats2 section to templates guide
- Update spec with h-entry/h-feed requirements

## Testing

Validate microformats with:
- [IndieWebify.me](https://indiewebify.me/)
- [Pin13](https://pin13.net/mf2/)

Fixes #651