### PR TITLE
feat: allow mentions sourced from contact posts

### DIFF
--- a/pkg/config/merge.go
+++ b/pkg/config/merge.go
@@ -108,6 +108,9 @@ func MergeConfigs(base, override *models.Config) *models.Config {
 	// TagAggregator - merge
 	result.TagAggregator = mergeTagAggregatorConfig(base.TagAggregator, override.TagAggregator)
 
+	// Mentions - merge
+	result.Mentions = mergeMentionsConfig(base.Mentions, override.Mentions)
+
 	// Extra (plugin configs) - merge
 	result.Extra = mergeExtra(base.Extra, override.Extra)
 
@@ -955,6 +958,48 @@ func mergeTagAggregatorConfig(base, override models.TagAggregatorConfig) models.
 	// GenerateReport - override if true
 	if override.GenerateReport {
 		result.GenerateReport = true
+	}
+
+	return result
+}
+
+// mergeMentionsConfig merges MentionsConfig values.
+func mergeMentionsConfig(base, override models.MentionsConfig) models.MentionsConfig {
+	result := base
+
+	// Enabled - override if explicitly set
+	if override.Enabled != nil {
+		result.Enabled = override.Enabled
+	}
+
+	// CSSClass - override if set
+	if override.CSSClass != "" {
+		result.CSSClass = override.CSSClass
+	}
+
+	// FromPosts - override if set (don't merge, replace entirely)
+	if len(override.FromPosts) > 0 {
+		result.FromPosts = override.FromPosts
+	}
+
+	// CacheDir - override if set
+	if override.CacheDir != "" {
+		result.CacheDir = override.CacheDir
+	}
+
+	// CacheDuration - override if set
+	if override.CacheDuration != "" {
+		result.CacheDuration = override.CacheDuration
+	}
+
+	// Timeout - override if set
+	if override.Timeout > 0 {
+		result.Timeout = override.Timeout
+	}
+
+	// ConcurrentRequests - override if set
+	if override.ConcurrentRequests > 0 {
+		result.ConcurrentRequests = override.ConcurrentRequests
 	}
 
 	return result


### PR DESCRIPTION
## Summary

- Adds support for mentions sourced from posts in addition to blogroll
- Implements configurable filters for selecting post sources
- Adds LSP hover and completion for post-sourced mentions

## Related Issue

Fixes #703

## Changes

- **Config**: Add `MentionsConfig` with `from_posts` field for configurable post filtering
- **Parser**: Add TOML/YAML/JSON parsing for mentions configuration
- **Merge**: Add merge logic for mentions configuration
- **LSP**: Index mentions from posts based on configured filters
- **LSP**: Support `handle_field` and `aliases_field` for extracting mention data from posts
- **LSP**: Add hover information and completion for post-sourced mentions
- **Tests**: Add comprehensive tests for post-based mention indexing and lookup

## Testing

All tests pass, including:
- Config parsing for mentions configuration
- Mention indexing from posts
- LSP hover and completion functionality
- Blogroll mentions continue to work as before