### PR TITLE
feat(embeds): add Obsidian-style attachment embed support

### DIFF
--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -1956,6 +1956,10 @@ type EmbedsConfig struct {
 
 	// ShowImage controls whether to display OG images in external embeds (default: true)
 	ShowImage bool `json:"show_image" yaml:"show_image" toml:"show_image"`
+
+	// AttachmentsPrefix is the URL prefix for attachment embeds (default: "/static/")
+	// Used for Obsidian-style ![[image.jpg]] syntax
+	AttachmentsPrefix string `json:"attachments_prefix" yaml:"attachments_prefix" toml:"attachments_prefix"`
 }
 
 // NewEmbedsConfig creates a new EmbedsConfig with default values.
@@ -1969,6 +1973,7 @@ func NewEmbedsConfig() EmbedsConfig {
 		Timeout:           10,
 		FallbackTitle:     "External Link",
 		ShowImage:         true,
+		AttachmentsPrefix: "/static/",
 	}
 }
 


### PR DESCRIPTION
## Summary

Add support for Obsidian-style image embed syntax `![[file.jpg]]` to convert attachments to proper markdown images.

## Changes

- Add `AttachmentsPrefix` config option (default: `/static/`)
- Add `attachmentEmbedRegex` to match files with extensions (`.jpg`, `.png`, `.gif`, `.svg`, `.pdf`, etc.)
- Convert `![[file.jpg]]` to `![file.jpg](/static/file.jpg)`
- Support alt text: `![[file.jpg|alt]]` -> `![alt](/static/file.jpg)`
- Process before internal embeds to avoid conflicts with post slugs
- Skip processing inside fenced code blocks

## Configuration

```toml
[markata-go.embeds]
attachments_prefix = "/static/"  # default attachment path
```

## Usage

| Input | Output |
|-------|--------|
| `![[photo.jpg]]` | `![photo.jpg](/static/photo.jpg)` |
| `![[photo.jpg\|Alt Text]]` | `![Alt Text](/static/photo.jpg)` |

## Tests

Added 6 new tests for attachment embed functionality.

## Related

- Fixes #811