### PR TITLE
fix: align footer license with copyright

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -154,7 +154,7 @@ concurrency = 4
 
 ### License configuration
 
-The `license` key controls the attribution shown in the footer and whether the dev server reminds you to pick a license. It accepts either a string key (selects the attribution) or the literal `false` (hides the line and silences the warning).
+The `license` key controls the attribution shown in the footer and whether the dev server reminds you to pick a license. It accepts either a string key (selects the attribution) or the literal `false` (hides the line and silences the warning). When the footer shows the copyright line, the license appears on the same line next to the copyright symbol; if copyright is disabled, the license renders as its own line.
 
 Supported license keys:
 

--- a/pkg/themes/default/templates/components/footer.html
+++ b/pkg/themes/default/templates/components/footer.html
@@ -20,24 +20,34 @@
         </nav>
         {% endif %}
 
-        {% if config.license and config.license.name %}
-        <p class="footer-license">
-            Content licensed under
-            {% if config.license.url %}
-            <a href="{{ config.license.url }}" target="_blank" rel="noopener noreferrer">{{ config.license.name }}</a>
-            {% else %}
-            {{ config.license.name }}
-            {% endif %}
-        </p>
-        {% endif %}
-
         {# Format links for alternate views/formats #}
         {% if post or feed %}
         {% include "components/format-links.html" %}
         {% endif %}
 
          {% if footer.show_copyright %}
-         <p class="footer-copyright">&copy; {{ "now" | date:"2006" }} {{ config.author | default:config.title | default:"" }}.{% if footer.show_built_with %} Built with <a href="https://github.com/WaylonWalker/markata-go">markata-go</a> using {{ config.theme.name | default:"default" }} theme.{% endif %}</p>
+         <p class="footer-copyright">
+             &copy; {{ "now" | date:"2006" }} {{ config.author | default:config.title | default:"" }}.
+             {% if config.license and config.license.name %}
+             Content licensed under
+             {% if config.license.url %}
+             <a href="{{ config.license.url }}" target="_blank" rel="noopener noreferrer">{{ config.license.name }}</a>
+             {% else %}
+             {{ config.license.name }}
+             {% endif %}.
+             {% endif %}
+             {% if footer.show_built_with %}Built with <a href="https://github.com/WaylonWalker/markata-go">markata-go</a> using {{ config.theme.name | default:"default" }} theme.{% endif %}
+         </p>
+         {% elif config.license and config.license.name %}
+         {# Show license even if copyright is hidden #}
+         <p class="footer-license">
+             Content licensed under
+             {% if config.license.url %}
+             <a href="{{ config.license.url }}" target="_blank" rel="noopener noreferrer">{{ config.license.name }}</a>
+             {% else %}
+             {{ config.license.name }}
+             {% endif %}
+         </p>
          {% endif %}
     </div>
 

--- a/spec/spec/TEMPLATES.md
+++ b/spec/spec/TEMPLATES.md
@@ -554,14 +554,26 @@ Small reusable template fragments:
 
 ## Footer License Display
 
-When `config.license` contains a string key the default footer renders a license line that links to the canonical text. Custom footers should honor the same guard to avoid losing attribution:
+When `config.license` contains a string key the default footer appends the license attribution to the copyright line (next to the copyright symbol). Custom footers should honor the same guard to avoid losing attribution:
 
 ```jinja
-{% if config.license and config.license.name %}
+{% if footer.show_copyright %}
+<p class="footer-copyright">
+  &copy; {{ "now" | date:"2006" }} {{ config.author | default:"" }}.
+  {% if config.license and config.license.name %}
+  Content licensed under
+  {% if config.license.url %}
+  <a href="{{ config.license.url }}" target="_blank" rel="noopener noreferrer">{{ config.license.name }}</a>.
+  {% else %}
+  {{ config.license.name }}.
+  {% endif %}
+  {% endif %}
+</p>
+{% elif config.license and config.license.name %}
 <p class="footer-license">
   Content licensed under
   {% if config.license.url %}
-  <a href="{{ config.license.url }}" target="_blank" rel="noopener">{{ config.license.name }}</a>
+  <a href="{{ config.license.url }}" target="_blank" rel="noopener noreferrer">{{ config.license.name }}</a>
   {% else %}
   {{ config.license.name }}
   {% endif %}
@@ -901,7 +913,7 @@ JavaScript (the `initArticleProgressIndicator` initializer) keeps the indicator 
 2. Computes progress as `clamp((window.innerHeight + scrollY - articleTop) / articleHeight, 0, 1)` so the indicator is full once the viewport reaches the bottom of the article.
 3. Uses `requestAnimationFrame` to throttle updates and avoids redundant DOM writes when the ratio is unchanged.
 4. Attaches `scroll` and `resize` listeners with `{ passive: true }`.
-5. Respects `prefers-reduced-motion` by delegating transition control to CSS (`@media (prefers-reduced-motion: reduce)` disables the transform animation). 
+5. Respects `prefers-reduced-motion` by delegating transition control to CSS (`@media (prefers-reduced-motion: reduce)` disables the transform animation).
 ```
 
 ### Feed Pages (h-feed)

--- a/templates/components/footer.html
+++ b/templates/components/footer.html
@@ -18,17 +18,6 @@
         </nav>
         {% endif %}
 
-        {% if config.license and config.license.name %}
-        <p class="footer-license">
-            Content licensed under
-            {% if config.license.url %}
-            <a href="{{ config.license.url }}" target="_blank" rel="noopener noreferrer">{{ config.license.name }}</a>
-            {% else %}
-            {{ config.license.name }}
-            {% endif %}
-        </p>
-        {% endif %}
-
         {# Format links for alternate views/formats #}
         {% if post or feed %}
         {% include "components/format-links.html" %}
@@ -36,7 +25,28 @@
 
         <div class="footer-bottom">
              {% if footer.show_copyright %}
-             <p class="footer-copyright">&copy; {{ "now" | date:"2006" }} {{ config.author | default:"" }}.{% if footer.show_built_with %} Built with <a href="https://github.com/WaylonWalker/markata-go">markata-go</a> using {{ config.theme.name | default:"default" }} theme.{% endif %}</p>
+             <p class="footer-copyright">
+                 &copy; {{ "now" | date:"2006" }} {{ config.author | default:"" }}.
+                 {% if config.license and config.license.name %}
+                 Content licensed under
+                 {% if config.license.url %}
+                 <a href="{{ config.license.url }}" target="_blank" rel="noopener noreferrer">{{ config.license.name }}</a>
+                 {% else %}
+                 {{ config.license.name }}
+                 {% endif %}.
+                 {% endif %}
+                 {% if footer.show_built_with %}Built with <a href="https://github.com/WaylonWalker/markata-go">markata-go</a> using {{ config.theme.name | default:"default" }} theme.{% endif %}
+             </p>
+             {% elif config.license and config.license.name %}
+             {# Show license even if copyright is hidden #}
+             <p class="footer-license">
+                 Content licensed under
+                 {% if config.license.url %}
+                 <a href="{{ config.license.url }}" target="_blank" rel="noopener noreferrer">{{ config.license.name }}</a>
+                 {% else %}
+                 {{ config.license.name }}
+                 {% endif %}
+             </p>
              {% endif %}
             <p class="footer-shortcuts-hint">Press <kbd>?</kbd> for keyboard shortcuts</p>
         </div>


### PR DESCRIPTION
## Summary
- align the footer license attribution with the copyright line to match common footer conventions
- keep a fallback license line when the copyright line is disabled
- update specs and configuration docs to reflect the new footer behavior

## Issue
Refs #814

## Changes
- update footer templates to render license next to the copyright symbol
- document the new footer behavior in the templates spec
- clarify license footer behavior in configuration guide