### PR TITLE
fix: reading progress bar position, calculation, and palette contrast

### DIFF
--- a/pkg/plugins/palette_css.go
+++ b/pkg/plugins/palette_css.go
@@ -544,6 +544,14 @@ func (p *PaletteCSSPlugin) writeNonColorVariables(buf *bytes.Buffer, indent stri
 	fmt.Fprintf(buf, "%s--page-width: 1200px;\n", indent)
 	fmt.Fprintf(buf, "%s--radius: 0.375rem;\n", indent)
 	fmt.Fprintf(buf, "%s--radius-lg: 0.5rem;\n", indent)
+
+	// Article reading progress indicator
+	fmt.Fprintf(buf, "\n%s/* Article reading progress indicator */\n", indent)
+	fmt.Fprintf(buf, "%s--article-progress-height: 4px;\n", indent)
+	fmt.Fprintf(buf, "%s--article-progress-track: color-mix(in srgb, var(--color-text) 15%%, var(--color-background) 85%%);\n", indent)
+	fmt.Fprintf(buf, "%s--article-progress-start: var(--color-primary);\n", indent)
+	fmt.Fprintf(buf, "%s--article-progress-end: color-mix(in srgb, var(--color-primary) 40%%, var(--color-primary-light, var(--color-primary)) 60%%);\n", indent)
+	fmt.Fprintf(buf, "%s--article-progress-glow: color-mix(in srgb, var(--color-primary) 60%%, transparent);\n", indent)
 }
 
 // writePaletteVariablesIndented writes CSS custom properties with custom indentation.

--- a/pkg/plugins/publish_html.go
+++ b/pkg/plugins/publish_html.go
@@ -879,8 +879,8 @@ func (p *PublishHTMLPlugin) wrapInTemplate(post *models.Post, config *lifecycle.
             <a href="{{.SiteURL}}">{{.SiteTitle}}</a>
         </nav>
     </header>
+    <div class="article-progress" role="presentation" aria-hidden="true"><span class="article-progress__indicator"></span></div>
     <main>
-        <div class="article-progress" role="presentation" aria-hidden="true"><span class="article-progress__indicator"></span></div>
         <article class="post">
             <header>
                 <h1>{{.Title}}</h1>
@@ -922,9 +922,15 @@ func (p *PublishHTMLPlugin) wrapInTemplate(post *models.Post, config *lifecycle.
           scheduled = false;
           var rect = article.getBoundingClientRect();
           var articleTop = window.scrollY + rect.top;
-          var articleHeight = Math.max(rect.height, 1);
-          var viewportBottom = window.scrollY + window.innerHeight;
-          var ratio = clamp((viewportBottom - articleTop) / articleHeight, 0, 1);
+          var articleHeight = rect.height;
+          var viewportHeight = window.innerHeight;
+          var scrollableDistance = articleHeight - viewportHeight;
+          var ratio;
+          if (scrollableDistance <= 0) {
+            ratio = 1;
+          } else {
+            ratio = clamp((window.scrollY - articleTop) / scrollableDistance, 0, 1);
+          }
           if (Math.abs(ratio - lastValue) < 0.001) {
             return;
           }

--- a/pkg/themes/default/static/css/components.css
+++ b/pkg/themes/default/static/css/components.css
@@ -208,15 +208,16 @@
 }
 
 .article-progress {
-  position: sticky;
-  top: calc(var(--layout-header-height, 64px) + var(--space-2, 0.5rem));
-  z-index: 10;
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1000;
   display: block;
-  width: min(100%, var(--content-max-width, 65ch));
+  width: 100%;
   height: var(--article-progress-height, 4px);
-  margin: 0 auto var(--space-5, 1.25rem);
-  background: var(--article-progress-track, color-mix(in srgb, var(--color-text) 90%, transparent));
-  border-radius: var(--article-progress-height, 4px);
+  margin: 0;
+  background: var(--article-progress-track, color-mix(in srgb, var(--color-text) 15%, var(--color-background) 85%));
+  border-radius: 0;
   overflow: hidden;
   pointer-events: none;
   isolation: isolate;
@@ -230,7 +231,7 @@
   transform: scaleX(0);
   background: linear-gradient(90deg, var(--article-progress-start, var(--color-primary)), var(--article-progress-end, var(--color-primary-light, var(--color-primary))));
   box-shadow: 0 0 18px var(--article-progress-glow, color-mix(in srgb, var(--color-primary) 60%, transparent));
-  opacity: 0.9;
+  opacity: 1;
   transition: transform 0.24s ease, opacity 0.24s ease;
   will-change: transform;
 }
@@ -2554,7 +2555,7 @@ main .container {
 
 /* ==========================================================================
    Heading Anchor Links (goldmark-anchor)
-   
+
    Styles for permalink anchors added by goldmark-anchor extension.
    Uses CSS variables to follow the site theme.
    ========================================================================== */

--- a/pkg/themes/default/static/css/variables.css
+++ b/pkg/themes/default/static/css/variables.css
@@ -84,7 +84,7 @@
 
     /* Darker article shadow for dark mode */
     --article-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.3), 0 2px 4px -1px rgba(0, 0, 0, 0.2);
-    --article-progress-track: color-mix(in srgb, var(--color-surface) 85%, transparent);
+    --article-progress-track: color-mix(in srgb, var(--color-background) 65%, white 35%);
     --article-progress-glow: color-mix(in srgb, var(--color-primary) 50%, transparent 60%);
   }
 }

--- a/pkg/themes/default/templates/base.html
+++ b/pkg/themes/default/templates/base.html
@@ -174,6 +174,8 @@
   </header>
   {% endblock %}
 
+  {% block progress %}{% endblock %}
+
   <div class="page-wrapper">
     {% block main %}
       {# Left sidebar for feed navigation (if enabled) #}
@@ -470,9 +472,16 @@
         scheduled = false;
         var rect = article.getBoundingClientRect();
         var articleTop = window.scrollY + rect.top;
-        var articleHeight = Math.max(rect.height, 1);
-        var viewportBottom = window.scrollY + window.innerHeight;
-        var ratio = clamp((viewportBottom - articleTop) / articleHeight, 0, 1);
+        var articleHeight = rect.height;
+        var viewportHeight = window.innerHeight;
+        var scrollableDistance = articleHeight - viewportHeight;
+        var ratio;
+        if (scrollableDistance <= 0) {
+          // Article fits entirely within the viewport
+          ratio = 1;
+        } else {
+          ratio = clamp((window.scrollY - articleTop) / scrollableDistance, 0, 1);
+        }
         if (Math.abs(ratio - lastValue) < 0.001) {
           return;
         }

--- a/pkg/themes/default/templates/post.html
+++ b/pkg/themes/default/templates/post.html
@@ -55,11 +55,13 @@
 {% endif %}
 {% endblock %}
 
-{% block content %}
+{% block progress %}
 <div class="article-progress" role="presentation" aria-hidden="true">
   <span class="article-progress__indicator"></span>
 </div>
+{% endblock %}
 
+{% block content %}
 <article class="post h-entry" data-pagefind-body>
   {# Hidden canonical URL for microformats parsers #}
   <a class="u-url" href="{{ config.url }}{{ post.href }}" hidden></a>

--- a/templates/base.html
+++ b/templates/base.html
@@ -156,6 +156,8 @@
   </header>
   {% endblock %}
 
+  {% block progress %}{% endblock %}
+
   <div class="page-wrapper">
     {% block main %}
       {# Left sidebar for feed navigation (if enabled) #}
@@ -451,9 +453,16 @@
         scheduled = false;
         var rect = article.getBoundingClientRect();
         var articleTop = window.scrollY + rect.top;
-        var articleHeight = Math.max(rect.height, 1);
-        var viewportBottom = window.scrollY + window.innerHeight;
-        var ratio = clamp((viewportBottom - articleTop) / articleHeight, 0, 1);
+        var articleHeight = rect.height;
+        var viewportHeight = window.innerHeight;
+        var scrollableDistance = articleHeight - viewportHeight;
+        var ratio;
+        if (scrollableDistance <= 0) {
+          // Article fits entirely within the viewport
+          ratio = 1;
+        } else {
+          ratio = clamp((window.scrollY - articleTop) / scrollableDistance, 0, 1);
+        }
         if (Math.abs(ratio - lastValue) < 0.001) {
           return;
         }

--- a/templates/post.html
+++ b/templates/post.html
@@ -55,11 +55,14 @@
 {% endif %}
 {% endblock %}
 
+{% block progress %}
+<div class="article-progress" role="presentation" aria-hidden="true">
+    <span class="article-progress__indicator"></span>
+</div>
+{% endblock %}
+
 {% block content %}
 <div class="content-wrapper{% if config.components.doc_sidebar.enabled and post.toc %} content-wrapper--with-sidebar content-wrapper--sidebar-{{ config.components.doc_sidebar.position | default:'right' }}{% endif %}">
-    <div class="article-progress" role="presentation" aria-hidden="true">
-        <span class="article-progress__indicator"></span>
-    </div>
     <article class="post h-entry" data-pagefind-body>
         {# Hidden canonical URL for microformats parsers #}
         <a class="u-url" href="{{ config.url }}{{ post.href }}" hidden></a>


### PR DESCRIPTION
## Summary

Fixes three issues with the article reading progress bar on post pages.

- **Position**: Move progress bar outside `page-wrapper`/`main` to a `{% block progress %}` as a direct `<body>` child, avoiding `backdrop-filter` containing block issues. Use `position: fixed` at viewport top spanning full width.
- **Progress calculation**: Change JS formula from "how much article entered the viewport" to "how far you've scrolled through the article": `(scrollY - articleTop) / (articleHeight - viewportHeight)`. Short articles that fit in the viewport show 100%.
- **Palette contrast**: The palette CSS plugin (`palette_css.go`) overwrites `variables.css` entirely, dropping all `--article-progress-*` variables. Add these variables to `writeNonColorVariables()` using a universal formula that works across light and dark palettes: `color-mix(in srgb, var(--color-text) 15%, var(--color-background) 85%)`. Update `components.css` fallback to match.

## Changed files

| File | Change |
|------|--------|
| `templates/base.html` | Add `{% block progress %}`, fix JS formula |
| `templates/post.html` | Move progress bar markup to `{% block progress %}` |
| `pkg/themes/default/templates/base.html` | Add `{% block progress %}`, fix JS formula |
| `pkg/themes/default/templates/post.html` | Move progress bar markup to `{% block progress %}` |
| `pkg/plugins/publish_html.go` | Move progress div before `<main>`, fix JS formula |
| `pkg/plugins/palette_css.go` | Add `--article-progress-*` vars to `writeNonColorVariables()` |
| `pkg/themes/default/static/css/components.css` | `position: fixed`, full-width, updated fallback formula, opacity 1 |
| `pkg/themes/default/static/css/variables.css` | Updated dark-mode track formula |

## Testing

- All unit and integration tests pass (`go test ./...`)
- Lint clean (`golangci-lint`, `go vet`, `go fmt`)
- Manually verified on ayu-dark, gruvbox-dark, halloween, midnight-ablaze, and 2bit-demichrome palettes

Fixes #829