### PR TITLE
fix: use Giphy oEmbed title and normalize embed syntax

### DIFF
--- a/pkg/plugins/oembed.go
+++ b/pkg/plugins/oembed.go
@@ -875,46 +875,47 @@ func fetchGitHubGistEmbed(client *http.Client, rawURL string) (*OEmbedResponse, 
 	}, nil
 }
 
-// Pre-compiled regexes for Giphy URL parsing.
-var (
-	giphyGifsRe  = regexp.MustCompile(`giphy\.com/gifs/[\w-]+-(\w+)`)
-	giphyMediaRe = regexp.MustCompile(`media\.giphy\.com/media/(\w+)/`)
-)
+// fetchGiphyEmbed fetches GIPHY embed data using the oEmbed API.
+func fetchGiphyEmbed(client *http.Client, rawURL string) (*OEmbedResponse, error) {
+	endpoint := "https://giphy.com/services/oembed"
 
-// fetchGiphyEmbed fetches GIPHY embed data.
-// GIPHY's oEmbed endpoint returns 404, so we construct the image URL from the GIF URL.
-func fetchGiphyEmbed(_ *http.Client, rawURL string) (*OEmbedResponse, error) {
-	// Extract the GIF ID from the URL
-	// GIPHY URLs: https://giphy.com/gifs/cat-Y0Pmx0NpVomy66nCGU
-	// or media.giphy.com/media/Y0Pmx0NpVomy66nCGU/giphy.gif
-	var gifID string
-
-	// Try to match giphy.com/gifs/{id}
-	matches := giphyGifsRe.FindStringSubmatch(rawURL)
-	if len(matches) > 1 {
-		gifID = matches[1]
-	} else {
-		// Try media.giphy.com/media/{id}/giphy.gif
-		matches2 := giphyMediaRe.FindStringSubmatch(rawURL)
-		if len(matches2) > 1 {
-			gifID = matches2[1]
-		}
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("giphy: parse endpoint: %w", err)
 	}
 
-	if gifID == "" {
-		return nil, fmt.Errorf("giphy: could not extract GIF ID from URL")
+	query := parsed.Query()
+	query.Set("url", rawURL)
+	parsed.RawQuery = query.Encode()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, parsed.String(), http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("giphy: create request: %w", err)
 	}
 
-	// Build the image URL (use fixed width for consistency)
-	imageURL := fmt.Sprintf("https://media.giphy.com/media/%s/giphy.gif", gifID)
+	req.Header.Set("User-Agent", "markata-go/1.0 (+https://github.com/WaylonWalker/markata-go)")
+	req.Header.Set("Accept", "application/json")
 
-	return &OEmbedResponse{
-		Type:         "photo",
-		Version:      "1.0",
-		Title:        "GIPHY Image",
-		URL:          imageURL,
-		ThumbnailURL: imageURL,
-		ProviderName: "GIPHY",
-		ProviderURL:  "https://giphy.com",
-	}, nil
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("giphy: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("giphy: status %s", resp.Status)
+	}
+
+	var payload OEmbedResponse
+	decoder := json.NewDecoder(resp.Body)
+	if err := decoder.Decode(&payload); err != nil {
+		return nil, fmt.Errorf("giphy: decode: %w", err)
+	}
+
+	// Ensure we have a thumbnail URL for image embeds
+	if payload.ThumbnailURL == "" {
+		payload.ThumbnailURL = payload.URL
+	}
+
+	return &payload, nil
 }


### PR DESCRIPTION
## Summary

- Fetch actual Giphy oEmbed API to get real title instead of hardcoded "GIPHY Image"
- Add `isKnownEmbedOption()` to detect option names like `image_only`, `card`, `center`, etc.
- Treat pipe values as options (not title override) when they match known option names
- This makes all embed syntaxes produce consistent results

## Changes

1. **oembed.go**: Fix Giphy to call actual oEmbed API and use real title
2. **embeds.go**: Add `isKnownEmbedOption()` helper and update Obsidian-style embed parsing

## Testing

**Giphy:** `https://giphy.com/gifs/no-ji6zzUZwNIuLS`
- Before: Hardcoded "GIPHY Image"
- After: Shows actual title like "Confused Little Girl GIF - Find & Share on GIPHY"

**Syntax consistency:**
- `![[https://giphy.com/gifs/xxx|image_only]]` - now correctly applies image_only option
- `![[https://giphy.com/gifs/xxx]]` - uses oEmbed title