### PR TITLE
feat: Enable chartjs/csv_fence/mermaid/glossary/wikilink_hover by default

### DIFF
--- a/pkg/plugins/registry.go
+++ b/pkg/plugins/registry.go
@@ -174,6 +174,11 @@ func DefaultPlugins() []lifecycle.Plugin {
 		NewContributionGraphPlugin(), // Process contribution graph code blocks
 		NewMDVideoPlugin(),           // Convert video images to video tags
 		NewYouTubePlugin(),           // Convert YouTube URLs to embeds
+		NewChartJSPlugin(),           // Convert Chart.js code blocks to charts
+		NewCSVFencePlugin(),          // Convert CSV code blocks to tables
+		NewMermaidPlugin(),           // Convert Mermaid code blocks to diagrams
+		NewGlossaryPlugin(),          // Auto-link glossary terms (Render + Write stages)
+		NewWikilinkHoverPlugin(),     // Add hover data to wikilinks (runs after wikilinks)
 		NewLinkCollectorPlugin(),     // Collect links after markdown rendering
 		NewEncryptionPlugin(),        // Encrypt content for private posts (runs late in Render)
 		NewTemplatesPlugin(),


### PR DESCRIPTION
## Summary

Enable these built-in plugins in `DefaultPlugins()` for improved out-of-the-box content features:

- **chartjs**: Convert Chart.js code blocks to interactive charts
- **csv_fence**: Convert CSV code blocks to HTML tables  
- **mermaid**: Convert Mermaid code blocks to diagrams
- **glossary**: Auto-link glossary terms in content
- **wikilink_hover**: Add hover preview data to wikilinks

All plugins still support opt-out via `enabled = false` in config.

## Changes

- Added 5 plugins to `DefaultPlugins()` in `pkg/plugins/registry.go`
- Updated `docs/reference/plugins.md`:
  - Updated "Default Plugin Order" section to include new plugins
  - Updated each plugin's documentation to indicate "enabled by default" status
  - Removed "Enabling the plugin" code examples (no longer needed)

## Testing

- All tests pass: `go test ./...`
- Lint passes: `golangci-lint` via pre-commit hook
- All plugins already have `Enabled: true` by default and respect their config's `enabled` field for opt-out

Fixes #711