### PR TITLE
feat(new): add TUI wizard with huh for interactive content creation

### DIFF
--- a/cmd/markata-go/cmd/explain.go
+++ b/cmd/markata-go/cmd/explain.go
@@ -352,26 +352,39 @@ Create a new content file with frontmatter template.
 
 ## Flags
 
-    --dir      Directory to create post in (default: posts)
-    --draft    Create as draft (default: true)
-    --tags     Comma-separated list of tags
+    --template, -t   Content template to use (default: post)
+    --list, -l       List available templates
+    --dir            Directory to create post in (default: template's default)
+    --draft          Create as draft (default: false)
+    --tags           Comma-separated list of tags
+    --plain          Use plain text prompts instead of TUI wizard
+
+## Interactive Wizard
+
+When called without arguments, launches a TUI wizard (charmbracelet/huh) that
+guides you through template selection, title, directory, tags, privacy, and
+author configuration. Falls back to plain text prompts when stdin is not a TTY
+or when --plain is passed.
 
 ## Examples
 
-    # Create new post (prompts for title)
+    # Launch interactive TUI wizard
     markata-go new
 
-    # Create with title
+    # Create with title (skips wizard)
     markata-go new "My First Post"
 
     # Create in specific directory
     markata-go new "Hello World" --dir blog
 
-    # Create as published (not draft)
-    markata-go new "Ready to Publish" --draft=false
+    # Create as a draft
+    markata-go new "Work in Progress" --draft
 
     # Create with tags
     markata-go new "Go Tutorial" --tags "go,tutorial,programming"
+
+    # Use plain text prompts instead of TUI
+    markata-go new --plain
 
 ## Generated File
 
@@ -381,8 +394,8 @@ The command creates a markdown file with this template:
     title: "My First Post"
     slug: "my-first-post"
     date: 2024-01-15
-    draft: true
-    published: false
+    draft: false
+    published: true
     tags: []
     description: ""
     ---
@@ -405,19 +418,23 @@ Examples:
 
 ## Key Source Files
 
-    cmd/markata-go/cmd/new.go    # New command implementation
+    cmd/markata-go/cmd/new.go      # New command implementation
+    cmd/markata-go/cmd/new_huh.go  # TUI wizard implementation
 
 ## Related Configuration
 
     [markata-go.glob]
     patterns = ["posts/**/*.md"]  # Ensure new posts match patterns
 
+    [content_templates.placement]
+    post = "blog"     # Override default directory per template type
+
 ## Common Issues
 
 1. **Post not appearing in build**
-   - Check draft: true (drafts excluded by default)
+   - New posts default to draft: false, published: true
    - Verify file matches glob patterns
-   - Ensure published: true for non-drafts
+   - If created with --draft, set draft: false when ready
 
 2. **Date format errors**
    - Use YYYY-MM-DD format

--- a/cmd/markata-go/cmd/new_huh.go
+++ b/cmd/markata-go/cmd/new_huh.go
@@ -1,0 +1,752 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
+	"github.com/charmbracelet/huh"
+
+	"github.com/WaylonWalker/markata-go/pkg/config"
+	"github.com/WaylonWalker/markata-go/pkg/models"
+	"github.com/WaylonWalker/markata-go/pkg/plugins"
+)
+
+// Template name constants used for conditional wizard groups.
+const (
+	tmplPhoto   = "photo"
+	tmplVideo   = "video"
+	tmplLink    = "link"
+	tmplQuote   = "quote"
+	tmplContact = "contact"
+	tmplAuthor  = "author"
+
+	dirCustomSentinel = "__custom__" // sentinel value for custom directory selection
+)
+
+// newWizardState holds all state gathered during the new post huh wizard.
+type newWizardState struct {
+	Title            string
+	Template         string
+	Directory        string
+	DirChoice        string // intermediate: selected directory or __custom__
+	CustomDir        string // intermediate: custom directory input
+	Tags             []string
+	CustomTag        string
+	Private          bool
+	Authors          []string
+	UseDefaultAuthor bool
+
+	// Template-specific fields
+	ImageURL string // photo, video (thumbnail), link (preview)
+	VideoURL string // video
+	Duration string // video
+	LinkURL  string // link
+	Quote    string // quote
+	Source   string // quote
+	Handle   string // contact
+	Name     string // author
+	Bio      string // author
+	Email    string // author
+	Role     string // author
+}
+
+// siteContext holds discovered site metadata used to populate wizard options.
+type siteContext struct {
+	Config             *models.Config
+	Templates          map[string]ContentTemplate
+	ExistingTags       []string
+	ExistingDirs       []string
+	HasMultipleAuthors bool
+	AuthorOptions      []authorOption
+	DefaultAuthorID    string
+}
+
+// authorOption represents an author choice in the wizard.
+type authorOption struct {
+	ID   string
+	Name string
+}
+
+// loadSiteContext loads config, discovers tags, directories, and authors.
+func loadSiteContext(templates map[string]ContentTemplate) *siteContext {
+	ctx := &siteContext{
+		Templates: templates,
+	}
+
+	// Load full config
+	cfg, err := config.Load("")
+	if err != nil {
+		cfg, _ = config.LoadWithDefaults() //nolint:errcheck // best-effort fallback to defaults
+	}
+	ctx.Config = cfg
+
+	// Discover existing tags from content
+	ctx.ExistingTags = discoverExistingTags(cfg)
+
+	// Discover existing directories
+	ctx.ExistingDirs = discoverExistingDirs(cfg)
+
+	// Discover author configuration
+	if cfg != nil && len(cfg.Authors.Authors) > 1 {
+		ctx.HasMultipleAuthors = true
+		ctx.AuthorOptions = make([]authorOption, 0, len(cfg.Authors.Authors))
+
+		for id := range cfg.Authors.Authors {
+			author := cfg.Authors.Authors[id]
+			if !author.Active && !author.Default {
+				continue
+			}
+			ctx.AuthorOptions = append(ctx.AuthorOptions, authorOption{
+				ID:   id,
+				Name: author.Name,
+			})
+			if author.Default {
+				ctx.DefaultAuthorID = id
+			}
+		}
+
+		// Sort authors by name for consistent display
+		sort.Slice(ctx.AuthorOptions, func(i, j int) bool {
+			return ctx.AuthorOptions[i].Name < ctx.AuthorOptions[j].Name
+		})
+
+		// If no default was set, use first active author
+		if ctx.DefaultAuthorID == "" && len(ctx.AuthorOptions) > 0 {
+			ctx.DefaultAuthorID = ctx.AuthorOptions[0].ID
+		}
+	}
+
+	return ctx
+}
+
+// discoverExistingTags scans content files to collect all unique tags.
+func discoverExistingTags(cfg *models.Config) []string {
+	if cfg == nil {
+		return nil
+	}
+
+	patterns := cfg.GlobConfig.Patterns
+	if len(patterns) == 0 {
+		patterns = []string{"**/*.md"}
+	}
+
+	tagSet := make(map[string]bool)
+
+	for _, pattern := range patterns {
+		matches, err := doublestar.FilepathGlob(pattern)
+		if err != nil {
+			continue
+		}
+		for _, path := range matches {
+			content, err := os.ReadFile(path)
+			if err != nil {
+				continue
+			}
+			metadata, _, err := plugins.ParseFrontmatter(string(content))
+			if err != nil {
+				continue
+			}
+			for _, tag := range plugins.GetStringSlice(metadata, "tags") {
+				tagSet[tag] = true
+			}
+		}
+	}
+
+	tags := make([]string, 0, len(tagSet))
+	for tag := range tagSet {
+		tags = append(tags, tag)
+	}
+	sort.Strings(tags)
+	return tags
+}
+
+// discoverExistingDirs finds all directories that contain markdown files.
+func discoverExistingDirs(cfg *models.Config) []string {
+	if cfg == nil {
+		return nil
+	}
+
+	patterns := cfg.GlobConfig.Patterns
+	if len(patterns) == 0 {
+		patterns = []string{"**/*.md"}
+	}
+
+	dirSet := make(map[string]bool)
+
+	for _, pattern := range patterns {
+		matches, err := doublestar.FilepathGlob(pattern)
+		if err != nil {
+			continue
+		}
+		for _, path := range matches {
+			dir := filepath.Dir(path)
+			if dir != "." {
+				dirSet[dir] = true
+			}
+		}
+	}
+
+	dirs := make([]string, 0, len(dirSet))
+	for dir := range dirSet {
+		dirs = append(dirs, dir)
+	}
+	sort.Strings(dirs)
+	return dirs
+}
+
+// runHuhNewWizard runs the huh-based interactive wizard for creating new content.
+// All groups are in a single form so Shift+Tab navigates backwards.
+func runHuhNewWizard(templates map[string]ContentTemplate) (*newWizardState, error) {
+	ctx := loadSiteContext(templates)
+
+	// Create theme from config palette
+	paletteName := ""
+	if ctx.Config != nil {
+		paletteName = ctx.Config.Theme.Palette
+	}
+	theme := createHuhTheme(paletteName)
+
+	state := &newWizardState{
+		Template: newTemplate,
+	}
+
+	// Build all groups for a single form with back navigation.
+
+	// --- Group 1: Template and Title ---
+	templateOptions := buildTemplateOptions(ctx.Templates)
+	titleGroup := huh.NewGroup(
+		huh.NewNote().
+			Title("Create New Content").
+			Description("Let's set up your new content file.\nUse Shift+Tab to go back to a previous step."),
+		huh.NewSelect[string]().
+			Title("Template").
+			Description("Choose the content type (/ to filter)").
+			Options(templateOptions...).
+			Value(&state.Template),
+		huh.NewInput().
+			Title("Title").
+			Description("The title of your new content").
+			Value(&state.Title).
+			Placeholder("My New Post").
+			Validate(func(s string) error {
+				if strings.TrimSpace(s) == "" {
+					return fmt.Errorf("title is required")
+				}
+				return nil
+			}),
+	)
+
+	// --- Group 2: Directory selection (dynamic based on template) ---
+	dirGroup := huh.NewGroup(
+		huh.NewSelect[string]().
+			Title("Directory").
+			Description("Where to create the file (/ to filter)").
+			OptionsFunc(func() []huh.Option[string] {
+				selectedTemplate := ctx.Templates[state.Template]
+				return buildDirectoryOptions(selectedTemplate, ctx.ExistingDirs)
+			}, &state.Template).
+			Value(&state.DirChoice),
+	)
+
+	// --- Group 2b: Custom directory (shown only if __custom__ selected) ---
+	customDirGroup := huh.NewGroup(
+		huh.NewInput().
+			Title("Custom Directory").
+			Description("Enter the directory path").
+			Value(&state.CustomDir).
+			Placeholder("pages/custom"),
+	).WithHideFunc(func() bool {
+		return state.DirChoice != dirCustomSentinel
+	})
+
+	// --- Template-specific groups ---
+
+	// Photo: image URL
+	photoGroup := huh.NewGroup(
+		huh.NewInput().
+			Title("Image URL").
+			Description("Path or URL to the image").
+			Value(&state.ImageURL).
+			Placeholder("/images/photo.jpg"),
+	).WithHideFunc(func() bool {
+		return state.Template != tmplPhoto
+	})
+
+	// Video: video URL, thumbnail, duration
+	videoGroup := huh.NewGroup(
+		huh.NewInput().
+			Title("Video URL").
+			Description("Path or URL to the video").
+			Value(&state.VideoURL).
+			Placeholder("https://youtube.com/watch?v=..."),
+		huh.NewInput().
+			Title("Thumbnail Image").
+			Description("Path or URL to the video thumbnail (optional)").
+			Value(&state.ImageURL).
+			Placeholder("/images/thumb.jpg"),
+		huh.NewInput().
+			Title("Duration").
+			Description("Video duration (optional)").
+			Value(&state.Duration).
+			Placeholder("5:30"),
+	).WithHideFunc(func() bool {
+		return state.Template != tmplVideo
+	})
+
+	// Link: URL and preview image
+	linkGroup := huh.NewGroup(
+		huh.NewInput().
+			Title("Link URL").
+			Description("The URL you are sharing").
+			Value(&state.LinkURL).
+			Placeholder("https://example.com/article"),
+		huh.NewInput().
+			Title("Preview Image").
+			Description("Image for the link preview (optional)").
+			Value(&state.ImageURL).
+			Placeholder("/images/preview.jpg"),
+	).WithHideFunc(func() bool {
+		return state.Template != tmplLink
+	})
+
+	// Quote: quote text and source
+	quoteGroup := huh.NewGroup(
+		huh.NewInput().
+			Title("Quote").
+			Description("The quote text").
+			Value(&state.Quote).
+			Placeholder("To be or not to be..."),
+		huh.NewInput().
+			Title("Source").
+			Description("Where the quote is from (optional)").
+			Value(&state.Source).
+			Placeholder("Shakespeare, Hamlet"),
+	).WithHideFunc(func() bool {
+		return state.Template != tmplQuote
+	})
+
+	// Contact: handle
+	contactGroup := huh.NewGroup(
+		huh.NewInput().
+			Title("Handle").
+			Description("Short handle for @mentions (e.g. alice)").
+			Value(&state.Handle).
+			Placeholder("alice"),
+	).WithHideFunc(func() bool {
+		return state.Template != tmplContact
+	})
+
+	// Author: name, bio, email, role
+	authorGroup := huh.NewGroup(
+		huh.NewInput().
+			Title("Author Name").
+			Description("Full name of the author").
+			Value(&state.Name).
+			Placeholder("Jane Doe"),
+		huh.NewInput().
+			Title("Bio").
+			Description("Short bio (optional)").
+			Value(&state.Bio).
+			Placeholder("Software engineer and writer"),
+		huh.NewInput().
+			Title("Email").
+			Description("Contact email (optional)").
+			Value(&state.Email).
+			Placeholder("jane@example.com"),
+		huh.NewInput().
+			Title("Role").
+			Description("Role or title (optional)").
+			Value(&state.Role).
+			Placeholder("author"),
+	).WithHideFunc(func() bool {
+		return state.Template != tmplAuthor
+	})
+
+	// --- Group 3: Tags ---
+	var tagFields []huh.Field
+
+	if len(ctx.ExistingTags) > 0 {
+		tagOptions := make([]huh.Option[string], 0, len(ctx.ExistingTags))
+		for _, tag := range ctx.ExistingTags {
+			tagOptions = append(tagOptions, huh.NewOption(tag, tag))
+		}
+		tagFields = append(tagFields,
+			huh.NewMultiSelect[string]().
+				Title("Tags").
+				Description("Select from existing tags (/ to filter, space to select)").
+				Options(tagOptions...).
+				Filterable(true).
+				Value(&state.Tags).
+				Height(min(len(tagOptions)+1, 12)),
+		)
+	}
+
+	tagFields = append(tagFields,
+		huh.NewInput().
+			Title("Additional Tags").
+			Description("Enter additional tags, comma-separated (or leave blank)").
+			Value(&state.CustomTag).
+			Placeholder("new-tag, another-tag"),
+	)
+
+	tagsGroup := huh.NewGroup(tagFields...)
+
+	// --- Group 4: Privacy ---
+	privateGroup := huh.NewGroup(
+		huh.NewConfirm().
+			Title("Is this post private?").
+			Description("Private posts are excluded from feeds and search").
+			Value(&state.Private).
+			Affirmative("Yes").
+			Negative("No"),
+	)
+
+	// --- Group 5: Authors (conditional - only for multi-author sites) ---
+	// Default author confirm
+	defaultAuthorName := ctx.DefaultAuthorID
+	for _, a := range ctx.AuthorOptions {
+		if a.ID == ctx.DefaultAuthorID {
+			defaultAuthorName = a.Name
+			break
+		}
+	}
+
+	defaultAuthorGroup := huh.NewGroup(
+		huh.NewConfirm().
+			Title(fmt.Sprintf("Use default author (%s)?", defaultAuthorName)).
+			Description("You can add multiple authors if needed").
+			Value(&state.UseDefaultAuthor).
+			Affirmative("Yes").
+			Negative("Choose authors"),
+	).WithHideFunc(func() bool {
+		return !ctx.HasMultipleAuthors
+	})
+
+	// Author multi-select (shown only if user chose to pick authors)
+	authorOpts := buildAuthorOptions(ctx)
+	authorSelectGroup := huh.NewGroup(
+		huh.NewMultiSelect[string]().
+			Title("Authors").
+			Description("Select authors for this post (/ to filter, space to select)").
+			Options(authorOpts...).
+			Filterable(true).
+			Value(&state.Authors),
+	).WithHideFunc(func() bool {
+		return !ctx.HasMultipleAuthors || state.UseDefaultAuthor
+	})
+
+	// --- Group 6: Summary and confirm ---
+	var confirmed bool
+	summaryGroup := huh.NewGroup(
+		huh.NewNote().
+			Title("Summary").
+			DescriptionFunc(func() string {
+				return buildSummary(state, ctx)
+			}, state),
+		huh.NewConfirm().
+			Title("Create this file?").
+			Value(&confirmed).
+			Affirmative("Create").
+			Negative("Cancel"),
+	)
+
+	// --- Single form: all groups, Shift+Tab goes back ---
+	form := huh.NewForm(
+		titleGroup,
+		dirGroup,
+		customDirGroup,
+		photoGroup,
+		videoGroup,
+		linkGroup,
+		quoteGroup,
+		contactGroup,
+		authorGroup,
+		tagsGroup,
+		privateGroup,
+		defaultAuthorGroup,
+		authorSelectGroup,
+		summaryGroup,
+	).WithTheme(theme)
+
+	if err := form.Run(); err != nil {
+		return nil, fmt.Errorf("wizard canceled: %w", err)
+	}
+
+	if !confirmed {
+		return nil, fmt.Errorf("canceled by user")
+	}
+
+	// Resolve directory
+	if state.DirChoice == dirCustomSentinel {
+		if state.CustomDir != "" {
+			state.Directory = state.CustomDir
+		} else {
+			state.Directory = ctx.Templates[state.Template].Directory
+		}
+	} else {
+		state.Directory = state.DirChoice
+	}
+
+	// Merge custom tags
+	if state.CustomTag != "" {
+		for _, tag := range parseTags(state.CustomTag) {
+			if !containsString(state.Tags, tag) {
+				state.Tags = append(state.Tags, tag)
+			}
+		}
+	}
+
+	// Resolve default author
+	if ctx.HasMultipleAuthors && state.UseDefaultAuthor {
+		state.Authors = []string{ctx.DefaultAuthorID}
+	}
+
+	return state, nil
+}
+
+// buildSummary generates the summary text for the confirmation step.
+func buildSummary(state *newWizardState, ctx *siteContext) string {
+	slug := generateSlug(state.Title)
+	filename := slug + ".md"
+
+	dir := state.DirChoice
+	if dir == dirCustomSentinel && state.CustomDir != "" {
+		dir = state.CustomDir
+	} else if dir == dirCustomSentinel {
+		dir = ctx.Templates[state.Template].Directory
+	}
+	fullPath := filepath.Join(dir, filename)
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Title:     %s\n", state.Title))
+	sb.WriteString(fmt.Sprintf("Template:  %s\n", state.Template))
+	sb.WriteString(fmt.Sprintf("File:      %s\n", fullPath))
+	sb.WriteString("Draft:     false\n")
+	sb.WriteString("Published: true\n")
+	sb.WriteString(fmt.Sprintf("Private:   %t\n", state.Private))
+
+	// Template-specific fields
+	sb.WriteString(buildTemplateSummary(state))
+
+	// Merge selected + custom tags for display
+	allTags := append([]string{}, state.Tags...)
+	if state.CustomTag != "" {
+		for _, tag := range parseTags(state.CustomTag) {
+			if !containsString(allTags, tag) {
+				allTags = append(allTags, tag)
+			}
+		}
+	}
+	if len(allTags) > 0 {
+		sb.WriteString(fmt.Sprintf("Tags:      %s\n", strings.Join(allTags, ", ")))
+	}
+	if ctx.HasMultipleAuthors {
+		if state.UseDefaultAuthor {
+			sb.WriteString(fmt.Sprintf("Author:    %s (default)\n", ctx.DefaultAuthorID))
+		} else if len(state.Authors) > 0 {
+			sb.WriteString(fmt.Sprintf("Authors:   %s\n", strings.Join(state.Authors, ", ")))
+		}
+	}
+
+	return sb.String()
+}
+
+// buildTemplateOptions creates huh options from available templates.
+func buildTemplateOptions(templates map[string]ContentTemplate) []huh.Option[string] {
+	// Sort template names for consistent display
+	names := make([]string, 0, len(templates))
+	for name := range templates {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	options := make([]huh.Option[string], 0, len(names))
+	for _, name := range names {
+		t := templates[name]
+		label := fmt.Sprintf("%s -> %s/ (%s)", name, t.Directory, t.Source)
+		options = append(options, huh.NewOption(label, name))
+	}
+	return options
+}
+
+// buildDirectoryOptions creates huh options for directory selection.
+func buildDirectoryOptions(template ContentTemplate, existingDirs []string) []huh.Option[string] {
+	seen := make(map[string]bool)
+	var options []huh.Option[string]
+
+	// First option: template's default directory
+	defaultDir := template.Directory
+	label := fmt.Sprintf("%s (default)", defaultDir)
+	options = append(options, huh.NewOption(label, defaultDir))
+	seen[defaultDir] = true
+
+	// Add existing directories from the site
+	for _, dir := range existingDirs {
+		if !seen[dir] {
+			options = append(options, huh.NewOption(dir, dir))
+			seen[dir] = true
+		}
+	}
+
+	// Custom option
+	options = append(options, huh.NewOption("Custom...", dirCustomSentinel))
+
+	return options
+}
+
+// buildAuthorOptions creates huh options for author multi-select.
+func buildAuthorOptions(ctx *siteContext) []huh.Option[string] {
+	opts := make([]huh.Option[string], 0, len(ctx.AuthorOptions))
+	for _, a := range ctx.AuthorOptions {
+		label := a.Name
+		if a.ID == ctx.DefaultAuthorID {
+			label = fmt.Sprintf("%s (default)", a.Name)
+		}
+		opts = append(opts, huh.NewOption(label, a.ID))
+	}
+	return opts
+}
+
+// buildTemplateSummary returns summary lines for template-specific fields.
+func buildTemplateSummary(state *newWizardState) string {
+	var sb strings.Builder
+
+	switch state.Template {
+	case tmplPhoto:
+		if state.ImageURL != "" {
+			sb.WriteString(fmt.Sprintf("Image:     %s\n", state.ImageURL))
+		}
+	case tmplVideo:
+		if state.VideoURL != "" {
+			sb.WriteString(fmt.Sprintf("Video:     %s\n", state.VideoURL))
+		}
+		if state.ImageURL != "" {
+			sb.WriteString(fmt.Sprintf("Thumbnail: %s\n", state.ImageURL))
+		}
+		if state.Duration != "" {
+			sb.WriteString(fmt.Sprintf("Duration:  %s\n", state.Duration))
+		}
+	case tmplLink:
+		if state.LinkURL != "" {
+			sb.WriteString(fmt.Sprintf("URL:       %s\n", state.LinkURL))
+		}
+	case tmplQuote:
+		if state.Quote != "" {
+			sb.WriteString(fmt.Sprintf("Quote:     %s\n", state.Quote))
+		}
+		if state.Source != "" {
+			sb.WriteString(fmt.Sprintf("Source:    %s\n", state.Source))
+		}
+	case tmplContact:
+		if state.Handle != "" {
+			sb.WriteString(fmt.Sprintf("Handle:    @%s\n", state.Handle))
+		}
+	case tmplAuthor:
+		if state.Name != "" {
+			sb.WriteString(fmt.Sprintf("Name:      %s\n", state.Name))
+		}
+		if state.Role != "" {
+			sb.WriteString(fmt.Sprintf("Role:      %s\n", state.Role))
+		}
+	}
+
+	return sb.String()
+}
+
+// applyTemplateFields sets template-specific frontmatter fields from wizard state.
+func applyTemplateFields(state *newWizardState, fm map[string]interface{}) {
+	switch state.Template {
+	case tmplPhoto:
+		if state.ImageURL != "" {
+			fm["image"] = state.ImageURL
+		}
+	case tmplVideo:
+		if state.VideoURL != "" {
+			fm["video"] = state.VideoURL
+		}
+		if state.ImageURL != "" {
+			fm["image"] = state.ImageURL
+		}
+		if state.Duration != "" {
+			fm["duration"] = state.Duration
+		}
+	case tmplLink:
+		if state.LinkURL != "" {
+			fm["url"] = state.LinkURL
+		}
+		if state.ImageURL != "" {
+			fm["image"] = state.ImageURL
+		}
+	case tmplQuote:
+		if state.Quote != "" {
+			fm["quote"] = state.Quote
+		}
+		if state.Source != "" {
+			fm["source"] = state.Source
+		}
+	case tmplContact:
+		if state.Handle != "" {
+			fm["handle"] = state.Handle
+		}
+	case tmplAuthor:
+		if state.Name != "" {
+			fm["name"] = state.Name
+		}
+		if state.Bio != "" {
+			fm["bio"] = state.Bio
+		}
+		if state.Email != "" {
+			fm["email"] = state.Email
+		}
+		if state.Role != "" {
+			fm["role"] = state.Role
+		}
+	}
+}
+
+// containsString checks if a string slice contains a value.
+func containsString(slice []string, val string) bool {
+	for _, s := range slice {
+		if s == val {
+			return true
+		}
+	}
+	return false
+}
+
+// applyNewWizardState generates and writes the content file from wizard state.
+func applyNewWizardState(state *newWizardState, templates map[string]ContentTemplate) error {
+	template := templates[state.Template]
+
+	// Override directory from wizard state
+	outputDir := state.Directory
+	if outputDir == "" {
+		outputDir = template.Directory
+	}
+
+	slug := generateSlug(state.Title)
+
+	// Build enhanced template that includes wizard-gathered fields
+	enhancedTemplate := template
+	if enhancedTemplate.Frontmatter == nil {
+		enhancedTemplate.Frontmatter = make(map[string]interface{})
+	}
+
+	// Set private flag
+	enhancedTemplate.Frontmatter["private"] = state.Private
+
+	// Set authors if provided
+	if len(state.Authors) > 0 {
+		enhancedTemplate.Frontmatter["authors"] = state.Authors
+	}
+
+	// Apply template-specific fields from wizard
+	applyTemplateFields(state, enhancedTemplate.Frontmatter)
+
+	// Use draft=false, published=true (new defaults)
+	return writeContentFile(state.Title, slug, outputDir, false, state.Tags, enhancedTemplate)
+}

--- a/cmd/markata-go/cmd/new_test.go
+++ b/cmd/markata-go/cmd/new_test.go
@@ -109,7 +109,7 @@ func TestBuiltinTemplates(t *testing.T) {
 	templates := builtinTemplates()
 
 	// Check that all expected templates exist
-	expectedTemplates := []string{"post", "page", "docs"}
+	expectedTemplates := []string{"post", "page", "docs", "article", "note", "photo", "video", "link", "quote", "guide", "inline", "contact", "author"}
 	for _, name := range expectedTemplates {
 		if _, exists := templates[name]; !exists {
 			t.Errorf("expected builtin template %q not found", name)
@@ -118,8 +118,8 @@ func TestBuiltinTemplates(t *testing.T) {
 
 	// Check post template
 	post := templates["post"]
-	if post.Directory != "posts" {
-		t.Errorf("post template directory = %q, want %q", post.Directory, "posts")
+	if post.Directory != "pages/post" {
+		t.Errorf("post template directory = %q, want %q", post.Directory, "pages/post")
 	}
 	if post.Source != "builtin" {
 		t.Errorf("post template source = %q, want %q", post.Source, "builtin")
@@ -135,6 +135,45 @@ func TestBuiltinTemplates(t *testing.T) {
 	docs := templates["docs"]
 	if docs.Directory != "docs" {
 		t.Errorf("docs template directory = %q, want %q", docs.Directory, "docs")
+	}
+
+	// Check contact template
+	contact := templates["contact"]
+	if contact.Directory != "pages/contact" {
+		t.Errorf("contact template directory = %q, want %q", contact.Directory, "pages/contact")
+	}
+	if contact.Frontmatter["handle"] != "" {
+		t.Errorf("contact template should have empty handle field")
+	}
+
+	// Check author template
+	author := templates["author"]
+	if author.Directory != "pages/author" {
+		t.Errorf("author template directory = %q, want %q", author.Directory, "pages/author")
+	}
+	if author.Frontmatter["role"] != "" {
+		t.Errorf("author template should have empty role field")
+	}
+
+	// Check video template has correct field name
+	video := templates["video"]
+	if _, ok := video.Frontmatter["video"]; !ok {
+		t.Error("video template should have 'video' field, not 'video_url'")
+	}
+	if _, ok := video.Frontmatter["video_url"]; ok {
+		t.Error("video template should not have 'video_url' field (renamed to 'video')")
+	}
+
+	// Check quote template has correct field names
+	quote := templates["quote"]
+	if _, ok := quote.Frontmatter["quote"]; !ok {
+		t.Error("quote template should have 'quote' field")
+	}
+	if _, ok := quote.Frontmatter["source"]; !ok {
+		t.Error("quote template should have 'source' field")
+	}
+	if _, ok := quote.Frontmatter["quote_author"]; ok {
+		t.Error("quote template should not have 'quote_author' field (use post.author instead)")
 	}
 }
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -405,8 +405,9 @@ markata-go new [title] [flags]
 | `--template` | `-t` | Content template to use | `post` |
 | `--list` | `-l` | List available templates | `false` |
 | `--dir` | | Directory to create the content in (overrides template) | Template's default |
-| `--draft` | | Create as a draft | `true` |
+| `--draft` | | Create as a draft | `false` |
 | `--tags` | | Comma-separated list of tags | `""` |
+| `--plain` | | Use plain text prompts instead of TUI wizard | `false` |
 
 #### Built-in Templates
 
@@ -436,21 +437,24 @@ markata-go new --list
 markata-go new "Hello World" --template post --dir blog
 # Creates: blog/hello-world.md
 
-# Create as a draft (default behavior)
+# Create as a draft (opt-in, default is published)
 markata-go new "Work in Progress" --draft
 # Creates: posts/work-in-progress.md with draft: true
 
-# Create as published
-markata-go new "Ready to Publish" --draft=false
+# Create as published (default behavior)
+markata-go new "Ready to Publish"
 # Creates: posts/ready-to-publish.md with draft: false, published: true
 
 # Create with tags
 markata-go new "Go Tutorial" --tags "go,tutorial,programming"
 # Creates: posts/go-tutorial.md with tags: ["go", "tutorial", "programming"]
 
-# Interactive mode (no arguments)
+# Interactive mode (no arguments) - launches TUI wizard
 markata-go new
-# Prompts for title, template, directory, tags, and draft status
+# TUI wizard prompts for: template, title, directory, tags, privacy, authors
+
+# Interactive mode with plain text prompts (no TUI)
+markata-go new --plain
 ```
 
 #### Template System
@@ -510,20 +514,38 @@ The `_directory` field in frontmatter sets the output directory (removed from ge
 
 #### Interactive Mode
 
-When called without a title argument, the command enters interactive mode:
+When called without a title argument (or no arguments at all), the command launches an
+interactive TUI wizard powered by [charmbracelet/huh](https://github.com/charmbracelet/huh).
+
+The wizard guides you through:
+
+1. **Template selection** - Pick from built-in, config, and file-based templates
+2. **Title** - Enter the post title
+3. **Directory** - Choose from existing directories or enter a custom one, with config-driven defaults per template type
+4. **Tags** - Select from existing site tags and/or type custom tags
+5. **Privacy** - Mark the post as private
+6. **Authors** - If multiple authors are configured, choose whether to use the default or select specific authors
+7. **Summary** - Review all choices before creating the file
 
 ```
 $ markata-go new
 
-Title: My New Post
-Available templates: docs, page, post
-Template [post]: post
-Directory [posts]: blog
-Tags (comma-separated): go, tutorial
-Create as draft? (Y/n): y
+? Select a template
+  > post - Blog post (posts/)
+    page - Static page (pages/)
+    docs - Documentation (docs/)
 
-Created: blog/my-new-post.md
+? Title: My New Post
+? Select a directory: posts (default)
+? Select tags: [go, tutorial]
+? Make this post private? No
+? Create my-new-post.md in posts/? Yes
+
+Created: posts/my-new-post.md
 ```
+
+**Plain text mode:** Use `--plain` or pipe input to get simple text prompts instead of the TUI.
+Falls back automatically when stdin is not a TTY.
 
 #### Generated File
 
@@ -534,8 +556,8 @@ The command creates a markdown file with template-specific frontmatter:
 title: My First Post
 slug: my-first-post
 date: "2024-01-15"
-published: false
-draft: true
+published: true
+draft: false
 templateKey: post
 tags:
   - go

--- a/spec/spec/CLI_NEW.md
+++ b/spec/spec/CLI_NEW.md
@@ -1,0 +1,226 @@
+# CLI `new` Command Specification
+
+This document specifies the `markata-go new` command behavior, including the
+interactive TUI wizard powered by charmbracelet/huh.
+
+## Overview
+
+The `new` command creates new content files with frontmatter templates. It
+operates in two modes:
+
+1. **Non-interactive mode** - title provided as argument, flags control all options
+2. **Interactive TUI mode** - no title argument, a huh-based wizard guides the user
+
+## Command Signature
+
+```
+markata-go new [title] [flags]
+```
+
+### Flags
+
+| Flag | Short | Description | Default |
+|------|-------|-------------|---------|
+| `--template` | `-t` | Content template to use | `post` |
+| `--list` | `-l` | List available templates | `false` |
+| `--dir` | | Output directory (overrides template) | Template default |
+| `--draft` | | Create as a draft | `false` |
+| `--tags` | | Comma-separated list of tags | `""` |
+| `--plain` | | Use plain text prompts instead of TUI | Auto-detected |
+
+**Note:** `--draft` defaults to `false`. New posts are created as published by
+default (`published: true`, `draft: false`).
+
+## Interactive TUI Wizard
+
+When no title argument is provided, the command enters interactive mode using
+charmbracelet/huh forms. The wizard falls back to plain text prompts when:
+
+- The `--plain` flag is specified
+- stdin is not a TTY
+
+### Wizard Flow
+
+```
+┌─────────────────────────────┐
+│  1. Title (text input)      │
+├─────────────────────────────┤
+│  2. Template (select)       │  ← Pick from available post types
+├─────────────────────────────┤
+│  3. Directory (select)      │  ← Pick from existing dirs or use default
+├─────────────────────────────┤
+│  4. Tags (multi-select)     │  ← Existing site tags as suggestions
+├─────────────────────────────┤
+│  5. Private? (confirm)      │  ← Whether post is private
+├─────────────────────────────┤
+│  6. Authors (multi-select)  │  ← Only shown if multi-author configured
+├─────────────────────────────┤
+│  7. Summary + Confirm       │  ← Review before creation
+└─────────────────────────────┘
+```
+
+### Step Details
+
+#### 1. Title (Required)
+
+- `huh.Input` with placeholder text
+- Cannot be empty (validated)
+- Generates slug automatically
+
+#### 2. Template Selection
+
+- `huh.Select` showing all available templates
+- Default: `post` (or value from `--template` flag)
+- Templates sourced from: builtins, config, content-templates/ directory
+- Each option shows: `name -> directory/ (source)`
+
+#### 3. Directory Selection
+
+- `huh.Select` presenting:
+  1. The template's default directory (first option, marked as default)
+  2. All existing content directories discovered from the filesystem
+  3. A "Custom..." option that reveals a text input
+- Default directories per template type are configurable in config under
+  `[content_templates.placement]`
+- Default directory pattern: `pages/<template>` for non-standard templates
+
+#### 4. Tag Selection
+
+- `huh.MultiSelect` populated with all existing tags from the site
+- Tags are collected by scanning existing content files using the glob patterns
+  from config
+- Additional custom tags can be typed in (text input after multi-select)
+- Tags sorted alphabetically
+
+#### 5. Private Flag
+
+- `huh.Confirm` asking "Is this post private?"
+- Default: `No`
+- When true, sets `private: true` in frontmatter
+
+#### 6. Authors (Conditional)
+
+Only shown when **all** of these conditions are met:
+- The config has `[authors]` section with multiple authors defined
+- At least 2 authors exist in config
+
+When shown:
+- First asks: "Use default author only?" (confirm)
+  - If yes, uses the author marked `default: true` (or first active)
+  - If no, shows `huh.MultiSelect` with all configured authors
+- Author IDs are written to `authors:` frontmatter field
+
+#### 7. Summary
+
+- `huh.Note` showing a summary of all selections
+- `huh.Confirm` to proceed or cancel
+
+## Generated Frontmatter
+
+The generated file includes these fields:
+
+```yaml
+---
+title: "The Post Title"
+slug: the-post-title
+date: "2024-01-15"
+published: true
+draft: false
+private: false
+tags:
+  - tag1
+  - tag2
+template: post
+description: ""
+authors:              # Only if multi-author configured
+  - author-id
+---
+
+# The Post Title
+
+Write your content here...
+```
+
+### Defaults
+
+| Field | Default |
+|-------|---------|
+| `published` | `true` |
+| `draft` | `false` |
+| `private` | `false` |
+| `description` | `""` |
+| `tags` | `[]` |
+| `template` | Selected template name |
+
+## Configuration
+
+### Default Directories per Template Type
+
+```toml
+[content_templates.placement]
+post = "posts"
+page = "pages"
+docs = "docs"
+article = "pages/article"
+note = "pages/note"
+# etc.
+```
+
+When no placement is configured for a template, the default directory is
+`pages/<template>`.
+
+### Author Configuration
+
+```toml
+[authors]
+generate_pages = true
+
+[authors.authors.alice]
+id = "alice"
+name = "Alice"
+default = true
+active = true
+
+[authors.authors.bob]
+id = "bob"
+name = "Bob"
+active = true
+```
+
+## Tag Discovery
+
+Tags are collected from existing content by:
+
+1. Loading config to get glob patterns
+2. Scanning all matching markdown files
+3. Extracting tags from frontmatter
+4. Deduplicating and sorting alphabetically
+
+This runs once at wizard startup. Performance is acceptable for typical sites
+(< 1000 files).
+
+## Theme Integration
+
+The TUI wizard uses the site's configured palette for styling (same as `init`
+command), falling back to the default Charm theme if no palette is configured.
+
+## Non-Interactive Mode
+
+When title is provided as an argument:
+
+```bash
+markata-go new "My Post" --template page --tags "go,web" --dir custom-dir
+```
+
+All options come from flags. No prompts are shown. The defaults apply for any
+unspecified flags.
+
+## Error Handling
+
+| Error | Behavior |
+|-------|----------|
+| File already exists | Error with path |
+| Invalid template name | Error listing available templates |
+| Empty title (interactive) | Validation prevents proceeding |
+| Config not found | Use defaults, skip author features |
+| No TTY + no --plain | Fall back to plain mode |


### PR DESCRIPTION
## Summary

- Add a `charmbracelet/huh`-based TUI wizard to the `new` command for interactive content creation with template selection, directory picking, tag selection, privacy settings, multi-author support, and template-specific field prompts
- Fix builtin template frontmatter bugs: `video_url` renamed to `video` (matching `video-card.html`), `quote_author` replaced with `quote`+`source` (matching `quote-card.html`), added missing `image` field to link/video templates
- Add `contact` and `author` builtin templates, standardize directories under `pages/` with singular subdirectory names, and change draft default from `true` to `false`

## Details

### TUI Wizard (`new_huh.go`)
- Single `huh.NewForm()` with multiple groups enables **Shift+Tab back navigation** between steps
- `WithHideFunc` for conditional template-specific groups (photo, video, link, quote, contact, author)
- `OptionsFunc` for dynamic directory options based on selected template
- `DescriptionFunc` for live summary preview
- `Filterable(true)` on multi-selects with filter hints in descriptions
- Falls back to plain text prompts with `--plain` flag or when stdin is not a TTY

### Template Fixes
| Template | Before | After |
|----------|--------|-------|
| video | `video_url` | `video`, `image`, `duration` |
| quote | `quote_author` | `quote`, `source` |
| link | missing | added `image` |
| post | `posts/` dir | `pages/post/` dir |

### New Templates
- **contact**: `handle`, `aliases`, `avatar`, `url` (for @mentions system)
- **author**: `name`, `bio`, `role`, `email`, `avatar`, `social`, `active`, `guest`

### New Flags
- `--plain` — force plain text prompts (non-TTY fallback)
- `--draft` default changed from `true` to `false`

## Files Changed
- `cmd/markata-go/cmd/new_huh.go` — New TUI wizard (~700 lines)
- `cmd/markata-go/cmd/new.go` — Template fixes, new templates, wizard integration
- `cmd/markata-go/cmd/new_test.go` — Updated expectations, new assertions
- `cmd/markata-go/cmd/explain.go` — Updated `explainNew` help text
- `docs/reference/cli.md` — Updated docs for new flags and wizard
- `spec/spec/CLI_NEW.md` — Full specification for the enhanced `new` command

## Testing
- `go test ./...` — all pass
- `just lint-fast` — clean
- `just lint-new` — clean
- Pre-commit hooks (go fmt, go vet, golangci-lint, go test) — all pass