### PR TITLE
feat(markdown): add Zensical-style icon shortcodes

### DIFF
--- a/pkg/themes/default/static/css/cards.css
+++ b/pkg/themes/default/static/css/cards.css
@@ -22,6 +22,56 @@
 }
 
 /* ==========================================================================
+   Feed Layouts: Grid & Masonry
+   ========================================================================== */
+
+/* Grid layout with subgrid support */
+.feed-layout-grid,
+.feed-layout-masonry {
+  max-width: var(--grid-max-width, 1400px) !important;
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.feed-layout-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 350px), 1fr));
+  gap: var(--space-6);
+  align-items: start;
+}
+
+/* Progressive Enhancement: Native Masonry */
+@supports (grid-template-rows: masonry) {
+  .feed-layout-masonry {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(min(100%, 350px), 1fr));
+    grid-template-rows: masonry;
+    gap: var(--space-6);
+    align-items: start;
+  }
+}
+
+/* CSS Subgrid for Card Alignment across rows */
+@supports (grid-template-rows: subgrid) {
+  /* Only apply subgrid in the grid layout (not masonry as it packs items) */
+  .feed-layout-grid .card {
+    grid-row: span 3;
+    display: grid;
+    grid-template-rows: subgrid;
+    gap: 0; /* Align perfectly across rows */
+  }
+
+  /* Card components participate in the subgrid */
+  .card .card-header { grid-row: 1; }
+  .card .card-body,
+  .card .card-content,
+  .card .card-excerpt { grid-row: 2; }
+  .card .card-meta,
+  .card footer { grid-row: 3; }
+}
+
+/* ==========================================================================
    Base Card Styles (shared by all card types)
    Extends the .card class from main.css
    ========================================================================== */

--- a/pkg/themes/default/static/css/variables.css
+++ b/pkg/themes/default/static/css/variables.css
@@ -62,6 +62,7 @@
   --content-width: 65ch;
   --content-max-width: var(--content-width);
   --page-width: 1200px;
+  --grid-max-width: 1400px;
   --radius: 0.375rem;
   --radius-lg: 0.5rem;
 

--- a/pkg/themes/default/templates/feed.html
+++ b/pkg/themes/default/templates/feed.html
@@ -34,7 +34,7 @@
   </div>
   {% endif %}
 
-  <div class="posts posts-list" id="posts-list">
+  <div class="posts posts-list feed-layout-grid feed-layout-masonry" id="posts-list">
     {% if page.pagination_type == "js" %}
     {# For JS pagination, render ALL posts - JavaScript will handle showing/hiding #}
     {% for post in feed.posts %}

--- a/pkg/themes/default/templates/partials/cards/article-card.html
+++ b/pkg/themes/default/templates/partials/cards/article-card.html
@@ -5,8 +5,10 @@
     <h2 class="card-title p-name"><a class="u-url" href="{{ post.href }}">{{ post.title | default:post.slug }}</a></h2>
   </header>
 
-  <div class="card-excerpt p-summary">
-    {{ post.article_html | excerpt | safe }}
+  <div class="card-body">
+    <div class="card-excerpt p-summary">
+      {{ post.article_html | excerpt | safe }}
+    </div>
   </div>
 
   <footer class="card-meta">

--- a/pkg/themes/default/templates/partials/cards/contact-card.html
+++ b/pkg/themes/default/templates/partials/cards/contact-card.html
@@ -2,40 +2,44 @@
 {# Shows avatar (from image/icon/avatar fields), name, description, handle #}
 <article class="card card-contact h-card h-entry">
   <a class="u-url" href="{{ post.href }}" hidden></a>
-  <div class="card-contact-layout">
-    {% with post.avatar|media_url:post.image as avatar_src %}
-    {% if avatar_src %}
-    <a href="{{ post.href }}" class="card-contact-avatar-link">
-      <div class="card-contact-avatar">
-        <img src="{{ avatar_src }}" alt="{{ post.title | default:post.slug }}" class="u-photo" loading="lazy">
+  <header class="card-header">
+    <div class="card-contact-layout">
+      {% with post.avatar|media_url:post.image as avatar_src %}
+      {% if avatar_src %}
+      <a href="{{ post.href }}" class="card-contact-avatar-link">
+        <div class="card-contact-avatar">
+          <img src="{{ avatar_src }}" alt="{{ post.title | default:post.slug }}" class="u-photo" loading="lazy">
+        </div>
+      </a>
+      {% else %}
+      <a href="{{ post.href }}" class="card-contact-avatar-link">
+        <div class="card-contact-avatar card-contact-initials">
+          {{ post.title | default:post.slug | first | upper }}
+        </div>
+      </a>
+      {% endif %}
+      {% endwith %}
+
+      <div class="card-contact-header-text">
+        <h3 class="card-title p-name">
+          <a href="{{ post.href }}">{{ post.title | default:post.slug }}</a>
+        </h3>
+
+        {% if post.handle %}
+        <span class="card-contact-handle p-nickname">@{{ post.handle }}</span>
+        {% endif %}
       </div>
-    </a>
-    {% else %}
-    <a href="{{ post.href }}" class="card-contact-avatar-link">
-      <div class="card-contact-avatar card-contact-initials">
-        {{ post.title | default:post.slug | first | upper }}
-      </div>
-    </a>
-    {% endif %}
-    {% endwith %}
-
-    <div class="card-contact-body">
-      <h3 class="card-title p-name">
-        <a href="{{ post.href }}">{{ post.title | default:post.slug }}</a>
-      </h3>
-
-      {% if post.handle %}
-      <span class="card-contact-handle p-nickname">@{{ post.handle }}</span>
-      {% endif %}
-
-      {% if post.description %}
-      <p class="card-contact-bio p-note">{{ post.description }}</p>
-      {% endif %}
-
-      {% if post.url %}
-      <a href="{{ post.url }}" class="card-contact-site u-url" rel="noopener" target="_blank">{{ post.url }}</a>
-      {% endif %}
     </div>
+  </header>
+
+  <div class="card-body">
+    {% if post.description %}
+    <p class="card-contact-bio p-note">{{ post.description }}</p>
+    {% endif %}
+
+    {% if post.url %}
+    <a href="{{ post.url }}" class="card-contact-site u-url" rel="noopener" target="_blank">{{ post.url }}</a>
+    {% endif %}
   </div>
 
   <footer class="card-meta">

--- a/pkg/themes/default/templates/partials/cards/default-card.html
+++ b/pkg/themes/default/templates/partials/cards/default-card.html
@@ -1,11 +1,15 @@
 {# Default Card - Fallback for unmapped templateKey values #}
 {# Basic card layout similar to original card.html #}
 <article class="card card-default h-entry">
-  <h2 class="card-title p-name"><a class="u-url" href="{{ post.href }}">{{ post.title | default:post.slug }}</a></h2>
+  <header class="card-header">
+    <h2 class="card-title p-name"><a class="u-url" href="{{ post.href }}">{{ post.title | default:post.slug }}</a></h2>
+  </header>
 
-  {% if post.description %}
-  <p class="card-description p-summary">{{ post.description }}</p>
-  {% endif %}
+  <div class="card-body">
+    {% if post.description %}
+    <p class="card-description p-summary">{{ post.description }}</p>
+    {% endif %}
+  </div>
 
   <footer class="card-meta">
     {% if post.date %}

--- a/pkg/themes/default/templates/partials/cards/guide-card.html
+++ b/pkg/themes/default/templates/partials/cards/guide-card.html
@@ -1,22 +1,23 @@
 {# Guide Card - Step/chapter indicator for guides, series, tutorials #}
 {# Shows step number (from forloop.counter), title, description #}
 <article class="card card-guide h-entry">
-  <div class="card-step-indicator">
-    <span class="step-number">{{ forloop.counter | default:"1" }}</span>
-  </div>
+  <header class="card-header">
+    <div class="card-step-indicator">
+      <span class="step-number">{{ forloop.counter | default:"1" }}</span>
+    </div>
+    <h3 class="card-title p-name"><a class="u-url" href="{{ post.href }}">{{ post.title | default:post.slug }}</a></h3>
+  </header>
 
   <div class="card-body">
-    <h3 class="card-title p-name"><a class="u-url" href="{{ post.href }}">{{ post.title | default:post.slug }}</a></h3>
-
     {% if post.description %}
     <p class="card-description p-summary">{{ post.description | truncatechars:200 }}</p>
     {% endif %}
-
-    <footer class="card-meta">
-      {% if post.date %}
-      <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
-      {% endif %}
-      {% if post.reading_time %}<span class="reading-time">{{ post.reading_time }} min</span>{% endif %}
-    </footer>
   </div>
+
+  <footer class="card-meta">
+    {% if post.date %}
+    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+    {% endif %}
+    {% if post.reading_time %}<span class="reading-time">{{ post.reading_time }} min</span>{% endif %}
+  </footer>
 </article>

--- a/pkg/themes/default/templates/partials/cards/inline-card.html
+++ b/pkg/themes/default/templates/partials/cards/inline-card.html
@@ -1,6 +1,7 @@
 {# Inline Card - Full rendered content for gratitude, micro posts #}
 {# Minimal wrapper, displays full article_html content #}
 <article class="card card-inline h-entry">
+  <header class="card-header"></header>
   <a class="u-url" href="{{ post.href }}" hidden></a>
   <div class="card-content e-content">
     {{ post.article_html | safe }}

--- a/pkg/themes/default/templates/partials/cards/link-card.html
+++ b/pkg/themes/default/templates/partials/cards/link-card.html
@@ -1,27 +1,31 @@
 {# Link Card - URL preview style for links, bookmarks, TIL posts #}
 {# Shows domain, title, description in preview card style #}
 <article class="card card-link h-entry">
-  <a href="{{ post.href }}" class="card-link-wrapper u-url">
-    {% if post.image %}
-    <div class="card-link-image">
-      <img src="{{ post.image }}" alt="" class="u-photo" width="120" height="80" loading="lazy">
-    </div>
+  <header class="card-header">
+    <a href="{{ post.href }}" class="card-link-wrapper u-url">
+      {% if post.image %}
+      <div class="card-link-image">
+        <img src="{{ post.image }}" alt="" class="u-photo" width="120" height="80" loading="lazy">
+      </div>
+      {% endif %}
+
+      <div class="card-link-content">
+        {% if post.url %}
+        <span class="card-domain">{{ post.url | default:post.href }}</span>
+        {# Mark external URL as bookmark-of for IndieWeb #}
+        <data class="u-bookmark-of" value="{{ post.url }}" hidden></data>
+        {% endif %}
+
+        <h3 class="card-title p-name">{{ post.title | default:post.slug }}</h3>
+      </div>
+    </a>
+  </header>
+
+  <div class="card-body">
+    {% if post.description %}
+    <p class="card-description p-summary">{{ post.description | truncatechars:120 }}</p>
     {% endif %}
-
-    <div class="card-link-content">
-      {% if post.url %}
-      <span class="card-domain">{{ post.url | default:post.href }}</span>
-      {# Mark external URL as bookmark-of for IndieWeb #}
-      <data class="u-bookmark-of" value="{{ post.url }}" hidden></data>
-      {% endif %}
-
-      <h3 class="card-title p-name">{{ post.title | default:post.slug }}</h3>
-
-      {% if post.description %}
-      <p class="card-description p-summary">{{ post.description | truncatechars:120 }}</p>
-      {% endif %}
-    </div>
-  </a>
+  </div>
 
   <footer class="card-meta">
     {% if post.date %}

--- a/pkg/themes/default/templates/partials/cards/note-card.html
+++ b/pkg/themes/default/templates/partials/cards/note-card.html
@@ -1,13 +1,18 @@
 {# Note Card - Low prominence for pings, thoughts, status updates #}
 {# Minimal styling, left border accent, no title shown #}
 <article class="card card-note h-entry">
-  <a class="u-url" href="{{ post.href }}" hidden></a>
-  <div class="card-content">
-    {% if post.description %}
-    <p class="card-text p-content">{{ post.description }}</p>
-    {% elif post.article_html %}
-    <div class="card-text p-content">{{ post.article_html | striptags | truncatechars:200 }}</div>
-    {% endif %}
+  <header class="card-header">
+    <a class="u-url" href="{{ post.href }}" hidden></a>
+  </header>
+
+  <div class="card-body">
+    <div class="card-content">
+      {% if post.description %}
+      <p class="card-text p-content">{{ post.description }}</p>
+      {% elif post.article_html %}
+      <div class="card-text p-content">{{ post.article_html | striptags | truncatechars:200 }}</div>
+      {% endif %}
+    </div>
   </div>
 
   <footer class="card-meta">

--- a/pkg/themes/default/templates/partials/cards/photo-card.html
+++ b/pkg/themes/default/templates/partials/cards/photo-card.html
@@ -3,33 +3,35 @@
 {# Auto-detects video files by extension: .mp4, .webm, .mov, .m4v, .ogv #}
 {# Supports both image and video frontmatter fields interchangeably #}
 <article class="card card-photo h-entry">
-  {% with post.image|media_url:post.video as media_src %}
-  {% if media_src %}
-  <a href="{{ post.href }}" class="card-image-link u-url">
-    {% if media_src|is_video %}
-    <video class="card-image u-video" autoplay muted loop playsinline>
-      <source src="{{ media_src }}" type="video/{% with media_src|lower as src_lower %}{% if src_lower|endswith:".mp4" or src_lower|endswith:".m4v" %}mp4{% elif src_lower|endswith:".webm" %}webm{% elif src_lower|endswith:".mov" %}quicktime{% else %}ogg{% endif %}{% endwith %}">
-    </video>
-    {% else %}
-    <img src="{{ media_src }}" alt="{{ post.title | default:post.description | default:'Photo' }}" class="card-image u-photo" width="1200" height="675" loading="lazy">
+  <header class="card-header">
+    {% with post.image|media_url:post.video as media_src %}
+    {% if media_src %}
+    <a href="{{ post.href }}" class="card-image-link u-url">
+      {% if media_src|is_video %}
+      <video class="card-image u-video" autoplay muted loop playsinline>
+        <source src="{{ media_src }}" type="video/{% with media_src|lower as src_lower %}{% if src_lower|endswith:".mp4" or src_lower|endswith:".m4v" %}mp4{% elif src_lower|endswith:".webm" %}webm{% elif src_lower|endswith:".mov" %}quicktime{% else %}ogg{% endif %}{% endwith %}">
+      </video>
+      {% else %}
+      <img src="{{ media_src }}" alt="{{ post.title | default:post.description | default:'Photo' }}" class="card-image u-photo" width="1200" height="675" loading="lazy">
+      {% endif %}
+    </a>
     {% endif %}
-  </a>
-  {% endif %}
-  {% endwith %}
+    {% endwith %}
 
-  <div class="card-body">
     {% if post.title %}
     <h3 class="card-title p-name"><a href="{{ post.href }}">{{ post.title }}</a></h3>
     {% endif %}
+  </header>
 
+  <div class="card-body">
     {% if post.description %}
     <p class="card-caption p-summary">{{ post.description }}</p>
     {% endif %}
-
-    <footer class="card-meta">
-      {% if post.date %}
-      <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
-      {% endif %}
-    </footer>
   </div>
+
+  <footer class="card-meta">
+    {% if post.date %}
+    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+    {% endif %}
+  </footer>
 </article>

--- a/pkg/themes/default/templates/partials/cards/quote-card.html
+++ b/pkg/themes/default/templates/partials/cards/quote-card.html
@@ -1,27 +1,31 @@
 {# Quote Card - Blockquote styling for quotes, quotations #}
 {# Large quote with source attribution #}
 <article class="card card-quote h-entry">
-  <a class="u-url" href="{{ post.href }}" hidden></a>
-  <blockquote class="card-blockquote e-content">
-    {% if post.quote %}
-    <p>{{ post.quote }}</p>
-    {% elif post.description %}
-    <p>{{ post.description }}</p>
-    {% elif post.article_html %}
-    <div>{{ post.article_html | striptags | truncatechars:300 }}</div>
+  <header class="card-header">
+    {% if post.title %}
+    <h3 class="card-title p-name"><a href="{{ post.href }}">{{ post.title }}</a></h3>
     {% endif %}
-  </blockquote>
+  </header>
 
-  <footer class="card-attribution">
+  <div class="card-body">
+    <a class="u-url" href="{{ post.href }}" hidden></a>
+    <blockquote class="card-blockquote e-content">
+      {% if post.quote %}
+      <p>{{ post.quote }}</p>
+      {% elif post.description %}
+      <p>{{ post.description }}</p>
+      {% elif post.article_html %}
+      <div>{{ post.article_html | striptags | truncatechars:300 }}</div>
+      {% endif %}
+    </blockquote>
+  </div>
+
+  <footer class="card-meta">
     {% if post.source or post.author %}
     <cite class="h-cite">
       {% if post.author %}<span class="quote-author p-author">{{ post.author }}</span>{% endif %}
       {% if post.source %}<span class="quote-source p-name">{{ post.source }}</span>{% endif %}
     </cite>
-    {% endif %}
-
-    {% if post.title %}
-    <a href="{{ post.href }}" class="card-title-link p-name">{{ post.title }}</a>
     {% endif %}
 
     {% if post.date %}

--- a/pkg/themes/default/templates/partials/cards/video-card.html
+++ b/pkg/themes/default/templates/partials/cards/video-card.html
@@ -2,41 +2,43 @@
 {# Video thumbnail with play indicator, title below #}
 {# Supports image, video, and thumbnail fields interchangeably #}
 <article class="card card-video h-entry">
-  {% with post.image|media_url:post.video as media_src %}
-  {% if media_src %}
-  <a href="{{ post.href }}" class="card-video-link u-url">
-    {% if media_src|is_video %}
-    <video class="card-thumbnail u-video" autoplay muted loop playsinline>
-      <source src="{{ media_src }}" type="video/{% with media_src|lower as src_lower %}{% if src_lower|endswith:".mp4" or src_lower|endswith:".m4v" %}mp4{% elif src_lower|endswith:".webm" %}webm{% elif src_lower|endswith:".mov" %}quicktime{% else %}ogg{% endif %}{% endwith %}">
-    </video>
-    {% else %}
-    <div class="card-video-container">
-      <img src="{{ media_src }}" alt="{{ post.title | default:'Video thumbnail' }}" class="card-thumbnail u-photo" width="1200" height="675" loading="lazy">
-      <div class="card-play-icon">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="48" height="48" aria-hidden="true" focusable="false">
-          <path d="M8 5v14l11-7z"/>
-        </svg>
+  <header class="card-header">
+    {% with post.image|media_url:post.video as media_src %}
+    {% if media_src %}
+    <a href="{{ post.href }}" class="card-video-link u-url">
+      {% if media_src|is_video %}
+      <video class="card-thumbnail u-video" autoplay muted loop playsinline>
+        <source src="{{ media_src }}" type="video/{% with media_src|lower as src_lower %}{% if src_lower|endswith:".mp4" or src_lower|endswith:".m4v" %}mp4{% elif src_lower|endswith:".webm" %}webm{% elif src_lower|endswith:".mov" %}quicktime{% else %}ogg{% endif %}{% endwith %}">
+      </video>
+      {% else %}
+      <div class="card-video-container">
+        <img src="{{ media_src }}" alt="{{ post.title | default:'Video thumbnail' }}" class="card-thumbnail u-photo" width="1200" height="675" loading="lazy">
+        <div class="card-play-icon">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="48" height="48" aria-hidden="true" focusable="false">
+            <path d="M8 5v14l11-7z"/>
+          </svg>
+        </div>
       </div>
-    </div>
+      {% endif %}
+    </a>
     {% endif %}
-  </a>
-  {% endif %}
-  {% endwith %}
+    {% endwith %}
 
-  <div class="card-body">
     {% if post.title %}
     <h3 class="card-title p-name"><a href="{{ post.href }}">{{ post.title }}</a></h3>
     {% endif %}
+  </header>
 
+  <div class="card-body">
     {% if post.description %}
     <p class="card-description p-summary">{{ post.description | truncatechars:150 }}</p>
     {% endif %}
-
-    <footer class="card-meta">
-      {% if post.date %}
-      <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
-      {% endif %}
-      {% if post.duration %}<span class="duration">{{ post.duration }}</span>{% endif %}
-    </footer>
   </div>
+
+  <footer class="card-meta">
+    {% if post.date %}
+    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+    {% endif %}
+    {% if post.duration %}<span class="duration">{{ post.duration }}</span>{% endif %}
+  </footer>
 </article>


### PR DESCRIPTION
## Summary
- add icon shortcode parsing/rendering with pack config and inline attribute support
- document icon syntax/config and add spec coverage for icons
- add default theme icon mask styling for `.icon`

## Issue
- Fixes #895

## Testing
- not run (not requested)