### PR TITLE
fix: remove Signal share and add copy toast

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -457,7 +457,7 @@ Add a "Share this post" grid to the end of every article so readers can send you
 | `enabled` | bool | `true` | Show the component. |
 | `title` | string | `"Share this post"` | Heading text above the buttons. |
 | `position` | string | `"bottom"` | Modifier used by CSS (applied as `share-panel--<position>`). |
-| `platforms` | array | `["twitter","bluesky","linkedin","whatsapp","signal","facebook","telegram","pinterest","reddit","hacker_news","email","copy"]` | Ordered list of platform keys to render. Omit entries to hide them. |
+| `platforms` | array | `["twitter","bluesky","linkedin","whatsapp","facebook","telegram","pinterest","reddit","hacker_news","email","copy"]` | Ordered list of platform keys to render. Omit entries to hide them. |
 | `custom` | table | `{}` | Custom platform definitions (`name`, `icon`, `url`). Icon paths without `/`, `http`, or `data:` are resolved via `theme_asset_hashed` (e.g., `icons/share/mastodon.svg`). |
 
 ```toml
@@ -476,7 +476,7 @@ Supported placeholders for share URLs:
 - `{{url}}` → URL-encoded absolute post URL (`config.url` + `post.href`).
 - `{{excerpt}}` → URL-encoded post description or excerpt when provided.
 
-Copying uses the Clipboard API with a DOM fallback and updates the button label/tooltip to "Link copied" for 2 seconds. Built-in platforms include Twitter, Bluesky, LinkedIn, WhatsApp, Signal, Facebook, Telegram, Pinterest, Reddit, Hacker News, Email, and Copy Link, each with a coordinated icon from `pkg/themes/default/static/icons/share/`.
+Copying uses the Clipboard API with a DOM fallback, updates the button label/tooltip to "Link copied" for 2 seconds, and shows a small desktop-only toast. Built-in platforms include Twitter, Bluesky, LinkedIn, WhatsApp, Facebook, Telegram, Pinterest, Reddit, Hacker News, Email, and Copy Link, each with a coordinated icon from `pkg/themes/default/static/icons/share/`.
 
 ### IndieAuth Settings (`[markata-go.indieauth]`)
 

--- a/pkg/models/share.go
+++ b/pkg/models/share.go
@@ -12,7 +12,7 @@ const (
 )
 
 // DefaultSharePlatformOrder defines the built-in share buttons in the default order.
-var DefaultSharePlatformOrder = []string{"twitter", "bluesky", "linkedin", "whatsapp", "signal", "facebook", "telegram", "pinterest", "reddit", "hacker_news", "email", "copy"}
+var DefaultSharePlatformOrder = []string{"twitter", "bluesky", "linkedin", "whatsapp", "facebook", "telegram", "pinterest", "reddit", "hacker_news", "email", "copy"}
 
 type sharePlatformDefinition struct {
 	Name     string
@@ -46,11 +46,6 @@ var sharePlatformDefinitions = map[string]sharePlatformDefinition{
 		Name:     "WhatsApp",
 		Icon:     "icons/share/whatsapp.svg",
 		Template: "https://wa.me/?text={{url}}",
-	},
-	"signal": {
-		Name:     "Signal",
-		Icon:     "icons/share/signal.svg",
-		Template: "https://signal.me/?text={{url}}",
 	},
 	"telegram": {
 		Name:     "Telegram",

--- a/pkg/themes/default/static/css/components.css
+++ b/pkg/themes/default/static/css/components.css
@@ -1842,6 +1842,7 @@ article.post {
    margin: var(--space-8) 0 var(--space-6);
    padding-top: var(--space-4);
    border-top: 1px solid var(--color-border);
+   position: relative;
 }
 
 .share-panel__header {
@@ -1940,6 +1941,40 @@ article.post {
    color: var(--color-primary);
    border-color: var(--color-primary);
    background: color-mix(in srgb, var(--color-primary) 16%, transparent);
+}
+
+.share-toast {
+   display: none;
+}
+
+@media (min-width: 769px) {
+   .share-toast {
+      display: inline-flex;
+      position: absolute;
+      right: 0;
+      top: 0;
+      transform: translateY(-120%);
+      padding: 0.35rem 0.7rem;
+      background: var(--color-surface);
+      color: var(--color-text);
+      border: 1px solid var(--color-border);
+      border-radius: 999px;
+      box-shadow: 0 6px 18px rgba(0, 0, 0, 0.18);
+      font-size: 0.75rem;
+      letter-spacing: 0.01em;
+      opacity: 0;
+      visibility: hidden;
+      transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s;
+      pointer-events: none;
+      white-space: nowrap;
+      z-index: 2;
+   }
+
+   .share-toast--visible {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(-150%);
+   }
 }
 
 @media (max-width: 768px) {

--- a/pkg/themes/default/templates/components/share.html
+++ b/pkg/themes/default/templates/components/share.html
@@ -20,6 +20,7 @@
         {% endif %}
         {% endfor %}
     </div>
+    <div class="share-toast" role="status" aria-live="polite"></div>
 </section>
 
 <script>
@@ -49,6 +50,21 @@
         return result ? Promise.resolve() : Promise.reject();
     }
 
+    function showDesktopToast(target, text) {
+        if (!target) {
+            return;
+        }
+        if (window.matchMedia && !window.matchMedia('(min-width: 769px)').matches) {
+            return;
+        }
+        target.textContent = text;
+        target.classList.add('share-toast--visible');
+        clearTimeout(target._timeout);
+        target._timeout = window.setTimeout(function() {
+            target.classList.remove('share-toast--visible');
+        }, 1600);
+    }
+
     document.addEventListener('click', function(event) {
         var button = event.target.closest('[data-share-action="copy"]');
         if (!button) {
@@ -62,6 +78,8 @@
         var hint = button.querySelector('.share-button__hint');
         var defaultLabel = button.dataset.shareLabel || button.getAttribute('aria-label') || 'Copy link';
         var feedback = button.dataset.shareFeedback || 'Link copied to clipboard';
+        var panel = button.closest('.share-panel');
+        var toast = panel ? panel.querySelector('.share-toast') : null;
 
         copyToClipboard(payload).then(function() {
             if (hint) {
@@ -69,6 +87,7 @@
             }
             button.setAttribute('aria-label', feedback);
             button.classList.add('share-button--copied');
+            showDesktopToast(toast, feedback);
             window.setTimeout(function() {
                 if (hint) {
                     hint.textContent = '';

--- a/spec/spec/LAYOUTS.md
+++ b/spec/spec/LAYOUTS.md
@@ -580,7 +580,7 @@ The share component provides a configurable "Share this post" experience at the 
 1. Displays icon buttons in a responsive grid. Mobile stacks vertically, desktop shows multi-column layout.
 2. Hover or focus reveals the platform name via visible text and `aria-label` attributes.
 3. Clicks open the platform share dialog in a new tab (or copy the link when `copy` is enabled).
-4. Copy button uses the Clipboard API with a DOM fallback and provides live feedback.
+4. Copy button uses the Clipboard API with a DOM fallback and provides live feedback (including a desktop-only toast).
 5. Uses CSS variables for colors, spacing, and border radius so palettes can theme the component.
 
 #### Configuration
@@ -590,7 +590,7 @@ The share component provides a configurable "Share this post" experience at the 
 enabled = true
 position = "bottom"            # Controls the style hook (CSS adds `share-panel--bottom`).
 title = "Share this post"     # Heading above the buttons.
-platforms = ["twitter", "bluesky", "linkedin", "whatsapp", "signal", "facebook", "telegram", "pinterest", "reddit", "hacker_news", "email", "copy"]
+platforms = ["twitter", "bluesky", "linkedin", "whatsapp", "facebook", "telegram", "pinterest", "reddit", "hacker_news", "email", "copy"]
 
 [markata-go.components.share.custom]
 mastodon = { name = "Mastodon", icon = "mastodon.svg", url = "https://mastodon.social/share?text={{title}}&url={{url}}" }
@@ -620,7 +620,6 @@ The component ships with these built-in platforms:
 | `bluesky` | `https://bsky.app/intent/compose?text={{url}}` | Icon: `icons/share/bluesky.svg`. |
 | `linkedin` | `https://www.linkedin.com/sharing/share-offsite/?url={{url}}` | Icon: `icons/share/linkedin.svg`. |
 | `whatsapp` | `https://wa.me/?text={{url}}` | Icon: `icons/share/whatsapp.svg`. |
-| `signal` | `https://signal.me/?text={{url}}` | Icon: `icons/share/signal.svg`. |
 | `facebook` | `https://www.facebook.com/sharer/sharer.php?u={{url}}` | Icon: `icons/share/facebook.svg`. |
 | `telegram` | `https://t.me/share/url?url={{url}}` | Icon: `icons/share/telegram.svg`. |
 | `pinterest` | `https://pinterest.com/pin/create/button/?url={{url}}` | Icon: `icons/share/pinterest.svg`. |

--- a/templates/components/share.html
+++ b/templates/components/share.html
@@ -20,6 +20,7 @@
         {% endif %}
         {% endfor %}
     </div>
+    <div class="share-toast" role="status" aria-live="polite"></div>
 </section>
 
 <script>
@@ -49,6 +50,21 @@
         return result ? Promise.resolve() : Promise.reject();
     }
 
+    function showDesktopToast(target, text) {
+        if (!target) {
+            return;
+        }
+        if (window.matchMedia && !window.matchMedia('(min-width: 769px)').matches) {
+            return;
+        }
+        target.textContent = text;
+        target.classList.add('share-toast--visible');
+        clearTimeout(target._timeout);
+        target._timeout = window.setTimeout(function() {
+            target.classList.remove('share-toast--visible');
+        }, 1600);
+    }
+
     document.addEventListener('click', function(event) {
         var button = event.target.closest('[data-share-action="copy"]');
         if (!button) {
@@ -62,6 +78,8 @@
         var hint = button.querySelector('.share-button__hint');
         var defaultLabel = button.dataset.shareLabel || button.getAttribute('aria-label') || 'Copy link';
         var feedback = button.dataset.shareFeedback || 'Link copied to clipboard';
+        var panel = button.closest('.share-panel');
+        var toast = panel ? panel.querySelector('.share-toast') : null;
 
         copyToClipboard(payload).then(function() {
             if (hint) {
@@ -69,6 +87,7 @@
             }
             button.setAttribute('aria-label', feedback);
             button.classList.add('share-button--copied');
+            showDesktopToast(toast, feedback);
             window.setTimeout(function() {
                 if (hint) {
                     hint.textContent = '';


### PR DESCRIPTION
## Summary
- remove Signal from the built-in share platform list and update share docs/specs
- add a desktop-only copy toast for the share button in the share panel
- keep existing accessibility copy feedback for screen readers and keyboard focus

## Issue
- Fixes #831