### PR TITLE
fix: include frontmatter images in OG card output

### DIFF
--- a/docs/guides/post-formats.md
+++ b/docs/guides/post-formats.md
@@ -130,6 +130,7 @@ await page.screenshot({ path: 'og-image.png' });
 
 The default OG card template includes:
 - Post title (large, prominent)
+- Frontmatter media when present (`image` → `cover_image` → `og_image`)
 - Author name and site URL
 - Publication date
 - Theme palette and background styling

--- a/pkg/plugins/publish_html.go
+++ b/pkg/plugins/publish_html.go
@@ -39,6 +39,31 @@ func isSpecialFile(slug string) bool {
 	return false
 }
 
+func getPostExtraString(post *models.Post, keys ...string) string {
+	if post == nil || post.Extra == nil {
+		return ""
+	}
+
+	for _, key := range keys {
+		value, ok := post.Extra[key]
+		if !ok {
+			continue
+		}
+
+		strValue, ok := value.(string)
+		if !ok {
+			continue
+		}
+
+		trimmed := strings.TrimSpace(strValue)
+		if trimmed != "" {
+			return trimmed
+		}
+	}
+
+	return ""
+}
+
 // PublishHTMLPlugin writes individual post HTML files during the write stage.
 // It supports multiple output formats: HTML, Markdown source, and OG card HTML.
 type PublishHTMLPlugin struct {
@@ -727,6 +752,8 @@ func (p *PublishHTMLPlugin) renderOGWithBuiltinTemplate(post *models.Post, confi
 		dateStr = post.Date.Format("January 2, 2006")
 	}
 
+	imageURL := getPostExtraString(post, "image", "cover_image", "og_image")
+
 	// Build canonical URL for the original post
 	canonicalURL := siteURL + "/" + post.Slug + "/"
 
@@ -774,6 +801,31 @@ func (p *PublishHTMLPlugin) renderOGWithBuiltinTemplate(post *models.Post, confi
             display: flex;
             flex-direction: column;
             justify-content: center;
+            gap: 24px;
+        }
+        .og-layout {
+            flex: 1;
+            display: flex;
+            align-items: center;
+            gap: 36px;
+        }
+        .og-copy {
+            flex: 1;
+            min-width: 0;
+        }
+        .og-image-wrap {
+            width: 360px;
+            height: 320px;
+            border-radius: 18px;
+            overflow: hidden;
+            border: 2px solid #e2e8f0;
+            box-shadow: 0 14px 35px -16px rgba(0, 0, 0, 0.45);
+            flex-shrink: 0;
+        }
+        .og-image {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
         }
         h1 {
             font-size: 56px;
@@ -831,15 +883,24 @@ func (p *PublishHTMLPlugin) renderOGWithBuiltinTemplate(post *models.Post, confi
 <body>
     <div class="og-card">
         <div class="og-content">
-            <h1>{{.Title}}</h1>
-            {{if .Description}}<p class="description">{{.Description}}</p>{{end}}
-            {{if .Tags}}
-            <div class="tags">
-                {{range .TagsDisplay}}
-                <span class="tag">{{.}}</span>
+            <div class="og-layout">
+                <div class="og-copy">
+                    <h1>{{.Title}}</h1>
+                    {{if .Description}}<p class="description">{{.Description}}</p>{{end}}
+                    {{if .Tags}}
+                    <div class="tags">
+                        {{range .TagsDisplay}}
+                        <span class="tag">{{.}}</span>
+                        {{end}}
+                    </div>
+                    {{end}}
+                </div>
+                {{if .ImageURL}}
+                <div class="og-image-wrap">
+                    <img src="{{.ImageURL}}" alt="{{.Title}}" class="og-image">
+                </div>
                 {{end}}
             </div>
-            {{end}}
         </div>
         <div class="og-footer">
             <span class="site-name">{{.SiteTitle}}</span>
@@ -868,6 +929,7 @@ func (p *PublishHTMLPlugin) renderOGWithBuiltinTemplate(post *models.Post, confi
 		DateStr      string
 		Tags         []string
 		TagsDisplay  []string
+		ImageURL     string
 		SiteTitle    string
 		CanonicalURL string
 	}{
@@ -876,6 +938,7 @@ func (p *PublishHTMLPlugin) renderOGWithBuiltinTemplate(post *models.Post, confi
 		DateStr:      dateStr,
 		Tags:         post.Tags,
 		TagsDisplay:  tagsDisplay,
+		ImageURL:     imageURL,
 		SiteTitle:    siteTitle,
 		CanonicalURL: canonicalURL,
 	}

--- a/pkg/plugins/publish_html_test.go
+++ b/pkg/plugins/publish_html_test.go
@@ -193,6 +193,126 @@ func TestPublishHTMLPlugin_OGCardCanonicalURL(t *testing.T) {
 	}
 }
 
+func TestPublishHTMLPlugin_OGCardIncludesFrontmatterImage(t *testing.T) {
+	tests := []struct {
+		name     string
+		extra    map[string]interface{}
+		imageURL string
+	}{
+		{
+			name: "uses image field first",
+			extra: map[string]interface{}{
+				"image":       "https://cdn.example.com/posts/image.webp",
+				"cover_image": "https://cdn.example.com/posts/cover.webp",
+				"og_image":    "https://cdn.example.com/posts/og.webp",
+			},
+			imageURL: "https://cdn.example.com/posts/image.webp",
+		},
+		{
+			name: "falls back to cover_image",
+			extra: map[string]interface{}{
+				"cover_image": "https://cdn.example.com/posts/cover.webp",
+			},
+			imageURL: "https://cdn.example.com/posts/cover.webp",
+		},
+		{
+			name: "falls back to og_image",
+			extra: map[string]interface{}{
+				"og_image": "https://cdn.example.com/posts/og.webp",
+			},
+			imageURL: "https://cdn.example.com/posts/og.webp",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			plugin := NewPublishHTMLPlugin()
+
+			config := &lifecycle.Config{
+				OutputDir: tempDir,
+				Extra: map[string]interface{}{
+					"url":          "https://example.com",
+					"title":        "Test Site",
+					"post_formats": models.PostFormatsConfig{OG: true},
+				},
+			}
+
+			title := "Post With Frontmatter Image"
+			post := &models.Post{
+				Path:        "test.md",
+				Slug:        "test-post",
+				Title:       &title,
+				HTML:        "<html><body>Test content</body></html>",
+				Published:   true,
+				Draft:       false,
+				Skip:        false,
+				ArticleHTML: "<p>Test content</p>",
+				Extra:       tt.extra,
+			}
+
+			m := createTestManager(t, config)
+			if err := plugin.writePost(post, config, nil, m); err != nil {
+				t.Fatalf("writePost() error = %v", err)
+			}
+
+			ogPath := filepath.Join(tempDir, "test-post", "og", "index.html")
+			content, err := os.ReadFile(ogPath)
+			if err != nil {
+				t.Fatalf("failed to read OG card: %v", err)
+			}
+
+			ogHTML := string(content)
+			expectedImageTag := fmt.Sprintf("src=%q", tt.imageURL)
+			if !strings.Contains(ogHTML, expectedImageTag) {
+				t.Errorf("OG card should include expected image source.\nExpected: %s\nGot: %s", expectedImageTag, ogHTML)
+			}
+		})
+	}
+}
+
+func TestPublishHTMLPlugin_OGCardWithoutFrontmatterImageOmitsImageTag(t *testing.T) {
+	tempDir := t.TempDir()
+	plugin := NewPublishHTMLPlugin()
+
+	config := &lifecycle.Config{
+		OutputDir: tempDir,
+		Extra: map[string]interface{}{
+			"url":          "https://example.com",
+			"title":        "Test Site",
+			"post_formats": models.PostFormatsConfig{OG: true},
+		},
+	}
+
+	title := "Post Without Image"
+	post := &models.Post{
+		Path:        "test.md",
+		Slug:        "test-post",
+		Title:       &title,
+		HTML:        "<html><body>Test content</body></html>",
+		Published:   true,
+		Draft:       false,
+		Skip:        false,
+		ArticleHTML: "<p>Test content</p>",
+	}
+
+	m := createTestManager(t, config)
+	if err := plugin.writePost(post, config, nil, m); err != nil {
+		t.Fatalf("writePost() error = %v", err)
+	}
+
+	ogPath := filepath.Join(tempDir, "test-post", "og", "index.html")
+	content, err := os.ReadFile(ogPath)
+	if err != nil {
+		t.Fatalf("failed to read OG card: %v", err)
+	}
+
+	ogHTML := string(content)
+	if strings.Contains(ogHTML, "class=\"og-image\"") {
+		t.Errorf("OG card should not include image tag when no frontmatter image is set. Got: %s", ogHTML)
+	}
+}
+
 // TestPublishHTMLPlugin_ShadowPagesDocumentation tests the expected behavior is documented.
 func TestPublishHTMLPlugin_ShadowPagesDocumentation(t *testing.T) {
 	// This test documents the shadow pages behavior:

--- a/pkg/themes/default/templates/og-card.html
+++ b/pkg/themes/default/templates/og-card.html
@@ -54,6 +54,36 @@
             padding: 48px 64px;
             padding-bottom: 160px; /* Space for larger footer */
             overflow: hidden;
+            gap: 28px;
+        }
+
+        .has-media .og-container {
+            display: grid;
+            grid-template-columns: minmax(0, 1fr) 420px;
+            align-items: center;
+            gap: 36px;
+        }
+
+        .og-copy {
+            min-width: 0;
+        }
+
+        .og-media {
+            width: 100%;
+            max-height: 320px;
+            border-radius: 18px;
+            overflow: hidden;
+            border: 1px solid var(--og-border);
+            background: rgba(0, 0, 0, 0.2);
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.28);
+        }
+
+        .og-media img {
+            display: block;
+            width: 100%;
+            height: 100%;
+            min-height: 320px;
+            object-fit: cover;
         }
 
         /* Title with gradient */
@@ -67,6 +97,10 @@
             max-width: 100%;
             word-wrap: break-word;
             hyphens: auto;
+            display: -webkit-box;
+            -webkit-box-orient: vertical;
+            overflow: hidden;
+            -webkit-line-clamp: 4;
         }
 
         /* Footer bar - use !important to override any background CSS */
@@ -134,6 +168,12 @@
         /* Extra long titles (100+ chars) */
         .title-xl .og-title { font-size: 2.5rem; }
 
+        .has-media.title-xs .og-title { font-size: 5.5rem; }
+        .has-media.title-sm .og-title { font-size: 4.4rem; }
+        .has-media.title-md .og-title { font-size: 3.4rem; }
+        .has-media.title-lg .og-title { font-size: 2.7rem; }
+        .has-media.title-xl .og-title { font-size: 2.2rem; }
+
         /* Background decoration styles */
         {% if config.theme.background.css %}
         {{ config.theme.background.css | safe }}
@@ -145,7 +185,7 @@
     <link rel="stylesheet" href="/css/palette.css">
     {% endif %}
 </head>
-<body class="{% if post.title|length < 20 %}title-xs{% elif post.title|length < 40 %}title-sm{% elif post.title|length < 60 %}title-md{% elif post.title|length < 100 %}title-lg{% else %}title-xl{% endif %}">
+<body class="{% if post.image or post.cover_image or post.og_image %}has-media {% endif %}{% if post.title|length < 20 %}title-xs{% elif post.title|length < 40 %}title-sm{% elif post.title|length < 60 %}title-md{% elif post.title|length < 100 %}title-lg{% else %}title-xl{% endif %}">
     <!-- Background Decorations -->
     {% if config.theme.background.enabled %}
     {% for bg in config.theme.background.backgrounds %}
@@ -154,7 +194,20 @@
     {% endif %}
 
     <div class="og-container">
-        <h1 class="og-title">{{ post.title }}</h1>
+        <div class="og-copy">
+            <h1 class="og-title">{{ post.title }}</h1>
+        </div>
+        {% if post.image or post.cover_image or post.og_image %}
+        <figure class="og-media">
+            {% if post.image %}
+            <img src="{{ post.image }}" alt="{{ post.title }}">
+            {% elif post.cover_image %}
+            <img src="{{ post.cover_image }}" alt="{{ post.title }}">
+            {% else %}
+            <img src="{{ post.og_image }}" alt="{{ post.title }}">
+            {% endif %}
+        </figure>
+        {% endif %}
     </div>
 
     <footer class="og-footer">

--- a/spec/spec/TEMPLATES.md
+++ b/spec/spec/TEMPLATES.md
@@ -205,6 +205,14 @@ post template when possible:
 The default theme ships both `post-og.html` and `og-card.html` so OG cards match the
 site palette and background styling.
 
+When an OG card template renders post media, it MUST use this frontmatter fallback order:
+
+1. `image`
+2. `cover_image`
+3. `og_image`
+
+If none of these fields are present, the OG card renders a text-only layout.
+
 ### Feed Templates
 
 | Variable | Type | Description |


### PR DESCRIPTION
## Summary
- include post frontmatter media in OG cards using fallback order: `image`, `cover_image`, then `og_image`
- update default `og-card.html` layout to keep titles readable while rendering optional media for posts such as `/shots/...`
- add OG rendering tests and document behavior in the templates spec and post formats guide

## Testing
- `go test ./pkg/plugins -run \"TestPublishHTMLPlugin_OGCard|TestPublishHTMLPlugin_OGCardIncludesFrontmatterImage|TestPublishHTMLPlugin_OGCardWithoutFrontmatterImageOmitsImageTag\"`
- `just lint-new`

Fixes #902