### PR TITLE
feat(embeds): expand oEmbed providers and discovery

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -163,6 +163,7 @@ Controls internal and external embed behavior, including oEmbed resolution and O
 | `external_card_class` | string | `"embed-card embed-card-external"` | CSS class for external embed cards |
 | `fetch_external` | bool | `true` | Fetch Open Graph metadata for external embeds |
 | `oembed_enabled` | bool | `true` | Enable oEmbed resolution |
+| `oembed_auto_discover` | bool | `false` | Discover oEmbed endpoints from HTML link tags |
 | `resolution_strategy` | string | `"oembed_first"` | `oembed_first`, `og_first`, `oembed_only` |
 | `cache_dir` | string | `".cache/embeds"` | Cache directory for metadata |
 | `cache_ttl` | int | `604800` | Cache TTL (seconds) |
@@ -177,6 +178,7 @@ internal_card_class = "embed-card"
 external_card_class = "embed-card embed-card-external"
 fetch_external = true
 oembed_enabled = true
+oembed_auto_discover = false
 resolution_strategy = "oembed_first"
 cache_dir = ".cache/embeds"
 cache_ttl = 604800
@@ -191,6 +193,22 @@ tiktok = { enabled = true }
 flickr = { enabled = true }
 spotify = { enabled = true }
 soundcloud = { enabled = true }
+codepen = { enabled = true }
+codesandbox = { enabled = true }
+jsfiddle = { enabled = true }
+observable = { enabled = true }
+github = { enabled = true }
+slideshare = { enabled = true }
+prezi = { enabled = true }
+speakerdeck = { enabled = true }
+issuu = { enabled = true }
+datawrapper = { enabled = true }
+flourish = { enabled = true }
+infogram = { enabled = true }
+reddit = { enabled = true }
+dailymotion = { enabled = true }
+wistia = { enabled = true }
+giphy = { enabled = true }
 ```
 
 ### License configuration

--- a/docs/guides/embeds.md
+++ b/docs/guides/embeds.md
@@ -40,7 +40,7 @@ Here's a great resource:
 ![[https://example.com/article|Custom Title]]
 ```
 
-This fetches metadata and displays a card with the title, description, and image.
+This resolves metadata via oEmbed (when available), then falls back to Open Graph, and displays a card with the title, description, and image.
 
 > **Note:** Obsidian-style external embeds like `![[https://example.com]]` are not supported yet. Track progress in issue #837.
 
@@ -96,7 +96,7 @@ This helps you spot broken embeds without breaking your build.
 
 > **Note:** The alt text must be exactly `embed`. Regular images are not affected. The Obsidian-style form is only recognized for full URLs (`http`/`https`).
 
-### Open Graph Metadata
+### Metadata Resolution
 
 External embeds fetch and display (in order based on strategy):
 - **oEmbed** - Title, provider name, thumbnail image (if available)
@@ -128,14 +128,15 @@ external_card_class = "embed-card embed-card-external"
 # External fetch settings
 fetch_external = true        # Set false to skip HTTP requests
 oembed_enabled = true        # Enable oEmbed resolution
+oembed_auto_discover = false # Use HTML auto-discovery when no provider matches
 resolution_strategy = "oembed_first"  # oembed_first | og_first | oembed_only
 cache_dir = ".cache/embeds"  # Where to store cached metadata
 cache_ttl = 604800           # Cache TTL in seconds (default 7 days)
 timeout = 10                 # HTTP timeout in seconds
 
 # Display settings
-fallback_title = "External Link"  # Title when OG is unavailable
-show_image = true                 # Show OG images
+fallback_title = "External Link"  # Title when metadata is unavailable
+show_image = true                 # Show images
 
 [embeds.providers]
 youtube = { enabled = true }
@@ -144,6 +145,22 @@ tiktok = { enabled = true }
 flickr = { enabled = true }
 spotify = { enabled = true }
 soundcloud = { enabled = true }
+codepen = { enabled = true }
+codesandbox = { enabled = true }
+jsfiddle = { enabled = true }
+observable = { enabled = true }
+github = { enabled = true }
+slideshare = { enabled = true }
+prezi = { enabled = true }
+speakerdeck = { enabled = true }
+issuu = { enabled = true }
+datawrapper = { enabled = true }
+flourish = { enabled = true }
+infogram = { enabled = true }
+reddit = { enabled = true }
+dailymotion = { enabled = true }
+wistia = { enabled = true }
+giphy = { enabled = true }
 ```
 
 ### Disabling External Fetching
@@ -166,6 +183,15 @@ resolution_strategy = "og_first"
 ```
 
 This skips oEmbed providers and falls back to Open Graph metadata only.
+
+### Enabling oEmbed Auto-Discovery
+
+```toml
+[embeds]
+oembed_auto_discover = true
+```
+
+When enabled, markata-go looks for oEmbed link tags in HTML pages and uses the discovered endpoint if no provider matches.
 
 ## Styling
 

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -2017,6 +2017,9 @@ type EmbedsConfig struct {
 	// OEmbedProviders configures provider-specific overrides (default: empty)
 	OEmbedProviders map[string]OEmbedProviderConfig `json:"providers" yaml:"providers" toml:"providers"`
 
+	// OEmbedAutoDiscover enables auto-discovery via HTML link tags (default: false)
+	OEmbedAutoDiscover bool `json:"oembed_auto_discover" yaml:"oembed_auto_discover" toml:"oembed_auto_discover"`
+
 	// CacheDir is the directory for caching external embed metadata (default: ".cache/embeds")
 	CacheDir string `json:"cache_dir" yaml:"cache_dir" toml:"cache_dir"`
 
@@ -2053,6 +2056,7 @@ func NewEmbedsConfig() EmbedsConfig {
 		OEmbedEnabled:      true,
 		ResolutionStrategy: "oembed_first",
 		OEmbedProviders:    map[string]OEmbedProviderConfig{},
+		OEmbedAutoDiscover: false,
 		CacheDir:           ".cache/embeds",
 		Timeout:            10,
 		CacheTTL:           7 * 24 * 60 * 60,

--- a/pkg/plugins/embeds.go
+++ b/pkg/plugins/embeds.go
@@ -97,6 +97,7 @@ func (p *EmbedsPlugin) applyEmbedsConfig(cfgMap map[string]interface{}) {
 	applyString(cfgMap, "fallback_title", &p.config.FallbackTitle)
 	applyBool(cfgMap, "show_image", &p.config.ShowImage)
 	applyString(cfgMap, "attachments_prefix", &p.config.AttachmentsPrefix)
+	applyBool(cfgMap, "oembed_auto_discover", &p.config.OEmbedAutoDiscover)
 
 	if p.config.Timeout > 0 {
 		p.httpClient.Timeout = time.Duration(p.config.Timeout) * time.Second

--- a/pkg/plugins/oembed.go
+++ b/pkg/plugins/oembed.go
@@ -3,9 +3,12 @@ package plugins
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/WaylonWalker/markata-go/pkg/models"
@@ -31,11 +34,12 @@ type OEmbedResponse struct {
 
 // oembedProvider describes a single oEmbed provider.
 type oembedProvider struct {
-	Name           string
-	Endpoint       string
-	URLPrefixes    []string
-	RequiresAuth   bool
-	SupportsFormat bool
+	Name             string
+	Endpoint         string
+	URLPrefixes      []string
+	RequiresAuth     bool
+	SupportsFormat   bool
+	SupportsDiscover bool
 }
 
 // oembedResolver resolves oEmbed data for URLs.
@@ -68,7 +72,41 @@ func (r *oembedResolver) updateConfig(config models.EmbedsConfig) {
 func (r *oembedResolver) Resolve(rawURL string) (*OEmbedResponse, bool, error) {
 	provider := r.matchProvider(rawURL)
 	if provider == nil {
-		return nil, false, nil
+		if !r.config.OEmbedAutoDiscover {
+			return nil, false, nil
+		}
+
+		endpoint, err := r.discoverEndpoint(rawURL)
+		if err != nil {
+			if errors.Is(err, errOEmbedDiscoveryDisabled) {
+				return nil, false, nil
+			}
+			return nil, false, err
+		}
+
+		payload, err := r.fetchOEmbedResponse(endpoint)
+		if err != nil {
+			return nil, false, err
+		}
+
+		return payload, true, nil
+	}
+
+	if provider.SupportsDiscover {
+		endpoint, err := r.discoverEndpoint(rawURL)
+		if err != nil {
+			if errors.Is(err, errOEmbedDiscoveryDisabled) {
+				return nil, false, nil
+			}
+			return nil, false, err
+		}
+
+		payload, err := r.fetchOEmbedResponse(endpoint)
+		if err != nil {
+			return nil, false, err
+		}
+
+		return payload, true, nil
 	}
 
 	if !r.isProviderEnabled(provider.Name) {
@@ -88,29 +126,26 @@ func (r *oembedResolver) Resolve(rawURL string) (*OEmbedResponse, bool, error) {
 	req.Header.Set("User-Agent", "markata-go/1.0 (+https://github.com/WaylonWalker/markata-go)")
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := r.client.Do(req)
+	payload, err := r.fetchOEmbedResponse(endpoint)
 	if err != nil {
 		return nil, true, err
 	}
-	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, true, fmt.Errorf("oembed request failed: %s", resp.Status)
-	}
-
-	var payload OEmbedResponse
-	decoder := json.NewDecoder(resp.Body)
-	if err := decoder.Decode(&payload); err != nil {
-		return nil, true, err
-	}
-
-	return &payload, true, nil
+	return payload, true, nil
 }
 
 func (r *oembedResolver) matchProvider(rawURL string) *oembedProvider {
 	for _, provider := range r.providers {
 		for _, prefix := range provider.URLPrefixes {
 			if strings.HasPrefix(rawURL, prefix) {
+				return &provider
+			}
+		}
+	}
+
+	if r.config.OEmbedAutoDiscover {
+		for _, provider := range r.providers {
+			if provider.SupportsDiscover {
 				return &provider
 			}
 		}
@@ -149,6 +184,103 @@ func (r *oembedResolver) buildEndpoint(provider *oembedProvider, rawURL string) 
 
 	return parsed.String(), nil
 }
+
+func (r *oembedResolver) fetchOEmbedResponse(endpoint string) (*OEmbedResponse, error) {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, endpoint, http.NoBody)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("User-Agent", "markata-go/1.0 (+https://github.com/WaylonWalker/markata-go)")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("oembed request failed: %s", resp.Status)
+	}
+
+	var payload OEmbedResponse
+	decoder := json.NewDecoder(resp.Body)
+	if err := decoder.Decode(&payload); err != nil {
+		return nil, err
+	}
+
+	return &payload, nil
+}
+
+func (r *oembedResolver) discoverEndpoint(rawURL string) (string, error) {
+	if !r.config.OEmbedAutoDiscover {
+		return "", errOEmbedDiscoveryDisabled
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, rawURL, http.NoBody)
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Set("User-Agent", "markata-go/1.0 (+https://github.com/WaylonWalker/markata-go)")
+	req.Header.Set("Accept", "text/html,application/xhtml+xml")
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("oembed discovery failed: %s", resp.Status)
+	}
+
+	const maxBody = 512 * 1024
+	limited := io.LimitReader(resp.Body, maxBody)
+	body, err := io.ReadAll(limited)
+	if err != nil {
+		return "", err
+	}
+
+	endpoint := findOEmbedLink(string(body))
+	if endpoint == "" {
+		return "", fmt.Errorf("oembed discovery: endpoint not found")
+	}
+
+	if strings.HasPrefix(endpoint, "//") {
+		endpoint = "https:" + endpoint
+	}
+
+	if strings.HasPrefix(endpoint, "/") {
+		parsed, err := url.Parse(rawURL)
+		if err != nil {
+			return "", err
+		}
+		endpoint = parsed.ResolveReference(&url.URL{Path: endpoint}).String()
+	}
+
+	return endpoint, nil
+}
+
+func findOEmbedLink(html string) string {
+	patterns := []*regexp.Regexp{
+		regexp.MustCompile(`<link[^>]*rel=["']alternate["'][^>]*type=["']application/json\+oembed["'][^>]*href=["']([^"']+)["']`),
+		regexp.MustCompile(`<link[^>]*type=["']application/json\+oembed["'][^>]*rel=["']alternate["'][^>]*href=["']([^"']+)["']`),
+		regexp.MustCompile(`<link[^>]*rel=["']alternate["'][^>]*href=["']([^"']+)["'][^>]*type=["']application/json\+oembed["']`),
+	}
+
+	for _, pattern := range patterns {
+		match := pattern.FindStringSubmatch(html)
+		if len(match) > 1 {
+			return match[1]
+		}
+	}
+
+	return ""
+}
+
+var errOEmbedDiscoveryDisabled = errors.New("oembed discovery disabled")
 
 func defaultOEmbedProviders() []oembedProvider {
 	return []oembedProvider{
@@ -193,6 +325,126 @@ func defaultOEmbedProviders() []oembedProvider {
 			URLPrefixes:    []string{"https://soundcloud.com/"},
 			RequiresAuth:   false,
 			SupportsFormat: false,
+		},
+		{
+			Name:           "codepen",
+			Endpoint:       "https://codepen.io/api/oembed",
+			URLPrefixes:    []string{"https://codepen.io/"},
+			RequiresAuth:   false,
+			SupportsFormat: false,
+		},
+		{
+			Name:           "codesandbox",
+			Endpoint:       "https://codesandbox.io/oembed",
+			URLPrefixes:    []string{"https://codesandbox.io/"},
+			RequiresAuth:   false,
+			SupportsFormat: false,
+		},
+		{
+			Name:           "jsfiddle",
+			Endpoint:       "https://jsfiddle.net/services/oembed/",
+			URLPrefixes:    []string{"https://jsfiddle.net/"},
+			RequiresAuth:   false,
+			SupportsFormat: false,
+		},
+		{
+			Name:           "observable",
+			Endpoint:       "https://api.observablehq.com/oembed",
+			URLPrefixes:    []string{"https://observablehq.com/"},
+			RequiresAuth:   false,
+			SupportsFormat: false,
+		},
+		{
+			Name:           "github",
+			Endpoint:       "https://github.com/services/oembed",
+			URLPrefixes:    []string{"https://gist.github.com/", "https://github.com/"},
+			RequiresAuth:   false,
+			SupportsFormat: false,
+		},
+		{
+			Name:           "slideshare",
+			Endpoint:       "https://www.slideshare.net/api/oembed/2",
+			URLPrefixes:    []string{"https://www.slideshare.net/", "https://slideshare.net/"},
+			RequiresAuth:   false,
+			SupportsFormat: false,
+		},
+		{
+			Name:           "prezi",
+			Endpoint:       "https://prezi.com/services/oembed/",
+			URLPrefixes:    []string{"https://prezi.com/"},
+			RequiresAuth:   false,
+			SupportsFormat: false,
+		},
+		{
+			Name:           "speakerdeck",
+			Endpoint:       "https://speakerdeck.com/oembed.json",
+			URLPrefixes:    []string{"https://speakerdeck.com/"},
+			RequiresAuth:   false,
+			SupportsFormat: false,
+		},
+		{
+			Name:           "issuu",
+			Endpoint:       "https://issuu.com/oembed",
+			URLPrefixes:    []string{"https://issuu.com/"},
+			RequiresAuth:   false,
+			SupportsFormat: false,
+		},
+		{
+			Name:           "datawrapper",
+			Endpoint:       "https://api.datawrapper.de/v3/oembed/",
+			URLPrefixes:    []string{"https://datawrapper.de/", "https://www.datawrapper.de/", "https://app.datawrapper.de/"},
+			RequiresAuth:   false,
+			SupportsFormat: false,
+		},
+		{
+			Name:           "flourish",
+			Endpoint:       "https://app.flourish.studio/api/v1/oembed",
+			URLPrefixes:    []string{"https://public.flourish.studio/", "https://app.flourish.studio/", "https://flourish.studio/"},
+			RequiresAuth:   false,
+			SupportsFormat: false,
+		},
+		{
+			Name:           "infogram",
+			Endpoint:       "https://infogram.com/oembed",
+			URLPrefixes:    []string{"https://infogram.com/"},
+			RequiresAuth:   false,
+			SupportsFormat: false,
+		},
+		{
+			Name:           "reddit",
+			Endpoint:       "https://www.reddit.com/oembed",
+			URLPrefixes:    []string{"https://www.reddit.com/", "https://reddit.com/"},
+			RequiresAuth:   false,
+			SupportsFormat: false,
+		},
+		{
+			Name:           "dailymotion",
+			Endpoint:       "https://www.dailymotion.com/services/oembed",
+			URLPrefixes:    []string{"https://www.dailymotion.com/"},
+			RequiresAuth:   false,
+			SupportsFormat: false,
+		},
+		{
+			Name:           "wistia",
+			Endpoint:       "https://fast.wistia.com/oembed.json",
+			URLPrefixes:    []string{"https://wistia.com/", "https://fast.wistia.com/"},
+			RequiresAuth:   false,
+			SupportsFormat: false,
+		},
+		{
+			Name:           "giphy",
+			Endpoint:       "https://giphy.com/services/oembed",
+			URLPrefixes:    []string{"https://giphy.com/"},
+			RequiresAuth:   false,
+			SupportsFormat: false,
+		},
+		{
+			Name:             "oembed",
+			Endpoint:         "",
+			URLPrefixes:      []string{},
+			RequiresAuth:     false,
+			SupportsFormat:   false,
+			SupportsDiscover: true,
 		},
 	}
 }

--- a/spec/spec/EMBEDS.md
+++ b/spec/spec/EMBEDS.md
@@ -37,6 +37,7 @@ internal_card_class = "embed-card"               # CSS class for internal cards
 external_card_class = "embed-card embed-card-external"  # CSS class for external cards
 fetch_external = true                            # Fetch OG metadata from external URLs
 oembed_enabled = true                            # Enable oEmbed resolution
+oembed_auto_discover = false                     # Discover oEmbed endpoints from HTML link tags
 resolution_strategy = "oembed_first"             # oembed_first | og_first | oembed_only
 cache_dir = ".cache/embeds"                      # Cache directory for external metadata
 cache_ttl = 604800                               # Cache TTL in seconds
@@ -51,6 +52,22 @@ tiktok = { enabled = true }
 flickr = { enabled = true }
 spotify = { enabled = true }
 soundcloud = { enabled = true }
+codepen = { enabled = true }
+codesandbox = { enabled = true }
+jsfiddle = { enabled = true }
+observable = { enabled = true }
+github = { enabled = true }
+slideshare = { enabled = true }
+prezi = { enabled = true }
+speakerdeck = { enabled = true }
+issuu = { enabled = true }
+datawrapper = { enabled = true }
+flourish = { enabled = true }
+infogram = { enabled = true }
+reddit = { enabled = true }
+dailymotion = { enabled = true }
+wistia = { enabled = true }
+giphy = { enabled = true }
 ```
 
 ## Internal Embeds
@@ -103,15 +120,15 @@ A post cannot embed itself. Attempting to do so adds a warning comment:
    - OG description (truncated)
    - Site name and domain
 
-### Open Graph Metadata Extraction
+### Metadata Resolution
 
 The plugin extracts:
 - **oEmbed**: title, provider name, thumbnail URL (if available)
 - **Open Graph**: `og:title`, `og:description`, `og:image`, `og:site_name`
 
-### oEmbed Providers (Phase 1)
+### oEmbed Providers (Phase 2)
 
-Supported providers for the initial implementation:
+Supported providers include Phase 1 plus additional Phase 2 providers:
 
 - YouTube (`https://www.youtube.com/oembed`)
 - Vimeo (`https://vimeo.com/api/oembed.json`)
@@ -119,6 +136,22 @@ Supported providers for the initial implementation:
 - Flickr (`https://www.flickr.com/services/oembed/`)
 - Spotify (`https://open.spotify.com/oembed`)
 - SoundCloud (`https://soundcloud.com/oembed`)
+- CodePen (`https://codepen.io/api/oembed`)
+- CodeSandbox (`https://codesandbox.io/oembed`)
+- JSFiddle (`https://jsfiddle.net/services/oembed/`)
+- Observable (`https://api.observablehq.com/oembed`)
+- GitHub Gist (`https://github.com/services/oembed`)
+- SlideShare (`https://www.slideshare.net/api/oembed/2`)
+- Prezi (`https://prezi.com/services/oembed/`)
+- Speaker Deck (`https://speakerdeck.com/oembed.json`)
+- Issuu (`https://issuu.com/oembed`)
+- Datawrapper (`https://api.datawrapper.de/v3/oembed/`)
+- Flourish (`https://app.flourish.studio/api/v1/oembed`)
+- Infogram (`https://infogram.com/oembed`)
+- Reddit (`https://www.reddit.com/oembed`)
+- Dailymotion (`https://www.dailymotion.com/services/oembed`)
+- Wistia (`https://fast.wistia.com/oembed.json`)
+- GIPHY (`https://giphy.com/services/oembed`)
 
 Falls back to `<title>` and `<meta name="description">` if OG tags are missing.
 
@@ -188,6 +221,7 @@ The embeds plugin runs in the **Transform** stage with `PriorityEarly` (-100), e
 | Obsidian external URL invalid | Original syntax preserved |
 | External fetch fails | Uses fallback title, no image |
 | oEmbed provider disabled | Treat as matched, fall back if allowed |
+| oEmbed discovery disabled | Treat as not matched |
 | External timeout | Uses fallback title, no image |
 
 ## CSS Classes
@@ -211,6 +245,7 @@ The embeds plugin runs in the **Transform** stage with `PriorityEarly` (-100), e
 4. **Body Limit** - External pages are limited to 1MB to prevent memory issues
 5. **Disable Fetching** - Set `fetch_external = false` to skip OG HTTP requests entirely
 6. **Disable oEmbed** - Set `oembed_enabled = false` or use `oembed_only` to avoid OG fallback
+7. **Auto-Discovery** - Set `oembed_auto_discover = true` to discover endpoints via HTML link tags
 
 ## Related Features
 


### PR DESCRIPTION
## Summary
- add Phase 2 oEmbed providers (code, slides, data viz, media)
- add optional oEmbed auto-discovery via HTML link tags
- update embeds spec and docs with new providers and config

## Testing
- go test ./pkg/plugins/...

## Issue
Refs #838