### PR TITLE
fix: properly handle TikTok oEmbed responses

### DIFF
--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -2072,7 +2072,9 @@ func NewEmbedsConfig() EmbedsConfig {
 		FetchExternal:      true,
 		OEmbedEnabled:      true,
 		ResolutionStrategy: "oembed_first",
-		OEmbedProviders:    map[string]OEmbedProviderConfig{},
+		OEmbedProviders: map[string]OEmbedProviderConfig{
+			"tiktok": {Enabled: true, Mode: "card"},
+		},
 		OEmbedAutoDiscover: false,
 		DefaultEmbedMode:   "card",
 		OEmbedProvidersURL: "https://oembed.com/providers.json",

--- a/pkg/plugins/embeds.go
+++ b/pkg/plugins/embeds.go
@@ -666,6 +666,10 @@ type OGMetadata struct {
 	// Provider info for mode selection
 	ProviderName string `json:"provider_name"`
 	HTML         string `json:"html"` // oEmbed HTML for rich embeds
+
+	// Author info from oEmbed
+	AuthorName string `json:"author_name"`
+	AuthorURL  string `json:"author_url"`
 }
 
 // EmbedOptions holds parsing options for embed syntax.
@@ -844,6 +848,12 @@ func (p *EmbedsPlugin) resolveOEmbedMetadata(rawURL string) (*OGMetadata, bool) 
 		HTML:         response.HTML,
 		FetchedAt:    time.Now().Unix(),
 		Source:       "oembed",
+		AuthorName:   response.AuthorName,
+		AuthorURL:    response.AuthorURL,
+	}
+
+	if response.AuthorName != "" {
+		metadata.Description = response.AuthorName
 	}
 
 	if metadata.Image == "" {

--- a/pkg/plugins/oembed.go
+++ b/pkg/plugins/oembed.go
@@ -24,14 +24,15 @@ type OEmbedResponse struct {
 	Title           string `json:"title"`
 	URL             string `json:"url"`
 	AuthorName      string `json:"author_name"`
+	AuthorURL       string `json:"author_url"`
 	ProviderName    string `json:"provider_name"`
 	ProviderURL     string `json:"provider_url"`
 	ThumbnailURL    string `json:"thumbnail_url"`
 	ThumbnailWidth  int    `json:"thumbnail_width"`
 	ThumbnailHeight int    `json:"thumbnail_height"`
 	HTML            string `json:"html"`
-	Width           int    `json:"width"`
-	Height          int    `json:"height"`
+	Width           string `json:"width"`
+	Height          string `json:"height"`
 	CacheAge        int    `json:"cache_age"`
 }
 


### PR DESCRIPTION
## Summary

- Fix TikTok oEmbed JSON decode failure by changing `Width`/`Height` fields from `int` to `string` (TikTok returns `"100%"` as a string)
- Add `AuthorURL` field to `OEmbedResponse` struct to capture creator profile URL
- Add `AuthorName` and `AuthorURL` fields to `OGMetadata` for template access
- Set `Description` to `author_name` so TikTok creator name displays on embed cards
- Fix missing `embedModeCard` case in `effectiveEmbedMode` switch statement
- Add default TikTok provider config with `mode = "card"` to use card display instead of rich embed (which uses JavaScript)

## New: Giphy Fixes

- Fix Giphy embed to actually call the oEmbed API and use the returned title (was hardcoded to "GIPHY Image")
- Make embed syntax consistent: now `![[url|option]]` treats "option" as an option (not a title override) when it matches a known option name like `image_only`, `card`, `center`, etc.

## Changes

1. **oembed.go**: 
   - Change `Width` and `Height` from `int` to `string`; add `AuthorURL` field
   - Fix Giphy to call actual oEmbed API and use real title

2. **embeds.go**: 
   - Add author fields to `OGMetadata`, populate from oEmbed response
   - Fix card mode handling
   - Add `isKnownEmbedOption()` helper to detect option names
   - Update Obsidian-style embed to treat pipe values as options when they match known option names

3. **config.go**: Add default TikTok provider config with card mode

## Testing

**TikTok:** `https://www.tiktok.com/@saranne_wrap/video/7328909790351002923`
- Before: Fallback to OG showing "TikTok - Make Your Day"  
- After: Shows TikTok thumbnail, title, and creator name in card format

**Giphy:** `https://giphy.com/gifs/no-ji6zzUZwNIuLS`
- Before: Hardcoded "GIPHY Image"
- After: Shows actual title like "Confused Little Girl GIF - Find & Share on GIPHY"

**Syntax consistency:**
- `![[https://giphy.com/gifs/xxx|image_only]]` - now correctly applies image_only option
- `![[https://giphy.com/gifs/xxx]]` - uses oEmbed title