### PR TITLE
Fix css_purge for pseudo-only selectors

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -363,6 +363,22 @@ custom_css = "my-styles.css"
 
 See the [[themes-and-styling|Themes Guide]] for detailed customization options.
 
+### CSS Purge (`[markata-go.css_purge]`)
+
+```toml
+[markata-go.css_purge]
+enabled = false
+verbose = false
+preserve = ["js-*", "htmx-*", "theme-*", "palette-*"]
+preserve_attributes = ["data-theme", "data-palette"]
+skip_files = ["vendor/*", "normalize.css"]
+warning_threshold = 0
+```
+
+CSS purge removes unused rules by scanning generated HTML and keeping only selectors
+that are actually present. The purge logic always preserves key @-rules and keeps
+pseudo-only selectors like `:root` or `::selection` to avoid dropping base/theme styles.
+
 ### Aesthetic Settings (`[markata-go]`)
 
 Aesthetics control the non-color visual aspects of your site: border radius, spacing, shadows, and borders. While palettes control *what colors* you use, aesthetics control *how things are shaped*.

--- a/pkg/csspurge/matcher.go
+++ b/pkg/csspurge/matcher.go
@@ -164,6 +164,13 @@ func isSingleSelectorUsed(selector string, used *UsedSelectors, opts PurgeOption
 	ids := ExtractIDsFromSelector(selector)
 	elements := ExtractElementsFromSelector(selector)
 	attrs := ExtractAttributesFromSelector(selector)
+	hasPseudo := strings.Contains(selector, ":")
+
+	// Keep pseudo-only selectors (e.g., :root, ::selection) to avoid
+	// dropping base/theme rules that are not tied to specific elements.
+	if hasPseudo && len(classes) == 0 && len(ids) == 0 && len(attrs) == 0 && len(elements) == 0 {
+		return true
+	}
 
 	// For pure element selectors (no class/id), check if element is used
 	if len(classes) == 0 && len(ids) == 0 && len(attrs) == 0 && len(elements) > 0 {

--- a/pkg/csspurge/matcher_test.go
+++ b/pkg/csspurge/matcher_test.go
@@ -266,6 +266,9 @@ func TestIsSelectorUsed(t *testing.T) {
 		{"span", false},
 		{"div.foo", true},
 		{"div.unused", false},
+		{":root", true},
+		{"::selection", true},
+		{":where(*)", true},
 		{".foo, .unused", true},       // One of multiple matches
 		{".unused1, .unused2", false}, // None match
 	}

--- a/spec/spec/CONFIG.md
+++ b/spec/spec/CONFIG.md
@@ -693,6 +693,22 @@ output_dir = "assets/vendor"
 verify_integrity = true
 ```
 
+### CSS Purge (`[my-ssg.css_purge]`)
+
+```toml
+[my-ssg.css_purge]
+enabled = false
+verbose = false
+preserve = ["js-*", "htmx-*", "theme-*", "palette-*"]
+preserve_attributes = ["data-theme", "data-palette"]
+skip_files = ["vendor/*", "normalize.css"]
+warning_threshold = 0
+```
+
+CSS purge removes unused rules by scanning generated HTML and keeping only selectors
+that are actually present. The purge logic always preserves key @-rules and keeps
+pseudo-only selectors like `:root` or `::selection` to avoid dropping base/theme styles.
+
 ### Theme (`[my-ssg.theme]`)
 
 ```toml


### PR DESCRIPTION
## Summary
- keep pseudo-only selectors like :root and ::selection during css_purge
- add tests for pseudo-only selector handling
- document css_purge configuration and pseudo selector behavior

## Issue
- Refs #887
