### PR TITLE
fix: align default content glob and archive feed

### DIFF
--- a/cmd/markata-go/cmd/config.go
+++ b/cmd/markata-go/cmd/config.go
@@ -917,18 +917,20 @@ orphan_threshold = 3
 
 [feed_defaults.formats]
 html = true
+simple_html = true
 rss = true
 atom = true
 json = true
 sitemap = true
 
-# Define custom feeds
-# [[feeds]]
-# slug = "blog"
-# title = "Blog Posts"
-# filter = "published == true"
-# sort = "date"
-# reverse = true
+# Default feed
+[[feeds]]
+slug = "archive"
+title = "Archive"
+description = "All posts"
+filter = "published == true"
+sort = "date"
+reverse = true
 `
 
 const defaultConfigYAML = `# Markata-go configuration file
@@ -964,18 +966,20 @@ feed_defaults:
   orphan_threshold: 3
   formats:
     html: true
+    simple_html: true
     rss: true
     atom: true
     json: true
     sitemap: true
 
-# Define custom feeds
-# feeds:
-#   - slug: blog
-#     title: Blog Posts
-#     filter: "published == true"
-#     sort: date
-#     reverse: true
+# Default feed
+feeds:
+  - slug: archive
+    title: Archive
+    description: All posts
+    filter: "published == true"
+    sort: date
+    reverse: true
 `
 
 const defaultConfigJSON = `{
@@ -1001,12 +1005,22 @@ const defaultConfigJSON = `{
     "orphan_threshold": 3,
     "formats": {
       "html": true,
+      "simple_html": true,
       "rss": true,
       "atom": true,
       "json": true,
       "sitemap": true
     }
   },
-  "feeds": []
+  "feeds": [
+    {
+      "slug": "archive",
+      "title": "Archive",
+      "description": "All posts",
+      "filter": "published == true",
+      "sort": "date",
+      "reverse": true
+    }
+  ]
 }
 `

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -1230,18 +1230,22 @@ orphan_threshold = 3
 
 [markata-go.feed_defaults.formats]
 html = true
+simple_html = true
 rss = true
-atom = false
-json = false
+atom = true
+json = true
+sitemap = true
 markdown = false
 text = false
 
 [markata-go.feed_defaults.templates]
 html = "feed.html"
+simple_html = "simple-feed.html"
 rss = "feed.xml"
 atom = "atom.xml"
 json = "feed.json"
 card = "card.html"
+sitemap = "sitemap.xml"
 
 [markata-go.feed_defaults.syndication]
 max_items = 20
@@ -1253,15 +1257,17 @@ include_content = true
 | Format | Output Path | Description |
 |--------|-------------|-------------|
 | `html` | `/{slug}/index.html` | Paginated HTML pages |
+| `simple_html` | `/{slug}/simple/index.html` | Compact HTML list |
 | `rss` | `/{slug}/rss.xml` | RSS 2.0 feed |
 | `atom` | `/{slug}/atom.xml` | Atom 1.0 feed |
 | `json` | `/{slug}/feed.json` | JSON Feed |
+| `sitemap` | `/{slug}/sitemap.xml` | Sitemap XML |
 | `markdown` | `/{slug}.md` | Markdown output |
 | `text` | `/{slug}.txt` | Plain text output |
 
 ### Feed Configuration (`[[markata-go.feeds]]`)
 
-Each feed is defined as an array item:
+Each feed is defined as an array item. The default config ships with an archive feed at `/archive/`.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|

--- a/docs/guides/feeds.md
+++ b/docs/guides/feeds.md
@@ -59,7 +59,7 @@ reverse = true
 This creates a feed at `/blog/` with:
 - All published posts
 - Sorted by date (newest first)
-- HTML, RSS, Atom, JSON, and sitemap output (default formats)
+- HTML, simple HTML, RSS, Atom, JSON, and sitemap output (default formats)
 
 ### Minimal Example
 
@@ -69,6 +69,8 @@ slug = "posts"
 title = "All Posts"
 filter = "published == True"
 ```
+
+If you use the default config, markata-go already includes an archive feed at `/archive/`.
 
 ### Full Configuration Example
 
@@ -96,6 +98,7 @@ simple_html = true                 # /blog/simple/index.html
 rss = true                         # /blog/rss.xml
 atom = true                        # /blog/atom.xml
 json = true                        # /blog/feed.json
+sitemap = true                     # /blog/sitemap.xml
 markdown = false                   # /blog.md
 text = false                       # /blog.txt
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -79,8 +79,8 @@ func TestConfig_DefaultGlobPatterns(t *testing.T) {
 	// Test case: "default glob patterns"
 	config := DefaultConfig()
 
-	expectedPatterns := []string{"**/*.md"}
-	if len(config.GlobConfig.Patterns) != 1 || config.GlobConfig.Patterns[0] != "**/*.md" {
+	expectedPatterns := []string{"pages/**/*.md", "posts/**/*.md"}
+	if len(config.GlobConfig.Patterns) != len(expectedPatterns) || config.GlobConfig.Patterns[0] != expectedPatterns[0] || config.GlobConfig.Patterns[1] != expectedPatterns[1] {
 		t.Errorf("glob.patterns: got %v, want %v", config.GlobConfig.Patterns, expectedPatterns)
 	}
 }

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -13,19 +13,22 @@ func DefaultConfig() *models.Config {
 		AssetsDir:    "static",
 		Hooks:        []string{"default"},
 		GlobConfig: models.GlobConfig{
-			Patterns:     []string{"**/*.md"},
+			Patterns:     []string{"pages/**/*.md", "posts/**/*.md"},
 			UseGitignore: true,
 		},
-		FeedDefaults: models.FeedDefaults{
-			ItemsPerPage:    10,
-			OrphanThreshold: 3,
-			Formats: models.FeedFormats{
-				HTML: true,
-				RSS:  true,
+		Feeds: []models.FeedConfig{
+			{
+				Slug:        "archive",
+				Title:       "Archive",
+				Description: "All posts",
+				Filter:      "published == true",
+				Sort:        "date",
+				Reverse:     true,
 			},
 		},
-		WellKnown:  models.NewWellKnownConfig(),
-		WebSub:     models.NewWebSubConfig(),
-		Encryption: models.NewEncryptionConfig(),
+		FeedDefaults: models.NewFeedDefaults(),
+		WellKnown:    models.NewWellKnownConfig(),
+		WebSub:       models.NewWebSubConfig(),
+		Encryption:   models.NewEncryptionConfig(),
 	}
 }

--- a/spec/spec/CONFIG.md
+++ b/spec/spec/CONFIG.md
@@ -574,7 +574,7 @@ concurrency = 0                   # Worker threads (0 = auto)
 
 ```toml
 [my-ssg.glob]
-patterns = ["**/*.md"]            # File patterns to match
+patterns = ["pages/**/*.md", "posts/**/*.md"] # File patterns to match
 use_gitignore = true              # Respect .gitignore
 exclude = ["node_modules/**"]     # Patterns to exclude
 ```
@@ -601,17 +601,20 @@ orphan_threshold = 3
 
 [my-ssg.feeds.defaults.formats]
 html = true
+simple_html = true
 rss = true
-atom = false
-json = false
+atom = true
+json = true
+sitemap = true
 
 [my-ssg.feeds.syndication]
 max_items = 20
 include_content = false
 
 [[my-ssg.feeds]]
-slug = "blog"
-title = "Blog"
+slug = "archive"
+title = "Archive"
+description = "All posts"
 filter = "published == True"
 sort = "date"
 reverse = true

--- a/spec/spec/FEEDS.md
+++ b/spec/spec/FEEDS.md
@@ -1132,16 +1132,16 @@ When overriding formats, you can:
 
 **1. Override specific formats (merge with defaults):**
 ```toml
-# Defaults: html=true, rss=true, atom=false, json=false
+# Defaults: html=true, simple_html=true, rss=true, atom=true, json=true, sitemap=true
 formats = { atom = true }
-# Result: html=true, rss=true, atom=true, json=false
+# Result: html=true, simple_html=true, rss=true, atom=true, json=true, sitemap=true
 ```
 
 **2. Disable specific formats:**
 ```toml
-# Defaults: html=true, rss=true
+# Defaults: html=true, simple_html=true, rss=true, atom=true, json=true, sitemap=true
 formats = { rss = false }
-# Result: html=true, rss=false
+# Result: html=true, simple_html=true, rss=false, atom=true, json=true, sitemap=true
 ```
 
 **3. Completely replace formats (explicit all):**
@@ -1184,11 +1184,11 @@ orphan_threshold = 3
 html = true
 simple_html = true
 rss = true
-atom = false
-json = false
+atom = true
+json = true
 markdown = false
 text = false
-sitemap = false
+sitemap = true
 
 # Templates used by default
 [markata-go.feeds.defaults.templates]
@@ -1205,7 +1205,7 @@ sitemap = "sitemap.xml"
 # Syndication settings (RSS/Atom/JSON)
 [markata-go.feeds.syndication]
 max_items = 20                     # Max items in RSS/Atom feeds
-include_content = false            # Include full content or just summary
+include_content = true             # Include full content or just summary
 ```
 
 ### Built-in Defaults
@@ -1225,7 +1225,7 @@ If no `[markata-go.feeds.defaults]` is specified, these built-in values apply:
 | `formats.text` | false |
 | `formats.sitemap` | true |
 | `syndication.max_items` | 20 |
-| `syndication.include_content` | false |
+| `syndication.include_content` | true |
 
 ### Feed Item Limits
 
@@ -1260,9 +1260,11 @@ orphan_threshold = 3
 
 [markata-go.feeds.defaults.formats]
 html = true
+simple_html = true
 rss = true
 atom = true
 json = true
+sitemap = true
 
 [markata-go.feeds.defaults.templates]
 html = "feed.html"
@@ -1270,7 +1272,7 @@ card = "partials/card.html"
 
 [markata-go.feeds.syndication]
 max_items = 20
-include_content = false
+include_content = true
 
 # =============================================================================
 # INDIVIDUAL FEEDS


### PR DESCRIPTION
## Summary
- switch default glob patterns to explicit pages/posts roots
- add a default archive feed to the base config
- align specs and docs with updated defaults

## Testing
- go test ./pkg/config

Refs #672