### PR TITLE
feat: expose author avatar via h-card + WebFinger + .well-known

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,11 @@ repos:
 
       # Data file validation
       - id: check-json
+        exclude: |
+          (?x)^(
+            templates/.*|
+            pkg/themes/.*/templates/.*
+          )$
       - id: check-yaml
         args: [--allow-multiple-documents]
       - id: check-toml

--- a/pkg/plugins/well_known_test.go
+++ b/pkg/plugins/well_known_test.go
@@ -3,6 +3,7 @@ package plugins
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -100,5 +101,183 @@ func TestWellKnownPlugin_Write_OptionalEntriesOnly(t *testing.T) {
 
 	if _, err := os.Stat(filepath.Join(outputDir, filepath.FromSlash(".well-known/host-meta"))); err == nil {
 		t.Fatalf("did not expect host-meta to be generated when auto_generate is empty")
+	}
+}
+
+func TestWellKnownPlugin_Write_WithAuthorImage(t *testing.T) {
+	outputDir := t.TempDir()
+	wellKnownConfig := models.NewWellKnownConfig()
+	config := &lifecycle.Config{
+		OutputDir: outputDir,
+		Extra: map[string]interface{}{
+			"url":        "https://example.com",
+			"title":      "Example Site",
+			"author":     "Jane Doe",
+			"well_known": wellKnownConfig,
+			"seo": map[string]interface{}{
+				"author_image": "/images/avatar.png",
+			},
+		},
+	}
+
+	m := lifecycle.NewManager()
+	m.SetConfig(config)
+
+	plugin := NewWellKnownPlugin()
+	plugin.now = func() time.Time { return time.Date(2026, time.February, 4, 12, 0, 0, 0, time.UTC) }
+
+	if err := plugin.Write(m); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	// Check that avatar endpoint was created
+	avatarPath := filepath.Join(outputDir, filepath.FromSlash(".well-known/avatar"))
+	if _, err := os.Stat(avatarPath); err != nil {
+		t.Fatalf("expected %s to exist: %v", avatarPath, err)
+	}
+
+	// Check avatar content contains redirect to image
+	content, err := os.ReadFile(avatarPath)
+	if err != nil {
+		t.Fatalf("reading avatar file: %v", err)
+	}
+	if !strings.Contains(string(content), "https://example.com/images/avatar.png") {
+		t.Errorf("avatar content should contain image URL, got: %s", string(content))
+	}
+
+	// Check webfinger contains avatar link
+	webfingerPath := filepath.Join(outputDir, filepath.FromSlash(".well-known/webfinger"))
+	webfingerContent, err := os.ReadFile(webfingerPath)
+	if err != nil {
+		t.Fatalf("reading webfinger file: %v", err)
+	}
+	if !strings.Contains(string(webfingerContent), "http://webfinger.net/rel/avatar") {
+		t.Errorf("webfinger should contain avatar rel, got: %s", string(webfingerContent))
+	}
+	if !strings.Contains(string(webfingerContent), "https://example.com/images/avatar.png") {
+		t.Errorf("webfinger should contain avatar URL, got: %s", string(webfingerContent))
+	}
+}
+
+func TestWellKnownPlugin_Write_WithoutAuthorImage(t *testing.T) {
+	outputDir := t.TempDir()
+	wellKnownConfig := models.NewWellKnownConfig()
+	config := &lifecycle.Config{
+		OutputDir: outputDir,
+		Extra: map[string]interface{}{
+			"url":        "https://example.com",
+			"title":      "Example Site",
+			"author":     "Jane Doe",
+			"well_known": wellKnownConfig,
+			// No SEO config with author_image
+		},
+	}
+
+	m := lifecycle.NewManager()
+	m.SetConfig(config)
+
+	plugin := NewWellKnownPlugin()
+	plugin.now = func() time.Time { return time.Date(2026, time.February, 4, 12, 0, 0, 0, time.UTC) }
+
+	if err := plugin.Write(m); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	// Check that avatar endpoint was NOT created (no author image)
+	avatarPath := filepath.Join(outputDir, filepath.FromSlash(".well-known/avatar"))
+	if _, err := os.Stat(avatarPath); err == nil {
+		t.Fatalf("did not expect %s to exist when no author image is configured", avatarPath)
+	}
+
+	// Check webfinger does NOT contain avatar link
+	webfingerPath := filepath.Join(outputDir, filepath.FromSlash(".well-known/webfinger"))
+	webfingerContent, err := os.ReadFile(webfingerPath)
+	if err != nil {
+		t.Fatalf("reading webfinger file: %v", err)
+	}
+	if strings.Contains(string(webfingerContent), "http://webfinger.net/rel/avatar") {
+		t.Errorf("webfinger should NOT contain avatar rel when no image configured, got: %s", string(webfingerContent))
+	}
+}
+
+func TestGetAuthorImageURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   *lifecycle.Config
+		siteURL  string
+		expected string
+	}{
+		{
+			name:     "nil config",
+			config:   nil,
+			siteURL:  "https://example.com",
+			expected: "",
+		},
+		{
+			name: "relative author image",
+			config: &lifecycle.Config{
+				Extra: map[string]interface{}{
+					"seo": map[string]interface{}{
+						"author_image": "/images/avatar.png",
+					},
+				},
+			},
+			siteURL:  "https://example.com",
+			expected: "https://example.com/images/avatar.png",
+		},
+		{
+			name: "absolute author image",
+			config: &lifecycle.Config{
+				Extra: map[string]interface{}{
+					"seo": map[string]interface{}{
+						"author_image": "https://cdn.example.com/avatar.png",
+					},
+				},
+			},
+			siteURL:  "https://example.com",
+			expected: "https://cdn.example.com/avatar.png",
+		},
+		{
+			name: "fallback to default_image",
+			config: &lifecycle.Config{
+				Extra: map[string]interface{}{
+					"seo": map[string]interface{}{
+						"default_image": "/images/default.png",
+					},
+				},
+			},
+			siteURL:  "https://example.com",
+			expected: "https://example.com/images/default.png",
+		},
+		{
+			name: "author_image takes precedence over default_image",
+			config: &lifecycle.Config{
+				Extra: map[string]interface{}{
+					"seo": map[string]interface{}{
+						"author_image":  "/images/author.png",
+						"default_image": "/images/default.png",
+					},
+				},
+			},
+			siteURL:  "https://example.com",
+			expected: "https://example.com/images/author.png",
+		},
+		{
+			name: "no seo config",
+			config: &lifecycle.Config{
+				Extra: map[string]interface{}{},
+			},
+			siteURL:  "https://example.com",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getAuthorImageURL(tt.config, tt.siteURL)
+			if result != tt.expected {
+				t.Errorf("getAuthorImageURL() = %q, want %q", result, tt.expected)
+			}
+		})
 	}
 }

--- a/pkg/themes/default/templates/components/footer.html
+++ b/pkg/themes/default/templates/components/footer.html
@@ -29,6 +29,9 @@
          <p class="footer-copyright">&copy; {{ "now" | date:"2006" }} {{ config.author | default:config.title | default:"" }}.{% if footer.show_built_with %} Built with <a href="https://github.com/WaylonWalker/markata-go">markata-go</a> using {{ config.theme.name | default:"default" }} theme.{% endif %}</p>
          {% endif %}
     </div>
+
+    {# Site-wide h-card for IndieWeb identity #}
+    {% include "components/h-card.html" %}
 </footer>
 {% endif %}
 {% endwith %}

--- a/pkg/themes/default/templates/components/h-card.html
+++ b/pkg/themes/default/templates/components/h-card.html
@@ -1,0 +1,31 @@
+{# Site-wide h-card (Microformats2) #}
+{# This provides IndieWeb-friendly author/site identity markup #}
+{# It's hidden by default but machine-readable for parsers #}
+
+{% if config.author or config.url %}
+<div class="h-card site-author-card" hidden>
+    {# Author/site name #}
+    {% if config.author %}
+    <span class="p-name">{{ config.author }}</span>
+    {% elif config.title %}
+    <span class="p-name">{{ config.title }}</span>
+    {% endif %}
+
+    {# Canonical site URL #}
+    {% if config.url %}
+    <a class="u-url u-uid" href="{{ config.url }}">{{ config.url }}</a>
+    {% endif %}
+
+    {# Author avatar/photo from SEO config #}
+    {% if config.seo.author_image %}
+    <img class="u-photo" src="{% if config.seo.author_image | startswith:'http' %}{{ config.seo.author_image }}{% else %}{{ config.url }}{{ config.seo.author_image }}{% endif %}" alt="{{ config.author | default:config.title }} avatar" hidden>
+    {% elif config.seo.default_image %}
+    <img class="u-photo" src="{% if config.seo.default_image | startswith:'http' %}{{ config.seo.default_image }}{% else %}{{ config.url }}{{ config.seo.default_image }}{% endif %}" alt="{{ config.author | default:config.title }} avatar" hidden>
+    {% endif %}
+
+    {# Optional note/bio if available #}
+    {% if config.description %}
+    <span class="p-note">{{ config.description }}</span>
+    {% endif %}
+</div>
+{% endif %}

--- a/pkg/themes/default/templates/well-known/webfinger.json
+++ b/pkg/themes/default/templates/well-known/webfinger.json
@@ -8,6 +8,10 @@
       "rel": "http://webfinger.net/rel/profile-page",
       "type": "text/html",
       "href": "{{ well_known.site_url }}/"
-    }
+    }{% if well_known.author_image_url %},
+    {
+      "rel": "http://webfinger.net/rel/avatar",
+      "href": "{{ well_known.author_image_url }}"
+    }{% endif %}
   ]
 }

--- a/templates/components/footer.html
+++ b/templates/components/footer.html
@@ -30,6 +30,9 @@
             <p class="footer-shortcuts-hint">Press <kbd>?</kbd> for keyboard shortcuts</p>
         </div>
     </div>
+
+    {# Site-wide h-card for IndieWeb identity #}
+    {% include "components/h-card.html" %}
 </footer>
 {% endif %}
 {% endwith %}

--- a/templates/components/h-card.html
+++ b/templates/components/h-card.html
@@ -1,0 +1,31 @@
+{# Site-wide h-card (Microformats2) #}
+{# This provides IndieWeb-friendly author/site identity markup #}
+{# It's hidden by default but machine-readable for parsers #}
+
+{% if config.author or config.url %}
+<div class="h-card site-author-card" hidden>
+    {# Author/site name #}
+    {% if config.author %}
+    <span class="p-name">{{ config.author }}</span>
+    {% elif config.title %}
+    <span class="p-name">{{ config.title }}</span>
+    {% endif %}
+
+    {# Canonical site URL #}
+    {% if config.url %}
+    <a class="u-url u-uid" href="{{ config.url }}">{{ config.url }}</a>
+    {% endif %}
+
+    {# Author avatar/photo from SEO config #}
+    {% if config.seo.author_image %}
+    <img class="u-photo" src="{% if config.seo.author_image | startswith:'http' %}{{ config.seo.author_image }}{% else %}{{ config.url }}{{ config.seo.author_image }}{% endif %}" alt="{{ config.author | default:config.title }} avatar" hidden>
+    {% elif config.seo.default_image %}
+    <img class="u-photo" src="{% if config.seo.default_image | startswith:'http' %}{{ config.seo.default_image }}{% else %}{{ config.url }}{{ config.seo.default_image }}{% endif %}" alt="{{ config.author | default:config.title }} avatar" hidden>
+    {% endif %}
+
+    {# Optional note/bio if available #}
+    {% if config.description %}
+    <span class="p-note">{{ config.description }}</span>
+    {% endif %}
+</div>
+{% endif %}


### PR DESCRIPTION
## Summary

Exposes the SEO `author_image` through multiple IndieWeb-compatible discovery mechanisms:

- **WebFinger**: Adds `rel=avatar` link to `/.well-known/webfinger` when author image is configured
- **Well-known endpoint**: Adds `/.well-known/avatar` redirect page pointing to author image
- **h-card**: Adds site-wide h-card microformat with `u-photo` property in footer

## Changes

- Updated `pkg/plugins/well_known.go` to:
  - Add `getAuthorImageURL()` helper to extract author image from SEO config
  - Add `resolveImageURL()` helper to convert relative URLs to absolute
  - Include `rel=avatar` link in WebFinger response
  - Generate `/.well-known/avatar` endpoint when author image available
- Created `templates/components/h-card.html` partial with p-name, u-url, u-photo
- Updated footer templates to include h-card
- Added comprehensive tests for avatar functionality
- Excluded template directories from JSON pre-commit validation (templates contain Jinja2 syntax)

## Testing

- All existing tests pass
- New tests added:
  - `TestWellKnownPlugin_Write_WithAuthorImage`
  - `TestWellKnownPlugin_Write_WithoutAuthorImage`
  - `TestGetAuthorImageURL` (6 sub-tests)

## Configuration

Uses existing SEO configuration:
```toml
[seo]
author_image = "/images/avatar.png"  # or absolute URL
```

Fixes #648