### PR TITLE
fix(css_purge): preserve theme selectors during CSS purging

### DIFF
--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -1680,6 +1680,12 @@ type CSSPurgeConfig struct {
 	// Example: ["js-*", "htmx-*", "active", "hidden"]
 	Preserve []string `json:"preserve" yaml:"preserve" toml:"preserve"`
 
+	// PreserveAttributes is a list of attribute names to always preserve.
+	// Selectors with these attributes (e.g., [data-theme], [data-palette]) will not be purged.
+	// This is essential for runtime theming where attributes are set via JavaScript.
+	// Example: ["data-theme", "data-palette"]
+	PreserveAttributes []string `json:"preserve_attributes" yaml:"preserve_attributes" toml:"preserve_attributes"`
+
 	// SkipFiles is a list of CSS file patterns to skip during purging.
 	// Useful for third-party CSS that should not be modified.
 	// Example: ["vendor/*", "normalize.css"]
@@ -1694,11 +1700,12 @@ type CSSPurgeConfig struct {
 // NewCSSPurgeConfig creates a new CSSPurgeConfig with default values.
 func NewCSSPurgeConfig() CSSPurgeConfig {
 	return CSSPurgeConfig{
-		Enabled:          false, // Disabled by default - opt-in feature
-		Verbose:          false,
-		Preserve:         []string{}, // Uses csspurge.DefaultPreservePatterns() when empty
-		SkipFiles:        []string{},
-		WarningThreshold: 0,
+		Enabled:            false, // Disabled by default - opt-in feature
+		Verbose:            false,
+		Preserve:           []string{}, // Uses csspurge.DefaultPreservePatterns() when empty
+		PreserveAttributes: []string{}, // Uses csspurge.DefaultPreserveAttributes() when empty
+		SkipFiles:          []string{},
+		WarningThreshold:   0,
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add default preserve patterns for theme-related class selectors (`theme-*`, `palette-*`)
- Add `PreserveAttributes` option to preserve attribute selectors like `[data-theme]`, `[data-palette]`
- Add comprehensive tests for theme selector preservation

## Problem

When `css_purge` is enabled, theme styles break because selectors applied at runtime (e.g., `data-theme`/`data-palette` attributes or `.dark`/`.light` classes) are not present in static HTML and get purged. This removes core theme styles for the default theme and palette switcher functionality.

## Solution

1. **Class patterns**: Added `theme-*` and `palette-*` to `DefaultPreservePatterns()` (`.dark`, `.light`, `dark-mode`, `light-mode` were already present)

2. **Attribute preservation**: Added new `PreserveAttributes` option with defaults:
   - `data-theme`
   - `data-palette`  
   - `data-mode`
   - `data-color-scheme`

3. **Configuration**: Users can customize via config:
   ```toml
   [markata-go.css_purge]
   preserve = ["my-custom-*"]
   preserve_attributes = ["data-my-custom"]
   ```

## Testing

Added `TestThemeSelectorsPreserved` with 9 test cases covering:
- `[data-theme]` attribute selector preservation
- `[data-palette]` attribute selector preservation  
- `theme-*` and `palette-*` class pattern preservation
- `.dark` and `.light` class preservation
- Combined theme attribute and class preservation
- Verifies non-theme selectors are still purged

Fixes #710