### PR TITLE
fix: normalize mention aliases and chat replies

### DIFF
--- a/docs/guides/frontmatter.md
+++ b/docs/guides/frontmatter.md
@@ -633,6 +633,8 @@ With these aliases, any of the following wikilinks will resolve to this post:
     that post (slug match) rather than the post with the alias. Slugs always take
     precedence over aliases.
 
+**Alias field synonyms:** The frontmatter loader also accepts `alias`, `handle`, and `handles` and normalizes them into `aliases`.
+
 ---
 
 ## Examples

--- a/docs/guides/markdown.md
+++ b/docs/guides/markdown.md
@@ -656,7 +656,7 @@ CSS
 <dl>
   <dt>Term 1</dt>
   <dd>Definition of the first term.</dd>
-  
+
   <dt>Term 2</dt>
   <dd>First definition of the second term.</dd>
   <dd>Second definition of the second term.</dd>
@@ -1437,6 +1437,11 @@ Admonitions can contain any Markdown content:
 
     - Works with Python 3.6+
     - Requires no dependencies
+
+!!! note
+
+    A blank line after the admonition header is allowed.
+    Content must still be indented.
 ```
 
 **Live example:**

--- a/docs/guides/mentions.md
+++ b/docs/guides/mentions.md
@@ -55,10 +55,12 @@ The default `from_posts` sources are equivalent to:
 [[markata-go.mentions.from_posts]]
 filter = "template == 'contact'"
 handle_field = "handle"
+aliases_field = "aliases"
 
 [[markata-go.mentions.from_posts]]
 filter = "template == 'author'"
 handle_field = "handle"
+aliases_field = "aliases"
 ```
 
 You can override this by specifying your own `from_posts` sources:
@@ -205,6 +207,7 @@ handle_field = "handle"
 [[markata-go.mentions.from_posts]]
 filter = "template == 'author'"
 handle_field = "handle"
+aliases_field = "aliases"
 ```
 
 This means if you have author profile pages with `template: author`, they are automatically included as mention sources.
@@ -251,6 +254,14 @@ Both quoted and unquoted forms work:
     Quoted form works too.
 ```
 
+`chat-reply` can also omit a handle to render as the post author:
+
+```markdown
+!!! chat-reply
+
+    Thanks for the update!
+```
+
 This renders with avatar images and linked names in the admonition title, creating a conversation-style display.
 
 Collapsible chat admonitions work too:
@@ -290,6 +301,10 @@ Chat admonitions include CSS classes for styling:
   height: 1.5em;
   border-radius: 50%;
   vertical-align: middle;
+}
+
+.chat-contact-name {
+  font-weight: 600;
 }
 ```
 

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -1251,10 +1251,14 @@ func (m *tomlMentionsConfig) toMentionsConfig() models.MentionsConfig {
 
 	// Convert from_posts sources
 	for _, src := range m.FromPosts {
+		aliasesField := src.AliasesField
+		if aliasesField == "" {
+			aliasesField = defaultAliasesField
+		}
 		config.FromPosts = append(config.FromPosts, models.MentionPostSource{
 			Filter:       src.Filter,
 			HandleField:  src.HandleField,
-			AliasesField: src.AliasesField,
+			AliasesField: aliasesField,
 			AvatarField:  src.AvatarField,
 		})
 	}
@@ -1266,6 +1270,8 @@ func (m *tomlMentionsConfig) toMentionsConfig() models.MentionsConfig {
 
 	return config
 }
+
+const defaultAliasesField = "aliases"
 
 func (b *tomlBlogrollConfig) toBlogrollConfig() models.BlogrollConfig {
 	// Get default values
@@ -1943,10 +1949,14 @@ func (m *yamlMentionsConfig) toMentionsConfig() models.MentionsConfig {
 
 	// Convert from_posts sources
 	for _, src := range m.FromPosts {
+		aliasesField := src.AliasesField
+		if aliasesField == "" {
+			aliasesField = defaultAliasesField
+		}
 		config.FromPosts = append(config.FromPosts, models.MentionPostSource{
 			Filter:       src.Filter,
 			HandleField:  src.HandleField,
-			AliasesField: src.AliasesField,
+			AliasesField: aliasesField,
 			AvatarField:  src.AvatarField,
 		})
 	}
@@ -3216,10 +3226,14 @@ func (m *jsonMentionsConfig) toMentionsConfig() models.MentionsConfig {
 
 	// Convert from_posts sources
 	for _, src := range m.FromPosts {
+		aliasesField := src.AliasesField
+		if aliasesField == "" {
+			aliasesField = defaultAliasesField
+		}
 		config.FromPosts = append(config.FromPosts, models.MentionPostSource{
 			Filter:       src.Filter,
 			HandleField:  src.HandleField,
-			AliasesField: src.AliasesField,
+			AliasesField: aliasesField,
 			AvatarField:  src.AvatarField,
 		})
 	}

--- a/pkg/models/mentions.go
+++ b/pkg/models/mentions.go
@@ -76,7 +76,7 @@ type MentionPostSource struct {
 	// Example: "handle" for frontmatter like `handle: alice`
 	HandleField string `json:"handle_field,omitempty" yaml:"handle_field,omitempty" toml:"handle_field,omitempty"`
 
-	// AliasesField is the frontmatter field containing handle aliases (optional)
+	// AliasesField is the frontmatter field containing handle aliases (defaults to "aliases")
 	// Example: "aliases" for frontmatter like `aliases: [alices, asmith]`
 	AliasesField string `json:"aliases_field,omitempty" yaml:"aliases_field,omitempty" toml:"aliases_field,omitempty"`
 
@@ -94,12 +94,14 @@ func NewMentionsConfig() MentionsConfig {
 		CSSClass: "mention",
 		FromPosts: []MentionPostSource{
 			{
-				Filter:      "template == 'contact'",
-				HandleField: "handle",
+				Filter:       "template == 'contact'",
+				HandleField:  "handle",
+				AliasesField: "aliases",
 			},
 			{
-				Filter:      "template == 'author'",
-				HandleField: "handle",
+				Filter:       "template == 'author'",
+				HandleField:  "handle",
+				AliasesField: "aliases",
 			},
 		},
 		CacheDir:           "cache/mentions",

--- a/pkg/plugins/admonitions.go
+++ b/pkg/plugins/admonitions.go
@@ -182,10 +182,10 @@ func (p *AdmonitionParser) Continue(_ ast.Node, reader text.Reader, _ parser.Con
 	line, _ := reader.PeekLine()
 
 	// Blank lines are allowed inside admonitions (paragraph separators).
-	// We let them through without advancing the reader; goldmark handles
-	// them as part of the block's child content.
+	// Consume the blank line and continue without allowing child block parsing.
 	if util.IsBlank(line) {
-		return parser.Continue | parser.HasChildren
+		reader.AdvanceToEOL()
+		return parser.Continue
 	}
 
 	// Non-blank line: check for proper indentation (at least 4 spaces).

--- a/pkg/plugins/admonitions_test.go
+++ b/pkg/plugins/admonitions_test.go
@@ -1001,6 +1001,13 @@ func TestAdmonitionRender_ContentLeakRegression(t *testing.T) {
 			wantOutside: []string{"Outside."},
 			closeTag:    "</div>",
 		},
+		{
+			name:        "blank line after header",
+			input:       "!!! note\n\n    Para 1.\n\n    Para 2.\n\nOutside.\n",
+			wantInside:  []string{"Para 1.", "Para 2."},
+			wantOutside: []string{"Outside."},
+			closeTag:    "</div>",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/plugins/frontmatter_test.go
+++ b/pkg/plugins/frontmatter_test.go
@@ -151,6 +151,33 @@ Content only`
 	}
 }
 
+func TestParseFrontmatter_NormalizeAliases(t *testing.T) {
+	content := `---
+aliases:
+  - alpha
+alias: beta
+handles:
+  - gamma
+handle: delta
+---
+Content`
+
+	metadata, body, err := ParseFrontmatter(content)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if body != "Content" {
+		t.Errorf("body: got %q, want 'Content'", body)
+	}
+
+	aliases := GetStringSlice(metadata, "aliases")
+	expected := []string{"alpha", "beta", "gamma", "delta"}
+	if !reflect.DeepEqual(aliases, expected) {
+		t.Errorf("aliases: got %v, want %v", aliases, expected)
+	}
+}
+
 func TestParseFrontmatter_BooleanValues(t *testing.T) {
 	// Test case: "frontmatter boolean values"
 	content := `---

--- a/pkg/themes/default/static/css/admonitions.css
+++ b/pkg/themes/default/static/css/admonitions.css
@@ -381,6 +381,10 @@ details.admonition[open] > summary::before {
   font-weight: 600;
 }
 
+.chat-contact-name {
+  font-weight: 600;
+}
+
 .chat-contact .mention:hover {
   text-decoration: underline;
 }

--- a/pkg/themes/default/templates/components/post_byline.html
+++ b/pkg/themes/default/templates/components/post_byline.html
@@ -9,7 +9,7 @@
     {% for author_obj in post.author_objects %}
         <div class="post-byline__author p-author h-card"{% if author_obj.details %} data-details="{{ author_obj.details }}" title="{{ author_obj.details }}"{% endif %}>
             {% if author_obj.avatar %}
-            <img class="u-photo post-byline__photo" src="{% if author_obj.avatar | startswith:'http' %}{{ author_obj.avatar }}{% else %}{{ config.url }}{{ author_obj.avatar }}{% endif %}" alt="{{ author_obj.name }} avatar" width="36" height="36" loading="lazy">
+            <img class="u-photo post-byline__photo" src="{{ author_obj.avatar }}" alt="{{ author_obj.name }} avatar" width="36" height="36" loading="lazy">
             {% elif config.seo.author_image %}
             <img class="u-photo post-byline__photo" src="{% if config.seo.author_image | startswith:'http' %}{{ config.seo.author_image }}{% else %}{{ config.url }}{{ config.seo.author_image }}{% endif %}" alt="{{ author_obj.name }} avatar" width="36" height="36" loading="lazy">
             {% endif %}

--- a/spec/spec/CONTENT.md
+++ b/spec/spec/CONTENT.md
@@ -46,6 +46,16 @@ Content starts here...
 3. Parse content between as YAML
 4. Everything after closing `---` is content
 
+### Frontmatter Aliases
+
+The frontmatter loader normalizes alias fields for compatibility:
+
+| Canonical | Accepted Aliases |
+|-----------|------------------|
+| `aliases` | `alias`, `handle`, `handles` |
+
+All values are merged into the canonical `aliases` key as a list of strings. Existing keys are preserved.
+
 ### YAML Features Supported
 
 | Feature | Example | Support |
@@ -485,6 +495,11 @@ With syntax highlighting (optional):
 !!! note "Optional Title"
     Admonition content here.
     Can span multiple lines.
+
+!!! note
+
+    A blank line after the admonition header is allowed.
+    Content must still be indented.
 
 !!! warning
     Warning without custom title uses type as title.

--- a/spec/spec/MENTIONS.md
+++ b/spec/spec/MENTIONS.md
@@ -61,6 +61,7 @@ When no `from_posts` sources are configured (or when a `[markata-go.mentions]` s
 [[markata-go.mentions.from_posts]]
 filter = "template == 'contact'"
 handle_field = "handle"
+aliases_field = "aliases"
 ```
 
 This means any post with `template: contact` in its frontmatter is automatically available as a mentionable contact. To disable this default, set `from_posts` to an explicit source with a different filter.
@@ -332,7 +333,7 @@ filter = "'project' in tags"
 enabled = true
 ```
 
-This uses the default `from_posts` source (`template == 'contact'` filter with `handle` field), so any post with `template: contact` frontmatter is automatically mentionable.
+This uses the default `from_posts` source (`template == 'contact'` filter with `handle` and `aliases` fields), so any post with `template: contact` frontmatter is automatically mentionable.
 
 ## Chat Admonition Integration
 
@@ -351,6 +352,13 @@ Both quoted and unquoted forms are supported:
 
 !!! chat "@alice"
     Quoted form also works.
+```
+
+`chat-reply` can also omit a handle to render as the post author:
+
+```markdown
+!!! chat-reply
+    Thanks for the update!
 ```
 
 When an unquoted `@handle` is used and resolves, the plugin wraps the enriched title in quotes so the admonition parser treats it correctly. When the handle does not resolve, the line is left unchanged.

--- a/templates/components/post_byline.html
+++ b/templates/components/post_byline.html
@@ -9,7 +9,7 @@
     {% for author_obj in post.author_objects %}
         <div class="post-byline__author p-author h-card"{% if author_obj.details %} data-details="{{ author_obj.details }}" title="{{ author_obj.details }}"{% endif %}>
             {% if author_obj.avatar %}
-            <img class="u-photo post-byline__photo" src="{% if author_obj.avatar | startswith:'http' %}{{ author_obj.avatar }}{% else %}{{ config.url }}{{ author_obj.avatar }}{% endif %}" alt="{{ author_obj.name }} avatar" width="36" height="36" loading="lazy">
+            <img class="u-photo post-byline__photo" src="{{ author_obj.avatar }}" alt="{{ author_obj.name }} avatar" width="36" height="36" loading="lazy">
             {% elif config.seo.author_image %}
             <img class="u-photo post-byline__photo" src="{% if config.seo.author_image | startswith:'http' %}{{ config.seo.author_image }}{% else %}{{ config.url }}{{ config.seo.author_image }}{% endif %}" alt="{{ author_obj.name }} avatar" width="36" height="36" loading="lazy">
             {% endif %}


### PR DESCRIPTION
## Summary\n- normalize frontmatter alias/handle keys into aliases and default aliases_field for mention sources\n- render chat-reply titles from the post author and ensure enriched titles don't create code blocks\n- keep byline avatars relative instead of forcing config.url, and document updated behavior\n\n## Issues\n- Refs #846\n