### PR TITLE
fix(mermaid): fix cursor, sequence diagram zoom, and view transition re-rendering

### DIFF
--- a/pkg/themes/default/static/css/components.css
+++ b/pkg/themes/default/static/css/components.css
@@ -2432,6 +2432,15 @@ div[class]:not([class=""]) {
   background-color: var(--color-text-muted);
 }
 
+/* Mermaid diagrams -- indicate clickability on the rendered SVG.
+   The wildcard is needed because mermaid uses <foreignObject> with
+   HTML content inside SVG, and browsers apply the default cursor to that HTML
+   (e.g. text cursor over labels).  We force pointer on every SVG descendant. */
+pre.mermaid svg,
+pre.mermaid svg * {
+  cursor: pointer;
+}
+
 /* Mermaid lightbox SVG wrapper
    The wrapper must have an explicit height so svg-pan-zoom has a concrete
    region to render into.  GLightbox passes height:'90vh' in setElements(),

--- a/pkg/themes/default/static/js/view-transitions.js
+++ b/pkg/themes/default/static/js/view-transitions.js
@@ -237,6 +237,16 @@
     // Replace body content
     document.body.innerHTML = newDoc.body.innerHTML;
 
+    // Re-execute inline module scripts (e.g. mermaid, chartjs).
+    // innerHTML assignment does not run <script> tags, so we clone them
+    // into fresh elements which the browser will evaluate.
+    document.body.querySelectorAll('script[type="module"]').forEach(old => {
+      const fresh = document.createElement('script');
+      fresh.type = 'module';
+      fresh.textContent = old.textContent;
+      old.replaceWith(fresh);
+    });
+
     // Re-initialize scripts
     reinitializeScripts();
 
@@ -311,6 +321,11 @@
 
     if (window.initNavigationShortcuts && typeof window.initNavigationShortcuts === 'function') {
       window.initNavigationShortcuts();
+    }
+
+    // Re-initialize mermaid diagrams (module script won't re-execute after DOM swap)
+    if (window.initMermaid && typeof window.initMermaid === 'function') {
+      window.initMermaid();
     }
 
     // Re-attach event listeners


### PR DESCRIPTION
## Summary

- **Pointer cursor**: Replace `zoom-in` cursor (invisible on Linux) with `pointer` on mermaid SVGs via CSS, mermaid themeCSS injection, and JS fallback -- targets SVG descendants only so `<pre>` padding keeps the default cursor
- **Sequence diagram zoom**: Fix viewBox derivation in lightbox pan-zoom to handle sequence diagrams (`style.maxWidth` fallback) with retry loop for unsettled animations
- **View transition re-rendering**: Re-execute inline `<script type="module">` tags after DOM swap and call `initMermaid()` in `reinitializeScripts()` so mermaid diagrams render after SPA-style navigation

## Changes

| File | What |
|------|------|
| `pkg/plugins/mermaid.go` | `startOnLoad:false` + async `await mermaid.run()`, pointer cursor in themeCSS + JS, viewBox retry logic, lightbox binding retry |
| `pkg/themes/default/static/css/components.css` | `pre.mermaid svg, pre.mermaid svg * { cursor: pointer }` |
| `pkg/themes/default/static/js/view-transitions.js` | Clone module scripts after innerHTML swap, call `window.initMermaid()` in reinit |

## Testing

- All 22 mermaid plugin unit tests pass
- `just lint-fast` clean
- Manually verified: pointer cursor on diagrams, click-to-lightbox with pan/zoom on sequence diagrams, mermaid re-renders after view transitions