### PR TITLE
feat: add license picker with footer attribution and serve warning

### DIFF
--- a/cmd/markata-go/cmd/init_huh_test.go
+++ b/cmd/markata-go/cmd/init_huh_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/WaylonWalker/markata-go/pkg/models"
 	"github.com/WaylonWalker/markata-go/pkg/palettes"
 )
 
@@ -153,4 +154,26 @@ func TestResolveColor_NotFound(t *testing.T) {
 // from a Palette without going through the loader (which needs files).
 func createHuhThemeFromPalette(palette *palettes.Palette) *huh.Theme {
 	return buildThemeFromPalette(palette)
+}
+
+func TestResolveWizardLicenseValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		selected string
+		want     interface{}
+	}{
+		{name: "recommended default", selected: "", want: models.DefaultLicenseKey},
+		{name: "explicit false", selected: "false", want: false},
+		{name: "valid key", selected: "mit", want: "mit"},
+		{name: "invalid key falls back", selected: "invalid", want: models.DefaultLicenseKey},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveWizardLicenseValue(tt.selected)
+			if got != tt.want {
+				t.Fatalf("resolveWizardLicenseValue(%q) = %v, want %v", tt.selected, got, tt.want)
+			}
+		})
+	}
 }

--- a/cmd/markata-go/cmd/serve_test.go
+++ b/cmd/markata-go/cmd/serve_test.go
@@ -293,3 +293,25 @@ func TestServe404Page_FallbackIncludesBanner(t *testing.T) {
 		t.Error("expected build banner in fallback 404")
 	}
 }
+
+func TestBuildStatusPayload_IncludesLicenseWarning(t *testing.T) {
+	payload := buildStatusPayload(BuildStatus{
+		Status:         buildStatusSuccess,
+		LicenseWarning: "set license in config",
+	})
+
+	if !strings.Contains(payload, "license_warning") {
+		t.Fatalf("expected license_warning field in payload, got %s", payload)
+	}
+}
+
+func TestBuildDevScript_IncludesLicenseToast(t *testing.T) {
+	script := buildDevScript(BuildStatus{Status: buildStatusSuccess})
+
+	if !strings.Contains(script, "markata-license-toast") {
+		t.Fatalf("expected license toast id in dev script")
+	}
+	if !strings.Contains(script, "license_warning") {
+		t.Fatalf("expected license_warning handling in dev script")
+	}
+}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -130,6 +130,8 @@ use_gitignore = true
 extensions = ["tables", "strikethrough", "autolinks", "tasklist"]
 ```
 
+The interactive `markata-go init` wizard now asks for a license and writes `license = "cc-by-4.0"` by default. Pick any of the supported keys (all-rights-reserved, `cc-by-*`, or `mit`) or enter `false` to opt out of the attribution and suppress the build warning that `markata-go serve` would otherwise show.
+
 ### Key Configuration Options
 
 | Option | Default | Description |

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -131,6 +131,7 @@ extensions = ["tables"]
 | `title` | string | `""` | Site title |
 | `description` | string | `""` | Site description |
 | `author` | string | `""` | Default author |
+| `license` | string `\|` bool | (unset) | Select a license key (see below). Set to `false` to skip the attribution and warning. |
 | `assets_dir` | string | `"static"` | Static assets directory |
 | `templates_dir` | string | `"templates"` | Templates directory |
 | `hooks` | string[] | `["default"]` | Plugins to load |
@@ -150,6 +151,22 @@ hooks = ["default"]
 disabled_hooks = ["sitemap"]
 concurrency = 4
 ```
+
+### License configuration
+
+The `license` key controls the attribution shown in the footer and whether the dev server reminds you to pick a license. It accepts either a string key (selects the attribution) or the literal `false` (hides the line and silences the warning).
+
+Supported license keys:
+
+- `all-rights-reserved` – All rights reserved.
+- `cc-by-4.0` (recommended) – Creative Commons Attribution 4.0 International (`https://creativecommons.org/licenses/by/4.0/`). The default when running `markata-go config init` or picking the recommended option in the init wizard.
+- `cc-by-sa-4.0` – Creative Commons Attribution-ShareAlike 4.0 International (`https://creativecommons.org/licenses/by-sa/4.0/`).
+- `cc-by-nc-4.0` – Creative Commons Attribution-NonCommercial 4.0 International (`https://creativecommons.org/licenses/by-nc/4.0/`).
+- `cc-by-nd-4.0` – Creative Commons Attribution-NoDerivatives 4.0 International (`https://creativecommons.org/licenses/by-nd/4.0/`).
+- `cc-by-nc-sa-4.0` – Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (`https://creativecommons.org/licenses/by-nc-sa/4.0/`).
+- `mit` – MIT License (`https://opensource.org/licenses/MIT`).
+
+Leaving the key absent (the default in older configs) triggers a validation warning and the serve banner/toast until you choose one of the supported strings or set `license = false`.
 
 ### Navigation Links (`[[markata-go.nav]]`)
 

--- a/pkg/config/merge.go
+++ b/pkg/config/merge.go
@@ -41,6 +41,9 @@ func MergeConfigs(base, override *models.Config) *models.Config {
 	if override.TemplatesDir != "" {
 		result.TemplatesDir = override.TemplatesDir
 	}
+	if override.License.Raw != nil {
+		result.License = override.License
+	}
 
 	// Slice fields - replace if non-nil and non-empty
 	if len(override.Hooks) > 0 {

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -43,6 +43,7 @@ type baseConfigData struct {
 	Title         string
 	Description   string
 	Author        string
+	License       interface{}
 	AssetsDir     string
 	TemplatesDir  string
 	Hooks         []string
@@ -167,6 +168,7 @@ func buildConfig(src configSource) *models.Config {
 		Theme:       base.Theme,
 		Footer:      base.Footer,
 	}
+	config.License = models.LicenseValue{Raw: base.License}
 
 	if base.UseGitignore != nil {
 		config.GlobConfig.UseGitignore = *base.UseGitignore
@@ -274,7 +276,7 @@ func ParseTOML(data []byte) (*models.Config, error) {
 		// List of known top-level keys that are already parsed into struct fields
 		knownKeys := map[string]bool{
 			"output_dir": true, "url": true, "title": true, "description": true,
-			"author": true, "assets_dir": true, "templates_dir": true,
+			"author": true, "license": true, "assets_dir": true, "templates_dir": true,
 			"nav": true, "footer": true, "hooks": true, "disabled_hooks": true,
 			"glob": true, "markdown": true, "feeds": true, "feed_defaults": true,
 			"concurrency": true, "theme": true, "post_formats": true, "well_known": true,
@@ -337,6 +339,7 @@ type tomlConfig struct {
 	Title         string                  `toml:"title"`
 	Description   string                  `toml:"description"`
 	Author        string                  `toml:"author"`
+	License       interface{}             `toml:"license"`
 	AssetsDir     string                  `toml:"assets_dir"`
 	TemplatesDir  string                  `toml:"templates_dir"`
 	Nav           []tomlNavItem           `toml:"nav"`
@@ -1320,6 +1323,7 @@ func (c *tomlConfig) getBaseConfig() baseConfigData {
 		Title:         c.Title,
 		Description:   c.Description,
 		Author:        c.Author,
+		License:       c.License,
 		AssetsDir:     c.AssetsDir,
 		TemplatesDir:  c.TemplatesDir,
 		Hooks:         c.Hooks,
@@ -1520,6 +1524,7 @@ type yamlConfig struct {
 	Title         string                  `yaml:"title"`
 	Description   string                  `yaml:"description"`
 	Author        string                  `yaml:"author"`
+	License       interface{}             `yaml:"license"`
 	AssetsDir     string                  `yaml:"assets_dir"`
 	TemplatesDir  string                  `yaml:"templates_dir"`
 	Nav           []yamlNavItem           `yaml:"nav"`
@@ -2554,6 +2559,7 @@ func (c *yamlConfig) getBaseConfig() baseConfigData {
 		Title:         c.Title,
 		Description:   c.Description,
 		Author:        c.Author,
+		License:       c.License,
 		AssetsDir:     c.AssetsDir,
 		TemplatesDir:  c.TemplatesDir,
 		Hooks:         c.Hooks,
@@ -2692,6 +2698,7 @@ type jsonConfig struct {
 	Title         string                  `json:"title"`
 	Description   string                  `json:"description"`
 	Author        string                  `json:"author"`
+	License       interface{}             `json:"license"`
 	AssetsDir     string                  `json:"assets_dir"`
 	TemplatesDir  string                  `json:"templates_dir"`
 	Nav           []jsonNavItem           `json:"nav"`
@@ -3726,6 +3733,7 @@ func (c *jsonConfig) getBaseConfig() baseConfigData {
 		Title:         c.Title,
 		Description:   c.Description,
 		Author:        c.Author,
+		License:       c.License,
 		AssetsDir:     c.AssetsDir,
 		TemplatesDir:  c.TemplatesDir,
 		Hooks:         c.Hooks,

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -62,6 +62,26 @@ func ValidateConfig(config *models.Config) []error {
 		})
 	}
 
+	// Validate license configuration
+	if !config.License.IsDisabled() {
+		if key, ok := config.License.Key(); ok {
+			if _, valid := models.GetLicenseOption(key); !valid {
+				supported := strings.Join(models.LicenseKeys(), ", ")
+				errs = append(errs, ValidationError{
+					Field:   "license",
+					Message: fmt.Sprintf("unsupported license key %q (supported: %s)", key, supported),
+				})
+			}
+		} else if !config.License.HasValue() {
+			supported := strings.Join(models.LicenseKeys(), ", ")
+			errs = append(errs, ValidationError{
+				Field:   "license",
+				Message: fmt.Sprintf("license not configured (supported: %s). Set license = %q or license = false to skip the footer.", supported, models.DefaultLicenseKey),
+				IsWarn:  true,
+			})
+		}
+	}
+
 	// Validate feed configurations
 	// Apply feed defaults before validation so we can check effective values
 	for i := range config.Feeds {

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -310,6 +310,9 @@ type Config struct {
 	// Author is the site author
 	Author string `json:"author" yaml:"author" toml:"author"`
 
+	// License controls the footer attribution (string key or false)
+	License LicenseValue `json:"license,omitempty" yaml:"license,omitempty" toml:"license,omitempty"`
+
 	// AssetsDir is the directory containing static assets (default: "static")
 	AssetsDir string `json:"assets_dir" yaml:"assets_dir" toml:"assets_dir"`
 
@@ -2492,6 +2495,31 @@ func NewConfig() *Config {
 		Tags:             NewTagsConfig(),
 		Assets:           NewAssetsConfig(),
 	}
+}
+
+// LicenseOption returns the configured license metadata when a valid key is present.
+func (c *Config) LicenseOption() (LicenseOption, bool) {
+	if c == nil {
+		return LicenseOption{}, false
+	}
+	if key, ok := c.License.Key(); ok {
+		return GetLicenseOption(key)
+	}
+	return LicenseOption{}, false
+}
+
+// NeedsLicenseWarning reports whether the license reminder should be shown to users.
+func (c *Config) NeedsLicenseWarning() bool {
+	if c == nil {
+		return false
+	}
+	if c.License.IsDisabled() {
+		return false
+	}
+	if _, ok := c.License.Key(); ok {
+		return false
+	}
+	return !c.License.HasValue()
 }
 
 // NewThemeConfig creates a new ThemeConfig with default values.

--- a/pkg/models/license.go
+++ b/pkg/models/license.go
@@ -1,0 +1,97 @@
+package models
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// LicenseOption describes a supported license key and the human-readable
+// attribution that is rendered in the footer.
+type LicenseOption struct {
+	Key         string
+	Name        string
+	URL         string
+	Description string
+	Recommended bool
+}
+
+// DefaultLicenseKey is the license key used by the init wizard when no choice is provided.
+const DefaultLicenseKey = "cc-by-4.0"
+
+// LicenseOptions lists the built-in license choices in display order.
+var LicenseOptions = []LicenseOption{
+	{Key: "all-rights-reserved", Name: "All rights reserved", Description: "No reuse without permission", URL: "", Recommended: false},
+	{Key: "cc-by-4.0", Name: "Creative Commons Attribution 4.0", Description: "Reuse with attribution", URL: "https://creativecommons.org/licenses/by/4.0/", Recommended: true},
+	{Key: "cc-by-sa-4.0", Name: "Creative Commons Attribution-ShareAlike 4.0", Description: "Reuse with attribution and share-alike", URL: "https://creativecommons.org/licenses/by-sa/4.0/", Recommended: false},
+	{Key: "cc-by-nc-4.0", Name: "Creative Commons Attribution-NonCommercial 4.0", Description: "Reuse non-commercially with attribution", URL: "https://creativecommons.org/licenses/by-nc/4.0/", Recommended: false},
+	{Key: "cc-by-nd-4.0", Name: "Creative Commons Attribution-NoDerivatives 4.0", Description: "Reuse with attribution, no derivatives", URL: "https://creativecommons.org/licenses/by-nd/4.0/", Recommended: false},
+	{Key: "cc-by-nc-sa-4.0", Name: "Creative Commons Attribution-NonCommercial-ShareAlike 4.0", Description: "Non-commercial reuse with attribution and share-alike", URL: "https://creativecommons.org/licenses/by-nc-sa/4.0/", Recommended: false},
+	{Key: "mit", Name: "MIT License", Description: "Permissive open source license", URL: "https://opensource.org/licenses/MIT", Recommended: false},
+}
+
+var licenseLookup = buildLicenseLookup()
+
+func buildLicenseLookup() map[string]LicenseOption {
+	lookup := make(map[string]LicenseOption, len(LicenseOptions))
+	for _, opt := range LicenseOptions {
+		lookup[strings.ToLower(opt.Key)] = opt
+	}
+	return lookup
+}
+
+// LicenseKeys returns the supported license keys in display order.
+func LicenseKeys() []string {
+	keys := make([]string, len(LicenseOptions))
+	for i, opt := range LicenseOptions {
+		keys[i] = opt.Key
+	}
+	return keys
+}
+
+// GetLicenseOption looks up the license option for a normalized key.
+func GetLicenseOption(key string) (LicenseOption, bool) {
+	opt, ok := licenseLookup[strings.ToLower(strings.TrimSpace(key))]
+	return opt, ok
+}
+
+// LicenseValue tracks the raw value provided for the `license` key.
+// It can be either a string, or the boolean false when the setting is disabled.
+type LicenseValue struct {
+	Raw interface{}
+}
+
+// HasValue reports whether any explicit license value was provided.
+func (l LicenseValue) HasValue() bool {
+	return l.Raw != nil
+}
+
+// IsDisabled returns true when the value was the boolean false starter.
+func (l LicenseValue) IsDisabled() bool {
+	if val, ok := l.Raw.(bool); ok {
+		return !val
+	}
+	return false
+}
+
+// Key returns the normalized string key when the value is a string.
+func (l LicenseValue) Key() (string, bool) {
+	if s, ok := l.Raw.(string); ok {
+		return strings.ToLower(strings.TrimSpace(s)), s != ""
+	}
+	return "", false
+}
+
+// MarshalJSON writes the raw value so serialized configs match the input.
+func (l LicenseValue) MarshalJSON() ([]byte, error) {
+	return json.Marshal(l.Raw)
+}
+
+// MarshalTOML implements the BurntSushi toml.Marshaler interface.
+func (l LicenseValue) MarshalTOML() (interface{}, error) {
+	return l.Raw, nil
+}
+
+// MarshalYAML implements yaml.Marshaler.
+func (l LicenseValue) MarshalYAML() (interface{}, error) {
+	return l.Raw, nil
+}

--- a/pkg/templates/context.go
+++ b/pkg/templates/context.go
@@ -403,6 +403,19 @@ func configToMap(c *models.Config) map[string]interface{} {
 	// Convert authors to map
 	authorsMap := authorsToMap(&c.Authors)
 
+	var licenseValue interface{}
+	if c.License.IsDisabled() {
+		licenseValue = false
+	} else if license, ok := c.LicenseOption(); ok {
+		licenseValue = map[string]interface{}{
+			"key":         license.Key,
+			"name":        license.Name,
+			"url":         license.URL,
+			"description": license.Description,
+			"recommended": license.Recommended,
+		}
+	}
+
 	result := map[string]interface{}{
 		"output_dir":    c.OutputDir,
 		"url":           c.URL,
@@ -427,6 +440,7 @@ func configToMap(c *models.Config) map[string]interface{} {
 		"header":        headerMap,
 		"theme":         themeMap,
 		"authors":       authorsMap,
+		"license":       licenseValue,
 	}
 
 	// Add Extra map for plugin configs (e.g., glightbox_enabled, glightbox_options)

--- a/pkg/themes/default/templates/components/footer.html
+++ b/pkg/themes/default/templates/components/footer.html
@@ -20,6 +20,17 @@
         </nav>
         {% endif %}
 
+        {% if config.license and config.license.name %}
+        <p class="footer-license">
+            Content licensed under
+            {% if config.license.url %}
+            <a href="{{ config.license.url }}" target="_blank" rel="noopener noreferrer">{{ config.license.name }}</a>
+            {% else %}
+            {{ config.license.name }}
+            {% endif %}
+        </p>
+        {% endif %}
+
         {# Format links for alternate views/formats #}
         {% if post or feed %}
         {% include "components/format-links.html" %}

--- a/spec/spec/CONFIG.md
+++ b/spec/spec/CONFIG.md
@@ -128,11 +128,30 @@ Only essential, cross-cutting concerns live at the root:
 | `title` | string? | null | Site title |
 | `description` | string? | null | Site description |
 | `author` | string? | null | Default author |
+| `license` | string `\|` bool | `(unset)` | Select from the supported license keys below or set to `false` to disable the footer attribution and associated warning. |
 | `lang` | string | `"en"` | Site language |
 | `hooks` | string[] | `["default"]` | Plugins to load |
 | `disabled_hooks` | string[] | `[]` | Plugins to exclude |
 
 Everything else goes in a plugin namespace.
+
+### License configuration
+
+The root `license` key lets you declare how visitors may reuse your content. It accepts either a string key or the literal `false` value:
+
+- **String keys** register a license that is rendered in the footer and made available to templates via `config.license`. Use one of the supported values:
+  - `all-rights-reserved` – All rights reserved (no reuse allowed).
+  - `cc-by-4.0` (recommended) – Creative Commons Attribution 4.0 International (`https://creativecommons.org/licenses/by/4.0/`).
+  - `cc-by-sa-4.0` – Creative Commons Attribution-ShareAlike 4.0 International (`https://creativecommons.org/licenses/by-sa/4.0/`).
+  - `cc-by-nc-4.0` – Creative Commons Attribution-NonCommercial 4.0 International (`https://creativecommons.org/licenses/by-nc/4.0/`).
+  - `cc-by-nd-4.0` – Creative Commons Attribution-NoDerivatives 4.0 International (`https://creativecommons.org/licenses/by-nd/4.0/`).
+  - `cc-by-nc-sa-4.0` – Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (`https://creativecommons.org/licenses/by-nc-sa/4.0/`).
+  - `mit` – MIT License (`https://opensource.org/licenses/MIT`).
+
+- **Boolean `false`** suppresses the license footer and prevents the validation warning (useful for sites that intentionally publish without an explicit license).
+- **Omitted key** (default) triggers a validation warning and the serve banner/toast reminder until a license string is configured or `false` is set.
+
+The default scaffolding details from `markata-go config init` include `license = "cc-by-4.0"`, so new sites ship with the recommended Creative Commons attribution out of the box.
 
 ---
 

--- a/spec/spec/LIFECYCLE.md
+++ b/spec/spec/LIFECYCLE.md
@@ -490,6 +490,7 @@ def configure(core):
 - Validate plugin-specific configuration
 - Check for required fields
 - Emit warnings for deprecated options
+- Warn when the root `license` key is missing so that local builds remind authors to declare or opt out.
 - Raise errors for invalid configurations
 
 **Core actions:**
@@ -507,6 +508,10 @@ def validate_config(core):
 
 **After this stage:**
 - Configuration is validated and ready to use
+
+## Live Serve Feedback
+
+The development server injects the validate stage status into every HTML page via `build_status`. When the root `license` field remains unset (and is not explicitly `false`), the validation warning is propagated as a `license_warning` payload so the live reload banner can show a toast reminding you to set a license key or opt out. Once a license string is configured the toast disappears, keeping the warning scoped to the local workflow until metadata is complete.
 
 ---
 

--- a/spec/spec/TEMPLATES.md
+++ b/spec/spec/TEMPLATES.md
@@ -552,6 +552,25 @@ Small reusable template fragments:
 </article>
 ```
 
+## Footer License Display
+
+When `config.license` contains a string key the default footer renders a license line that links to the canonical text. Custom footers should honor the same guard to avoid losing attribution:
+
+```jinja
+{% if config.license and config.license.name %}
+<p class="footer-license">
+  Content licensed under
+  {% if config.license.url %}
+  <a href="{{ config.license.url }}" target="_blank" rel="noopener">{{ config.license.name }}</a>
+  {% else %}
+  {{ config.license.name }}
+  {% endif %}
+</p>
+{% endif %}
+```
+
+The `config.license` object is intentionally empty when `license = false` so the paragraph is skipped, and is `nil` when the value is omitted (which triggers the live serve warning until an explicit string is configured).
+
 ---
 
 ## Error Handling

--- a/templates/components/footer.html
+++ b/templates/components/footer.html
@@ -18,6 +18,17 @@
         </nav>
         {% endif %}
 
+        {% if config.license and config.license.name %}
+        <p class="footer-license">
+            Content licensed under
+            {% if config.license.url %}
+            <a href="{{ config.license.url }}" target="_blank" rel="noopener noreferrer">{{ config.license.name }}</a>
+            {% else %}
+            {{ config.license.name }}
+            {% endif %}
+        </p>
+        {% endif %}
+
         {# Format links for alternate views/formats #}
         {% if post or feed %}
         {% include "components/format-links.html" %}


### PR DESCRIPTION
## Summary
- add a first-class `license` config value with supported built-in options, validation, and template context mapping for footer rendering
- extend `markata-go init` wizard with a license picker (defaulting to recommended `cc-by-4.0`) and support opting out with `false`
- render footer attribution when configured and surface missing-license reminders in serve mode as a live toast/banner warning

## Testing
- go fmt ./...
- go test ./cmd/markata-go/cmd ./pkg/config ./pkg/models ./pkg/templates
- just lint-new

Fixes #814