### PR TITLE
chore: slim builder image by removing nodejs/npm/mermaid-cli

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -1285,7 +1285,7 @@ root_selector = "main"       # CSS selector for searchable content
 exclude_selectors = [".no-search", "nav", "footer"]  # Elements to exclude
 ```
 
-**Requirements:** Pagefind CLI must be installed (`npm install -g pagefind`). If not installed, search is skipped with a warning.
+**Requirements:** Pagefind CLI must be installed. Install the standalone binary from [GitHub releases](https://github.com/Pagefind/pagefind/releases), or enable `auto_install = true` under `[search.pagefind]` to let markata-go download it automatically. If not installed, search is skipped with a warning.
 
 See the [[search|Search Guide]] for detailed usage and customization.
 

--- a/docs/guides/deployment/docker.md
+++ b/docs/guides/deployment/docker.md
@@ -24,7 +24,7 @@ Docker provides a consistent, reproducible environment for building and serving 
 markata-go publishes two official container images for different workflows:
 
 - `ghcr.io/waylonwalker/markata-go:<version>`: Minimal runtime image (scratch) that runs the `markata-go` binary directly.
-- `ghcr.io/waylonwalker/markata-go-builder:<version>`: Builder image with `/bin/sh`, core utilities, `rsync`, image encoders (`avifenc`, `cwebp`), Pagefind, and Mermaid CLI dependencies (`nodejs`, `npm`, `chromium`, `mmdc`).
+- `ghcr.io/waylonwalker/markata-go-builder:<version>`: Builder image with `/bin/sh`, core utilities, `rsync`, image encoders (`avifenc`, `cwebp`), Pagefind (standalone binary), and Chromium for mermaid rendering (via Go-native chromedp, no Node.js required).
 
 ### Builder Image Quick Start
 

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -4179,7 +4179,7 @@ exclude_selectors = []      # CSS selectors to exclude from indexing
 | `pagefind.exclude_selectors` | `[]` | Elements to exclude from indexing |
 
 **Requirements:**
-- Pagefind CLI must be installed: `npm install -g pagefind`
+- Pagefind CLI must be installed (standalone binary from [GitHub releases](https://github.com/Pagefind/pagefind/releases), or via `auto_install = true` in config)
 - If not installed, the plugin logs a warning but does not fail the build
 
 **Behavior:**

--- a/spec/spec/CONTAINERS.md
+++ b/spec/spec/CONTAINERS.md
@@ -42,15 +42,15 @@ The builder image MUST include:
 
 The builder image MAY include:
 
-- `chromium` (for Mermaid Chromium rendering)
+- `chromium` (for Mermaid Chromium rendering via Go-native chromedp)
 - `git`
 - `libavif-apps` (provides `avifenc`)
 - `libwebp-tools` (provides `cwebp`)
-- `nodejs` and `npm`
-- `pagefind` (for search index generation)
-- `@mermaid-js/mermaid-cli` (provides `mmdc`)
+- `pagefind` (standalone binary for search index generation)
 - `openssh-client` (for rsync over SSH)
 - `tzdata`
+
+Note: `nodejs`, `npm`, and `@mermaid-js/mermaid-cli` are NOT required. Mermaid rendering uses chromedp (Go CDP) directly, and pagefind is installed as a standalone musl-static binary.
 
 ### Behavior
 


### PR DESCRIPTION
## Summary

- Remove `nodejs`, `npm`, and `@mermaid-js/mermaid-cli` from the builder-runtime Docker image
- Install `pagefind` as a standalone musl-static binary instead of via npm
- Estimated ~100-150 MiB reduction in installed image size

## Why

markata-go's `chromium` mermaid rendering mode uses `chromedp` (Go-native Chrome DevTools Protocol) to render diagrams directly in the browser. It never calls `mmdc` (the Node.js mermaid-cli binary). This means `nodejs`, `npm`, and `@mermaid-js/mermaid-cli` were dead weight in the builder image.

Pagefind publishes standalone musl-static binaries on [GitHub Releases](https://github.com/Pagefind/pagefind/releases), eliminating the last reason for Node.js in the image.

## Changes

### Dockerfile
- Removed `nodejs` and `npm` from `apk add`
- Removed `PUPPETEER_SKIP_DOWNLOAD` and `PUPPETEER_EXECUTABLE_PATH` env vars
- Replaced `npm install -g @mermaid-js/mermaid-cli pagefind` with standalone pagefind binary download
- Added `PAGEFIND_VERSION` build arg for version pinning (default: `v1.4.0`)

### Docs/Spec
- Updated `docs/guides/deployment/docker.md` builder image description
- Updated `docs/guides/configuration.md` and `docs/reference/plugins.md` pagefind install instructions (standalone binary + auto_install)
- Updated `spec/spec/CONTAINERS.md` optional tools list

## What stays the same
- Alpine's native `chromium` package (musl-built, required for chromedp)
- All other builder tools (rsync, git, avifenc, cwebp, etc.)
- CLI mode (`mmdc`) still works for users who install it manually — this only changes what ships in the Docker image

## Future optimization opportunity
Switching to `debian:bookworm-slim` + `chrome-headless-shell` (~180 MiB vs ~350-400 MiB for Alpine's chromium) could save another ~100-150 MiB but requires a base image change. Filed as a separate consideration.