### PR TITLE
feat: add build dependencies to builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,9 +59,17 @@ RUN apk add --no-cache \
     git \
     libavif-apps \
     libwebp-tools \
+    chromium \
+    nodejs \
+    npm \
     openssh-client \
     rsync \
     tzdata
+
+# Install build-time tools for optional plugins
+ENV PUPPETEER_SKIP_DOWNLOAD=1
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
+RUN npm install -g @mermaid-js/mermaid-cli pagefind
 
 # Copy the binary
 COPY --from=builder /app/markata-go /usr/local/bin/markata-go

--- a/docs/guides/deployment/docker.md
+++ b/docs/guides/deployment/docker.md
@@ -24,7 +24,7 @@ Docker provides a consistent, reproducible environment for building and serving 
 markata-go publishes two official container images for different workflows:
 
 - `ghcr.io/waylonwalker/markata-go:<version>`: Minimal runtime image (scratch) that runs the `markata-go` binary directly.
-- `ghcr.io/waylonwalker/markata-go-builder:<version>`: Builder image with `/bin/sh`, core utilities, `rsync`, and image encoders (`avifenc`, `cwebp`) for CI and publish scripts.
+- `ghcr.io/waylonwalker/markata-go-builder:<version>`: Builder image with `/bin/sh`, core utilities, `rsync`, image encoders (`avifenc`, `cwebp`), Pagefind, and Mermaid CLI dependencies (`nodejs`, `npm`, `chromium`, `mmdc`).
 
 ### Builder Image Quick Start
 

--- a/spec/spec/CONTAINERS.md
+++ b/spec/spec/CONTAINERS.md
@@ -42,9 +42,13 @@ The builder image MUST include:
 
 The builder image MAY include:
 
+- `chromium` (for Mermaid Chromium rendering)
 - `git`
 - `libavif-apps` (provides `avifenc`)
 - `libwebp-tools` (provides `cwebp`)
+- `nodejs` and `npm`
+- `pagefind` (for search index generation)
+- `@mermaid-js/mermaid-cli` (provides `mmdc`)
 - `openssh-client` (for rsync over SSH)
 - `tzdata`
 


### PR DESCRIPTION
## Summary
- add pagefind, mermaid CLI, chromium, and node/npm to builder image
- include avifenc and cwebp for image optimization workflows
- document builder image dependencies

## Issue
- Refs #772