### PR TITLE
fix: invalidate build cache when feed membership changes

### DIFF
--- a/pkg/buildcache/cache.go
+++ b/pkg/buildcache/cache.go
@@ -35,6 +35,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 )
@@ -129,6 +130,11 @@ type PostCache struct {
 
 	// LinkHrefs caches extracted href values for the post
 	LinkHrefs []string `json:"link_hrefs,omitempty"`
+
+	// FeedMembershipHash is the hash of the sorted slugs of feed co-members.
+	// When feed membership changes (posts added/removed from a tag), this hash
+	// changes and the post is rebuilt with the updated sidebar.
+	FeedMembershipHash string `json:"feed_membership_hash,omitempty"`
 }
 
 // FeedCache stores cached metadata for a single feed.
@@ -446,6 +452,38 @@ func (c *Cache) CacheLinkHrefs(sourcePath, articleHash string, hrefs []string) {
 		}
 	}
 	c.dirty = true
+}
+
+// SetFeedMembershipHash stores the feed membership hash for a post.
+func (c *Cache) SetFeedMembershipHash(sourcePath, hash string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if cached, ok := c.Posts[sourcePath]; ok {
+		cached.FeedMembershipHash = hash
+	}
+	c.dirty = true
+}
+
+// GetFeedMembershipHash returns the cached feed membership hash for a post.
+func (c *Cache) GetFeedMembershipHash(sourcePath string) string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if cached, ok := c.Posts[sourcePath]; ok {
+		return cached.FeedMembershipHash
+	}
+	return ""
+}
+
+// ComputeFeedMembershipHash computes a hash of the sorted slugs of feed co-members.
+// Returns empty string if the slug list is empty.
+func ComputeFeedMembershipHash(slugs []string) string {
+	if len(slugs) == 0 {
+		return ""
+	}
+	sorted := make([]string, len(slugs))
+	copy(sorted, slugs)
+	sort.Strings(sorted)
+	return HashContent(strings.Join(sorted, "\x00"))
 }
 
 // Stats returns build statistics.

--- a/spec/spec/LIFECYCLE.md
+++ b/spec/spec/LIFECYCLE.md
@@ -947,9 +947,18 @@ When a dependency changes, all dependent posts are marked for rebuild.
 | Template file | All posts using that template |
 | Base template | All posts (cascades through inheritance) |
 | Partial/include | All posts whose templates use it |
+| Feed membership change | All posts in the affected feed |
 | Config change | Full rebuild |
 | Plugin code change | Full rebuild |
 | Markdown extension settings | Full rebuild |
+
+**Feed Membership Tracking:**
+
+Posts that belong to a feed sidebar (configured via `[components.feed_sidebar]`) track a
+`FeedMembershipHash` -- a hash of the sorted slugs of all co-members in the feed. When a
+post is added to or removed from a tag-based feed, this hash changes and all existing
+members are rebuilt with the updated sidebar. This ensures sidebar navigation stays
+consistent even when only one post's content changes.
 
 ### Implementation Notes
 


### PR DESCRIPTION
## Summary

Fixes #723

When a new post is created with a tag that is part of `feed_sidebar.feeds`, existing posts with the same tag now correctly have their cached HTML invalidated and rebuilt with the updated sidebar.

## Changes

- **`pkg/buildcache/cache.go`**: Added `FeedMembershipHash` field to `PostCache` struct, plus `SetFeedMembershipHash()`, `GetFeedMembershipHash()`, and `ComputeFeedMembershipHash()` methods
- **`pkg/plugins/templates.go`**: Updated `tryGetCachedHTML()` to check feed membership hash; added `computeFeedMembershipHash()` method; store membership hash after rendering
- **`pkg/buildcache/cache_test.go`**: 6 new tests covering hash computation, persistence, and change detection
- **`spec/spec/LIFECYCLE.md`**: Documented feed membership tracking in the build cache spec

## How It Works

1. When a post belongs to a feed sidebar (via tags), the system computes a hash of the sorted slugs of all co-members
2. This hash is stored in the build cache alongside the post
3. On subsequent builds, the hash is recomputed and compared -- if membership changed (post added/removed), the cached HTML is invalidated
4. The post is then re-rendered with the current sidebar content

## Testing

- `go test ./pkg/buildcache/...` -- all pass
- `go test ./pkg/plugins/...` -- all pass
- `just lint-fast` -- clean