### PR TITLE
fix: improve template accessibility (image dimensions, SR text, reduced motion)

### DIFF
--- a/pkg/themes/default/static/css/cards.css
+++ b/pkg/themes/default/static/css/cards.css
@@ -740,3 +740,24 @@
     max-height: 150px;
   }
 }
+
+/* ==========================================================================
+   Reduced Motion - Respect prefers-reduced-motion for card hover effects
+   ========================================================================== */
+
+@media (prefers-reduced-motion: reduce) {
+  .card-photo .card-image,
+  .card-video .card-thumbnail,
+  .card-video .card-play-icon {
+    transition: none;
+  }
+
+  .card-photo:hover .card-image,
+  .card-video:hover .card-thumbnail {
+    transform: none;
+  }
+
+  .card-video:hover .card-play-icon {
+    transform: translate(-50%, -50%);
+  }
+}

--- a/pkg/themes/default/templates/blogroll.html
+++ b/pkg/themes/default/templates/blogroll.html
@@ -34,7 +34,7 @@
         {% endif %}
         <h3 class="blogroll-card-title">
           {% if feed.site_url %}
-          <a href="{{ feed.site_url }}" target="_blank" rel="noopener noreferrer">{{ feed.title }}</a>
+           <a href="{{ feed.site_url }}" target="_blank" rel="noopener noreferrer">{{ feed.title }}<span class="visually-hidden">(opens in new tab)</span></a>
           {% else %}
           {{ feed.title }}
           {% endif %}

--- a/pkg/themes/default/templates/components/footer.html
+++ b/pkg/themes/default/templates/components/footer.html
@@ -15,7 +15,7 @@
         {% if footer.links %}
         <nav class="footer-links" aria-label="Footer navigation">
             {% for link in footer.links %}
-            <a href="{{ link.url }}"{% if link.external %} target="_blank" rel="noopener noreferrer"{% endif %}>{{ link.label }}</a>
+            <a href="{{ link.url }}"{% if link.external %} target="_blank" rel="noopener noreferrer"{% endif %}>{{ link.label }}{% if link.external %}<span class="visually-hidden">(opens in new tab)</span>{% endif %}</a>
             {% endfor %}
         </nav>
         {% endif %}

--- a/pkg/themes/default/templates/components/nav.html
+++ b/pkg/themes/default/templates/components/nav.html
@@ -7,12 +7,12 @@
 <nav class="site-nav site-nav--{{ nav.position | default:'header' }} site-nav--{{ nav.style | default:'horizontal' }}" aria-label="Main navigation">
     {% if nav.items %}
         {% for item in nav.items %}
-    <a href="{{ item.url }}"{% if item.external %} target="_blank" rel="noopener noreferrer"{% endif %} class="nav-link">{{ item.label }}</a>
+    <a href="{{ item.url }}"{% if item.external %} target="_blank" rel="noopener noreferrer"{% endif %} class="nav-link">{{ item.label }}{% if item.external %}<span class="visually-hidden">(opens in new tab)</span>{% endif %}</a>
         {% endfor %}
     {% elif config.nav %}
         {# Fallback to legacy config.nav for backward compatibility #}
         {% for item in config.nav %}
-    <a href="{{ item.url }}"{% if item.external %} target="_blank" rel="noopener noreferrer"{% endif %} class="nav-link">{{ item.label }}</a>
+    <a href="{{ item.url }}"{% if item.external %} target="_blank" rel="noopener noreferrer"{% endif %} class="nav-link">{{ item.label }}{% if item.external %}<span class="visually-hidden">(opens in new tab)</span>{% endif %}</a>
         {% endfor %}
     {% else %}
     <a href="/" class="nav-link">Home</a>

--- a/pkg/themes/default/templates/reader.html
+++ b/pkg/themes/default/templates/reader.html
@@ -38,7 +38,7 @@
         {% endif %}
         <div class="reader-entry-content">
           <h2 class="reader-entry-title">
-            <a href="{{ entry.url }}" target="_blank" rel="noopener noreferrer">{{ entry.title }}</a>
+            <a href="{{ entry.url }}" target="_blank" rel="noopener noreferrer">{{ entry.title }}<span class="visually-hidden">(opens in new tab)</span></a>
           </h2>
           <div class="reader-entry-meta">
             <span class="reader-entry-source">{{ entry.feed_title }}</span>

--- a/spec/spec/TEMPLATES.md
+++ b/spec/spec/TEMPLATES.md
@@ -830,3 +830,25 @@ Feed/listing templates MUST include `h-feed` markup:
 - [CONFIG.md](./CONFIG.md) - Template configuration
 - [CONTENT.md](./CONTENT.md) - Markdown processing
 - [PLUGINS.md](./PLUGINS.md) - Plugin development
+
+---
+
+## Accessibility Requirements
+
+Templates MUST follow these accessibility guidelines:
+
+### Image Dimensions
+
+All `<img>` tags MUST include explicit `width` and `height` attributes to prevent
+Cumulative Layout Shift (CLS). Large content images SHOULD also include `loading="lazy"`.
+
+### External Link Hints
+
+Links that open in a new tab (`target="_blank"`) MUST include a visually-hidden
+screen reader hint such as `<span class="visually-hidden">(opens in new tab)</span>`
+so that assistive technology users are warned about the navigation change.
+
+### Reduced Motion
+
+CSS hover/transition effects MUST be disabled or reduced inside a
+`@media (prefers-reduced-motion: reduce)` block to respect user motion preferences.

--- a/templates/blogroll.html
+++ b/templates/blogroll.html
@@ -36,7 +36,7 @@
         <div class="blogroll-card-content">
           <h3 class="blogroll-card-title">
             {% if feed.site_url %}
-            <a href="{{ feed.site_url }}" target="_blank" rel="noopener noreferrer">{{ feed.title }}</a>
+            <a href="{{ feed.site_url }}" target="_blank" rel="noopener noreferrer">{{ feed.title }}<span class="visually-hidden">(opens in new tab)</span></a>
             {% else %}
             {{ feed.title }}
             {% endif %}

--- a/templates/components/footer.html
+++ b/templates/components/footer.html
@@ -13,7 +13,7 @@
         {% if footer.links %}
         <nav class="footer-links">
             {% for link in footer.links %}
-            <a href="{{ link.url }}"{% if link.external %} target="_blank" rel="noopener noreferrer"{% endif %}>{{ link.label }}</a>
+            <a href="{{ link.url }}"{% if link.external %} target="_blank" rel="noopener noreferrer"{% endif %}>{{ link.label }}{% if link.external %}<span class="visually-hidden">(opens in new tab)</span>{% endif %}</a>
             {% endfor %}
         </nav>
         {% endif %}

--- a/templates/components/nav.html
+++ b/templates/components/nav.html
@@ -7,12 +7,12 @@
 <nav class="site-nav site-nav--{{ nav.position | default:'header' }} site-nav--{{ nav.style | default:'horizontal' }}">
     {% if nav.items %}
         {% for item in nav.items %}
-    <a href="{{ item.url }}"{% if item.external %} target="_blank" rel="noopener noreferrer"{% endif %} class="nav-link">{{ item.label }}</a>
+    <a href="{{ item.url }}"{% if item.external %} target="_blank" rel="noopener noreferrer"{% endif %} class="nav-link">{{ item.label }}{% if item.external %}<span class="visually-hidden">(opens in new tab)</span>{% endif %}</a>
         {% endfor %}
     {% elif config.nav %}
         {# Fallback to legacy config.nav for backward compatibility #}
         {% for item in config.nav %}
-    <a href="{{ item.url }}"{% if item.external %} target="_blank" rel="noopener noreferrer"{% endif %} class="nav-link">{{ item.label }}</a>
+    <a href="{{ item.url }}"{% if item.external %} target="_blank" rel="noopener noreferrer"{% endif %} class="nav-link">{{ item.label }}{% if item.external %}<span class="visually-hidden">(opens in new tab)</span>{% endif %}</a>
         {% endfor %}
     {% else %}
     <a href="/blog/" class="nav-link">Blog</a>

--- a/templates/layouts/blog.html
+++ b/templates/layouts/blog.html
@@ -12,7 +12,7 @@
         {% if config.header.show_logo or config.header.show_title %}
         <a href="/" class="site-title">
             {% if config.header.show_logo and config.logo %}
-            <img src="{{ config.logo }}" alt="{{ config.title }}" class="site-logo">
+            <img src="{{ config.logo }}" alt="{{ config.title }}" class="site-logo" width="32" height="32">
             {% endif %}
             {% if config.header.show_title %}{{ config.title | default:"Home" }}{% endif %}
         </a>
@@ -64,7 +64,7 @@
 
             {% if post.cover_image %}
             <figure class="post-cover">
-                <img src="{{ post.cover_image }}" alt="{{ post.title }}">
+                <img src="{{ post.cover_image }}" alt="{{ post.title }}" width="1200" height="675" loading="lazy">
             </figure>
             {% endif %}
 

--- a/templates/layouts/docs.html
+++ b/templates/layouts/docs.html
@@ -12,7 +12,7 @@
         {% if config.header.show_logo or config.header.show_title %}
         <a href="/" class="site-title">
             {% if config.header.show_logo and config.logo %}
-            <img src="{{ config.logo }}" alt="{{ config.title }}" class="site-logo">
+            <img src="{{ config.logo }}" alt="{{ config.title }}" class="site-logo" width="32" height="32">
             {% endif %}
             {% if config.header.show_title %}{{ config.title | default:"Home" }}{% endif %}
         </a>

--- a/templates/layouts/landing.html
+++ b/templates/layouts/landing.html
@@ -12,7 +12,7 @@
         {% if config.header.show_logo or config.header.show_title %}
         <a href="/" class="site-title">
             {% if config.header.show_logo and config.logo %}
-            <img src="{{ config.logo }}" alt="{{ config.title }}" class="site-logo">
+            <img src="{{ config.logo }}" alt="{{ config.title }}" class="site-logo" width="32" height="32">
             {% endif %}
             {% if config.header.show_title %}{{ config.title | default:"Home" }}{% endif %}
         </a>
@@ -58,7 +58,7 @@
         </div>
         {% if post.hero.image %}
         <div class="hero-image">
-            <img src="{{ post.hero.image }}" alt="{{ post.hero.title | default:post.title }}">
+            <img src="{{ post.hero.image }}" alt="{{ post.hero.title | default:post.title }}" width="1200" height="630" loading="lazy">
         </div>
         {% endif %}
     </section>

--- a/templates/partials/external-embed.html
+++ b/templates/partials/external-embed.html
@@ -9,7 +9,7 @@
     </div>
     {% endif %}
     <div class="embed-card-content">
-      <div class="embed-card-title">{{ og_title|default:fallback_title }}</div>
+      <div class="embed-card-title">{{ og_title|default:fallback_title }}<span class="visually-hidden">(opens in new tab)</span></div>
       {% if og_description %}
       <div class="embed-card-description">{{ og_description|truncate:200 }}</div>
       {% endif %}

--- a/templates/reader.html
+++ b/templates/reader.html
@@ -36,7 +36,7 @@
         <img src="{{ entry.image_url }}" alt="" class="entry-image" width="120" height="80" loading="lazy">
         {% endif %}
         <h2 class="reader-entry-title">
-          <a href="{{ entry.url }}" target="_blank" rel="noopener noreferrer">{{ entry.title }}</a>
+          <a href="{{ entry.url }}" target="_blank" rel="noopener noreferrer">{{ entry.title }}<span class="visually-hidden">(opens in new tab)</span></a>
         </h2>
         <div class="reader-entry-meta">
           <span class="reader-entry-source">{{ entry.feed_title }}</span>


### PR DESCRIPTION
## Summary

- Adds explicit `width`/`height` attributes to images to prevent CLS (Cumulative Layout Shift)
- Adds screen reader text `(opens in new tab)` to all external links with `target="_blank"`
- Adds `@media (prefers-reduced-motion: reduce)` CSS rule for card hover animations

## Audit Results

Most accessibility items were already correct (skip links, no `transition:all`, proper `aria-hidden`, `rel` attributes, `body_class`, pagination). Only 3 categories needed fixes.

## Changes

**Image dimensions (5 template files):**
- `templates/layouts/docs.html`, `blog.html`, `landing.html` — Added width/height to site-logo (32x32), cover_image (1200x675), hero image (1200x630), plus `loading="lazy"`

**Screen reader text (8 files):**
- Added `<span class="visually-hidden">(opens in new tab)</span>` to all `target="_blank"` links in `nav.html`, `footer.html`, `reader.html`, `blogroll.html`, `external-embed.html` + their `pkg/themes/default/templates/` mirrors

**Reduced motion (1 CSS file):**
- `pkg/themes/default/static/css/cards.css` — Added `@media (prefers-reduced-motion: reduce)` block

**Spec:**
- `spec/spec/TEMPLATES.md` — Added Accessibility Requirements section

## Testing

Verified templates render correctly with `go test ./...`

Fixes #669