### PR TITLE
Expose link graph data in templates

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -1327,16 +1327,16 @@ strict_wikilinks = true    # Fail build on broken links
 
 ### Backlinks
 
-The wikilinks plugin can generate backlinks (posts that link to the current post):
+The link collector provides backlinks (posts that link to the current post):
 
 ```html
 {# In post.html template #}
-{% if post.Extra.backlinks %}
+{% if post.inlinks %}
 <aside class="backlinks">
     <h3>Linked from</h3>
     <ul>
-    {% for link in post.Extra.backlinks %}
-        <li><a href="{{ link.Href }}">{{ link.Title }}</a></li>
+    {% for link in post.inlinks %}
+        <li><a href="{{ link.source_post.href }}">{{ link.source_post.title }}</a></li>
     {% endfor %}
     </ul>
 </aside>

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -1452,8 +1452,8 @@ include_index = false  # Include index page in inlinks (default: false)
 | Field | Type | Description |
 |-------|------|-------------|
 | `hrefs` | []string | All href values found in the post |
-| `inlinks` | []*Link | Links from other posts pointing to this post |
-| `outlinks` | []*Link | Links from this post to other pages |
+| `inlinks` | []map | Links from other posts pointing to this post (template-friendly) |
+| `outlinks` | []map | Links from this post to other pages (template-friendly) |
 
 **Link structure:**
 ```go
@@ -1473,27 +1473,27 @@ type Link struct {
 
 **Template usage:**
 ```html
-{% if post.Inlinks %}
+{% if post.inlinks %}
 <aside class="backlinks">
     <h3>Pages that link here</h3>
     <ul>
-    {% for link in post.Inlinks %}
-        <li><a href="{{ link.SourcePost.Href }}">{{ link.SourcePost.Title }}</a></li>
+    {% for link in post.inlinks %}
+        <li><a href="{{ link.source_post.href }}">{{ link.source_post.title }}</a></li>
     {% endfor %}
     </ul>
 </aside>
 {% endif %}
 
-{% if post.Outlinks %}
+{% if post.outlinks %}
 <aside class="outlinks">
     <h3>Links from this page</h3>
     <ul>
-    {% for link in post.Outlinks %}
+    {% for link in post.outlinks %}
         <li>
-            <a href="{{ link.TargetURL }}">
-                {% if link.IsInternal %}{{ link.TargetText }}{% else %}{{ link.TargetDomain }}{% endif %}
+            <a href="{{ link.target_url }}">
+                {% if link.is_internal %}{{ link.target_text }}{% else %}{{ link.target_domain }}{% endif %}
             </a>
-            {% if not link.IsInternal %}<span class="external">↗</span>{% endif %}
+            {% if not link.is_internal %}<span class="external">↗</span>{% endif %}
         </li>
     {% endfor %}
     </ul>

--- a/pkg/templates/context.go
+++ b/pkg/templates/context.go
@@ -115,6 +115,9 @@ func postToMapUncached(p *models.Post) map[string]interface{} {
 		"content":      p.Content,
 		"slug":         p.Slug,
 		"href":         p.Href,
+		"hrefs":        p.Hrefs,
+		"inlinks":      linksToMaps(p.Inlinks),
+		"outlinks":     linksToMaps(p.Outlinks),
 		"published":    p.Published,
 		"draft":        p.Draft,
 		"private":      p.Private,
@@ -194,6 +197,56 @@ func postToMapUncached(p *models.Post) map[string]interface{} {
 	}
 
 	return m
+}
+
+func linksToMaps(links []*models.Link) []map[string]interface{} {
+	if len(links) == 0 {
+		return nil
+	}
+	result := make([]map[string]interface{}, 0, len(links))
+	for _, link := range links {
+		if link == nil {
+			continue
+		}
+		result = append(result, linkToMap(link))
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+func linkToMap(link *models.Link) map[string]interface{} {
+	return map[string]interface{}{
+		"source_url":    link.SourceURL,
+		"source_text":   link.SourceText,
+		"target_url":    link.TargetURL,
+		"target_domain": link.TargetDomain,
+		"is_internal":   link.IsInternal,
+		"is_self":       link.IsSelf,
+		"raw_target":    link.RawTarget,
+		"target_text":   link.TargetText,
+		"source_post":   postSummaryToMap(link.SourcePost),
+		"target_post":   postSummaryToMap(link.TargetPost),
+	}
+}
+
+func postSummaryToMap(post *models.Post) map[string]interface{} {
+	if post == nil {
+		return nil
+	}
+
+	result := map[string]interface{}{
+		"href": post.Href,
+		"slug": post.Slug,
+	}
+	if post.Title != nil {
+		result["title"] = *post.Title
+	} else {
+		result["title"] = nil
+	}
+
+	return result
 }
 
 // authorToMap converts an Author to a map for template access.

--- a/pkg/templates/context_test.go
+++ b/pkg/templates/context_test.go
@@ -1,0 +1,72 @@
+package templates
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/WaylonWalker/markata-go/pkg/models"
+)
+
+func TestPostToMap_InlinksOutlinks(t *testing.T) {
+	sourceTitle := "Source"
+	targetTitle := "Target"
+
+	sourcePost := &models.Post{Slug: "source", Href: "/source/", Title: &sourceTitle}
+	targetPost := &models.Post{Slug: "target", Href: "/target/", Title: &targetTitle}
+
+	link := &models.Link{
+		SourceURL:    "https://example.com/source/",
+		SourcePost:   sourcePost,
+		TargetPost:   targetPost,
+		RawTarget:    "/target/",
+		TargetURL:    "https://example.com/target/",
+		TargetDomain: "example.com",
+		IsInternal:   true,
+		SourceText:   "Source",
+		TargetText:   "Target",
+	}
+
+	post := &models.Post{
+		Slug:     "target",
+		Href:     "/target/",
+		Hrefs:    []string{"/target/"},
+		Inlinks:  []*models.Link{link},
+		Outlinks: []*models.Link{link},
+	}
+
+	mapped := postToMapUncached(post)
+	if mapped["hrefs"] == nil {
+		t.Fatalf("expected hrefs to be set")
+	}
+
+	if !reflect.DeepEqual(mapped["hrefs"], []string{"/target/"}) {
+		t.Errorf("unexpected hrefs: %#v", mapped["hrefs"])
+	}
+
+	inlinks, ok := mapped["inlinks"].([]map[string]interface{})
+	if !ok || len(inlinks) != 1 {
+		t.Fatalf("expected inlinks map slice, got %#v", mapped["inlinks"])
+	}
+
+	linkMap := inlinks[0]
+	if linkMap["source_url"] != "https://example.com/source/" {
+		t.Errorf("unexpected source_url: %#v", linkMap["source_url"])
+	}
+	if linkMap["target_domain"] != "example.com" {
+		t.Errorf("unexpected target_domain: %#v", linkMap["target_domain"])
+	}
+	if linkMap["is_internal"] != true {
+		t.Errorf("unexpected is_internal: %#v", linkMap["is_internal"])
+	}
+
+	sourceMap, ok := linkMap["source_post"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected source_post map, got %#v", linkMap["source_post"])
+	}
+	if sourceMap["href"] != "/source/" {
+		t.Errorf("unexpected source_post href: %#v", sourceMap["href"])
+	}
+	if sourceMap["title"] != "Source" {
+		t.Errorf("unexpected source_post title: %#v", sourceMap["title"])
+	}
+}

--- a/spec/spec/TEMPLATES.md
+++ b/spec/spec/TEMPLATES.md
@@ -181,6 +181,19 @@ Template for index/listing pages:
 | `config` | Config | Site configuration |
 | `core` | Core | Core instance |
 
+**Link graph fields (from link_collector):**
+
+- `post.hrefs` - list of href strings found in the post
+- `post.inlinks` - list of link maps pointing to this post
+- `post.outlinks` - list of link maps pointing from this post
+
+Each link map includes:
+
+- `source_url`, `source_text`
+- `target_url`, `target_domain`, `target_text`
+- `is_internal`, `is_self`, `raw_target`
+- `source_post`, `target_post` (maps with `href`, `slug`, `title`)
+
 ### OG Templates
 
 OpenGraph card pages use dedicated templates. The template name is derived from the


### PR DESCRIPTION
## Summary
- expose link_collector hrefs/inlinks/outlinks as template-friendly maps
- document new keys in template spec and docs
- add coverage for link map conversion

## Testing
- go test ./pkg/templates

Fixes #679