### PR TITLE
fix: keep series navigation consistent

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -1315,6 +1315,42 @@ sort = "date"
 reverse = true
 ```
 
+### Series Settings (`[markata-go.series]`)
+
+Series automatically generate ordered feed pages and navigation from `series` frontmatter.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `slug_prefix` | string | `"series"` | URL prefix for series feeds (e.g., `/series/<name>/`) |
+| `auto_sidebar` | bool | `true` | Auto-enable the series sidebar on series posts |
+| `defaults` | object | see below | Default settings for all series feeds |
+| `overrides` | map[string]object | `{}` | Per-series overrides (keyed by series slug or name) |
+
+```toml
+[markata-go.series]
+slug_prefix = "series"
+auto_sidebar = true
+
+[markata-go.series.defaults]
+items_per_page = 0
+sidebar = true
+
+[markata-go.series.defaults.formats]
+html = true
+simple_html = true
+rss = true
+atom = true
+json = true
+sitemap = true
+
+[markata-go.series.overrides."building-a-rest-api"]
+title = "Building a REST API with Go"
+description = "A complete guide from zero to production"
+
+[markata-go.series.overrides."building-a-rest-api".formats]
+markdown = true
+```
+
 ## Environment Variable Overrides
 
 All configuration options can be overridden via environment variables using the `MARKATA_GO_` prefix.

--- a/docs/guides/series.md
+++ b/docs/guides/series.md
@@ -277,6 +277,8 @@ When a post belongs to a series:
 
 Posts with `published: false` are excluded from the series feed output but still count for ordering purposes. Prev/next links skip unpublished posts.
 
+Private posts are treated as unpublished for series navigation and output.
+
 ### Single-Post Series
 
 A series with one post is valid. No prev/next navigation is generated, but the sidebar and index page are still created.

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -32,7 +32,7 @@ Configure -> Glob -> Load -> Transform -> Render -> Collect -> Write -> Cleanup
 | Load | Parse files into posts | load, frontmatter |
 | Transform | Pre-render modifications | description, reading_time, stats, breadcrumbs, jinja_md, wikilinks, toc |
 | Render | Convert content to HTML | render_markdown, templates, admonitions, heading_anchors, link_collector, mermaid, glossary, csv_fence, youtube |
-| Collect | Build collections/feeds | feeds, auto_feeds, prevnext, overwrite_check, static_file_conflicts |
+| Collect | Build collections/feeds | series, feeds, auto_feeds, prevnext, overwrite_check, static_file_conflicts |
 | Write | Output files to disk | publish_html, random_post, publish_feeds, sitemap, rss, atom, jsonfeed, static_assets, redirects |
 | Cleanup | Post-build tasks | pagefind |
 

--- a/pkg/plugins/prevnext_test.go
+++ b/pkg/plugins/prevnext_test.go
@@ -214,7 +214,7 @@ func TestPrevNextPlugin_Collect_SeriesStrategy(t *testing.T) {
 			Posts: []*models.Post{post1, post2, post3},
 		},
 		{
-			Name:  "tutorial",
+			Name:  "series/tutorial",
 			Title: "Tutorial Series",
 			Posts: []*models.Post{post3, post2}, // post2 is last in tutorial
 		},
@@ -240,8 +240,8 @@ func TestPrevNextPlugin_Collect_SeriesStrategy(t *testing.T) {
 	}
 
 	// post2 uses tutorial series
-	if post2.PrevNextFeed != "tutorial" {
-		t.Errorf("post2.PrevNextFeed = %q, want %q (from series)", post2.PrevNextFeed, "tutorial")
+	if post2.PrevNextFeed != "series/tutorial" {
+		t.Errorf("post2.PrevNextFeed = %q, want %q (from series)", post2.PrevNextFeed, "series/tutorial")
 	}
 	if post2.Prev != post3 {
 		t.Errorf("post2.Prev = %v, want post3 (in tutorial)", post2.Prev)

--- a/pkg/plugins/series_test.go
+++ b/pkg/plugins/series_test.go
@@ -81,15 +81,18 @@ func TestSeriesPlugin_BasicSeries(t *testing.T) {
 
 	post1 := &models.Post{
 		Path: "part1.md", Slug: "part1", Title: strPtr("Part 1"), Date: &date1,
-		Extra: map[string]interface{}{"series": "building-rest-api"},
+		Published: true,
+		Extra:     map[string]interface{}{"series": "building-rest-api"},
 	}
 	post2 := &models.Post{
 		Path: "part2.md", Slug: "part2", Title: strPtr("Part 2"), Date: &date2,
-		Extra: map[string]interface{}{"series": "building-rest-api"},
+		Published: true,
+		Extra:     map[string]interface{}{"series": "building-rest-api"},
 	}
 	post3 := &models.Post{
 		Path: "part3.md", Slug: "part3", Title: strPtr("Part 3"), Date: &date3,
-		Extra: map[string]interface{}{"series": "building-rest-api"},
+		Published: true,
+		Extra:     map[string]interface{}{"series": "building-rest-api"},
 	}
 
 	m.SetPosts([]*models.Post{post3, post1, post2}) // out of order
@@ -202,15 +205,18 @@ func TestSeriesPlugin_ExplicitOrder(t *testing.T) {
 	// Posts with explicit order, reversed from date order
 	post1 := &models.Post{
 		Path: "setup.md", Slug: "setup", Title: strPtr("Setup"), Date: &date3,
-		Extra: map[string]interface{}{"series": "tutorial", "series_order": 1},
+		Published: true,
+		Extra:     map[string]interface{}{"series": "tutorial", "series_order": 1},
 	}
 	post2 := &models.Post{
 		Path: "basics.md", Slug: "basics", Title: strPtr("Basics"), Date: &date1,
-		Extra: map[string]interface{}{"series": "tutorial", "series_order": 2},
+		Published: true,
+		Extra:     map[string]interface{}{"series": "tutorial", "series_order": 2},
 	}
 	post3 := &models.Post{
 		Path: "advanced.md", Slug: "advanced", Title: strPtr("Advanced"), Date: &date2,
-		Extra: map[string]interface{}{"series": "tutorial", "series_order": 3},
+		Published: true,
+		Extra:     map[string]interface{}{"series": "tutorial", "series_order": 3},
 	}
 
 	m.SetPosts([]*models.Post{post3, post2, post1}) // random order
@@ -253,16 +259,19 @@ func TestSeriesPlugin_MixedOrder(t *testing.T) {
 	// Some posts have explicit order, others don't
 	post1 := &models.Post{
 		Path: "intro.md", Slug: "intro", Title: strPtr("Intro"), Date: &date3,
-		Extra: map[string]interface{}{"series": "guide", "series_order": 1},
+		Published: true,
+		Extra:     map[string]interface{}{"series": "guide", "series_order": 1},
 	}
 	post2 := &models.Post{
 		Path: "setup.md", Slug: "setup", Title: strPtr("Setup"), Date: &date1,
-		Extra: map[string]interface{}{"series": "guide", "series_order": 2},
+		Published: true,
+		Extra:     map[string]interface{}{"series": "guide", "series_order": 2},
 	}
 	// No series_order - should come after ordered posts, sorted by date
 	post3 := &models.Post{
 		Path: "extra.md", Slug: "extra", Title: strPtr("Extra"), Date: &date2,
-		Extra: map[string]interface{}{"series": "guide"},
+		Published: true,
+		Extra:     map[string]interface{}{"series": "guide"},
 	}
 
 	m.SetPosts([]*models.Post{post3, post1, post2})
@@ -301,13 +310,13 @@ func TestSeriesPlugin_MultipleSeries(t *testing.T) {
 	date2 := time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)
 
 	m.SetPosts([]*models.Post{
-		{Path: "go1.md", Slug: "go1", Title: strPtr("Go Part 1"), Date: &date1,
+		{Path: "go1.md", Slug: "go1", Title: strPtr("Go Part 1"), Date: &date1, Published: true,
 			Extra: map[string]interface{}{"series": "learn-go"}},
-		{Path: "go2.md", Slug: "go2", Title: strPtr("Go Part 2"), Date: &date2,
+		{Path: "go2.md", Slug: "go2", Title: strPtr("Go Part 2"), Date: &date2, Published: true,
 			Extra: map[string]interface{}{"series": "learn-go"}},
-		{Path: "py1.md", Slug: "py1", Title: strPtr("Python Part 1"), Date: &date2,
+		{Path: "py1.md", Slug: "py1", Title: strPtr("Python Part 1"), Date: &date2, Published: true,
 			Extra: map[string]interface{}{"series": "learn-python"}},
-		{Path: "py2.md", Slug: "py2", Title: strPtr("Python Part 2"), Date: &date1,
+		{Path: "py2.md", Slug: "py2", Title: strPtr("Python Part 2"), Date: &date1, Published: true,
 			Extra: map[string]interface{}{"series": "learn-python"}},
 	})
 
@@ -359,7 +368,8 @@ func TestSeriesPlugin_SinglePost(t *testing.T) {
 	date := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	post := &models.Post{
 		Path: "solo.md", Slug: "solo", Title: strPtr("Solo Post"), Date: &date,
-		Extra: map[string]interface{}{"series": "one-part"},
+		Published: true,
+		Extra:     map[string]interface{}{"series": "one-part"},
 	}
 	m.SetPosts([]*models.Post{post})
 
@@ -402,7 +412,8 @@ func TestSeriesPlugin_ConfigOverride(t *testing.T) {
 	date := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	m.SetPosts([]*models.Post{
 		{Path: "p1.md", Slug: "p1", Title: strPtr("P1"), Date: &date,
-			Extra: map[string]interface{}{"series": "my-series"}},
+			Published: true,
+			Extra:     map[string]interface{}{"series": "my-series"}},
 	})
 
 	config := lifecycle.NewConfig()
@@ -444,7 +455,8 @@ func TestSeriesPlugin_CustomSlugPrefix(t *testing.T) {
 	date := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	m.SetPosts([]*models.Post{
 		{Path: "p1.md", Slug: "p1", Title: strPtr("P1"), Date: &date,
-			Extra: map[string]interface{}{"series": "my-series"}},
+			Published: true,
+			Extra:     map[string]interface{}{"series": "my-series"}},
 	})
 
 	config := lifecycle.NewConfig()
@@ -477,7 +489,8 @@ func TestSeriesPlugin_DefaultsConfig(t *testing.T) {
 	date := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	m.SetPosts([]*models.Post{
 		{Path: "p1.md", Slug: "p1", Title: strPtr("P1"), Date: &date,
-			Extra: map[string]interface{}{"series": "test"}},
+			Published: true,
+			Extra:     map[string]interface{}{"series": "test"}},
 	})
 
 	config := lifecycle.NewConfig()
@@ -517,7 +530,8 @@ func TestSeriesPlugin_PreservesExistingFeeds(t *testing.T) {
 	date := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	m.SetPosts([]*models.Post{
 		{Path: "p1.md", Slug: "p1", Title: strPtr("P1"), Date: &date,
-			Extra: map[string]interface{}{"series": "test"}},
+			Published: true,
+			Extra:     map[string]interface{}{"series": "test"}},
 		{Path: "p2.md", Slug: "p2", Title: strPtr("P2"), Date: &date, Tags: []string{"go"}},
 	})
 
@@ -563,9 +577,11 @@ func TestSeriesPlugin_NameNormalization(t *testing.T) {
 	// Different posts use different casings of the same series name
 	m.SetPosts([]*models.Post{
 		{Path: "p1.md", Slug: "p1", Title: strPtr("P1"), Date: &date,
-			Extra: map[string]interface{}{"series": "My Series"}},
+			Published: true,
+			Extra:     map[string]interface{}{"series": "My Series"}},
 		{Path: "p2.md", Slug: "p2", Title: strPtr("P2"), Date: &date,
-			Extra: map[string]interface{}{"series": "my-series"}},
+			Published: true,
+			Extra:     map[string]interface{}{"series": "my-series"}},
 	})
 
 	plugin := NewSeriesPlugin()

--- a/pkg/plugins/subscription_feeds.go
+++ b/pkg/plugins/subscription_feeds.go
@@ -2,7 +2,6 @@
 package plugins
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
@@ -276,6 +275,8 @@ func GetFeedBySlug(slug string, feedConfigs []models.FeedConfig) *models.FeedCon
 // It checks if the post belongs to any feed configured for sidebar display.
 // Returns the feed config and a boolean indicating if a match was found.
 func FindPostSidebarFeed(post *models.Post, config *lifecycle.Config, feedConfigs []models.FeedConfig) *models.FeedConfig {
+	seriesCfg := parseSeriesConfig(config)
+
 	// Get components config
 	components, ok := config.Extra["components"].(models.ComponentsConfig)
 	if !ok {
@@ -316,7 +317,10 @@ func FindPostSidebarFeed(post *models.Post, config *lifecycle.Config, feedConfig
 
 		// Handle series-based feeds
 		if series, ok := post.Extra["series"].(string); ok {
-			seriesSlug := fmt.Sprintf("series/%s", models.Slugify(series))
+			seriesSlug := getStringFromExtra(post.Extra, "series_slug")
+			if seriesSlug == "" {
+				seriesSlug = buildSeriesFeedSlug(seriesCfg.SlugPrefix, models.Slugify(series))
+			}
 			if feedSlug == seriesSlug {
 				return GetFeedBySlug(feedSlug, feedConfigs)
 			}

--- a/spec/spec/DEFAULT_PLUGINS.md
+++ b/spec/spec/DEFAULT_PLUGINS.md
@@ -310,7 +310,7 @@ series_order: 1                   # Optional explicit ordering
 1. Scan all posts for `series` frontmatter
 2. Group posts by series name (slugified)
 3. Sort posts within each series by `series_order` (if set) or by date ascending
-4. Set guide navigation (Prev/Next pointers) on each post
+4. Set guide navigation (Prev/Next pointers) on published posts
 5. Set `PrevNextContext` with position info (part X of Y)
 6. Build `FeedConfig` entries with `FeedTypeSeries` type
 7. Inject configs into `config.Extra["feeds"]` for the `feeds` plugin to process

--- a/spec/spec/SERIES.md
+++ b/spec/spec/SERIES.md
@@ -85,7 +85,7 @@ The `series` plugin scans all posts during the **Collect** stage (before feeds).
 
 3. Sorts them according to ordering rules above
 
-4. Sets guide navigation (Prev/Next) on each post in the series
+4. Sets guide navigation (Prev/Next) on published posts in the series
 
 5. Injects the feed config into the feed config list (before the feeds plugin runs)
 
@@ -296,7 +296,7 @@ The series plugin runs early in the Collect stage so that:
 │     - Set position metadata on each post                             │
 │                                                                      │
 │  4. NAVIGATE                                                         │
-│     - Set Prev/Next pointers on each post                            │
+│     - Set Prev/Next pointers on published posts                      │
 │     - Set PrevNextFeed to series slug                                │
 │     - Set PrevNextContext with position info                         │
 │                                                                      │
@@ -380,6 +380,7 @@ markdown = true                    # Also generate markdown for this series
 - Post is included in series ordering for context
 - Post is **excluded** from series feed output (not in HTML/RSS/etc.)
 - Prev/Next skip unpublished posts (link to next published post)
+- Private posts are treated as unpublished for navigation and output
 
 ### Empty Series
 


### PR DESCRIPTION
## Summary
- preserve series ordering and navigation by using published-only series posts
- avoid overwriting existing series prev/next context and respect slug prefixes
- ensure series sidebar/discovery matches series feeds and document behavior

## Issue
Fixes #674

## Testing
- go test ./...