### PR TITLE
feat: add configurable share post component

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -431,6 +431,36 @@ feeds = ["tutorials", "guides"]
 
 **Responsive behavior:** Sidebars are hidden on mobile (< 768px) and shown inline on tablets (768px - 1024px).
 
+#### Share Component (`[markata-go.components.share]`)
+
+Add a "Share this post" grid to the end of every article so readers can send your content to social platforms or copy the link.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `true` | Show the component. |
+| `title` | string | `"Share this post"` | Heading text above the buttons. |
+| `position` | string | `"bottom"` | Modifier used by CSS (applied as `share-panel--<position>`). |
+| `platforms` | array | `["twitter","facebook","linkedin","reddit","hacker_news","email","copy"]` | Ordered list of platform keys to render. Omit entries to hide them. |
+| `custom` | table | `{}` | Custom platform definitions (`name`, `icon`, `url`). Icon paths without `/`, `http`, or `data:` are resolved via `theme_asset_hashed` (e.g., `icons/share/mastodon.svg`). |
+
+```toml
+[markata-go.components.share]
+enabled = true
+title = "Share this post"
+platforms = ["twitter", "mastodon", "linkedin", "copy"]
+
+[markata-go.components.share.custom]
+mastodon = { name = "Mastodon", icon = "mastodon.svg", url = "https://mastodon.social/share?text={{title}}&url={{url}}" }
+```
+
+Supported placeholders for share URLs:
+
+- `{{title}}` → URL-encoded post title (falls back to site title or slug).
+- `{{url}}` → URL-encoded absolute post URL (`config.url` + `post.href`).
+- `{{excerpt}}` → URL-encoded post description or excerpt when provided.
+
+Copying uses the Clipboard API with a DOM fallback and updates the button label/tooltip to "Link copied" for 2 seconds. Built-in platforms include Twitter, Facebook, LinkedIn, Reddit, Hacker News, Email, and Copy Link, each with a coordinated icon from `pkg/themes/default/static/icons/share/`.
+
 ### IndieAuth Settings (`[markata-go.indieauth]`)
 
 [IndieAuth](https://indieauth.net/) is a decentralized identity protocol that allows you to use your own domain to sign in to websites. markata-go can add the necessary `<link>` tags to your site's HTML head.

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -53,6 +53,9 @@ type ComponentsConfig struct {
 
 	// CardRouter configures the card template routing for feeds
 	CardRouter CardRouterConfig `json:"card_router" yaml:"card_router" toml:"card_router"`
+
+	// Share configures the per-post share component
+	Share ShareComponentConfig `json:"share" yaml:"share" toml:"share"`
 }
 
 // NavComponentConfig configures the navigation component.
@@ -131,6 +134,56 @@ type CardRouterConfig struct {
 	// User mappings are merged with defaults, allowing overrides.
 	// Example: {"daily": "article", "meeting": "note"}
 	Mappings map[string]string `json:"mappings,omitempty" yaml:"mappings,omitempty" toml:"mappings,omitempty"`
+}
+
+// SharePlatformConfig defines a custom share button  entry.
+type SharePlatformConfig struct {
+	// Name is the accessible label for the platform button
+	Name string `json:"name,omitempty" yaml:"name,omitempty" toml:"name,omitempty"`
+
+	// Icon is the path to an icon file (relative to theme assets by default)
+	Icon string `json:"icon,omitempty" yaml:"icon,omitempty" toml:"icon,omitempty"`
+
+	// URL is the share URL template (supports {{title}}, {{url}}, {{excerpt}})
+	URL string `json:"url,omitempty" yaml:"url,omitempty" toml:"url,omitempty"`
+}
+
+// ShareComponentConfig configures the share buttons that appear at the end of posts.
+type ShareComponentConfig struct {
+	// Enabled toggles the entire component (default: true)
+	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty" toml:"enabled,omitempty"`
+
+	// Platforms controls which platform keys render and in what order
+	Platforms []string `json:"platforms,omitempty" yaml:"platforms,omitempty" toml:"platforms,omitempty"`
+
+	// Position adds `share-panel--<position>` modifier for CSS hooks
+	Position string `json:"position,omitempty" yaml:"position,omitempty" toml:"position,omitempty"`
+
+	// Title is the heading text displayed above the buttons
+	Title string `json:"title,omitempty" yaml:"title,omitempty" toml:"title,omitempty"`
+
+	// Custom maps platform keys to bespoke definitions
+	Custom map[string]SharePlatformConfig `json:"custom,omitempty" yaml:"custom,omitempty" toml:"custom,omitempty"`
+}
+
+// NewShareComponentConfig returns the default share component configuration.
+func NewShareComponentConfig() ShareComponentConfig {
+	enabled := true
+	return ShareComponentConfig{
+		Enabled:   &enabled,
+		Platforms: append([]string{}, DefaultSharePlatformOrder...),
+		Position:  "bottom",
+		Title:     "Share this post",
+		Custom:    map[string]SharePlatformConfig{},
+	}
+}
+
+// IsEnabled reports whether the share component is enabled.
+func (c ShareComponentConfig) IsEnabled() bool {
+	if c.Enabled == nil {
+		return true
+	}
+	return *c.Enabled
 }
 
 // DefaultCardMappings returns the default template-to-card mappings.
@@ -258,6 +311,7 @@ func NewComponentsConfig() ComponentsConfig {
 			Position: "left",
 			Width:    "250px",
 		},
+		Share: NewShareComponentConfig(),
 	}
 }
 

--- a/pkg/models/share.go
+++ b/pkg/models/share.go
@@ -1,0 +1,225 @@
+package models
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+const (
+	sharePlatformCopyKey = "copy"
+	shareActionCopy      = "copy"
+)
+
+// DefaultSharePlatformOrder defines the built-in share buttons in the default order.
+var DefaultSharePlatformOrder = []string{"twitter", "facebook", "linkedin", "reddit", "hacker_news", "email", "copy"}
+
+type sharePlatformDefinition struct {
+	Name     string
+	Icon     string
+	Template string
+	Action   string
+}
+
+var sharePlatformDefinitions = map[string]sharePlatformDefinition{
+	"twitter": {
+		Name:     "Twitter",
+		Icon:     "icons/share/twitter.svg",
+		Template: "https://twitter.com/intent/tweet?text={{title}}&url={{url}}",
+	},
+	"facebook": {
+		Name:     "Facebook",
+		Icon:     "icons/share/facebook.svg",
+		Template: "https://www.facebook.com/sharer/sharer.php?u={{url}}",
+	},
+	"linkedin": {
+		Name:     "LinkedIn",
+		Icon:     "icons/share/linkedin.svg",
+		Template: "https://www.linkedin.com/sharing/share-offsite/?url={{url}}",
+	},
+	"reddit": {
+		Name:     "Reddit",
+		Icon:     "icons/share/reddit.svg",
+		Template: "https://reddit.com/submit?url={{url}}&title={{title}}",
+	},
+	"hacker_news": {
+		Name:     "Hacker News",
+		Icon:     "icons/share/hacker_news.svg",
+		Template: "https://news.ycombinator.com/submitlink?u={{url}}&t={{title}}",
+	},
+	"email": {
+		Name:     "Email",
+		Icon:     "icons/share/email.svg",
+		Template: "mailto:?subject={{title}}&body={{url}}",
+	},
+	sharePlatformCopyKey: {
+		Name:   "Copy link",
+		Icon:   "icons/share/copy.svg",
+		Action: shareActionCopy,
+	},
+}
+
+// ShareButton exposes data required by share templates.
+type ShareButton struct {
+	Key              string
+	Name             string
+	Icon             string
+	IconIsThemeAsset bool
+	Action           string
+	Link             string
+	CopyText         string
+	AriaLabel        string
+	CopyFeedback     string
+}
+
+// BuildShareButtons creates the share buttons for a specific post using the current config.
+func BuildShareButtons(cfg ShareComponentConfig, baseURL, fallbackTitle string, post *Post) []ShareButton {
+	if post == nil || !cfg.IsEnabled() {
+		return nil
+	}
+
+	order := cfg.Platforms
+	if len(order) == 0 {
+		order = append([]string{}, DefaultSharePlatformOrder...)
+	}
+
+	postURL := buildPostURL(baseURL, post.Href)
+	placeholders := newSharePlaceholders(post, fallbackTitle, postURL)
+
+	buttons := make([]ShareButton, 0, len(order))
+	for _, key := range order {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+
+		def, hasBuiltin := sharePlatformDefinitions[key]
+		custom, hasCustom := cfg.Custom[key]
+		if !hasBuiltin && !hasCustom {
+			continue
+		}
+
+		if hasCustom {
+			if custom.Name != "" {
+				def.Name = custom.Name
+			}
+			if custom.Icon != "" {
+				def.Icon = custom.Icon
+			}
+			if custom.URL != "" {
+				def.Template = custom.URL
+			}
+		}
+
+		name := def.Name
+		if name == "" {
+			name = fallbackSharePlatformName(key)
+		}
+
+		icon := def.Icon
+		iconIsThemeAsset := shouldTreatAsThemeAsset(icon)
+		if icon == "" {
+			icon = "icons/share/copy.svg"
+			iconIsThemeAsset = true
+		}
+
+		if key == sharePlatformCopyKey || def.Action == shareActionCopy {
+			buttons = append(buttons, ShareButton{
+				Key:              key,
+				Name:             name,
+				Icon:             icon,
+				IconIsThemeAsset: iconIsThemeAsset,
+				Action:           shareActionCopy,
+				CopyText:         postURL,
+				AriaLabel:        "Copy link to clipboard",
+				CopyFeedback:     "Link copied to clipboard",
+			})
+			continue
+		}
+
+		if def.Template == "" {
+			continue
+		}
+
+		buttons = append(buttons, ShareButton{
+			Key:              key,
+			Name:             name,
+			Icon:             icon,
+			IconIsThemeAsset: iconIsThemeAsset,
+			Action:           "share",
+			Link:             applySharePlaceholders(def.Template, placeholders),
+			AriaLabel:        fmt.Sprintf("Share on %s", name),
+		})
+	}
+
+	return buttons
+}
+
+func shouldTreatAsThemeAsset(path string) bool {
+	if path == "" {
+		return true
+	}
+	lower := strings.ToLower(path)
+	return !(strings.HasPrefix(lower, "http") || strings.HasPrefix(path, "/") || strings.HasPrefix(lower, "data:"))
+}
+
+func fallbackSharePlatformName(key string) string {
+	words := strings.Fields(strings.ReplaceAll(key, "_", " "))
+	for i := range words {
+		if words[i] == "" {
+			continue
+		}
+		if len(words[i]) == 1 {
+			words[i] = strings.ToUpper(words[i])
+			continue
+		}
+		words[i] = strings.ToUpper(words[i][:1]) + strings.ToLower(words[i][1:])
+	}
+	return strings.Join(words, " ")
+}
+
+func buildPostURL(base, href string) string {
+	if href == "" {
+		href = "/"
+	}
+	if base == "" {
+		return href
+	}
+	clean := strings.TrimRight(base, "/")
+	if href == "/" {
+		return clean + "/"
+	}
+	return clean + href
+}
+
+func newSharePlaceholders(post *Post, fallbackTitle, postURL string) map[string]string {
+	title := fallbackTitle
+	if post.Title != nil && *post.Title != "" {
+		title = *post.Title
+	}
+	if title == "" {
+		title = post.Slug
+	}
+	excerpt := ""
+	if post.Description != nil {
+		excerpt = *post.Description
+	} else if v, ok := post.Extra["excerpt"]; ok {
+		if str, ok := v.(string); ok {
+			excerpt = str
+		}
+	}
+
+	return map[string]string{
+		"title":   url.QueryEscape(title),
+		"url":     url.QueryEscape(postURL),
+		"excerpt": url.QueryEscape(excerpt),
+	}
+}
+
+func applySharePlaceholders(template string, substitutions map[string]string) string {
+	result := template
+	for key, value := range substitutions {
+		result = strings.ReplaceAll(result, "{{"+key+"}}", value)
+	}
+	return result
+}

--- a/pkg/models/share_test.go
+++ b/pkg/models/share_test.go
@@ -1,0 +1,72 @@
+package models
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildShareButtonsDefaults(t *testing.T) {
+	post := &Post{
+		Slug:        "hello-world",
+		Href:        "/hello-world/",
+		Title:       stringPtr("Hello World"),
+		Description: stringPtr("A friendly introduction"),
+	}
+	config := NewShareComponentConfig()
+	buttons := BuildShareButtons(config, "https://example.com", "Site", post)
+	if len(buttons) != len(DefaultSharePlatformOrder) {
+		t.Fatalf("expected %d buttons, got %d", len(DefaultSharePlatformOrder), len(buttons))
+	}
+	if buttons[0].Key != "twitter" {
+		t.Fatalf("expected first button to be twitter, got %s", buttons[0].Key)
+	}
+	if !strings.Contains(buttons[0].Link, "twitter.com/intent/tweet") {
+		t.Fatalf("unexpected twitter link: %s", buttons[0].Link)
+	}
+	last := buttons[len(buttons)-1]
+	if last.Action != "copy" || last.CopyText != "https://example.com/hello-world/" {
+		t.Fatalf("copy button malformed: %+v", last)
+	}
+}
+
+func TestBuildShareButtonsCustomPlatform(t *testing.T) {
+	post := &Post{
+		Slug:  "custom",
+		Href:  "/custom/",
+		Title: stringPtr("Custom Share"),
+	}
+	config := NewShareComponentConfig()
+	config.Platforms = []string{"mastodon", "copy"}
+	config.Custom = map[string]SharePlatformConfig{
+		"mastodon": {
+			Name: "Mastodon",
+			Icon: "mastodon.svg",
+			URL:  "https://mastodon.social/share?text={{title}}&url={{url}}",
+		},
+	}
+	buttons := BuildShareButtons(config, "https://example.com", "Site", post)
+	if len(buttons) != 2 {
+		t.Fatalf("expected 2 buttons, got %d", len(buttons))
+	}
+	if buttons[0].Key != "mastodon" {
+		t.Fatalf("expected mastodon platform first, got %s", buttons[0].Key)
+	}
+	if !strings.Contains(buttons[0].Link, "mastodon.social/share") {
+		t.Fatalf("unexpected mastodon link: %s", buttons[0].Link)
+	}
+}
+
+func TestBuildShareButtonsDisabled(t *testing.T) {
+	post := &Post{Slug: "nothing", Href: "/nothing/"}
+	config := NewShareComponentConfig()
+	enabled := false
+	config.Enabled = &enabled
+	buttons := BuildShareButtons(config, "https://example.com", "Site", post)
+	if len(buttons) != 0 {
+		t.Fatalf("expected no buttons when disabled, got %d", len(buttons))
+	}
+}
+
+func stringPtr(value string) *string {
+	return &value
+}

--- a/pkg/plugins/templates.go
+++ b/pkg/plugins/templates.go
@@ -424,6 +424,12 @@ func (p *TemplatesPlugin) renderPost(post *models.Post, config *lifecycle.Config
 	ctx = ctx.WithCore(m)
 	ctx.Set("private_paths", privatePaths)
 
+	// Share buttons at the end of posts
+	shareButtons := models.BuildShareButtons(modelsConfig.Components.Share, modelsConfig.URL, modelsConfig.Title, post)
+	if len(shareButtons) > 0 {
+		ctx.Set("share_buttons", shareButtons)
+	}
+
 	// Inject feed sidebar posts if configured
 	sidebarPosts, sidebarFeed := p.getFeedSidebarPosts(post, config, m)
 	if sidebarPosts != nil {

--- a/pkg/templates/context.go
+++ b/pkg/templates/context.go
@@ -518,12 +518,34 @@ func componentsToMap(c *models.ComponentsConfig) map[string]interface{} {
 		"mappings": c.CardRouter.MergedMappings(),
 	}
 
+	shareEnabled := true
+	if c.Share.Enabled != nil {
+		shareEnabled = *c.Share.Enabled
+	}
+	sharePlatforms := append([]string{}, c.Share.Platforms...)
+	shareCustom := make(map[string]map[string]interface{})
+	for key, custom := range c.Share.Custom {
+		shareCustom[key] = map[string]interface{}{
+			"name": custom.Name,
+			"icon": custom.Icon,
+			"url":  custom.URL,
+		}
+	}
+	shareMap := map[string]interface{}{
+		"enabled":   shareEnabled,
+		"title":     c.Share.Title,
+		"position":  c.Share.Position,
+		"platforms": sharePlatforms,
+		"custom":    shareCustom,
+	}
+
 	return map[string]interface{}{
 		"nav":          navMap,
 		"footer":       footerMap,
 		"doc_sidebar":  docSidebarMap,
 		"feed_sidebar": feedSidebarMap,
 		"card_router":  cardRouterMap,
+		"share":        shareMap,
 	}
 }
 

--- a/pkg/themes/default/static/css/components.css
+++ b/pkg/themes/default/static/css/components.css
@@ -1799,6 +1799,102 @@ article.post {
    animation: fade-in 180ms ease both, slide-down 220ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
 }
 
+/* ==========================================================================
+   Share Component
+   ========================================================================== */
+
+.share-panel {
+   margin: var(--space-8) 0;
+   padding: var(--space-6);
+   border-radius: 1rem;
+   background: linear-gradient(135deg, color-mix(in srgb, var(--color-primary) 20%, transparent), color-mix(in srgb, var(--color-surface) 90%, transparent));
+   border: 1px solid color-mix(in srgb, var(--color-primary) 30%, var(--color-border));
+   box-shadow: 0 15px 35px rgba(0, 0, 0, 0.08);
+}
+
+.share-panel__header {
+   display: flex;
+   flex-direction: column;
+   gap: 0.25rem;
+   margin-bottom: var(--space-5);
+}
+
+.share-panel__title {
+   font-size: 1.25rem;
+   font-weight: 600;
+   margin: 0;
+}
+
+.share-panel__description {
+   margin: 0;
+   font-size: var(--text-sm);
+   color: var(--color-text-muted);
+}
+
+.share-panel__grid {
+   display: grid;
+   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+   gap: 0.75rem;
+}
+
+.share-button {
+   display: flex;
+   align-items: center;
+   gap: 0.75rem;
+   padding: 0.75rem 1rem;
+   background: color-mix(in srgb, var(--color-background) 80%, var(--color-surface));
+   border-radius: 0.85rem;
+   border: 1px solid color-mix(in srgb, var(--color-border) 40%, transparent);
+   color: var(--color-text);
+   font-weight: 500;
+   text-decoration: none;
+   transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.share-button__icon {
+   width: 2rem;
+   height: 2rem;
+   display: inline-flex;
+   align-items: center;
+   justify-content: center;
+   border-radius: 0.65rem;
+   background-color: color-mix(in srgb, var(--color-surface) 90%, var(--color-primary));
+}
+
+.share-button__icon img {
+   width: 1.25rem;
+   height: 1.25rem;
+   display: block;
+}
+
+.share-button__name {
+   flex: 1;
+}
+
+.share-button__hint {
+   font-size: 0.75rem;
+   color: var(--color-text-muted);
+}
+
+.share-button:hover,
+.share-button:focus-visible {
+   transform: translateY(-2px);
+   border-color: var(--color-primary);
+   box-shadow: 0 10px 25px rgba(0, 0, 0, 0.12);
+}
+
+.share-button--copied {
+   border-color: var(--color-primary);
+   background-color: color-mix(in srgb, var(--color-primary) 15%, var(--color-surface));
+   color: var(--color-text);
+}
+
+@media (max-width: 768px) {
+   .share-panel__grid {
+     grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+   }
+}
+
 /* Keep global chrome stable (no morphing). */
 ::view-transition-old(site-nav),
 ::view-transition-new(site-nav),

--- a/pkg/themes/default/static/icons/share/copy.svg
+++ b/pkg/themes/default/static/icons/share/copy.svg
@@ -1,0 +1,4 @@
+<svg width="48" height="48" viewBox="0 0 24 24" role="presentation" xmlns="http://www.w3.org/2000/svg">
+  <rect x="6" y="6" width="12" height="12" rx="2" fill="currentColor"/>
+  <rect x="8" y="8" width="12" height="12" rx="2" fill="var(--color-background, #fff)"/>
+</svg>

--- a/pkg/themes/default/static/icons/share/email.svg
+++ b/pkg/themes/default/static/icons/share/email.svg
@@ -1,0 +1,4 @@
+<svg width="48" height="48" viewBox="0 0 24 24" role="presentation" xmlns="http://www.w3.org/2000/svg">
+  <rect x="3" y="7" width="18" height="10" rx="2" fill="currentColor"/>
+  <path d="M3 7l9 6 9-6" fill="var(--color-background, #fff)"/>
+</svg>

--- a/pkg/themes/default/static/icons/share/facebook.svg
+++ b/pkg/themes/default/static/icons/share/facebook.svg
@@ -1,0 +1,4 @@
+<svg width="48" height="48" viewBox="0 0 24 24" role="presentation" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="12" r="11" fill="currentColor"/>
+  <text x="12" y="15" text-anchor="middle" dominant-baseline="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-weight="700" font-size="12" fill="var(--color-background, #fff)">f</text>
+</svg>

--- a/pkg/themes/default/static/icons/share/hacker_news.svg
+++ b/pkg/themes/default/static/icons/share/hacker_news.svg
@@ -1,0 +1,4 @@
+<svg width="48" height="48" viewBox="0 0 24 24" role="presentation" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="12" r="11" fill="currentColor"/>
+  <text x="12" y="15" text-anchor="middle" dominant-baseline="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-weight="700" font-size="10" letter-spacing="0.1em" fill="var(--color-background, #fff)">HN</text>
+</svg>

--- a/pkg/themes/default/static/icons/share/linkedin.svg
+++ b/pkg/themes/default/static/icons/share/linkedin.svg
@@ -1,0 +1,4 @@
+<svg width="48" height="48" viewBox="0 0 24 24" role="presentation" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="12" r="11" fill="currentColor"/>
+  <text x="12" y="15" text-anchor="middle" dominant-baseline="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-weight="700" font-size="10" fill="var(--color-background, #fff)">in</text>
+</svg>

--- a/pkg/themes/default/static/icons/share/reddit.svg
+++ b/pkg/themes/default/static/icons/share/reddit.svg
@@ -1,0 +1,4 @@
+<svg width="48" height="48" viewBox="0 0 24 24" role="presentation" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="12" r="11" fill="currentColor"/>
+  <text x="12" y="15" text-anchor="middle" dominant-baseline="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-weight="700" font-size="12" fill="var(--color-background, #fff)">R</text>
+</svg>

--- a/pkg/themes/default/static/icons/share/twitter.svg
+++ b/pkg/themes/default/static/icons/share/twitter.svg
@@ -1,0 +1,4 @@
+<svg width="48" height="48" viewBox="0 0 24 24" role="presentation" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="12" r="11" fill="currentColor"/>
+  <text x="12" y="15" text-anchor="middle" dominant-baseline="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-weight="700" font-size="12" fill="var(--color-background, #fff)">T</text>
+</svg>

--- a/pkg/themes/default/templates/components/share.html
+++ b/pkg/themes/default/templates/components/share.html
@@ -1,0 +1,100 @@
+{% if share_buttons %}
+<section class="share-panel share-panel--{{ config.components.share.position | default:'bottom' }}" aria-label="Share this post">
+    <div class="share-panel__header">
+        <h2 class="share-panel__title">{{ config.components.share.title | default:'Share this post' }}</h2>
+        <p class="share-panel__description">Help readers send this post to their favorite platforms.</p>
+    </div>
+    <div class="share-panel__grid">
+        {% for platform in share_buttons %}
+        {% if platform.Action == 'share' %}
+        <a href="{{ platform.Link }}" class="share-button" target="_blank" rel="noopener noreferrer" aria-label="{{ platform.AriaLabel }}">
+            <span class="share-button__icon" aria-hidden="true">
+                {% if platform.IconIsThemeAsset %}
+                <img src="{{ platform.Icon | theme_asset_hashed }}" alt="" aria-hidden="true">
+                {% else %}
+                <img src="{{ platform.Icon }}" alt="" aria-hidden="true">
+                {% endif %}
+            </span>
+            <span class="share-button__name">{{ platform.Name }}</span>
+            <span class="share-button__hint" aria-live="polite"></span>
+        </a>
+        {% else %}
+        <button type="button" class="share-button" data-share-action="copy" data-share-copy="{{ platform.CopyText }}" data-share-label="{{ platform.AriaLabel }}" data-share-feedback="{{ platform.CopyFeedback }}" aria-label="{{ platform.AriaLabel }}">
+            <span class="share-button__icon" aria-hidden="true">
+                {% if platform.IconIsThemeAsset %}
+                <img src="{{ platform.Icon | theme_asset_hashed }}" alt="" aria-hidden="true">
+                {% else %}
+                <img src="{{ platform.Icon }}" alt="" aria-hidden="true">
+                {% endif %}
+            </span>
+            <span class="share-button__name">{{ platform.Name }}</span>
+            <span class="share-button__hint" aria-live="polite"></span>
+        </button>
+        {% endif %}
+        {% endfor %}
+    </div>
+</section>
+
+<script>
+(function() {
+    if (window.__markataShareCopyBound) {
+        return;
+    }
+    window.__markataShareCopyBound = true;
+
+    function copyToClipboard(text) {
+        if (!text) {
+            return Promise.reject();
+        }
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            return navigator.clipboard.writeText(text);
+        }
+        var textarea = document.createElement('textarea');
+        textarea.value = text;
+        textarea.setAttribute('readonly', '');
+        textarea.style.position = 'absolute';
+        textarea.style.left = '-9999px';
+        document.body.appendChild(textarea);
+        textarea.select();
+        textarea.setSelectionRange(0, textarea.value.length);
+        var result = document.execCommand('copy');
+        document.body.removeChild(textarea);
+        return result ? Promise.resolve() : Promise.reject();
+    }
+
+    document.addEventListener('click', function(event) {
+        var button = event.target.closest('[data-share-action="copy"]');
+        if (!button) {
+            return;
+        }
+        event.preventDefault();
+        var payload = button.dataset.shareCopy;
+        if (!payload) {
+            return;
+        }
+        var hint = button.querySelector('.share-button__hint');
+        var defaultLabel = button.dataset.shareLabel || button.getAttribute('aria-label') || 'Copy link';
+        var feedback = button.dataset.shareFeedback || 'Link copied to clipboard';
+
+        copyToClipboard(payload).then(function() {
+            if (hint) {
+                hint.textContent = feedback;
+            }
+            button.setAttribute('aria-label', feedback);
+            button.classList.add('share-button--copied');
+            window.setTimeout(function() {
+                if (hint) {
+                    hint.textContent = '';
+                }
+                button.setAttribute('aria-label', defaultLabel);
+                button.classList.remove('share-button--copied');
+            }, 1800);
+        }).catch(function() {
+            if (hint) {
+                hint.textContent = 'Unable to copy';
+            }
+        });
+    });
+})();
+</script>
+{% endif %}

--- a/pkg/themes/default/templates/post.html
+++ b/pkg/themes/default/templates/post.html
@@ -77,6 +77,8 @@
     {{ body | safe }}
   </div>
 
+  {% include "components/share.html" %}
+
   {% if post.tags %}
   <footer class="post-footer">
     <div class="tags">

--- a/spec/spec/LAYOUTS.md
+++ b/spec/spec/LAYOUTS.md
@@ -569,6 +569,70 @@ When `scroll_spy: true`, the TOC highlights the currently visible section:
 </footer>
 ```
 
+### Share Component
+
+The share component provides a configurable "Share this post" experience at the end of article templates. It renders icon buttons for each platform, exposes hover labels, and keeps copy-to-clipboard functionality accessible via keyboard and screen readers.
+
+**Placement**: Injected into `post.html` (and theme equivalents) between the article body and ancillary sections (guide navigation, webmentions) so it appears at the end of every article before comments/footers.
+
+**Behavior**:
+
+1. Displays icon buttons in a responsive grid. Mobile stacks vertically, desktop shows multi-column layout.
+2. Hover or focus reveals the platform name via visible text and `aria-label` attributes.
+3. Clicks open the platform share dialog in a new tab (or copy the link when `copy` is enabled).
+4. Copy button uses the Clipboard API with a DOM fallback and provides live feedback.
+5. Uses CSS variables for colors, spacing, and border radius so palettes can theme the component.
+
+#### Configuration
+
+```toml
+[markata-go.components.share]
+enabled = true
+position = "bottom"            # Controls the style hook (CSS adds `share-panel--bottom`).
+title = "Share this post"     # Heading above the buttons.
+platforms = ["twitter", "facebook", "linkedin", "reddit", "hacker_news", "email", "copy"]
+
+[markata-go.components.share.custom]
+mastodon = { name = "Mastodon", icon = "mastodon.svg", url = "https://mastodon.social/share?text={{title}}&url={{url}}" }
+```
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `enabled` | `bool` | Flip the entire component. Defaults to `true`. |
+| `position` | `string` | Adds a modifier class `share-panel--<position>` (default `bottom`). |
+| `title` | `string` | Heading text shown above the buttons.
+| `platforms` | `[]string` | Ordered list of platform keys to render. Missing list falls back to the built-in order. |
+| `custom` | `table` | Keyed definitions (`name`, `icon`, `url`). Icon paths are resolved via `theme_asset_hashed` when they do not start with `/`, `http`, or `data:`.
+
+Valid placeholders in share URLs:
+
+| Placeholder | Description |
+| --- | --- |
+| `{{title}}` | URL-encoded post title (falls back to site title). |
+| `{{url}}` | URL-encoded absolute post URL (`config.url` + `post.href`). |
+| `{{excerpt}}` | URL-encoded post description/excerpt when provided.
+
+The component ships with these built-in platforms:
+
+| Key | Template | Notes |
+| --- | --- | --- |
+| `twitter` | `https://twitter.com/intent/tweet?text={{title}}&url={{url}}` | Icon: `icons/share/twitter.svg`. |
+| `facebook` | `https://www.facebook.com/sharer/sharer.php?u={{url}}` | Icon: `icons/share/facebook.svg`. |
+| `linkedin` | `https://www.linkedin.com/sharing/share-offsite/?url={{url}}` | Icon: `icons/share/linkedin.svg`. |
+| `reddit` | `https://reddit.com/submit?url={{url}}&title={{title}}` | Icon: `icons/share/reddit.svg`. |
+| `hacker_news` | `https://news.ycombinator.com/submitlink?u={{url}}&t={{title}}` | Icon: `icons/share/hacker_news.svg`. |
+| `email` | `mailto:?subject={{title}}&body={{url}}` | Icon: `icons/share/email.svg`. |
+| `copy` | Copy clipboard | Icon: `icons/share/copy.svg`. |
+
+Custom entries can reuse the built-in keys (e.g., override the icon for `copy`) or introduce new platforms (`mastodon`, `bluesky`, etc.). If the `platforms` list omits a built-in key, that button is hidden.
+
+#### Accessibility & Interaction
+
+- Buttons are focusable, provide `aria-label`s like "Share on Twitter" (copy button reads "Copy link to clipboard"), and update their label to "Link copied" after copying.
+- The component loads a tiny Clipboard helper script only once.
+- Responsive states stack items on narrow viewports and transition with `transform`/`opacity` to feel deliberate.
+
+
 ---
 
 ## CSS Structure

--- a/templates/components/share.html
+++ b/templates/components/share.html
@@ -1,0 +1,100 @@
+{% if share_buttons %}
+<section class="share-panel share-panel--{{ config.components.share.position | default:'bottom' }}" aria-label="Share this post">
+    <div class="share-panel__header">
+        <h2 class="share-panel__title">{{ config.components.share.title | default:'Share this post' }}</h2>
+        <p class="share-panel__description">Help readers send this post to their favorite platforms.</p>
+    </div>
+    <div class="share-panel__grid">
+        {% for platform in share_buttons %}
+        {% if platform.Action == 'share' %}
+        <a href="{{ platform.Link }}" class="share-button" target="_blank" rel="noopener noreferrer" aria-label="{{ platform.AriaLabel }}">
+            <span class="share-button__icon" aria-hidden="true">
+                {% if platform.IconIsThemeAsset %}
+                <img src="{{ platform.Icon | theme_asset_hashed }}" alt="" aria-hidden="true">
+                {% else %}
+                <img src="{{ platform.Icon }}" alt="" aria-hidden="true">
+                {% endif %}
+            </span>
+            <span class="share-button__name">{{ platform.Name }}</span>
+            <span class="share-button__hint" aria-live="polite"></span>
+        </a>
+        {% else %}
+        <button type="button" class="share-button" data-share-action="copy" data-share-copy="{{ platform.CopyText }}" data-share-label="{{ platform.AriaLabel }}" data-share-feedback="{{ platform.CopyFeedback }}" aria-label="{{ platform.AriaLabel }}">
+            <span class="share-button__icon" aria-hidden="true">
+                {% if platform.IconIsThemeAsset %}
+                <img src="{{ platform.Icon | theme_asset_hashed }}" alt="" aria-hidden="true">
+                {% else %}
+                <img src="{{ platform.Icon }}" alt="" aria-hidden="true">
+                {% endif %}
+            </span>
+            <span class="share-button__name">{{ platform.Name }}</span>
+            <span class="share-button__hint" aria-live="polite"></span>
+        </button>
+        {% endif %}
+        {% endfor %}
+    </div>
+</section>
+
+<script>
+(function() {
+    if (window.__markataShareCopyBound) {
+        return;
+    }
+    window.__markataShareCopyBound = true;
+
+    function copyToClipboard(text) {
+        if (!text) {
+            return Promise.reject();
+        }
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            return navigator.clipboard.writeText(text);
+        }
+        var textarea = document.createElement('textarea');
+        textarea.value = text;
+        textarea.setAttribute('readonly', '');
+        textarea.style.position = 'absolute';
+        textarea.style.left = '-9999px';
+        document.body.appendChild(textarea);
+        textarea.select();
+        textarea.setSelectionRange(0, textarea.value.length);
+        var result = document.execCommand('copy');
+        document.body.removeChild(textarea);
+        return result ? Promise.resolve() : Promise.reject();
+    }
+
+    document.addEventListener('click', function(event) {
+        var button = event.target.closest('[data-share-action="copy"]');
+        if (!button) {
+            return;
+        }
+        event.preventDefault();
+        var payload = button.dataset.shareCopy;
+        if (!payload) {
+            return;
+        }
+        var hint = button.querySelector('.share-button__hint');
+        var defaultLabel = button.dataset.shareLabel || button.getAttribute('aria-label') || 'Copy link';
+        var feedback = button.dataset.shareFeedback || 'Link copied to clipboard';
+
+        copyToClipboard(payload).then(function() {
+            if (hint) {
+                hint.textContent = feedback;
+            }
+            button.setAttribute('aria-label', feedback);
+            button.classList.add('share-button--copied');
+            window.setTimeout(function() {
+                if (hint) {
+                    hint.textContent = '';
+                }
+                button.setAttribute('aria-label', defaultLabel);
+                button.classList.remove('share-button--copied');
+            }, 1800);
+        }).catch(function() {
+            if (hint) {
+                hint.textContent = 'Unable to copy';
+            }
+        });
+    });
+})();
+</script>
+{% endif %}

--- a/templates/post.html
+++ b/templates/post.html
@@ -107,6 +107,8 @@
             {{ body | safe }}
         </div>
 
+        {% include "components/share.html" %}
+
         {# Guide series navigation #}
         {% include "partials/guide-navigation.html" %}
 


### PR DESCRIPTION
## Summary
- add a new share component rendered at the end of post pages with built-in social platforms and copy-link support
- add configuration for enabling/disabling the component, platform ordering/opt-out, and custom platform definitions with placeholder substitution
- update spec/docs, add share button model tests, and include default theme templates/styles/icons

## Testing
- go fmt ./...
- go test ./pkg/models ./pkg/plugins ./pkg/templates
- just lint-new

Fixes #816