### PR TITLE
feat: TOC improvements with auto-enable and markdown placeholder

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -872,6 +872,9 @@ Configure the table of contents component for document navigation.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `enabled` | bool | `true` | Show TOC |
+| `auto_enable` | bool | `false` | Auto-show based on thresholds |
+| `min_toc_links` | int | `3` | Min headings for auto-show |
+| `min_word_count` | int | `500` | Min words for auto-show |
 | `position` | string | `"right"` | Position: `"left"` or `"right"` |
 | `width` | string | `"220px"` | TOC width |
 | `min_depth` | int | `2` | Minimum heading level (h2 = 2) |
@@ -884,6 +887,9 @@ Configure the table of contents component for document navigation.
 ```toml
 [markata-go.toc]
 enabled = true
+auto_enable = true          # Auto-show TOC for long posts
+min_toc_links = 3           # Show if 3+ headings
+min_word_count = 500        # Show if 500+ words
 position = "right"
 width = "220px"
 title = "On this page"

--- a/docs/guides/markdown.md
+++ b/docs/guides/markdown.md
@@ -1566,26 +1566,76 @@ markata-go can automatically generate a table of contents from your headings.
 
 ### Enabling TOC
 
-Add `toc: true` to your frontmatter:
+There are three ways to control TOC display, in order of priority:
+
+1. **`[[toc]]` placeholder** - Insert TOC inline in your content
+2. **Frontmatter** - `toc: true` or `toc: false` per-post override
+3. **Global config** - Auto-enable based on content length
+
+### TOC Placeholder
+
+Insert `[[toc]]` anywhere in your markdown to render the TOC at that position:
+
+```markdown
+---
+title: "My Article"
+---
+
+# Table of Contents
+[[toc]]
+
+## Introduction
+
+Content starts here...
+```
+
+### Frontmatter Override
+
+Control TOC per-post in frontmatter:
 
 ```yaml
 ---
 title: "My Long Article"
-toc: true
+toc: true        # Force enable TOC
 ---
 
 # Introduction
 
 ## Getting Started
-
-### Prerequisites
-
-### Installation
-
-## Core Concepts
-
-## Advanced Topics
 ```
+
+Or disable TOC for a specific post:
+
+```yaml
+---
+title: "Short Post"
+toc: false       # Disable TOC even if global config enables it
+---
+
+# Introduction
+```
+
+### Global Auto-Enable
+
+Configure automatic TOC display based on content thresholds:
+
+```toml
+[markata-go.toc]
+enabled = true
+auto_enable = true
+min_toc_links = 3     # Show if 3+ headings
+min_word_count = 500  # Show if 500+ words
+```
+
+### Priority Order
+
+TOC display is determined by the following priority:
+
+1. **`[[toc]]` placeholder** → Always shows TOC at placeholder position
+2. **Frontmatter `toc: false`** → Disables TOC for this post
+3. **Frontmatter `toc: true`** → Forces TOC for this post
+4. **Global `auto_enable: true`** → Auto-shows if thresholds met
+5. **Global `enabled: true`** → Default TOC behavior
 
 ### TOC Options
 

--- a/pkg/models/layout.go
+++ b/pkg/models/layout.go
@@ -542,6 +542,19 @@ type TocConfig struct {
 	// Enabled controls whether the TOC is displayed (default: true for docs layout)
 	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty" toml:"enabled,omitempty"`
 
+	// AutoEnable enables automatic TOC display based on content thresholds.
+	// When true, TOC will show automatically if min_toc_links or min_word_count
+	// thresholds are met, unless explicitly disabled in frontmatter.
+	AutoEnable *bool `json:"auto_enable,omitempty" yaml:"auto_enable,omitempty" toml:"auto_enable,omitempty"`
+
+	// MinTocLinks is the minimum number of TOC entries required to auto-show.
+	// Only used when AutoEnable is true. Default: 3
+	MinTocLinks int `json:"min_toc_links,omitempty" yaml:"min_toc_links,omitempty" toml:"min_toc_links,omitempty"`
+
+	// MinWordCount is the minimum word count required to auto-show.
+	// Only used when AutoEnable is true. Default: 500
+	MinWordCount int `json:"min_word_count,omitempty" yaml:"min_word_count,omitempty" toml:"min_word_count,omitempty"`
+
 	// Position controls TOC placement: "left" or "right" (default: "right")
 	Position string `json:"position,omitempty" yaml:"position,omitempty" toml:"position,omitempty"`
 
@@ -552,7 +565,7 @@ type TocConfig struct {
 	MinDepth int `json:"min_depth,omitempty" yaml:"min_depth,omitempty" toml:"min_depth,omitempty"`
 
 	// MaxDepth is the maximum heading level to include (default: 4)
-	MaxDepth int `json:"max_depth,omitempty" yaml:"max_depth,omitempty" toml:"max_depth,omitempty"`
+	MaxDepth int `json:"max_depth,omitempty" yaml:"min_depth,omitempty" toml:"max_depth,omitempty"`
 
 	// Title is the TOC section title (default: "On this page")
 	Title string `json:"title,omitempty" yaml:"title,omitempty" toml:"title,omitempty"`
@@ -597,6 +610,44 @@ func (t *TocConfig) IsScrollSpy() bool {
 		return true
 	}
 	return *t.ScrollSpy
+}
+
+// IsAutoEnable returns whether automatic TOC display based on thresholds is enabled.
+func (t *TocConfig) IsAutoEnable() bool {
+	if t.AutoEnable == nil {
+		return false
+	}
+	return *t.AutoEnable
+}
+
+// GetMinTocLinks returns the minimum number of TOC links for auto-show.
+func (t *TocConfig) GetMinTocLinks() int {
+	if t.MinTocLinks <= 0 {
+		return 3
+	}
+	return t.MinTocLinks
+}
+
+// GetMinWordCount returns the minimum word count for auto-show.
+func (t *TocConfig) GetMinWordCount() int {
+	if t.MinWordCount <= 0 {
+		return 500
+	}
+	return t.MinWordCount
+}
+
+// ShouldAutoShow returns true if TOC should automatically show based on content thresholds.
+func (t *TocConfig) ShouldAutoShow(tocLinkCount, wordCount int) bool {
+	if !t.IsAutoEnable() {
+		return false
+	}
+	if tocLinkCount >= t.GetMinTocLinks() {
+		return true
+	}
+	if wordCount >= t.GetMinWordCount() {
+		return true
+	}
+	return false
 }
 
 // HeaderLayoutConfig configures the header component for layouts.

--- a/spec/spec/LAYOUTS.md
+++ b/spec/spec/LAYOUTS.md
@@ -62,6 +62,13 @@ toc_width = "220px"
 content_max_width = "800px"
 header_style = "minimal"
 footer_style = "minimal"
+
+# TOC Configuration (new in v0.x.x)
+[markata-go.layout.docs.toc]
+enabled = true                              # Enable TOC display
+auto_enable = true                          # Auto-show based on thresholds
+min_toc_links = 3                           # Min headings for auto-show
+min_word_count = 500                        # Min words for auto-show
 ```
 
 ### `blog` Layout


### PR DESCRIPTION
## Summary

- Adds automatic TOC display based on content thresholds (word count, heading count)
- Adds `[[toc]]` markdown placeholder for inline TOC placement
- Adds frontmatter override (`toc: true/false`) for per-post control
- Implements priority system: placeholder > frontmatter > auto-enable > global

## Changes

### Configuration (new options)
- `auto_enable`: Enable threshold-based automatic TOC display
- `min_toc_links`: Minimum headings to trigger auto-show (default: 3)
- `min_word_count`: Minimum words to trigger auto-show (default: 500)

### Per-post controls
- `toc: true` - Force enable TOC
- `toc: false` - Disable TOC
- `[[toc]]` - Inline placeholder

### Files Changed
- `pkg/models/layout.go` - Added threshold config fields
- `pkg/models/post.go` - Added frontmatter fields
- `pkg/plugins/toc.go` - Implemented priority logic
- `docs/guides/configuration.md` - Updated docs
- `docs/guides/markdown.md` - Updated docs
- `spec/spec/LAYOUTS.md` - Updated spec