### PR TITLE
feat: add link_avatars plugin for external link favicons

### DIFF
--- a/docs/guides/link-avatars.md
+++ b/docs/guides/link-avatars.md
@@ -1,0 +1,252 @@
+---
+title: "Link Avatars"
+description: "Add favicon icons next to external links for better visual identification"
+date: 2026-02-09
+published: true
+slug: /docs/guides/link-avatars/
+tags:
+  - plugins
+  - links
+  - customization
+---
+
+# Link Avatars
+
+The `link_avatars` plugin automatically adds small favicon icons next to external links in your content. This helps readers quickly identify link destinations before clicking.
+
+## Quick Start
+
+Enable link avatars with minimal configuration:
+
+```toml
+[markata-go.link_avatars]
+enabled = true
+```
+
+This will add a 16x16 pixel favicon icon before each external link using DuckDuckGo's icon service.
+
+## How It Works
+
+The plugin generates client-side JavaScript and CSS that:
+
+1. Finds all external links (URLs starting with `http`)
+2. Skips same-origin links automatically
+3. Applies configured ignore rules
+4. Fetches the favicon URL from the configured service
+5. Displays the favicon as a pseudo-element next to the link
+
+All processing happens in the browser, so there's no build-time overhead.
+
+## Configuration
+
+### Basic Options
+
+```toml
+[markata-go.link_avatars]
+enabled = true
+
+# CSS selector for links to enhance (default: "a[href^='http']")
+selector = "a[href^='http']"
+
+# Avatar size in pixels (default: 16)
+size = 16
+
+# Position: "before" or "after" the link text (default: "before")
+position = "before"
+```
+
+### Service Selection
+
+Choose your favicon service provider:
+
+```toml
+[markata-go.link_avatars]
+enabled = true
+
+# Options: "duckduckgo", "google", "custom"
+service = "duckduckgo"
+```
+
+| Service | URL Template | Notes |
+|---------|--------------|-------|
+| `duckduckgo` | `icons.duckduckgo.com/ip3/{host}.ico` | Default, privacy-focused |
+| `google` | `google.com/s2/favicons?domain={host}` | Reliable, supports size param |
+| `custom` | User-provided template | For self-hosted services |
+
+### Custom Template
+
+Use a custom favicon service:
+
+```toml
+[markata-go.link_avatars]
+enabled = true
+service = "custom"
+template = "https://favicon.splitbee.io/?url={origin}"
+```
+
+Template placeholders:
+- `{host}` - Domain name (e.g., `github.com`)
+- `{origin}` - Full origin URL-encoded (e.g., `https%3A%2F%2Fgithub.com`)
+
+### Ignore Rules
+
+Exclude specific links from getting avatars:
+
+```toml
+[markata-go.link_avatars]
+enabled = true
+
+# Skip links to these domains
+ignore_domains = ["localhost", "127.0.0.1", "example.com"]
+
+# Skip links to these exact origins
+ignore_origins = ["https://internal.example.com"]
+
+# Skip links matching these CSS selectors
+ignore_selectors = ["nav a", ".footer a", "a.plain-link"]
+
+# Skip links with these classes
+ignore_classes = ["no-avatar", "internal"]
+
+# Skip links inside elements with these IDs
+ignore_ids = ["site-nav", "footer"]
+```
+
+## Full Configuration Example
+
+```toml
+[markata-go.link_avatars]
+enabled = true
+selector = "article a[href^='http']"  # Only article links
+service = "google"
+size = 14
+position = "after"
+ignore_domains = ["localhost", "127.0.0.1"]
+ignore_classes = ["no-avatar"]
+ignore_selectors = ["nav a", ".sidebar a"]
+```
+
+## CSS Customization
+
+The plugin adds these classes to enhanced links:
+
+- `.has-avatar` - Applied to all links with avatars
+- `.has-avatar-before` - Avatar appears before text
+- `.has-avatar-after` - Avatar appears after text
+
+### Override Default Styles
+
+```css
+/* Change avatar appearance */
+a.has-avatar::before,
+a.has-avatar::after {
+  opacity: 0.7;
+  border-radius: 2px;
+  margin: 0 0.4em;
+}
+
+/* Add hover effect */
+a.has-avatar:hover::before,
+a.has-avatar:hover::after {
+  opacity: 1;
+  transform: scale(1.1);
+}
+
+/* Hide avatars in specific contexts */
+.prose a.has-avatar::before,
+.prose a.has-avatar::after {
+  display: none;
+}
+```
+
+### Dark Mode Considerations
+
+The CSS handles both light and dark modes automatically. For custom styling:
+
+```css
+/* Dark mode avatar styling */
+@media (prefers-color-scheme: dark) {
+  a.has-avatar::before,
+  a.has-avatar::after {
+    filter: brightness(1.2);
+  }
+}
+```
+
+## Opt-Out Per Link
+
+Add the `no-avatar` class (or your configured ignore class) to skip specific links:
+
+```markdown
+[Regular link](https://github.com) gets an avatar.
+
+[No avatar link](https://github.com){.no-avatar} is excluded.
+```
+
+Or use inline HTML:
+
+```html
+<a href="https://example.com" class="no-avatar">Plain link</a>
+```
+
+## Performance
+
+The plugin is designed for minimal performance impact:
+
+- **Zero build-time overhead** - All processing is client-side
+- **Lazy loading** - Uses Intersection Observer to load favicons only when visible
+- **No network requests at build time** - Favicon fetching happens in the browser
+- **Deterministic builds** - Generated JS/CSS is stable between builds
+
+## Generated Files
+
+When enabled, the plugin creates:
+
+```
+output/
+└── assets/
+    └── markata/
+        ├── link-avatars.js   # Client-side JavaScript
+        └── link-avatars.css  # Styling
+```
+
+These are automatically included in your page's `<head>`.
+
+## Troubleshooting
+
+### Favicons Not Showing
+
+1. **Check browser console** for errors
+2. **Verify links match selector** - Default is `a[href^='http']`
+3. **Check ignore rules** - Link might match an ignore pattern
+4. **Test favicon service** - Try the URL directly in browser
+
+### Favicon Service Blocked
+
+Some ad blockers may block favicon services. Consider:
+- Using a self-hosted favicon service
+- Adding exceptions for trusted services
+- Providing fallback styling
+
+### Layout Shift
+
+If avatars cause layout shift:
+
+```css
+/* Reserve space for avatar */
+a.has-avatar {
+  padding-left: 1.5em;
+  position: relative;
+}
+
+a.has-avatar::before {
+  position: absolute;
+  left: 0;
+}
+```
+
+## See Also
+
+- [Configuration Reference](/docs/guides/configuration/)
+- [Plugin Development](/docs/guides/plugin-development/)
+- [Themes and Styling](/docs/guides/themes/)

--- a/pkg/plugins/link_avatars.go
+++ b/pkg/plugins/link_avatars.go
@@ -1,0 +1,560 @@
+// Package plugins provides lifecycle plugins for markata-go.
+package plugins
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
+	"github.com/WaylonWalker/markata-go/pkg/models"
+)
+
+// LinkAvatarsConfig holds configuration for the link_avatars plugin.
+type LinkAvatarsConfig struct {
+	// Enabled controls whether the plugin is active.
+	// Default: false
+	Enabled bool
+
+	// Selector is the CSS selector for links to enhance.
+	// Default: "a[href^='http']"
+	Selector string
+
+	// Service is the avatar service provider: "duckduckgo", "google", "custom"
+	// Default: "duckduckgo"
+	Service string
+
+	// Template is a custom URL template (only used when Service = "custom").
+	// Supports placeholders: {origin}, {host}
+	Template string
+
+	// IgnoreDomains is a list of domains to skip.
+	IgnoreDomains []string
+
+	// IgnoreOrigins is a list of full origins to skip (includes protocol).
+	IgnoreOrigins []string
+
+	// IgnoreSelectors is a list of CSS selectors to exclude.
+	IgnoreSelectors []string
+
+	// IgnoreClasses is a list of CSS classes to exclude.
+	IgnoreClasses []string
+
+	// IgnoreIDs is a list of element IDs to exclude.
+	IgnoreIDs []string
+
+	// Size is the avatar icon size in pixels.
+	// Default: 16
+	Size int
+
+	// Position is where to place the avatar: "before" or "after" link text.
+	// Default: "before"
+	Position string
+}
+
+// defaultLinkAvatarsConfig returns the default configuration.
+func defaultLinkAvatarsConfig() LinkAvatarsConfig {
+	return LinkAvatarsConfig{
+		Enabled:         false,
+		Selector:        "a[href^='http']",
+		Service:         "duckduckgo",
+		Template:        "",
+		IgnoreDomains:   []string{},
+		IgnoreOrigins:   []string{},
+		IgnoreSelectors: []string{},
+		IgnoreClasses:   []string{},
+		IgnoreIDs:       []string{},
+		Size:            16,
+		Position:        "before",
+	}
+}
+
+// LinkAvatarsPlugin adds favicon/avatar icons next to external links.
+// It generates client-side JavaScript and CSS assets that enhance links
+// at runtime in the browser.
+type LinkAvatarsPlugin struct {
+	config LinkAvatarsConfig
+}
+
+// NewLinkAvatarsPlugin creates a new LinkAvatarsPlugin.
+func NewLinkAvatarsPlugin() *LinkAvatarsPlugin {
+	return &LinkAvatarsPlugin{config: defaultLinkAvatarsConfig()}
+}
+
+// Name returns the unique name of the plugin.
+func (p *LinkAvatarsPlugin) Name() string {
+	return "link_avatars"
+}
+
+// Configure loads plugin configuration from the manager.
+func (p *LinkAvatarsPlugin) Configure(m *lifecycle.Manager) error {
+	p.config = parseLinkAvatarsConfig(m.Config())
+	return nil
+}
+
+// Write generates the JavaScript and CSS assets and injects head tags.
+func (p *LinkAvatarsPlugin) Write(m *lifecycle.Manager) error {
+	if !p.config.Enabled {
+		return nil
+	}
+
+	cfg := m.Config()
+	outputDir := cfg.OutputDir
+	if outputDir == "" {
+		outputDir = defaultOutputDir
+	}
+
+	// Create assets directory
+	assetsDir := filepath.Join(outputDir, "assets", "markata")
+	if err := os.MkdirAll(assetsDir, 0o755); err != nil {
+		return fmt.Errorf("creating link_avatars assets directory: %w", err)
+	}
+
+	// Generate JavaScript
+	jsContent := p.generateJavaScript()
+	jsPath := filepath.Join(assetsDir, "link-avatars.js")
+	if err := os.WriteFile(jsPath, []byte(jsContent), 0o644); err != nil { //nolint:gosec // static JS needs world-readable permissions
+		return fmt.Errorf("writing link-avatars.js: %w", err)
+	}
+
+	// Generate CSS
+	cssContent := p.generateCSS()
+	cssPath := filepath.Join(assetsDir, "link-avatars.css")
+	if err := os.WriteFile(cssPath, []byte(cssContent), 0o644); err != nil { //nolint:gosec // static CSS needs world-readable permissions
+		return fmt.Errorf("writing link-avatars.css: %w", err)
+	}
+
+	// Inject head tags
+	p.injectHeadTags(cfg)
+
+	return nil
+}
+
+// generateJavaScript generates the client-side JavaScript.
+func (p *LinkAvatarsPlugin) generateJavaScript() string {
+	// Marshal config values for JavaScript - this won't fail with basic Go types
+	configJSON, err := json.Marshal(map[string]interface{}{
+		"selector":        p.config.Selector,
+		"service":         p.config.Service,
+		"template":        p.config.Template,
+		"ignoreDomains":   p.config.IgnoreDomains,
+		"ignoreOrigins":   p.config.IgnoreOrigins,
+		"ignoreSelectors": p.config.IgnoreSelectors,
+		"ignoreClasses":   p.config.IgnoreClasses,
+		"ignoreIds":       p.config.IgnoreIDs,
+		"size":            p.config.Size,
+		"position":        p.config.Position,
+	})
+	if err != nil {
+		// Fallback to empty config on error (should never happen with basic types)
+		configJSON = []byte("{}")
+	}
+
+	return `/**
+ * Link Avatars - markata-go
+ * Adds favicon icons next to external links
+ */
+(function() {
+  'use strict';
+
+  var config = ` + string(configJSON) + `;
+
+  // Service URL templates
+  var serviceTemplates = {
+    'duckduckgo': 'https://icons.duckduckgo.com/ip3/{host}.ico',
+    'google': 'https://www.google.com/s2/favicons?domain={host}&sz=' + config.size
+  };
+
+  function getFaviconURL(href) {
+    try {
+      var url = new URL(href);
+      var host = url.hostname;
+      var origin = url.origin;
+      var template;
+
+      if (config.service === 'custom' && config.template) {
+        template = config.template;
+      } else {
+        template = serviceTemplates[config.service] || serviceTemplates['duckduckgo'];
+      }
+
+      return template
+        .replace('{host}', host)
+        .replace('{origin}', encodeURIComponent(origin));
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function shouldIgnoreLink(link) {
+    var href = link.href;
+    var url;
+
+    try {
+      url = new URL(href);
+    } catch (e) {
+      return true; // Invalid URL
+    }
+
+    // Skip same-origin links
+    if (url.origin === window.location.origin) {
+      return true;
+    }
+
+    // Check ignore domains
+    for (var i = 0; i < config.ignoreDomains.length; i++) {
+      if (url.hostname === config.ignoreDomains[i] ||
+          url.hostname.endsWith('.' + config.ignoreDomains[i])) {
+        return true;
+      }
+    }
+
+    // Check ignore origins
+    for (var j = 0; j < config.ignoreOrigins.length; j++) {
+      if (url.origin === config.ignoreOrigins[j]) {
+        return true;
+      }
+    }
+
+    // Check ignore classes
+    for (var k = 0; k < config.ignoreClasses.length; k++) {
+      if (link.classList.contains(config.ignoreClasses[k])) {
+        return true;
+      }
+    }
+
+    // Check ignore IDs (link is inside an element with ignored ID)
+    for (var l = 0; l < config.ignoreIds.length; l++) {
+      if (link.closest('#' + config.ignoreIds[l])) {
+        return true;
+      }
+    }
+
+    // Check ignore selectors
+    for (var m = 0; m < config.ignoreSelectors.length; m++) {
+      try {
+        if (link.matches(config.ignoreSelectors[m])) {
+          return true;
+        }
+      } catch (e) {
+        // Invalid selector, skip
+      }
+    }
+
+    return false;
+  }
+
+  function processLink(link) {
+    if (link.classList.contains('has-avatar')) {
+      return; // Already processed
+    }
+
+    if (shouldIgnoreLink(link)) {
+      return;
+    }
+
+    var faviconURL = getFaviconURL(link.href);
+    if (!faviconURL) {
+      return;
+    }
+
+    link.setAttribute('data-favicon', faviconURL);
+    link.style.setProperty('--favicon-url', 'url("' + faviconURL + '")');
+    link.classList.add('has-avatar');
+    link.classList.add('has-avatar-' + config.position);
+  }
+
+  function processLinks() {
+    var links = document.querySelectorAll(config.selector);
+    links.forEach(processLink);
+  }
+
+  // Use Intersection Observer for lazy loading if available
+  function observeLinks() {
+    if (!('IntersectionObserver' in window)) {
+      processLinks();
+      return;
+    }
+
+    var observer = new IntersectionObserver(function(entries) {
+      entries.forEach(function(entry) {
+        if (entry.isIntersecting) {
+          processLink(entry.target);
+          observer.unobserve(entry.target);
+        }
+      });
+    }, { rootMargin: '100px' });
+
+    var links = document.querySelectorAll(config.selector);
+    links.forEach(function(link) {
+      if (!shouldIgnoreLink(link)) {
+        observer.observe(link);
+      }
+    });
+  }
+
+  // Initialize
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', observeLinks);
+  } else {
+    observeLinks();
+  }
+})();
+`
+}
+
+// generateCSS generates the CSS styles for link avatars.
+func (p *LinkAvatarsPlugin) generateCSS() string {
+	size := p.config.Size
+	if size <= 0 {
+		size = 16
+	}
+
+	return fmt.Sprintf(`/**
+ * Link Avatars - markata-go
+ * Styles for favicon icons next to external links
+ */
+
+/* Common avatar styles */
+a.has-avatar {
+  position: relative;
+}
+
+a.has-avatar::before,
+a.has-avatar::after {
+  content: '';
+  display: inline-block;
+  width: %dpx;
+  height: %dpx;
+  background-image: var(--favicon-url);
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
+  vertical-align: middle;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+/* Show avatar when image loads */
+a.has-avatar::before,
+a.has-avatar::after {
+  opacity: 0.8;
+}
+
+/* Avatar before link text */
+a.has-avatar-before::before {
+  margin-right: 0.35em;
+}
+
+a.has-avatar-before::after {
+  display: none;
+}
+
+/* Avatar after link text */
+a.has-avatar-after::after {
+  margin-left: 0.35em;
+}
+
+a.has-avatar-after::before {
+  display: none;
+}
+
+/* Hover effect */
+a.has-avatar:hover::before,
+a.has-avatar:hover::after {
+  opacity: 1;
+}
+
+/* Hide avatar if image fails to load (fallback) */
+a.has-avatar[data-favicon-error]::before,
+a.has-avatar[data-favicon-error]::after {
+  display: none;
+}
+`, size, size)
+}
+
+// injectHeadTags adds the CSS and JS references to the config head.
+func (p *LinkAvatarsPlugin) injectHeadTags(cfg *lifecycle.Config) {
+	if cfg.Extra == nil {
+		cfg.Extra = make(map[string]interface{})
+	}
+
+	// Get existing head config or create new one
+	headConfig := getOrCreateHeadConfig(cfg)
+
+	// Add CSS link
+	headConfig.Link = append(headConfig.Link, models.LinkTag{
+		Rel:  "stylesheet",
+		Href: "/assets/markata/link-avatars.css",
+	})
+
+	// Add JS script
+	headConfig.Script = append(headConfig.Script, models.ScriptTag{
+		Src: "/assets/markata/link-avatars.js",
+	})
+
+	// Mark link avatars as enabled for templates
+	cfg.Extra["link_avatars_enabled"] = true
+}
+
+// getOrCreateHeadConfig gets the existing head config or creates a new one.
+func getOrCreateHeadConfig(cfg *lifecycle.Config) *models.HeadConfig {
+	if cfg.Extra == nil {
+		cfg.Extra = make(map[string]interface{})
+	}
+
+	// Check if we have direct access to models.Config through Extra
+	if modelsConfig, ok := cfg.Extra["_models_config"].(*models.Config); ok {
+		return &modelsConfig.Head
+	}
+
+	// For standalone lifecycle.Config, we need to use Extra to store head elements
+	// The templates plugin will read these
+	links, linksOK := cfg.Extra["head_links"].([]models.LinkTag)
+	if !linksOK {
+		links = []models.LinkTag{}
+	}
+	scripts, scriptsOK := cfg.Extra["head_scripts"].([]models.ScriptTag)
+	if !scriptsOK {
+		scripts = []models.ScriptTag{}
+	}
+
+	headConfig := &models.HeadConfig{
+		Link:   links,
+		Script: scripts,
+	}
+
+	// Store back
+	cfg.Extra["head_links"] = headConfig.Link
+	cfg.Extra["head_scripts"] = headConfig.Script
+
+	return headConfig
+}
+
+// parseLinkAvatarsConfig parses the configuration from the manager config.
+func parseLinkAvatarsConfig(cfg *lifecycle.Config) LinkAvatarsConfig {
+	result := defaultLinkAvatarsConfig()
+	if cfg == nil || cfg.Extra == nil {
+		return result
+	}
+
+	raw := getLinkAvatarsConfigRaw(cfg.Extra)
+	if raw == nil {
+		return result
+	}
+
+	// Allow directly providing a typed config
+	if typed, ok := raw.(LinkAvatarsConfig); ok {
+		return typed
+	}
+
+	m := coerceToMapAny(raw)
+	if m == nil {
+		return result
+	}
+
+	applyLinkAvatarsConfigMap(&result, m)
+	return result
+}
+
+// getLinkAvatarsConfigRaw retrieves the raw config from Extra.
+func getLinkAvatarsConfigRaw(extra map[string]interface{}) any {
+	if extra == nil {
+		return nil
+	}
+	if v, ok := extra["link_avatars"]; ok {
+		return v
+	}
+	// Back-compat: allow a nested "markata-go" map
+	if markataGo, ok := extra["markata-go"].(map[string]any); ok {
+		return markataGo["link_avatars"]
+	}
+	if markataGo, ok := extra["markata-go"].(map[string]interface{}); ok {
+		return markataGo["link_avatars"]
+	}
+	return nil
+}
+
+// applyLinkAvatarsConfigMap applies map values to the config.
+func applyLinkAvatarsConfigMap(dst *LinkAvatarsConfig, m map[string]any) {
+	if dst == nil || m == nil {
+		return
+	}
+
+	applyLinkAvatarsBasicFields(dst, m)
+	applyLinkAvatarsIgnoreFields(dst, m)
+	applyLinkAvatarsSizeAndPosition(dst, m)
+}
+
+// applyLinkAvatarsBasicFields applies basic string/bool fields.
+func applyLinkAvatarsBasicFields(dst *LinkAvatarsConfig, m map[string]any) {
+	if v, ok := m["enabled"].(bool); ok {
+		dst.Enabled = v
+	}
+	if v, ok := m["selector"].(string); ok && strings.TrimSpace(v) != "" {
+		dst.Selector = v
+	}
+	if v, ok := m["service"].(string); ok && strings.TrimSpace(v) != "" {
+		dst.Service = strings.ToLower(strings.TrimSpace(v))
+	}
+	if v, ok := m["template"].(string); ok {
+		dst.Template = v
+	}
+}
+
+// applyLinkAvatarsIgnoreFields applies ignore list fields.
+func applyLinkAvatarsIgnoreFields(dst *LinkAvatarsConfig, m map[string]any) {
+	if v, ok := m["ignore_domains"]; ok {
+		dst.IgnoreDomains = coerceStringSlice(v)
+	}
+	if v, ok := m["ignore_origins"]; ok {
+		dst.IgnoreOrigins = coerceStringSlice(v)
+	}
+	if v, ok := m["ignore_selectors"]; ok {
+		dst.IgnoreSelectors = coerceStringSlice(v)
+	}
+	if v, ok := m["ignore_classes"]; ok {
+		dst.IgnoreClasses = coerceStringSlice(v)
+	}
+	if v, ok := m["ignore_ids"]; ok {
+		dst.IgnoreIDs = coerceStringSlice(v)
+	}
+}
+
+// applyLinkAvatarsSizeAndPosition applies size and position fields.
+func applyLinkAvatarsSizeAndPosition(dst *LinkAvatarsConfig, m map[string]any) {
+	// Size can come as int, int64, or float64 depending on the source
+	if v, ok := m["size"].(int); ok && v > 0 {
+		dst.Size = v
+	} else if v, ok := m["size"].(int64); ok && v > 0 {
+		dst.Size = int(v)
+	} else if v, ok := m["size"].(float64); ok && v > 0 {
+		dst.Size = int(v)
+	}
+
+	if v, ok := m["position"].(string); ok {
+		pos := strings.ToLower(strings.TrimSpace(v))
+		if pos == "before" || pos == "after" {
+			dst.Position = pos
+		}
+	}
+}
+
+// SetConfig sets the link avatars configuration directly (for testing).
+func (p *LinkAvatarsPlugin) SetConfig(config LinkAvatarsConfig) {
+	p.config = config
+}
+
+// Config returns the current configuration (for testing).
+func (p *LinkAvatarsPlugin) Config() LinkAvatarsConfig {
+	return p.config
+}
+
+// Ensure LinkAvatarsPlugin implements the required interfaces.
+var (
+	_ lifecycle.Plugin          = (*LinkAvatarsPlugin)(nil)
+	_ lifecycle.ConfigurePlugin = (*LinkAvatarsPlugin)(nil)
+	_ lifecycle.WritePlugin     = (*LinkAvatarsPlugin)(nil)
+)

--- a/pkg/plugins/link_avatars_test.go
+++ b/pkg/plugins/link_avatars_test.go
@@ -1,0 +1,408 @@
+package plugins
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
+)
+
+func TestLinkAvatarsPlugin_Name(t *testing.T) {
+	p := NewLinkAvatarsPlugin()
+	if got := p.Name(); got != "link_avatars" {
+		t.Errorf("Name() = %q, want %q", got, "link_avatars")
+	}
+}
+
+func TestLinkAvatarsPlugin_DefaultConfig(t *testing.T) {
+	p := NewLinkAvatarsPlugin()
+	cfg := p.Config()
+
+	if cfg.Enabled != false {
+		t.Errorf("default Enabled = %v, want false", cfg.Enabled)
+	}
+	if cfg.Selector != "a[href^='http']" {
+		t.Errorf("default Selector = %q, want %q", cfg.Selector, "a[href^='http']")
+	}
+	if cfg.Service != "duckduckgo" {
+		t.Errorf("default Service = %q, want %q", cfg.Service, "duckduckgo")
+	}
+	if cfg.Size != 16 {
+		t.Errorf("default Size = %d, want %d", cfg.Size, 16)
+	}
+	if cfg.Position != "before" {
+		t.Errorf("default Position = %q, want %q", cfg.Position, "before")
+	}
+}
+
+func TestLinkAvatarsPlugin_Configure(t *testing.T) {
+	tests := []struct {
+		name     string
+		extra    map[string]interface{}
+		expected LinkAvatarsConfig
+	}{
+		{
+			name:  "nil_extra",
+			extra: nil,
+			expected: LinkAvatarsConfig{
+				Enabled:  false,
+				Selector: "a[href^='http']",
+				Service:  "duckduckgo",
+				Size:     16,
+				Position: "before",
+			},
+		},
+		{
+			name: "enabled_only",
+			extra: map[string]interface{}{
+				"link_avatars": map[string]interface{}{
+					"enabled": true,
+				},
+			},
+			expected: LinkAvatarsConfig{
+				Enabled:  true,
+				Selector: "a[href^='http']",
+				Service:  "duckduckgo",
+				Size:     16,
+				Position: "before",
+			},
+		},
+		{
+			name: "custom_service",
+			extra: map[string]interface{}{
+				"link_avatars": map[string]interface{}{
+					"enabled": true,
+					"service": "google",
+					"size":    14,
+				},
+			},
+			expected: LinkAvatarsConfig{
+				Enabled:  true,
+				Selector: "a[href^='http']",
+				Service:  "google",
+				Size:     14,
+				Position: "before",
+			},
+		},
+		{
+			name: "ignore_lists",
+			extra: map[string]interface{}{
+				"link_avatars": map[string]interface{}{
+					"enabled":          true,
+					"ignore_domains":   []interface{}{"example.com", "test.org"},
+					"ignore_classes":   []interface{}{"no-avatar"},
+					"ignore_selectors": []interface{}{"nav a", ".footer a"},
+				},
+			},
+			expected: LinkAvatarsConfig{
+				Enabled:         true,
+				Selector:        "a[href^='http']",
+				Service:         "duckduckgo",
+				Size:            16,
+				Position:        "before",
+				IgnoreDomains:   []string{"example.com", "test.org"},
+				IgnoreClasses:   []string{"no-avatar"},
+				IgnoreSelectors: []string{"nav a", ".footer a"},
+			},
+		},
+		{
+			name: "position_after",
+			extra: map[string]interface{}{
+				"link_avatars": map[string]interface{}{
+					"enabled":  true,
+					"position": "after",
+				},
+			},
+			expected: LinkAvatarsConfig{
+				Enabled:  true,
+				Selector: "a[href^='http']",
+				Service:  "duckduckgo",
+				Size:     16,
+				Position: "after",
+			},
+		},
+		{
+			name: "custom_template",
+			extra: map[string]interface{}{
+				"link_avatars": map[string]interface{}{
+					"enabled":  true,
+					"service":  "custom",
+					"template": "https://favicon.example.com/?url={origin}",
+				},
+			},
+			expected: LinkAvatarsConfig{
+				Enabled:  true,
+				Selector: "a[href^='http']",
+				Service:  "custom",
+				Template: "https://favicon.example.com/?url={origin}",
+				Size:     16,
+				Position: "before",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewLinkAvatarsPlugin()
+			m := lifecycle.NewManager()
+			cfg := m.Config()
+			cfg.Extra = tt.extra
+
+			err := p.Configure(m)
+			if err != nil {
+				t.Fatalf("Configure() error = %v", err)
+			}
+
+			got := p.Config()
+			if got.Enabled != tt.expected.Enabled {
+				t.Errorf("Enabled = %v, want %v", got.Enabled, tt.expected.Enabled)
+			}
+			if got.Selector != tt.expected.Selector {
+				t.Errorf("Selector = %q, want %q", got.Selector, tt.expected.Selector)
+			}
+			if got.Service != tt.expected.Service {
+				t.Errorf("Service = %q, want %q", got.Service, tt.expected.Service)
+			}
+			if got.Size != tt.expected.Size {
+				t.Errorf("Size = %d, want %d", got.Size, tt.expected.Size)
+			}
+			if got.Position != tt.expected.Position {
+				t.Errorf("Position = %q, want %q", got.Position, tt.expected.Position)
+			}
+			if got.Template != tt.expected.Template {
+				t.Errorf("Template = %q, want %q", got.Template, tt.expected.Template)
+			}
+			if !stringSliceEqual(got.IgnoreDomains, tt.expected.IgnoreDomains) {
+				t.Errorf("IgnoreDomains = %v, want %v", got.IgnoreDomains, tt.expected.IgnoreDomains)
+			}
+			if !stringSliceEqual(got.IgnoreClasses, tt.expected.IgnoreClasses) {
+				t.Errorf("IgnoreClasses = %v, want %v", got.IgnoreClasses, tt.expected.IgnoreClasses)
+			}
+			if !stringSliceEqual(got.IgnoreSelectors, tt.expected.IgnoreSelectors) {
+				t.Errorf("IgnoreSelectors = %v, want %v", got.IgnoreSelectors, tt.expected.IgnoreSelectors)
+			}
+		})
+	}
+}
+
+func TestLinkAvatarsPlugin_WriteDisabled(t *testing.T) {
+	p := NewLinkAvatarsPlugin()
+	m := lifecycle.NewManager()
+
+	// Plugin is disabled by default
+	tmpDir := t.TempDir()
+	cfg := m.Config()
+	cfg.OutputDir = tmpDir
+
+	err := p.Write(m)
+	if err != nil {
+		t.Errorf("Write() error = %v", err)
+	}
+
+	// Assets should not be created
+	jsPath := filepath.Join(tmpDir, "assets", "markata", "link-avatars.js")
+	if _, err := os.Stat(jsPath); !os.IsNotExist(err) {
+		t.Errorf("link-avatars.js should not exist when disabled")
+	}
+}
+
+func TestLinkAvatarsPlugin_WriteEnabled(t *testing.T) {
+	p := NewLinkAvatarsPlugin()
+	p.SetConfig(LinkAvatarsConfig{
+		Enabled:  true,
+		Selector: "a[href^='http']",
+		Service:  "duckduckgo",
+		Size:     16,
+		Position: "before",
+	})
+
+	m := lifecycle.NewManager()
+	tmpDir := t.TempDir()
+	cfg := m.Config()
+	cfg.OutputDir = tmpDir
+
+	err := p.Write(m)
+	if err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	// Check JavaScript file was created
+	jsPath := filepath.Join(tmpDir, "assets", "markata", "link-avatars.js")
+	jsContent, err := os.ReadFile(jsPath)
+	if err != nil {
+		t.Fatalf("Failed to read link-avatars.js: %v", err)
+	}
+	if len(jsContent) == 0 {
+		t.Error("link-avatars.js is empty")
+	}
+
+	// Verify JS contains expected content
+	jsStr := string(jsContent)
+	if !strings.Contains(jsStr, "Link Avatars") {
+		t.Error("JS should contain header comment")
+	}
+	if !strings.Contains(jsStr, "duckduckgo") {
+		t.Error("JS should contain service name")
+	}
+	if !strings.Contains(jsStr, "getFaviconURL") {
+		t.Error("JS should contain getFaviconURL function")
+	}
+
+	// Check CSS file was created
+	cssPath := filepath.Join(tmpDir, "assets", "markata", "link-avatars.css")
+	cssContent, err := os.ReadFile(cssPath)
+	if err != nil {
+		t.Fatalf("Failed to read link-avatars.css: %v", err)
+	}
+	if len(cssContent) == 0 {
+		t.Error("link-avatars.css is empty")
+	}
+
+	// Verify CSS contains expected content
+	cssStr := string(cssContent)
+	if !strings.Contains(cssStr, ".has-avatar") {
+		t.Error("CSS should contain .has-avatar class")
+	}
+	if !strings.Contains(cssStr, "--favicon-url") {
+		t.Error("CSS should contain --favicon-url variable")
+	}
+	if !strings.Contains(cssStr, "16px") {
+		t.Error("CSS should contain icon size")
+	}
+}
+
+func TestLinkAvatarsPlugin_WriteCustomSize(t *testing.T) {
+	p := NewLinkAvatarsPlugin()
+	p.SetConfig(LinkAvatarsConfig{
+		Enabled:  true,
+		Selector: "a[href^='http']",
+		Service:  "google",
+		Size:     24,
+		Position: "after",
+	})
+
+	m := lifecycle.NewManager()
+	tmpDir := t.TempDir()
+	cfg := m.Config()
+	cfg.OutputDir = tmpDir
+
+	err := p.Write(m)
+	if err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	// Check CSS has custom size
+	cssPath := filepath.Join(tmpDir, "assets", "markata", "link-avatars.css")
+	cssContent, err := os.ReadFile(cssPath)
+	if err != nil {
+		t.Fatalf("Failed to read link-avatars.css: %v", err)
+	}
+
+	cssStr := string(cssContent)
+	if !strings.Contains(cssStr, "24px") {
+		t.Errorf("CSS should contain custom icon size 24px, got: %s", cssStr)
+	}
+}
+
+func TestLinkAvatarsPlugin_GenerateJavaScript(t *testing.T) {
+	p := NewLinkAvatarsPlugin()
+	p.SetConfig(LinkAvatarsConfig{
+		Enabled:         true,
+		Selector:        "article a[href^='http']",
+		Service:         "custom",
+		Template:        "https://my-service.com/favicon?url={host}",
+		IgnoreDomains:   []string{"example.com"},
+		IgnoreClasses:   []string{"no-avatar"},
+		IgnoreSelectors: []string{"nav a"},
+		Size:            20,
+		Position:        "after",
+	})
+
+	js := p.generateJavaScript()
+
+	// Check that config is embedded
+	if !strings.Contains(js, `"selector":"article a[href^='http']"`) {
+		t.Error("JS should contain custom selector")
+	}
+	if !strings.Contains(js, `"service":"custom"`) {
+		t.Error("JS should contain custom service")
+	}
+	if !strings.Contains(js, `"template":"https://my-service.com/favicon?url={host}"`) {
+		t.Error("JS should contain custom template")
+	}
+	if !strings.Contains(js, `"example.com"`) {
+		t.Error("JS should contain ignore domain")
+	}
+	if !strings.Contains(js, `"no-avatar"`) {
+		t.Error("JS should contain ignore class")
+	}
+	if !strings.Contains(js, `"nav a"`) {
+		t.Error("JS should contain ignore selector")
+	}
+}
+
+func TestLinkAvatarsPlugin_GenerateCSS(t *testing.T) {
+	p := NewLinkAvatarsPlugin()
+	p.SetConfig(LinkAvatarsConfig{
+		Enabled:  true,
+		Size:     18,
+		Position: "before",
+	})
+
+	css := p.generateCSS()
+
+	// Check CSS structure
+	if !strings.Contains(css, "a.has-avatar {") {
+		t.Error("CSS should contain base .has-avatar rule")
+	}
+	if !strings.Contains(css, "::before") {
+		t.Error("CSS should contain ::before pseudo-element")
+	}
+	if !strings.Contains(css, "::after") {
+		t.Error("CSS should contain ::after pseudo-element")
+	}
+	if !strings.Contains(css, "18px") {
+		t.Error("CSS should contain custom size")
+	}
+	if !strings.Contains(css, "background-image: var(--favicon-url)") {
+		t.Error("CSS should use --favicon-url variable")
+	}
+}
+
+func TestLinkAvatarsPlugin_HeadInjection(t *testing.T) {
+	p := NewLinkAvatarsPlugin()
+	p.SetConfig(LinkAvatarsConfig{
+		Enabled: true,
+	})
+
+	m := lifecycle.NewManager()
+	tmpDir := t.TempDir()
+	cfg := m.Config()
+	cfg.OutputDir = tmpDir
+	cfg.Extra = make(map[string]interface{})
+
+	err := p.Write(m)
+	if err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	// Check that link_avatars_enabled is set in Extra
+	if enabled, ok := cfg.Extra["link_avatars_enabled"].(bool); !ok || !enabled {
+		t.Error("link_avatars_enabled should be true in Extra")
+	}
+}
+
+// stringSliceEqual checks if two string slices are equal.
+func stringSliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/plugins/registry.go
+++ b/pkg/plugins/registry.go
@@ -94,6 +94,7 @@ func registerBuiltinPluginsLocked() {
 	pluginRegistry.constructors["cdn_assets"] = func() lifecycle.Plugin { return NewCDNAssetsPlugin() }
 	pluginRegistry.constructors["tags_listing"] = func() lifecycle.Plugin { return NewTagsListingPlugin() }
 	pluginRegistry.constructors["theme_calendar"] = func() lifecycle.Plugin { return NewThemeCalendarPlugin() }
+	pluginRegistry.constructors["link_avatars"] = func() lifecycle.Plugin { return NewLinkAvatarsPlugin() }
 }
 
 // RegisterPluginConstructor registers a plugin constructor with the given name.
@@ -197,6 +198,7 @@ func DefaultPlugins() []lifecycle.Plugin {
 		NewWellKnownPlugin(),
 		NewPublishHTMLPlugin(),
 		NewRandomPostPlugin(),  // Generate /random/ client-side redirect endpoint
+		NewLinkAvatarsPlugin(), // Add favicon icons to external links
 		NewRedirectsPlugin(),   // Generate redirect pages
 		NewErrorPagesPlugin(),  // Generate static 404 page
 		NewTagsListingPlugin(), // Generate /tags listing page

--- a/spec/spec/LINK_AVATARS.md
+++ b/spec/spec/LINK_AVATARS.md
@@ -1,0 +1,186 @@
+# Link Avatars Specification
+
+This document specifies the built-in `link_avatars` plugin.
+
+## Goal
+
+Add small favicon/avatar icons next to external links to improve visual identification of link destinations. The feature is implemented entirely client-side for zero build-time overhead.
+
+## Lifecycle
+
+- **Stage:** `configure` (reads config), `write` (generates assets, injects head tags)
+- **Determinism:** Build output is deterministic; favicon loading happens at runtime in the browser.
+
+## Configuration
+
+Configuration is namespaced under the top-level `markata-go` section.
+
+```toml
+[markata-go.link_avatars]
+enabled = true
+
+# CSS selector for links to enhance (default: "a[href^='http']")
+selector = "a[href^='http']"
+
+# Avatar service provider (default: "duckduckgo")
+# Options: "duckduckgo", "google", "custom"
+service = "duckduckgo"
+
+# Custom template URL (only used when service = "custom")
+# Supports placeholders: {origin}, {host}
+# template = "https://my-service.com/favicon?domain={host}"
+
+# Domains to exclude from avatar display
+ignore_domains = ["example.com", "localhost"]
+
+# Full origins to exclude (includes protocol)
+ignore_origins = ["https://example.com"]
+
+# CSS selectors to exclude from processing
+ignore_selectors = [".no-avatars", "#nav", "a.no-avatar"]
+
+# CSS classes to exclude (links with these classes are skipped)
+ignore_classes = ["no-avatar", "internal-link"]
+
+# Element IDs to exclude (links inside elements with these IDs are skipped)
+ignore_ids = ["site-nav", "footer-links"]
+
+# Avatar size in pixels (default: 16)
+size = 16
+
+# Position of the avatar relative to link text (default: "before")
+# Options: "before", "after"
+position = "before"
+```
+
+### Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `false` | Enable/disable the plugin |
+| `selector` | string | `"a[href^='http']"` | CSS selector for links to enhance |
+| `service` | string | `"duckduckgo"` | Avatar service: "duckduckgo", "google", "custom" |
+| `template` | string | `""` | Custom URL template (when service="custom") |
+| `ignore_domains` | []string | `[]` | Domains to skip (e.g., `["example.com"]`) |
+| `ignore_origins` | []string | `[]` | Full origins to skip (e.g., `["https://example.com"]`) |
+| `ignore_selectors` | []string | `[]` | CSS selectors to skip |
+| `ignore_classes` | []string | `[]` | Classes to skip |
+| `ignore_ids` | []string | `[]` | Element IDs to skip |
+| `size` | int | `16` | Avatar icon size in pixels |
+| `position` | string | `"before"` | Position: "before" or "after" link text |
+
+### Service Templates
+
+| Service | URL Template |
+|---------|--------------|
+| `duckduckgo` | `https://icons.duckduckgo.com/ip3/{host}.ico` |
+| `google` | `https://www.google.com/s2/favicons?domain={host}&sz={size}` |
+| `custom` | User-provided template |
+
+## Behavior
+
+1. **Link Selection**: The JavaScript finds all links matching the `selector` (default: external links starting with `http`).
+
+2. **Same-Origin Skip**: Links pointing to the same origin as the current page are automatically skipped.
+
+3. **Ignore Rules Applied**: Links are filtered out based on:
+   - Domain matches `ignore_domains`
+   - Origin matches `ignore_origins`
+   - Link matches any `ignore_selectors`
+   - Link has any class in `ignore_classes`
+   - Link is inside an element with ID in `ignore_ids`
+
+4. **Avatar Injection**: For qualifying links:
+   - A `data-favicon` attribute is set with the favicon URL
+   - A CSS custom property `--favicon-url` is set for styling
+   - The link gets a `has-avatar` class for CSS targeting
+
+5. **CSS Styling**: The generated CSS uses `::before` or `::after` pseudo-elements to display the favicon using `background-image`.
+
+## Generated Output
+
+When enabled, the plugin generates:
+
+- `{output_dir}/assets/markata/link-avatars.js` - Client-side JavaScript
+- `{output_dir}/assets/markata/link-avatars.css` - Minimal CSS styles
+
+And injects into the HTML `<head>`:
+
+```html
+<link rel="stylesheet" href="/assets/markata/link-avatars.css">
+<script src="/assets/markata/link-avatars.js" defer></script>
+```
+
+### JavaScript Behavior
+
+The JavaScript:
+- Runs on `DOMContentLoaded`
+- Finds links matching the selector
+- Filters based on ignore rules
+- Sets `data-favicon` attribute and `--favicon-url` CSS variable
+- Adds `has-avatar` class
+- Handles lazy loading via Intersection Observer for performance
+
+### CSS Styling
+
+The CSS:
+- Uses `::before` or `::after` pseudo-element
+- Sets `background-image: var(--favicon-url)`
+- Applies appropriate sizing and spacing
+- Includes fallback for failed favicon loads (hide the pseudo-element)
+
+## Error Handling
+
+- If the plugin is disabled (default), it does nothing.
+- If output directories cannot be created or files cannot be written, the plugin returns an error.
+- Invalid favicon URLs gracefully fail (favicon simply doesn't display).
+- Network errors for favicons don't break the page.
+
+## Example Usage
+
+### Minimal Configuration
+
+```toml
+[markata-go.link_avatars]
+enabled = true
+```
+
+### Customized Configuration
+
+```toml
+[markata-go.link_avatars]
+enabled = true
+service = "google"
+size = 14
+position = "after"
+ignore_domains = ["localhost", "127.0.0.1"]
+ignore_classes = ["no-favicon", "plain-link"]
+ignore_selectors = ["nav a", ".footer a"]
+```
+
+### Custom Service
+
+```toml
+[markata-go.link_avatars]
+enabled = true
+service = "custom"
+template = "https://favicon.splitbee.io/?url={origin}"
+```
+
+## CSS Customization
+
+Users can override the default styles:
+
+```css
+/* Custom avatar styling */
+a.has-avatar::before {
+  margin-right: 0.5em;
+  opacity: 0.8;
+  border-radius: 2px;
+}
+
+/* Hide avatars in specific contexts */
+.prose a.has-avatar::before {
+  display: none;
+}
+```


### PR DESCRIPTION
## Summary

Fixes #664 - Adds a new `link_avatars` plugin that displays favicon icons next to external links.

## Changes

### New Files
- `spec/spec/LINK_AVATARS.md` - Technical specification
- `pkg/plugins/link_avatars.go` - Plugin implementation
- `pkg/plugins/link_avatars_test.go` - Comprehensive tests (12 tests)
- `docs/guides/link-avatars.md` - User documentation

### Modified Files
- `pkg/plugins/registry.go` - Plugin registration

## Features

- Automatically adds favicon icons to external links using DuckDuckGo icons service
- Configurable via TOML config:
  ```toml
  [markata-go.link_avatars]
  enabled = true
  # service = "duckduckgo"  # default
  # ignore_domains = ["example.com"]
  # ignore_origins = ["https://example.com"]
  # ignore_selectors = [".no-avatars", "#nav"]
  # ignore_classes = ["no-avatar"]
  # ignore_ids = ["no-avatar"]
  ```
- Generates CSS and JS assets in `output/assets/markata/`
- Automatically injects assets into page head
- Supports multiple favicon services (DuckDuckGo, Google, custom template)

## How it works

1. During the Write stage, generates `link-avatars.js` and `link-avatars.css`
2. JavaScript finds external links, applies ignore rules, and sets CSS variables
3. CSS displays the favicon as a `::before` pseudo-element