### PR TITLE
feat(aesthetics): dynamic tokens and live switcher

### DIFF
--- a/pkg/aesthetic/aesthetic.go
+++ b/pkg/aesthetic/aesthetic.go
@@ -12,6 +12,7 @@ type Tokens struct {
 	Border     map[string]string `json:"border,omitempty" yaml:"border,omitempty" toml:"border,omitempty"`
 	Shadow     map[string]string `json:"shadow,omitempty" yaml:"shadow,omitempty" toml:"shadow,omitempty"`
 	Typography map[string]string `json:"typography,omitempty" yaml:"typography,omitempty" toml:"typography,omitempty"`
+	Effects    map[string]string `json:"effects,omitempty" yaml:"effects,omitempty" toml:"effects,omitempty"`
 }
 
 // Aesthetic represents a complete design token set with metadata.
@@ -45,6 +46,7 @@ func NewAesthetic(name string) *Aesthetic {
 			Border:     make(map[string]string),
 			Shadow:     make(map[string]string),
 			Typography: make(map[string]string),
+			Effects:    make(map[string]string),
 		},
 	}
 }
@@ -73,6 +75,11 @@ func (a *Aesthetic) Get(tokenType, tokenKey string) string {
 			return ""
 		}
 		return a.Tokens.Typography[tokenKey]
+	case "effects":
+		if a.Tokens.Effects == nil {
+			return ""
+		}
+		return a.Tokens.Effects[tokenKey]
 	default:
 		return ""
 	}
@@ -111,6 +118,7 @@ func (a *Aesthetic) Clone() *Aesthetic {
 			Border:     make(map[string]string),
 			Shadow:     make(map[string]string),
 			Typography: make(map[string]string),
+			Effects:    make(map[string]string),
 		},
 	}
 
@@ -133,6 +141,9 @@ func (a *Aesthetic) Clone() *Aesthetic {
 	}
 	for k, v := range a.Tokens.Typography {
 		clone.Tokens.Typography[k] = v
+	}
+	for k, v := range a.Tokens.Effects {
+		clone.Tokens.Effects[k] = v
 	}
 
 	// Copy legacy flat maps if populated
@@ -208,6 +219,11 @@ func (a *Aesthetic) Merge(override *Aesthetic) *Aesthetic {
 	if override.Tokens.Typography != nil {
 		for k, v := range override.Tokens.Typography {
 			merged.Tokens.Typography[k] = v
+		}
+	}
+	if override.Tokens.Effects != nil {
+		for k, v := range override.Tokens.Effects {
+			merged.Tokens.Effects[k] = v
 		}
 	}
 

--- a/pkg/aesthetic/loader.go
+++ b/pkg/aesthetic/loader.go
@@ -144,6 +144,7 @@ type rawTokens struct {
 	Border     map[string]any `toml:"border"`
 	Shadow     map[string]any `toml:"shadow"`
 	Typography map[string]any `toml:"typography"`
+	Effects    map[string]any `toml:"effects"`
 }
 
 // rawAesthetic is an intermediate type for parsing TOML files.
@@ -172,6 +173,7 @@ func parseAesthetic(data []byte, path, source string) (*Aesthetic, error) {
 			Border:     convertToStringMap(raw.Tokens.Border),
 			Shadow:     convertToStringMap(raw.Tokens.Shadow),
 			Typography: convertToStringMap(raw.Tokens.Typography),
+			Effects:    convertToStringMap(raw.Tokens.Effects),
 		},
 	}
 
@@ -187,6 +189,9 @@ func parseAesthetic(data []byte, path, source string) (*Aesthetic, error) {
 	}
 	if a.Tokens.Typography == nil {
 		a.Tokens.Typography = make(map[string]string)
+	}
+	if a.Tokens.Effects == nil {
+		a.Tokens.Effects = make(map[string]string)
 	}
 
 	// Validate the loaded aesthetic

--- a/pkg/config/merge.go
+++ b/pkg/config/merge.go
@@ -133,6 +133,9 @@ func mergeThemeConfig(base, override models.ThemeConfig) models.ThemeConfig {
 	if override.Name != "" {
 		result.Name = override.Name
 	}
+	if override.Aesthetic != "" {
+		result.Aesthetic = override.Aesthetic
+	}
 	if override.Palette != "" {
 		result.Palette = override.Palette
 	}

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -395,6 +395,7 @@ type tomlFooterConfig struct {
 
 type tomlThemeConfig struct {
 	Name         string                  `toml:"name"`
+	Aesthetic    string                  `toml:"aesthetic"`
 	Palette      string                  `toml:"palette"`
 	PaletteLight string                  `toml:"palette_light"`
 	PaletteDark  string                  `toml:"palette_dark"`
@@ -1533,6 +1534,7 @@ func (t *tomlThemeConfig) toThemeConfig() models.ThemeConfig {
 	}
 	return models.ThemeConfig{
 		Name:         t.Name,
+		Aesthetic:    t.Aesthetic,
 		Palette:      t.Palette,
 		PaletteLight: t.PaletteLight,
 		PaletteDark:  t.PaletteDark,
@@ -2140,6 +2142,7 @@ func (g *yamlGardenConfig) toGardenConfig() models.GardenConfig {
 
 type yamlThemeConfig struct {
 	Name         string                  `yaml:"name"`
+	Aesthetic    string                  `yaml:"aesthetic"`
 	Palette      string                  `yaml:"palette"`
 	PaletteLight string                  `yaml:"palette_light"`
 	PaletteDark  string                  `yaml:"palette_dark"`
@@ -2194,6 +2197,7 @@ func (t *yamlThemeConfig) toThemeConfig() models.ThemeConfig {
 	}
 	return models.ThemeConfig{
 		Name:         t.Name,
+		Aesthetic:    t.Aesthetic,
 		Palette:      t.Palette,
 		PaletteLight: t.PaletteLight,
 		PaletteDark:  t.PaletteDark,
@@ -3419,6 +3423,7 @@ func (g *jsonGardenConfig) toGardenConfig() models.GardenConfig {
 
 type jsonThemeConfig struct {
 	Name         string                  `json:"name"`
+	Aesthetic    string                  `json:"aesthetic"`
 	Palette      string                  `json:"palette"`
 	PaletteLight string                  `json:"palette_light"`
 	PaletteDark  string                  `json:"palette_dark"`
@@ -3473,6 +3478,7 @@ func (t *jsonThemeConfig) toThemeConfig() models.ThemeConfig {
 	}
 	return models.ThemeConfig{
 		Name:         t.Name,
+		Aesthetic:    t.Aesthetic,
 		Palette:      t.Palette,
 		PaletteLight: t.PaletteLight,
 		PaletteDark:  t.PaletteDark,

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -771,6 +771,9 @@ type ThemeConfig struct {
 	// Name is the theme name (default: "default")
 	Name string `json:"name" yaml:"name" toml:"name"`
 
+	// Aesthetic configures the structural token set to use
+	Aesthetic string `json:"aesthetic,omitempty" yaml:"aesthetic,omitempty" toml:"aesthetic,omitempty"`
+
 	// Palette is the base color palette to use (default: "default-light")
 	// When set to a base name like "everforest", the system will auto-detect
 	// light/dark variants (e.g., "everforest-light" and "everforest-dark")

--- a/pkg/plugins/aesthetic_css.go
+++ b/pkg/plugins/aesthetic_css.go
@@ -1,0 +1,317 @@
+package plugins
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/WaylonWalker/markata-go/pkg/aesthetic"
+	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
+	"github.com/WaylonWalker/markata-go/pkg/models"
+	"github.com/WaylonWalker/markata-go/pkg/templates"
+)
+
+// AestheticCSSPlugin generates CSS variables from the configured aesthetic.
+// It runs during the Write stage and creates/overwrites css/aesthetic.css
+// with the aesthetic's CSS custom properties.
+type AestheticCSSPlugin struct{}
+
+// NewAestheticCSSPlugin creates a new AestheticCSSPlugin.
+func NewAestheticCSSPlugin() *AestheticCSSPlugin {
+	return &AestheticCSSPlugin{}
+}
+
+// Name returns the unique name of the plugin.
+func (p *AestheticCSSPlugin) Name() string {
+	return "aesthetic_css"
+}
+
+// Configure generates CSS from the configured aesthetic and registers its hash
+func (p *AestheticCSSPlugin) Configure(m *lifecycle.Manager) error {
+	config := m.Config()
+
+	aestheticName := p.getAestheticConfig(config.Extra)
+	if aestheticName == "" {
+		return nil
+	}
+
+	loader := aesthetic.NewLoader()
+	switcherEnabled := p.isSwitcherEnabled(config.Extra)
+
+	var css string
+	if switcherEnabled {
+		css = p.generateMultiAestheticCSS(loader, config.Extra, aestheticName)
+	} else {
+		css = p.generateSingleAestheticCSS(loader, aestheticName)
+	}
+
+	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(css)))[:8]
+
+	m.SetAssetHash("css/aesthetic.css", hash)
+	templates.SetAssetHashes(map[string]string{"css/aesthetic.css": hash})
+
+	log.Printf("[aesthetic_css] Registered hash %s for aesthetic.css", hash)
+
+	return nil
+}
+
+// Write generates CSS from the configured aesthetic and writes it to the output directory.
+func (p *AestheticCSSPlugin) Write(m *lifecycle.Manager) error {
+	config := m.Config()
+	outputDir := config.OutputDir
+	if config.Extra != nil {
+		if fast, ok := config.Extra["fast_mode"].(bool); ok && fast {
+			return nil
+		}
+	}
+
+	aestheticName := p.getAestheticConfig(config.Extra)
+	if aestheticName == "" {
+		return nil
+	}
+
+	log.Printf("[aesthetic_css] Generating CSS for aesthetic: %s", aestheticName)
+
+	switcherEnabled := p.isSwitcherEnabled(config.Extra)
+	loader := aesthetic.NewLoader()
+
+	var css string
+	if switcherEnabled {
+		css = p.generateMultiAestheticCSS(loader, config.Extra, aestheticName)
+	} else {
+		css = p.generateSingleAestheticCSS(loader, aestheticName)
+	}
+
+	cssDir := filepath.Join(outputDir, "css")
+	cssPath := filepath.Join(cssDir, "aesthetic.css")
+	if existing, err := os.ReadFile(cssPath); err == nil {
+		if bytes.Equal(existing, []byte(css)) {
+			return nil
+		}
+	}
+
+	if err := os.MkdirAll(cssDir, 0o755); err != nil {
+		return fmt.Errorf("creating css directory: %w", err)
+	}
+	if err := os.WriteFile(cssPath, []byte(css), 0o600); err != nil {
+		return fmt.Errorf("writing aesthetic CSS: %w", err)
+	}
+
+	if hash := m.GetAssetHash("css/aesthetic.css"); hash != "" {
+		base := strings.TrimSuffix(filepath.Base(cssPath), filepath.Ext(cssPath))
+		hashedPath := filepath.Join(cssDir, fmt.Sprintf("%s.%s.css", base, hash))
+		if err := os.WriteFile(hashedPath, []byte(css), 0o600); err != nil {
+			return fmt.Errorf("writing hashed aesthetic CSS: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (p *AestheticCSSPlugin) isSwitcherEnabled(extra map[string]interface{}) bool {
+	if extra == nil {
+		return false
+	}
+	if themeConfig, ok := extra["theme"].(models.ThemeConfig); ok {
+		return themeConfig.Switcher.IsEnabled()
+	}
+	if theme, ok := extra["theme"].(map[string]interface{}); ok {
+		if switcher, ok := theme["switcher"].(map[string]interface{}); ok {
+			if enabled, ok := switcher["enabled"].(bool); ok {
+				return enabled
+			}
+		}
+	}
+	return false
+}
+
+func (p *AestheticCSSPlugin) getSwitcherConfig(extra map[string]interface{}) models.ThemeSwitcherConfig {
+	if extra == nil {
+		return models.NewThemeSwitcherConfig()
+	}
+	if themeConfig, ok := extra["theme"].(models.ThemeConfig); ok {
+		return themeConfig.Switcher
+	}
+	return models.NewThemeSwitcherConfig()
+}
+
+func (p *AestheticCSSPlugin) generateSingleAestheticCSS(loader *aesthetic.Loader, aestheticName string) string {
+	a, err := loader.Load(aestheticName)
+	if err != nil {
+		return ""
+	}
+
+	var buf bytes.Buffer
+	buf.WriteString("@layer reset, tokens, base, components, utilities, overrides;\n\n")
+	buf.WriteString("@layer tokens {\n")
+	buf.WriteString(fmt.Sprintf("/* Aesthetic: %s */\n", a.Name))
+
+	// Just use the root level CSS block directly, but strip out the :root { ... } to format it ourselves
+	// or we can just append a.GenerateCSS() directly. Wait, a.GenerateCSS() returns :root { ... }
+	cssContent := a.GenerateCSS()
+	buf.WriteString(cssContent)
+
+	buf.WriteString("}\n")
+	return buf.String()
+}
+
+type AestheticManifestEntry struct {
+	Name        string `json:"name"`
+	DisplayName string `json:"displayName"`
+}
+
+func (p *AestheticCSSPlugin) generateMultiAestheticCSS(loader *aesthetic.Loader, extra map[string]interface{}, defaultAestheticName string) string {
+	var buf bytes.Buffer
+
+	buf.WriteString("@layer reset, tokens, base, components, utilities, overrides;\n\n")
+	buf.WriteString("@layer tokens {\n")
+
+	allAesthetics, err := loader.Discover()
+	if err != nil {
+		return p.generateSingleAestheticCSS(loader, defaultAestheticName)
+	}
+
+	// Filter based on switcher
+	// ... we will filter just by name for now, using the palette include/exclude logic
+	switcherConfig := p.getSwitcherConfig(extra)
+	filteredAesthetics := p.filterAesthetics(allAesthetics, switcherConfig)
+
+	manifest := make([]AestheticManifestEntry, 0, len(filteredAesthetics))
+	for _, info := range filteredAesthetics {
+		manifest = append(manifest, AestheticManifestEntry{
+			Name:        info.Name,
+			DisplayName: info.Name,
+		})
+	}
+
+	sort.Slice(manifest, func(i, j int) bool {
+		return manifest[i].Name < manifest[j].Name
+	})
+
+	manifestJSON, err := json.Marshal(manifest)
+	if err != nil {
+		manifestJSON = []byte("[]")
+	}
+	escapedManifest := strings.ReplaceAll(string(manifestJSON), "'", "\\'")
+
+	buf.WriteString("/* Global aesthetic configuration */\n")
+	buf.WriteString(":root {\n")
+	buf.WriteString(fmt.Sprintf("  --aesthetic-default: %q;\n", defaultAestheticName))
+	buf.WriteString(fmt.Sprintf("  --aesthetic-manifest: '%s';\n", escapedManifest))
+	buf.WriteString("}\n\n")
+
+	for _, info := range filteredAesthetics {
+		a, err := loader.Load(info.Name)
+		if err != nil {
+			continue
+		}
+
+		buf.WriteString(fmt.Sprintf("/* Aesthetic: %s */\n", info.Name))
+		buf.WriteString(fmt.Sprintf("[data-aesthetic=%q] {\n", info.Name))
+
+		// Extract variables directly to inject in [data-aesthetic] scope
+		p.writeAestheticVariablesIndented(&buf, a, "  ")
+
+		buf.WriteString("}\n\n")
+	}
+
+	if defaultAestheticName != "" {
+		a, err := loader.Load(defaultAestheticName)
+		if err == nil {
+			buf.WriteString(fmt.Sprintf("/* Default aesthetic - %s */\n", defaultAestheticName))
+			buf.WriteString(":root:not([data-aesthetic]) {\n")
+			p.writeAestheticVariablesIndented(&buf, a, "  ")
+			buf.WriteString("}\n\n")
+		}
+	}
+
+	buf.WriteString("}\n")
+	return buf.String()
+}
+
+func (p *AestheticCSSPlugin) writeAestheticVariablesIndented(buf *bytes.Buffer, a *aesthetic.Aesthetic, indent string) {
+	cssLines := strings.Split(a.GenerateCSS(), "\n")
+	for _, line := range cssLines {
+		if strings.HasPrefix(line, "--") {
+			buf.WriteString(indent + line + "\n")
+		} else if strings.HasPrefix(strings.TrimSpace(line), "--") {
+			buf.WriteString(indent + strings.TrimSpace(line) + "\n")
+		}
+	}
+}
+
+func (p *AestheticCSSPlugin) filterAesthetics(all []aesthetic.Info, switcherConfig models.ThemeSwitcherConfig) []aesthetic.Info {
+	if switcherConfig.IsIncludeAll() {
+		excludeSet := make(map[string]bool)
+		for _, name := range switcherConfig.Exclude {
+			excludeSet[strings.ToLower(name)] = true
+		}
+
+		var result []aesthetic.Info
+		for _, info := range all {
+			lowerName := strings.ToLower(info.Name)
+			if !excludeSet[lowerName] {
+				result = append(result, info)
+			}
+		}
+		return result
+	}
+
+	includeSet := make(map[string]bool)
+	for _, name := range switcherConfig.Include {
+		includeSet[strings.ToLower(name)] = true
+	}
+
+	var result []aesthetic.Info
+	for _, info := range all {
+		lowerName := strings.ToLower(info.Name)
+		if includeSet[lowerName] {
+			result = append(result, info)
+		}
+	}
+	return result
+}
+
+func (p *AestheticCSSPlugin) getAestheticConfig(extra map[string]interface{}) string {
+	if extra == nil {
+		return ""
+	}
+
+	if modelsConfig, ok := extra["models_config"].(*models.Config); ok {
+		if modelsConfig.Theme.Aesthetic != "" {
+			return modelsConfig.Theme.Aesthetic
+		}
+	}
+
+	if themeConfig, ok := extra["theme"].(models.ThemeConfig); ok {
+		return themeConfig.Aesthetic
+	}
+
+	theme, ok := extra["theme"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+
+	if asth, ok := theme["aesthetic"].(string); ok && asth != "" {
+		return asth
+	}
+
+	return ""
+}
+
+func (p *AestheticCSSPlugin) Priority(_ lifecycle.Stage) int {
+	return lifecycle.PriorityDefault
+}
+
+var (
+	_ lifecycle.Plugin          = (*AestheticCSSPlugin)(nil)
+	_ lifecycle.ConfigurePlugin = (*AestheticCSSPlugin)(nil)
+	_ lifecycle.WritePlugin     = (*AestheticCSSPlugin)(nil)
+	_ lifecycle.PriorityPlugin  = (*AestheticCSSPlugin)(nil)
+)

--- a/pkg/plugins/aesthetic_css_test.go
+++ b/pkg/plugins/aesthetic_css_test.go
@@ -1,0 +1,37 @@
+package plugins
+
+import (
+	"testing"
+
+	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
+	"github.com/WaylonWalker/markata-go/pkg/models"
+)
+
+func TestAestheticCSSPlugin_Configure(t *testing.T) {
+	plugin := NewAestheticCSSPlugin()
+	m := lifecycle.NewManager()
+
+	// Create config
+	cfg := lifecycle.NewConfig()
+
+	// Setup extra
+	b := true
+	themeCfg := models.NewThemeConfig()
+	themeCfg.Aesthetic = "brutal"
+	themeCfg.Switcher.Enabled = &b
+
+	cfg.Extra = map[string]interface{}{
+		"theme": themeCfg,
+	}
+	m.SetConfig(cfg)
+
+	err := plugin.Configure(m)
+	if err != nil {
+		t.Fatalf("Configure failed: %v", err)
+	}
+
+	hash := m.GetAssetHash("css/aesthetic.css")
+	if hash == "" {
+		t.Error("Expected hash to be set for css/aesthetic.css")
+	}
+}

--- a/pkg/plugins/registry.go
+++ b/pkg/plugins/registry.go
@@ -52,6 +52,7 @@ func registerBuiltinPluginsLocked() {
 	pluginRegistry.constructors["reading_time"] = func() lifecycle.Plugin { return NewReadingTimePlugin() }
 	pluginRegistry.constructors["static_assets"] = func() lifecycle.Plugin { return NewStaticAssetsPlugin() }
 	pluginRegistry.constructors["palette_css"] = func() lifecycle.Plugin { return NewPaletteCSSPlugin() }
+	pluginRegistry.constructors["aesthetic_css"] = func() lifecycle.Plugin { return NewAestheticCSSPlugin() }
 	pluginRegistry.constructors["prevnext"] = func() lifecycle.Plugin { return NewPrevNextPlugin() }
 	pluginRegistry.constructors["heading_anchors"] = func() lifecycle.Plugin { return NewHeadingAnchorsPlugin() }
 	pluginRegistry.constructors["redirects"] = func() lifecycle.Plugin { return NewRedirectsPlugin() }
@@ -207,6 +208,7 @@ func DefaultPlugins() []lifecycle.Plugin {
 		// Write stage plugins
 		NewStaticAssetsPlugin(), // Copy static assets first
 		NewPaletteCSSPlugin(),   // Generate palette CSS (overwrites variables.css)
+		NewAestheticCSSPlugin(), // Generate aesthetic CSS
 		NewChromaCSSPlugin(),    // Generate syntax highlighting CSS
 		NewCSSBundlePlugin(),    // Bundle CSS files (runs after CSS generators)
 		NewPublishFeedsPlugin(),

--- a/pkg/themes/default/templates/partials/palette-switcher.html
+++ b/pkg/themes/default/templates/partials/palette-switcher.html
@@ -28,11 +28,7 @@
   {# Aesthetic Selector #}
   <div class="aesthetic-wrapper">
     <select id="aesthetic-select" class="aesthetic-select" aria-label="Select aesthetic">
-      <option value="brutal">Brutal</option>
-      <option value="precision">Precision</option>
-      <option value="balanced" selected>Balanced</option>
-      <option value="elevated">Elevated</option>
-      <option value="minimal">Minimal</option>
+      {# Options are populated dynamically by palette-switcher.js from --aesthetic-manifest #}
     </select>
   </div>
 </div>
@@ -100,64 +96,46 @@
   'use strict';
 
   const AESTHETIC_KEY = 'selected-aesthetic';
-  const DEFAULT_AESTHETIC = 'balanced';
 
-  // Aesthetic definitions with their CSS custom property values
-  // Uses --radius and --radius-lg to match the actual CSS variable names
-  const AESTHETICS = {
-    brutal: {
-      '--radius': '0',
-      '--radius-lg': '0',
-      '--article-shadow': '4px 4px 0 var(--color-border)',
-      '--font-body': 'var(--font-mono, ui-monospace, monospace)',
-      '--leading-normal': '1.5',
-      '--leading-relaxed': '1.6'
-    },
-    precision: {
-      '--radius': '2px',
-      '--radius-lg': '4px',
-      '--article-shadow': '0 2px 4px rgba(0,0,0,0.06)',
-      '--font-body': 'system-ui, -apple-system, sans-serif',
-      '--leading-normal': '1.5',
-      '--leading-relaxed': '1.625'
-    },
-    balanced: {
-      '--radius': '0.375rem',
-      '--radius-lg': '0.5rem',
-      '--article-shadow': '0 4px 12px rgba(0,0,0,0.1)',
-      '--font-body': 'system-ui, -apple-system, sans-serif',
-      '--leading-normal': '1.5',
-      '--leading-relaxed': '1.625'
-    },
-    elevated: {
-      '--radius': '0.75rem',
-      '--radius-lg': '1rem',
-      '--article-shadow': '0 8px 24px rgba(0,0,0,0.1), 0 2px 8px rgba(0,0,0,0.06)',
-      '--font-body': 'system-ui, -apple-system, sans-serif',
-      '--leading-normal': '1.6',
-      '--leading-relaxed': '1.75'
-    },
-    minimal: {
-      '--radius': '2px',
-      '--radius-lg': '4px',
-      '--article-shadow': 'none',
-      '--font-body': 'system-ui, -apple-system, sans-serif',
-      '--leading-normal': '1.5',
-      '--leading-relaxed': '1.625'
+  // Extract the manifest dynamically from CSS properties.
+  function getAestheticManifest() {
+    const styles = getComputedStyle(document.documentElement);
+    let manifest = styles.getPropertyValue('--aesthetic-manifest').trim();
+
+    if (!manifest || manifest === 'none' || manifest === '') {
+      return [];
     }
-  };
+
+    try {
+      if (manifest.startsWith("'") && manifest.endsWith("'")) {
+        manifest = manifest.slice(1, -1);
+      }
+      if (manifest.startsWith('"') && manifest.endsWith('"')) {
+        manifest = manifest.slice(1, -1);
+      }
+      manifest = manifest.replace(/\\'/g, "'");
+
+      return JSON.parse(manifest);
+    } catch (e) {
+      console.warn('[palette-switcher] Failed to parse aesthetic manifest:', e);
+      return [];
+    }
+  }
+
+  function getDefaultAesthetic() {
+    const styles = getComputedStyle(document.documentElement);
+    let def = styles.getPropertyValue('--aesthetic-default').trim();
+    if (def.startsWith("'") || def.startsWith('"')) {
+      def = def.slice(1, -1);
+    }
+    return def || 'balanced';
+  }
 
   function applyAesthetic(name) {
     const root = document.documentElement;
-    const aesthetic = AESTHETICS[name] || AESTHETICS[DEFAULT_AESTHETIC];
 
-    // Set data attribute for potential CSS targeting
+    // Set data attribute for CSS targeting (auto-handled by generated aesthetic.css)
     root.dataset.aesthetic = name;
-
-    // Apply all CSS custom properties
-    for (const [prop, value] of Object.entries(aesthetic)) {
-      root.style.setProperty(prop, value);
-    }
 
     // Persist selection
     localStorage.setItem(AESTHETIC_KEY, name);
@@ -172,8 +150,28 @@
     const select = document.getElementById('aesthetic-select');
     if (!select) return;
 
+    const manifest = getAestheticManifest();
+    const defaultAesthetic = getDefaultAesthetic();
+
+    // Populate the dropdown
+    if (manifest && manifest.length > 0) {
+      select.innerHTML = ''; // clear initial content
+      manifest.forEach(item => {
+        const option = document.createElement('option');
+        option.value = item.name;
+        // Capitalize display name
+        option.textContent = item.displayName ? item.displayName.charAt(0).toUpperCase() + item.displayName.slice(1) : item.name;
+        select.appendChild(option);
+      });
+    }
+
     // Load saved aesthetic
-    const saved = localStorage.getItem(AESTHETIC_KEY) || DEFAULT_AESTHETIC;
+    let saved = localStorage.getItem(AESTHETIC_KEY);
+    // fallback to default if saved not in manifest
+    if (!saved || (manifest.length > 0 && !manifest.find(m => m.name === saved))) {
+      saved = defaultAesthetic;
+    }
+
     select.value = saved;
     applyAesthetic(saved);
 
@@ -198,15 +196,17 @@
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', initAesthetic);
   } else {
+    // try immediately, but if styles haven't loaded, try again soon.
     initAesthetic();
+    setTimeout(initAesthetic, 100);
   }
 
   // Expose API
   window.markata = window.markata || {};
   window.markata.aesthetic = {
     apply: applyAesthetic,
-    get: () => localStorage.getItem(AESTHETIC_KEY) || DEFAULT_AESTHETIC,
-    list: () => Object.keys(AESTHETICS)
+    get: () => localStorage.getItem(AESTHETIC_KEY) || getDefaultAesthetic(),
+    list: () => getAestheticManifest().map(m => m.name)
   };
 })();
 </script>

--- a/templates/partials/palette-switcher.html
+++ b/templates/partials/palette-switcher.html
@@ -28,11 +28,7 @@
   {# Aesthetic Selector #}
   <div class="aesthetic-wrapper">
     <select id="aesthetic-select" class="aesthetic-select" aria-label="Select aesthetic">
-      <option value="brutal">Brutal</option>
-      <option value="precision">Precision</option>
-      <option value="balanced" selected>Balanced</option>
-      <option value="elevated">Elevated</option>
-      <option value="minimal">Minimal</option>
+      {# Options are populated dynamically by palette-switcher.js from --aesthetic-manifest #}
     </select>
   </div>
 </div>
@@ -100,103 +96,46 @@
   'use strict';
 
   const AESTHETIC_KEY = 'selected-aesthetic';
-  const DEFAULT_AESTHETIC = 'balanced';
 
-  // Aesthetic definitions with their CSS custom property values
-  const AESTHETICS = {
-    brutal: {
-      '--radius-sm': '0',
-      '--radius-md': '0',
-      '--radius-lg': '0',
-      '--radius-xl': '0',
-      '--spacing-scale': '1.25',
-      '--border-width-thin': '1px',
-      '--border-width-normal': '2px',
-      '--border-width-thick': '4px',
-      '--shadow-sm': 'none',
-      '--shadow-md': '4px 4px 0 var(--color-border)',
-      '--shadow-lg': '6px 6px 0 var(--color-border)',
-      '--shadow-xl': '8px 8px 0 var(--color-border)',
-      '--font-primary': 'var(--font-mono, monospace)',
-      '--leading-scale': '1.5'
-    },
-    precision: {
-      '--radius-sm': '2px',
-      '--radius-md': '4px',
-      '--radius-lg': '6px',
-      '--radius-xl': '8px',
-      '--spacing-scale': '1',
-      '--border-width-thin': '1px',
-      '--border-width-normal': '1px',
-      '--border-width-thick': '2px',
-      '--shadow-sm': '0 1px 2px rgba(0,0,0,0.04)',
-      '--shadow-md': '0 2px 4px rgba(0,0,0,0.06)',
-      '--shadow-lg': '0 4px 8px rgba(0,0,0,0.08)',
-      '--shadow-xl': '0 8px 16px rgba(0,0,0,0.1)',
-      '--font-primary': 'var(--font-body, system-ui)',
-      '--leading-scale': '1.5'
-    },
-    balanced: {
-      '--radius-sm': '4px',
-      '--radius-md': '8px',
-      '--radius-lg': '12px',
-      '--radius-xl': '16px',
-      '--spacing-scale': '1',
-      '--border-width-thin': '1px',
-      '--border-width-normal': '1px',
-      '--border-width-thick': '2px',
-      '--shadow-sm': '0 1px 3px rgba(0,0,0,0.08)',
-      '--shadow-md': '0 4px 12px rgba(0,0,0,0.1)',
-      '--shadow-lg': '0 8px 24px rgba(0,0,0,0.12)',
-      '--shadow-xl': '0 12px 40px rgba(0,0,0,0.15)',
-      '--font-primary': 'var(--font-body, system-ui)',
-      '--leading-scale': '1.6'
-    },
-    elevated: {
-      '--radius-sm': '8px',
-      '--radius-md': '12px',
-      '--radius-lg': '20px',
-      '--radius-xl': '28px',
-      '--spacing-scale': '1.15',
-      '--border-width-thin': '1px',
-      '--border-width-normal': '1px',
-      '--border-width-thick': '2px',
-      '--shadow-sm': '0 2px 8px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04)',
-      '--shadow-md': '0 8px 24px rgba(0,0,0,0.1), 0 2px 8px rgba(0,0,0,0.06)',
-      '--shadow-lg': '0 16px 48px rgba(0,0,0,0.12), 0 4px 12px rgba(0,0,0,0.08)',
-      '--shadow-xl': '0 24px 64px rgba(0,0,0,0.15), 0 8px 24px rgba(0,0,0,0.1)',
-      '--font-primary': 'var(--font-body, system-ui)',
-      '--leading-scale': '1.7'
-    },
-    minimal: {
-      '--radius-sm': '2px',
-      '--radius-md': '4px',
-      '--radius-lg': '6px',
-      '--radius-xl': '8px',
-      '--spacing-scale': '0.9',
-      '--border-width-thin': '1px',
-      '--border-width-normal': '1px',
-      '--border-width-thick': '1px',
-      '--shadow-sm': 'none',
-      '--shadow-md': 'none',
-      '--shadow-lg': '0 1px 3px rgba(0,0,0,0.05)',
-      '--shadow-xl': '0 2px 6px rgba(0,0,0,0.08)',
-      '--font-primary': 'var(--font-body, system-ui)',
-      '--leading-scale': '1.6'
+  // Extract the manifest dynamically from CSS properties.
+  function getAestheticManifest() {
+    const styles = getComputedStyle(document.documentElement);
+    let manifest = styles.getPropertyValue('--aesthetic-manifest').trim();
+
+    if (!manifest || manifest === 'none' || manifest === '') {
+      return [];
     }
-  };
+
+    try {
+      if (manifest.startsWith("'") && manifest.endsWith("'")) {
+        manifest = manifest.slice(1, -1);
+      }
+      if (manifest.startsWith('"') && manifest.endsWith('"')) {
+        manifest = manifest.slice(1, -1);
+      }
+      manifest = manifest.replace(/\\'/g, "'");
+
+      return JSON.parse(manifest);
+    } catch (e) {
+      console.warn('[palette-switcher] Failed to parse aesthetic manifest:', e);
+      return [];
+    }
+  }
+
+  function getDefaultAesthetic() {
+    const styles = getComputedStyle(document.documentElement);
+    let def = styles.getPropertyValue('--aesthetic-default').trim();
+    if (def.startsWith("'") || def.startsWith('"')) {
+      def = def.slice(1, -1);
+    }
+    return def || 'balanced';
+  }
 
   function applyAesthetic(name) {
     const root = document.documentElement;
-    const aesthetic = AESTHETICS[name] || AESTHETICS[DEFAULT_AESTHETIC];
 
-    // Set data attribute for potential CSS targeting
+    // Set data attribute for CSS targeting (auto-handled by generated aesthetic.css)
     root.dataset.aesthetic = name;
-
-    // Apply all CSS custom properties
-    for (const [prop, value] of Object.entries(aesthetic)) {
-      root.style.setProperty(prop, value);
-    }
 
     // Persist selection
     localStorage.setItem(AESTHETIC_KEY, name);
@@ -211,8 +150,28 @@
     const select = document.getElementById('aesthetic-select');
     if (!select) return;
 
+    const manifest = getAestheticManifest();
+    const defaultAesthetic = getDefaultAesthetic();
+
+    // Populate the dropdown
+    if (manifest && manifest.length > 0) {
+      select.innerHTML = ''; // clear initial content
+      manifest.forEach(item => {
+        const option = document.createElement('option');
+        option.value = item.name;
+        // Capitalize display name
+        option.textContent = item.displayName ? item.displayName.charAt(0).toUpperCase() + item.displayName.slice(1) : item.name;
+        select.appendChild(option);
+      });
+    }
+
     // Load saved aesthetic
-    const saved = localStorage.getItem(AESTHETIC_KEY) || DEFAULT_AESTHETIC;
+    let saved = localStorage.getItem(AESTHETIC_KEY);
+    // fallback to default if saved not in manifest
+    if (!saved || (manifest.length > 0 && !manifest.find(m => m.name === saved))) {
+      saved = defaultAesthetic;
+    }
+
     select.value = saved;
     applyAesthetic(saved);
 
@@ -237,15 +196,17 @@
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', initAesthetic);
   } else {
+    // try immediately, but if styles haven't loaded, try again soon.
     initAesthetic();
+    setTimeout(initAesthetic, 100);
   }
 
   // Expose API
   window.markata = window.markata || {};
   window.markata.aesthetic = {
     apply: applyAesthetic,
-    get: () => localStorage.getItem(AESTHETIC_KEY) || DEFAULT_AESTHETIC,
-    list: () => Object.keys(AESTHETICS)
+    get: () => localStorage.getItem(AESTHETIC_KEY) || getDefaultAesthetic(),
+    list: () => getAestheticManifest().map(m => m.name)
   };
 })();
 </script>


### PR DESCRIPTION
## Summary
- Introduces design tokens (typography, spacing, borders, shadows, effects) allowing configuration via JSON/YAML/TOML.
- Adds `aesthetic_css` plugin to dynamically generate and serve CSS variables.
- Updates frontend palette-switcher JS to apply live dynamic aesthetic styles.
- Integrated successfully into `main` keeping `SeedColor` and other recently added fields intact.
- Fixes #869