### PR TITLE
Fixes #806: Skip slow tests with testing.Short()

### DIFF
--- a/cmd/markata-go/cmd/config_test.go
+++ b/cmd/markata-go/cmd/config_test.go
@@ -135,6 +135,9 @@ title = "Test"
 }
 
 func TestConfigSetIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	// Create a temporary directory for test files
 	tmpDir := t.TempDir()
 
@@ -360,6 +363,9 @@ func TestShowDiffConfig(t *testing.T) {
 }
 
 func TestConfigShowAnnotateIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	// Create a temporary directory with a config file
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "markata-go.toml")

--- a/pkg/plugins/glossary_test.go
+++ b/pkg/plugins/glossary_test.go
@@ -530,6 +530,9 @@ func TestGlossaryPlugin_ProcessPost_SkipExcludedTags(t *testing.T) {
 }
 
 func TestGlossaryPlugin_Render_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	p := NewGlossaryPlugin()
 	m := lifecycle.NewManager()
 

--- a/pkg/plugins/webmentions_test.go
+++ b/pkg/plugins/webmentions_test.go
@@ -416,6 +416,9 @@ func TestWebMentionsPlugin_ResolveURL(t *testing.T) {
 }
 
 func TestWebMentionsPlugin_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	// Create a mock target server with webmention endpoint
 	targetServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Link", fmt.Sprintf(`<%s/webmention>; rel="webmention"`, r.Host))

--- a/tests/encryption_integration_test.go
+++ b/tests/encryption_integration_test.go
@@ -59,6 +59,9 @@ func buildWithEncryption(t *testing.T, site *testSite, modelsConfig *models.Conf
 // TestIntegration_Encryption_PrivateContentNeverPlaintext verifies that private
 // content is encrypted and the marker text never appears in plaintext output.
 func TestIntegration_Encryption_PrivateContentNeverPlaintext(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	// Set encryption key
 	t.Setenv("MARKATA_GO_ENCRYPTION_KEY_DEFAULT", "test-password-xyz") // pragma: allowlist secret
 
@@ -178,6 +181,9 @@ Another private post with `+privateMarker+` inside it.`)
 // TestIntegration_Encryption_BuildFailsWithoutKey verifies the build fails with
 // a CriticalError when private posts exist but no encryption key is available.
 func TestIntegration_Encryption_BuildFailsWithoutKey(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	// Ensure NO encryption keys are set
 	t.Setenv("MARKATA_GO_ENCRYPTION_KEY_DEFAULT", "") // pragma: allowlist secret
 
@@ -216,6 +222,9 @@ This must not be published without encryption.`)
 // TestIntegration_Encryption_PrivateTags verifies that posts are automatically
 // marked private based on configured private_tags.
 func TestIntegration_Encryption_PrivateTags(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	t.Setenv("MARKATA_GO_ENCRYPTION_KEY_DEFAULT", "test-password-xyz") // pragma: allowlist secret
 	t.Setenv("MARKATA_GO_ENCRYPTION_KEY_PERSONAL", "personal-pass")    // pragma: allowlist secret
 
@@ -289,6 +298,9 @@ This is a public blog post.`)
 // TestIntegration_Encryption_FrontmatterAliases verifies that private_key and
 // encryption_key frontmatter fields work as aliases for secret_key.
 func TestIntegration_Encryption_FrontmatterAliases(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	t.Setenv("MARKATA_GO_ENCRYPTION_KEY_DEFAULT", "test-password-xyz") // pragma: allowlist secret
 
 	site := newTestSite(t)
@@ -347,6 +359,9 @@ Secret content C `+privateMarker)
 // TestIntegration_Encryption_FrontmatterKeyOverridesTagKey verifies that
 // a frontmatter secret_key takes precedence over a tag-level key.
 func TestIntegration_Encryption_FrontmatterKeyOverridesTagKey(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	t.Setenv("MARKATA_GO_ENCRYPTION_KEY_DEFAULT", "default-pass")   // pragma: allowlist secret
 	t.Setenv("MARKATA_GO_ENCRYPTION_KEY_PERSONAL", "personal-pass") // pragma: allowlist secret
 	t.Setenv("MARKATA_GO_ENCRYPTION_KEY_CUSTOM", "custom-pass")     // pragma: allowlist secret
@@ -414,6 +429,9 @@ Override content `+privateMarker)
 // TestIntegration_Encryption_DisabledSkipsEncryption verifies that when
 // encryption is disabled, private posts pass through unmodified.
 func TestIntegration_Encryption_DisabledSkipsEncryption(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	site := newTestSite(t)
 
 	site.addPost("secret.md", `---
@@ -442,6 +460,9 @@ Content here.`)
 // TestIntegration_Encryption_DraftAndSkippedPostsIgnored verifies that
 // draft and skipped posts are not subject to encryption requirements.
 func TestIntegration_Encryption_DraftAndSkippedPostsIgnored(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	// No encryption key -- normally this would fail if private posts exist
 	t.Setenv("MARKATA_GO_ENCRYPTION_KEY_DEFAULT", "") // pragma: allowlist secret
 
@@ -490,6 +511,9 @@ Public content.`)
 //   - Search index (pagefind, if present)
 //   - Any other file written to the output directory
 func TestIntegration_Encryption_TracerScan(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	// Set encryption key
 	t.Setenv("MARKATA_GO_ENCRYPTION_KEY_DEFAULT", "tracer-test-password-xyz") // pragma: allowlist secret
 
@@ -733,6 +757,9 @@ Another public post for navigation testing.
 // is handled correctly after encryption: title and explicit description are preserved,
 // raw content is scrubbed, and structured data is kept.
 func TestIntegration_Encryption_MetadataScrubbing(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	t.Setenv("MARKATA_GO_ENCRYPTION_KEY_DEFAULT", "scrub-test-password") // pragma: allowlist secret
 
 	site := newTestSite(t)

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -687,6 +687,9 @@ Content`)
 }
 
 func TestIntegration_ConcurrentProcessing(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	// Test case: "concurrent post processing" from tests.yaml
 	site := newTestSite(t)
 
@@ -976,6 +979,9 @@ Content`)
 // This simulates the bug reported in issue #492 where palette changes
 // would revert to default during serve mode.
 func TestIntegration_PaletteChangeOnRebuild(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	site := newTestSite(t)
 
 	// Add a simple post
@@ -1050,6 +1056,9 @@ Content`)
 // TestIntegration_PaletteChangeWithConfigFile tests palette changes using actual
 // config file loading, more closely simulating the serve mode scenario.
 func TestIntegration_PaletteChangeWithConfigFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	site := newTestSite(t)
 
 	// Add a simple post
@@ -1161,6 +1170,9 @@ palette = "dracula"
 // TestIntegration_PaletteChangeWithBuildCache tests that palette changes work correctly
 // when the build cache is involved. This more closely simulates the serve mode scenario.
 func TestIntegration_PaletteChangeWithBuildCache(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	site := newTestSite(t)
 
 	// Create the .markata cache directory


### PR DESCRIPTION
## Summary
- Add testing.Short() skips to slow integration tests to reduce Windows CI runtime

## Changes
- 4 tests in tests/integration_test.go (concurrent processing, palette rebuild tests)
- 9 tests in tests/encryption_integration_test.go  
- 1 test in pkg/plugins/webmentions_test.go
- 1 test in pkg/plugins/glossary_test.go
- 2 tests in cmd/markata-go/cmd/config_test.go

## Testing
- go test -short ./tests/... - all integration tests skip properly
- go test ./tests/... - full tests still run on non-short runs