### PR TITLE
feat(render_markdown): add goldmark typographer, definition lists, and footnotes

### DIFF
--- a/docs/guides/markdown.md
+++ b/docs/guides/markdown.md
@@ -596,6 +596,144 @@ www.example.com also works.
 
 ---
 
+## Smart Quotes (Typographer)
+
+markata-go automatically converts straight quotes and punctuation to their typographic (curly) equivalents:
+
+| Input | Output | Description |
+|-------|--------|-------------|
+| `"Hello"` | `"Hello"` | Double curly quotes |
+| `'Hello'` | `'Hello'` | Single curly quotes |
+| `It's` | `It's` | Apostrophe |
+| `9--5` | `9–5` | En dash |
+| `hello---world` | `hello—world` | Em dash |
+| `wait...` | `wait…` | Ellipsis |
+
+**Live example:**
+
+"This sentence uses smart quotes." It's automatic—you don't need to do anything special. Just write normally and markata-go handles the conversion.
+
+Use en dashes for ranges like 9–5, and em dashes for breaks in thought—like this. Ellipses work too…
+
+**Disabling:**
+
+To disable smart quotes (use straight quotes instead):
+
+```toml
+[markdown.extensions]
+typographer = false
+```
+
+---
+
+## Definition Lists
+
+Create definition lists (glossary-style terms and definitions) using PHP Markdown Extra syntax:
+
+**Input:**
+
+```markdown
+Term 1
+:   Definition of the first term.
+
+Term 2
+:   First definition of the second term.
+:   Second definition of the second term.
+```
+
+**Live example:**
+
+HTML
+:   HyperText Markup Language - the standard markup language for documents designed to be displayed in a web browser.
+
+CSS
+:   Cascading Style Sheets - a style sheet language used for describing the presentation of a document.
+:   Can also refer to Content Scramble System (in different contexts).
+
+**Output:**
+
+```html
+<dl>
+  <dt>Term 1</dt>
+  <dd>Definition of the first term.</dd>
+  
+  <dt>Term 2</dt>
+  <dd>First definition of the second term.</dd>
+  <dd>Second definition of the second term.</dd>
+</dl>
+```
+
+**Use cases:**
+- Glossaries and terminology lists
+- FAQ sections (question as term, answer as definition)
+- Key-value documentation
+- API parameter descriptions
+
+**Disabling:**
+
+```toml
+[markdown.extensions]
+definition_list = false
+```
+
+---
+
+## Footnotes
+
+Add footnotes to your content using PHP Markdown Extra syntax:
+
+**Input:**
+
+```markdown
+Here's a sentence that needs a citation.[^1]
+
+[^1]: This is the footnote content that appears at the bottom of the document.
+```
+
+**Live example:**
+
+markata-go supports footnotes for academic writing and citations.[^footnote-demo]
+
+[^footnote-demo]: Footnotes are automatically collected and placed at the end of the document with backlinks for easy navigation.
+
+**Output:**
+
+```html
+<p>Here's a sentence that needs a citation.<sup><a href="#fn:1">1</a></sup></p>
+
+<!-- Later in the document -->
+<section class="footnotes">
+  <ol>
+    <li id="fn:1">
+      <p>This is the footnote content. <a href="#fnref:1">↩</a></p>
+    </li>
+  </ol>
+</section>
+```
+
+**Multiple footnotes:**
+
+```markdown
+First citation.[^1] Second citation.[^2] Reuse first.[^1]
+
+[^1]: First footnote content.
+[^2]: Second footnote content.
+```
+
+**Best practices:**
+- Keep footnotes brief and focused
+- Use descriptive reference labels (e.g., `[^smith-2020]` instead of `[^1]`) for maintainability
+- Place all footnote definitions at the end of your document
+
+**Disabling:**
+
+```toml
+[markdown.extensions]
+footnote = false
+```
+
+---
+
 ## Code Blocks
 
 Fenced code blocks support syntax highlighting for many languages.

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -918,13 +918,23 @@ The extended frontmatter format supports key aliases for convenience (`name`/`ha
 **Stage:** Render  
 **Purpose:** Converts markdown content to HTML using goldmark with extensions.
 
-**Configuration:** None (extensions enabled by default)
+**Configuration (TOML):**
+
+```toml
+[markdown.extensions]
+typographer = true       # Smart quotes, dashes, ellipses (default: true)
+definition_list = true   # PHP Markdown Extra definition lists (default: true)
+footnote = true          # PHP Markdown Extra footnotes (default: true)
+```
 
 **Enabled extensions:**
 - **GFM** - GitHub Flavored Markdown (tables, strikethrough, autolinks, task lists)
-- **Syntax Highlighting** - Code block highlighting with Chroma (monokai theme)
+- **Syntax Highlighting** - Code block highlighting with Chroma
 - **Admonitions** - Note/warning blocks
 - **Auto Heading IDs** - Generates IDs for headings
+- **Typographer** - Smart quotes, dashes, ellipses
+- **Definition Lists** - PHP Markdown Extra style definition lists
+- **Footnotes** - PHP Markdown Extra style footnotes
 
 **Behavior:**
 1. Takes `post.Content` (raw markdown)
@@ -961,6 +971,31 @@ func main() {
 Here's a sentence with a footnote.[^1]
 
 [^1]: This is the footnote content.
+
+## Smart Quotes
+"Straight quotes" become curly.
+
+## Definition Lists
+Term
+:   Definition of the term.
+```
+
+**Disabling extensions:**
+
+All extensions are enabled by default. To disable any:
+
+```toml
+# Disable specific extensions
+[markdown.extensions]
+typographer = false       # Use straight quotes instead
+definition_list = false   # Disable definition lists
+footnote = false          # Disable footnotes
+
+# Or disable all three
+[markdown.extensions]
+typographer = false
+definition_list = false
+footnote = false
 ```
 
 ---

--- a/spec/spec/CONTENT.md
+++ b/spec/spec/CONTENT.md
@@ -227,6 +227,8 @@ Implementations SHOULD support:
 | Footnotes | `[^1]` | Footnote |
 | Heading IDs | `## Title {#custom-id}` | `<h2 id="custom-id">` |
 | Attributes | `{.class}`, `{#id}` | Element with class/id |
+| Smart Quotes | `"text"` | `"text"` (curly) |
+| Definition Lists | `Term\n:   Def` | `<dl>`, `<dt>`, `<dd>` |
 
 ### Attribute Syntax
 
@@ -306,6 +308,86 @@ Output:
     </tr>
   </tbody>
 </table>
+```
+
+### Smart Quotes (Typographer)
+
+Automatically converts straight quotes to typographic (curly) quotes and other punctuation:
+
+| Input | Output | Description |
+|-------|--------|-------------|
+| `"text"` | `"text"` | Double curly quotes |
+| `'text'` | `'text'` | Single curly quotes |
+| `It's` | `It's` | Apostrophe |
+| `9--5` | `9–5` | En dash |
+| `hello---world` | `hello—world` | Em dash |
+| `wait...` | `wait…` | Ellipsis |
+
+**Note:** These are HTML entities (`&ldquo;`, `&rdquo;`, etc.) that render as proper typographic characters.
+
+**Configuration:**
+```toml
+[markdown.extensions]
+typographer = true  # Enable smart quotes (default: true)
+```
+
+### Definition Lists
+
+PHP Markdown Extra style definition lists:
+
+```markdown
+Term 1
+:   Definition 1
+
+Term 2
+:   Definition 2a
+:   Definition 2b
+```
+
+Output:
+```html
+<dl>
+  <dt>Term 1</dt>
+  <dd>Definition 1</dd>
+  <dt>Term 2</dt>
+  <dd>Definition 2a</dd>
+  <dd>Definition 2b</dd>
+</dl>
+```
+
+**Configuration:**
+```toml
+[markdown.extensions]
+definition_list = true  # Enable definition lists (default: true)
+```
+
+### Footnotes
+
+PHP Markdown Extra style footnotes:
+
+```markdown
+Here's a sentence with a footnote.[^1]
+
+[^1]: This is the footnote content.
+```
+
+Output:
+```html
+<p>Here's a sentence with a footnote.<sup><a href="#fn:1">1</a></sup></p>
+<!-- ... later in document ... -->
+<section class="footnotes">
+  <ol>
+    <li id="fn:1">
+      <p>This is the footnote content. <a href="#fnref:1">↩</a></p>
+    </li>
+  </ol>
+</section>
+```
+
+**Configuration:**
+```toml
+[markdown.extensions]
+footnote = true  # Enable footnotes (default: true)
 ```
 
 ### Code Blocks
@@ -663,6 +745,28 @@ symbol = "#"
 [tool-name.markdown.admonitions]
 enabled = true
 collapsible = true
+
+# Extension configuration (markata-go specific)
+[markdown.extensions]
+typographer = true       # Smart quotes, dashes, ellipses (default: true)
+definition_list = true   # PHP Markdown Extra definition lists (default: true)
+footnote = true          # PHP Markdown Extra footnotes (default: true)
+```
+
+### Disabling Extensions
+
+Individual extensions can be disabled if needed:
+
+```toml
+# Disable all optional extensions
+[markdown.extensions]
+typographer = false
+definition_list = false
+footnote = false
+
+# Or disable just one
+[markdown.extensions]
+typographer = false  # Keep straight quotes
 ```
 
 ---


### PR DESCRIPTION
## Summary

This PR adds three new goldmark extensions to the markdown renderer, improving typography and adding support for academic/technical writing features.

## New Extensions

### 1. Typographer (Smart Quotes)
Automatically converts straight quotes and punctuation to typographic equivalents:
- "text" → "text" (curly quotes)
- It's → It's (apostrophe)
- 9--5 → 9–5 (en dash)
- hello---world → hello—world (em dash)
- wait... → wait… (ellipsis)

### 2. Definition Lists
PHP Markdown Extra style definition lists for glossaries and terminology:



### 3. Footnotes
PHP Markdown Extra style footnotes for citations:



## Configuration

All extensions are **enabled by default** and can be configured via:



To disable any extension:



## Changes

- Added `MarkdownExtensionConfig` struct for extension configuration
- Updated `createMarkdownRenderer` to accept extension config
- Added `resolveExtensionConfig` method to parse config from TOML
- Added comprehensive tests for all three extensions
- Updated spec/spec/CONTENT.md with new features
- Updated docs/guides/markdown.md with user-facing documentation
- Updated docs/reference/plugins.md with configuration reference

## Testing

- All new tests pass
- Existing tests continue to pass
- Linting passes (`just lint-fast`)

## Documentation

- User guide: docs/guides/markdown.md
- Plugin reference: docs/reference/plugins.md
- Specification: spec/spec/CONTENT.md