### PR TITLE
fix(htmltotext): prevent panic from nested anchor tags

### DIFF
--- a/pkg/htmltotext/htmltotext.go
+++ b/pkg/htmltotext/htmltotext.go
@@ -134,8 +134,15 @@ func processAnchors(
 
 	spans := make([]anchorSpan, 0, len(openMatches))
 
+	lastEnd := 0
 	// For each open tag, find the matching close tag
 	for _, openIdx := range openMatches {
+		// Skip if this open tag starts before the previous span ended
+		// (handles nested anchors which would create invalid spans)
+		if openIdx[0] < lastEnd {
+			continue
+		}
+
 		openTag := htmlContent[openIdx[0]:openIdx[1]]
 		hrefMatch := anchorOpenRe.FindStringSubmatch(openTag)
 		if len(hrefMatch) < 2 {
@@ -159,6 +166,7 @@ func processAnchors(
 			href:     href,
 			textHTML: htmlContent[textStart:textEnd],
 		})
+		lastEnd = fullEnd
 	}
 
 	if len(spans) == 0 {


### PR DESCRIPTION
## Summary

- Fixes a panic in `processAnchors` when HTML contains nested anchor tags (`<a><a>...</a></a>`)
- The bug caused `slice bounds out of range [1019:995]` because the inner `</a>` was matched to the outer `<a>`, creating an invalid span
- Skips anchors that overlap with previous spans instead of crashing

## Changes

- Add `lastEnd` tracking to detect overlapping anchor spans
- Skip nested anchors to prevent invalid span generation