### PR TITLE
fix: use semantic HTML selectors for j/k keybinding detection

### DIFF
--- a/pkg/themes/default/static/js/navigation-shortcuts.js
+++ b/pkg/themes/default/static/js/navigation-shortcuts.js
@@ -32,26 +32,34 @@
     }
   }
 
-  var state = {
-    selectedCard: null,
-    cards: [],
-    lastKeyTime: 0,
-    lastKey: null,
-    keySequenceTimeout: 500, // ms
-    jKeyDown: false,
-    kKeyDown: false,
-    navRepeatTimer: null,
-    navRepeatDelay: 80, // ms between navigations when key held (faster)
-    initialized: false,  // Track if already initialized
-    jkRegistered: false  // Track if j/k shortcuts are registered
-  };
+   var state = {
+     selectedCard: null,
+     cards: [],
+     lastKeyTime: 0,
+     lastKey: null,
+     keySequenceTimeout: 500, // ms
+     jKeyDown: false,
+     kKeyDown: false,
+     navRepeatTimer: null,
+     navRepeatDelay: 80, // ms between navigations when key held (faster)
+     initialized: false,  // Track if already initialized
+     jkRegistered: false  // Track if j/k shortcuts are registered
+   };
 
-  /**
-   * Get all post cards on the page
-   */
-  function getCards() {
-    return Array.from(document.querySelectorAll('.card, [data-card]'));
-  }
+   /**
+    * Check if we're on a feed page
+    * Feed pages have a <div class="feed"> wrapper
+    */
+   function isFeedPage() {
+     return document.querySelector('div.feed') !== null;
+   }
+
+   /**
+    * Get all post cards on the page
+    */
+   function getCards() {
+     return Array.from(document.querySelectorAll('.card, [data-card]'));
+   }
 
   /**
    * Highlight a card
@@ -164,41 +172,41 @@
     }
   }
 
-  /**
-   * Toggle between simple and rich feed views.
-   * On simple feed pages (URL contains /simple/), navigates to the rich feed.
-   * On rich feed pages, navigates to the simple feed variant.
-   * Only works on feed pages (elements with .feed class).
-   */
-  function toggleFeedView() {
-    var feedEl = document.querySelector('.feed');
-    if (!feedEl) return;
+   /**
+    * Toggle between simple and rich feed views.
+    * On simple feed pages (URL contains /simple/), navigates to the rich feed.
+    * On rich feed pages, navigates to the simple feed variant.
+    * Only works on feed pages (div.feed element).
+    */
+   function toggleFeedView() {
+     if (!isFeedPage()) return;
 
-    var path = window.location.pathname;
-    var isSimple = feedEl.classList.contains('feed-simple');
+     var path = window.location.pathname;
+     var feedEl = document.querySelector('div.feed');
+     var isSimple = feedEl.classList.contains('feed-simple');
 
-    if (isSimple) {
-      // On simple feed -> go to rich feed: remove /simple/ from path
-      var richPath = path.replace(/\/simple\/(page\/\d+\/)?$/, '/');
-      // Preserve page number if present
-      var pageMatch = path.match(/\/simple\/page\/(\d+)\//);
-      if (pageMatch) {
-        richPath = path.replace(/\/simple\/page\/(\d+)\//, '/page/' + pageMatch[1] + '/');
-      }
-      window.location.href = richPath;
-    } else {
-      // On rich feed -> go to simple feed: insert /simple/ before any /page/ or at end
-      var simplePath;
-      var richPageMatch = path.match(/\/page\/(\d+)\/$/);
-      if (richPageMatch) {
-        simplePath = path.replace(/\/page\/(\d+)\/$/, '/simple/page/' + richPageMatch[1] + '/');
-      } else {
-        // Ensure trailing slash
-        simplePath = path.replace(/\/?$/, '/') + 'simple/';
-      }
-      window.location.href = simplePath;
-    }
-  }
+     if (isSimple) {
+       // On simple feed -> go to rich feed: remove /simple/ from path
+       var richPath = path.replace(/\/simple\/(page\/\d+\/)?$/, '/');
+       // Preserve page number if present
+       var pageMatch = path.match(/\/simple\/page\/(\d+)\//);
+       if (pageMatch) {
+         richPath = path.replace(/\/simple\/page\/(\d+)\//, '/page/' + pageMatch[1] + '/');
+       }
+       window.location.href = richPath;
+     } else {
+       // On rich feed -> go to simple feed: insert /simple/ before any /page/ or at end
+       var simplePath;
+       var richPageMatch = path.match(/\/page\/(\d+)\/$/);
+       if (richPageMatch) {
+         simplePath = path.replace(/\/page\/(\d+)\/$/, '/simple/page/' + richPageMatch[1] + '/');
+       } else {
+         // Ensure trailing slash
+         simplePath = path.replace(/\/?$/, '/') + 'simple/';
+       }
+       window.location.href = simplePath;
+     }
+   }
 
   /**
    * Navigate to next page.
@@ -417,14 +425,14 @@
           focusSearch();
           state.lastKey = null;
           state.lastKeyTime = 0;
-        } else if (e.key === 's' && state.lastKey !== 'g') {
-          // Standalone s - toggle simple/rich feed view (only on feed pages)
-          if (document.querySelector('.feed')) {
-            e.preventDefault();
-            toggleFeedView();
-          }
-          state.lastKey = null;
-          state.lastKeyTime = 0;
+         } else if (e.key === 's' && state.lastKey !== 'g') {
+           // Standalone s - toggle simple/rich feed view (only on feed pages)
+           if (isFeedPage()) {
+             e.preventDefault();
+             toggleFeedView();
+           }
+           state.lastKey = null;
+           state.lastKeyTime = 0;
         } else {
           state.lastKey = null;
           state.lastKeyTime = 0;

--- a/pkg/themes/default/static/js/scrolling-shortcuts.js
+++ b/pkg/themes/default/static/js/scrolling-shortcuts.js
@@ -84,13 +84,24 @@
     });
   }
 
-  /**
-   * Check if we're on a post/article page
-   */
-  function isPostPage() {
-    // Check for article element or post-specific classes/data attributes
-    return document.querySelector('article, [data-type="post"], .post-content') !== null;
-  }
+   /**
+    * Check if we're on a post/article page
+    * Post pages have a single <article> element, not a feed
+    */
+   function isPostPage() {
+     // Check for article element (only on individual post pages)
+     // Feed pages don't have article tags
+     return document.querySelector('article.post') !== null;
+   }
+
+   /**
+    * Check if we're on a feed page
+    * Feed pages have a <div class="feed"> wrapper
+    */
+   function isFeedPage() {
+     // All feed pages (rich feed, simple feed, etc.) have this structure
+     return document.querySelector('div.feed') !== null;
+   }
 
   /**
    * Continuous scroll loop - runs while keys are held
@@ -208,6 +219,11 @@
       if (window.shortcutsRegistry.isInputElement(e.target)) return;
 
       var key = e.key.toLowerCase();
+
+      // Skip j/k on feed pages - let navigation module handle them
+      if ((key === 'j' || key === 'k') && isFeedPage()) {
+        return;
+      }
 
       // Track if scroll keys are pressed (for held key detection)
       if (isPostPage() && (key === 'j' || key === 'k')) {


### PR DESCRIPTION
## Summary
- Fixes j/k keybinding conflicts between scrolling and feed navigation
- Replaces unreliable CSS class selectors with semantic HTML detection
- Post pages: scrolling-shortcuts checks for `article.post`
- Feed pages: navigation-shortcuts checks for `div.feed`
- Prevents ambiguous behavior by leveraging template structure as source of truth

## Changes
- **scrolling-shortcuts.js**: Updated `isPostPage()` and `isFeedPage()` to use semantic selectors; checks `isFeedPage()` before handling j/k keys
- **navigation-shortcuts.js**: Added `isFeedPage()` helper; updated `toggleFeedView()` to use semantic detection

## Why this approach is better
- Semantically tied to actual HTML structure (not arbitrary CSS classes)
- Mutual exclusivity: pages have either `article.post` OR `div.feed`, never both
- Clear ownership: j/k binding determined by page structure, not collision detection
- Future-proof: if templates change, selectors should be updated alongside them

## Testing
- All existing tests pass
- No regressions in behavior
- j/k now correctly handles feed navigation on feed pages, scrolling on post pages