### PR TITLE
fix: skip link avatars on image links

### DIFF
--- a/docs/guides/link-avatars.md
+++ b/docs/guides/link-avatars.md
@@ -94,7 +94,7 @@ Template placeholders:
 
 ### Ignore Rules
 
-Exclude specific links from getting avatars:
+Exclude specific links from getting avatars. Links that wrap images are always skipped.
 
 ```toml
 [markata-go.link_avatars]

--- a/pkg/plugins/link_avatars.go
+++ b/pkg/plugins/link_avatars.go
@@ -316,6 +316,11 @@ func (p *LinkAvatarsPlugin) generateJavaScript() string {
       }
     }
 
+    // Skip links that wrap images
+    if (link.querySelector('img, picture')) {
+      return true;
+    }
+
     // Check ignore selectors
     for (var m = 0; m < config.ignoreSelectors.length; m++) {
       try {
@@ -797,6 +802,10 @@ func parseIgnoreSelectors(selectors []string) []cascadia.Sel {
 
 func shouldIgnoreLink(link *goquery.Selection, host, origin, siteOrigin string, selectors []cascadia.Sel, cfg LinkAvatarsConfig) bool {
 	if siteOrigin != "" && origin == siteOrigin {
+		return true
+	}
+
+	if link.Find("img, picture").Length() > 0 {
 		return true
 	}
 

--- a/spec/spec/LINK_AVATARS.md
+++ b/spec/spec/LINK_AVATARS.md
@@ -100,6 +100,7 @@ position = "before"
    - Link matches any `ignore_selectors`
    - Link has any class in `ignore_classes`
    - Link is inside an element with ID in `ignore_ids`
+   - Link contains an `img` or `picture` element
 
 4. **Avatar Injection**:
    - **js mode**: client-side JavaScript sets `data-favicon`, `--favicon-url`, and `has-avatar` classes at runtime.


### PR DESCRIPTION
## Summary
- skip link avatar injection for anchors that wrap images
- document the behavior in link avatars spec and guide

## Issue
- Fixes #777