### PR TITLE
fix: fail fast on encryption key errors

### DIFF
--- a/docs/guides/encryption.md
+++ b/docs/guides/encryption.md
@@ -221,12 +221,11 @@ gratitude = "default"    # Matches posts with tag "gratitude" OR templateKey "gr
 
 ### Missing Keys Fail the Build
 
-If any private post has no available encryption key, the build **fails with a critical error** listing all affected posts and the expected environment variables:
+If any private post has no available encryption key, the build **fails early with a critical error** that summarizes the failures by key and reason:
 
 ```
-encryption error: private posts found without available encryption keys.
-Build halted to prevent exposing private content
-(posts: diary/2024-01-15.md (key "personal": set MARKATA_GO_ENCRYPTION_KEY_PERSONAL in environment or .env))
+encryption error: private posts found without available encryption keys. Build halted to prevent exposing private content
+key "personal": set MARKATA_GO_ENCRYPTION_KEY_PERSONAL in environment or .env (posts: 12, sample: diary/2024-01-15.md, diary/2024-01-16.md, diary/2024-01-17.md)
 ```
 
 This is intentional. Private content must never be published unencrypted.

--- a/pkg/plugins/encryption.go
+++ b/pkg/plugins/encryption.go
@@ -4,6 +4,7 @@ package plugins
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -26,7 +27,10 @@ type EncryptionBuildError struct {
 }
 
 func (e *EncryptionBuildError) Error() string {
-	return fmt.Sprintf("encryption error: %s (posts: %s)", e.Msg, strings.Join(e.Posts, ", "))
+	if len(e.Posts) == 0 {
+		return fmt.Sprintf("encryption error: %s", e.Msg)
+	}
+	return fmt.Sprintf("encryption error: %s\n%s", e.Msg, strings.Join(e.Posts, "\n"))
 }
 
 // IsCritical marks this error as a build-halting error.
@@ -94,9 +98,9 @@ func (p *EncryptionPlugin) Configure(m *lifecycle.Manager) error {
 		p.defaultKey = modelsConfig.Encryption.DefaultKey
 		p.decryptionHint = modelsConfig.Encryption.DecryptionHint
 		p.enforceStrength = modelsConfig.Encryption.EnforceStrength
-		p.minPasswordLength = modelsConfig.Encryption.MinPasswordLength
+		p.minPasswordLength = modelsConfig.Encryption.MinPasswordLength // pragma: allowlist secret
 		if p.minPasswordLength == 0 {
-			p.minPasswordLength = encryption.DefaultMinPasswordLength
+			p.minPasswordLength = encryption.DefaultMinPasswordLength // pragma: allowlist secret
 		}
 		durationStr := modelsConfig.Encryption.MinEstimatedCrackTime
 		if durationStr == "" {
@@ -254,7 +258,7 @@ func (p *EncryptionPlugin) Transform(m *lifecycle.Manager) error {
 	}
 
 	p.applyPrivateTags(m.Posts())
-	return nil
+	return p.validatePrivatePosts(m.Posts())
 }
 
 // Render encrypts content for private posts with encryption keys.
@@ -278,45 +282,8 @@ func (p *EncryptionPlugin) Render(m *lifecycle.Manager) error {
 
 	// Check that every private post can be encrypted.
 	// This is a safety check: we must NEVER expose private content unencrypted.
-	var failedPosts []string
-	passwordCache := make(map[string]string)
-	policyCache := make(map[string]error)
-	for _, post := range privatePosts {
-		keyName := post.SecretKey
-		if keyName == "" {
-			keyName = p.defaultKey
-		}
-		if keyName == "" {
-			failedPosts = append(failedPosts, fmt.Sprintf("%s (no encryption key specified and no default key configured)", post.Path))
-			continue
-		}
-		normalized := strings.ToLower(keyName)
-		if _, cached := passwordCache[normalized]; !cached {
-			var password string
-			var err error
-			password, err = p.getKeyPassword(keyName)
-			if err != nil {
-				failedPosts = append(failedPosts, fmt.Sprintf("%s (key %q: set %s%s in environment or .env)",
-					post.Path, keyName, EncryptionEnvPrefix, strings.ToUpper(keyName)))
-				continue
-			}
-			passwordCache[normalized] = password
-			if p.enforceStrength {
-				policyCache[normalized] = p.validatePasswordPolicy(password)
-			} else {
-				policyCache[normalized] = nil
-			}
-		}
-		if err := policyCache[normalized]; err != nil {
-			failedPosts = append(failedPosts, fmt.Sprintf("%s (key %q: %s)", post.Path, keyName, err.Error()))
-		}
-	}
-
-	if len(failedPosts) > 0 {
-		return &EncryptionBuildError{
-			Posts: failedPosts,
-			Msg:   "private posts found without available encryption keys. Build halted to prevent exposing private content",
-		}
+	if err := p.validatePrivatePosts(privatePosts); err != nil {
+		return err
 	}
 
 	// Filter to posts that actually have content to encrypt
@@ -333,6 +300,122 @@ func (p *EncryptionPlugin) Render(m *lifecycle.Manager) error {
 	return m.ProcessPostsSliceConcurrently(postsToEncrypt, func(post *models.Post) error {
 		return p.encryptPostWithCache(post, cache)
 	})
+}
+
+func (p *EncryptionPlugin) validatePrivatePosts(posts []*models.Post) error {
+	if len(posts) == 0 {
+		return nil
+	}
+
+	var failures []encryptionFailure
+	passwordCache := make(map[string]string)
+	policyCache := make(map[string]error)
+	for _, post := range posts {
+		if post.Skip || post.Draft || !post.Private {
+			continue
+		}
+		keyName := post.SecretKey
+		if keyName == "" {
+			keyName = p.defaultKey
+		}
+		if keyName == "" {
+			failures = append(failures, encryptionFailure{
+				postPath: post.Path,
+				keyName:  "(none)",
+				reason:   "no encryption key specified and no default key configured",
+			})
+			continue
+		}
+		normalized := strings.ToLower(keyName)
+		if _, cached := passwordCache[normalized]; !cached {
+			var password string
+			var err error
+			password, err = p.getKeyPassword(keyName)
+			if err != nil {
+				failures = append(failures, encryptionFailure{
+					postPath: post.Path,
+					keyName:  keyName,
+					reason:   fmt.Sprintf("set %s%s in environment or .env", EncryptionEnvPrefix, strings.ToUpper(keyName)),
+				})
+				continue
+			}
+			passwordCache[normalized] = password
+			if p.enforceStrength {
+				policyCache[normalized] = p.validatePasswordPolicy(password)
+			} else {
+				policyCache[normalized] = nil
+			}
+		}
+		if err := policyCache[normalized]; err != nil {
+			failures = append(failures, encryptionFailure{
+				postPath: post.Path,
+				keyName:  keyName,
+				reason:   err.Error(),
+			})
+		}
+	}
+
+	if len(failures) == 0 {
+		return nil
+	}
+
+	return &EncryptionBuildError{
+		Posts: summarizeEncryptionFailures(failures),
+		Msg:   "private posts found without available encryption keys. Build halted to prevent exposing private content",
+	}
+}
+
+const maxEncryptionFailureSamples = 3
+
+type encryptionFailure struct {
+	postPath string
+	keyName  string
+	reason   string
+}
+
+type encryptionFailureGroup struct {
+	keyName string
+	reason  string
+	posts   []string
+}
+
+func summarizeEncryptionFailures(failures []encryptionFailure) []string {
+	if len(failures) == 0 {
+		return nil
+	}
+
+	groups := make(map[string]*encryptionFailureGroup)
+	keys := make([]string, 0, len(failures))
+	for _, failure := range failures {
+		groupKey := failure.keyName + "\x00" + failure.reason
+		group, ok := groups[groupKey]
+		if !ok {
+			group = &encryptionFailureGroup{keyName: failure.keyName, reason: failure.reason}
+			groups[groupKey] = group
+			keys = append(keys, groupKey)
+		}
+		group.posts = append(group.posts, failure.postPath)
+	}
+
+	sort.Strings(keys)
+	lines := make([]string, 0, len(keys))
+	for _, key := range keys {
+		group := groups[key]
+		sample := group.posts
+		more := false
+		if len(sample) > maxEncryptionFailureSamples {
+			sample = sample[:maxEncryptionFailureSamples]
+			more = true
+		}
+		line := fmt.Sprintf("key %q: %s (posts: %d, sample: %s", group.keyName, group.reason, len(group.posts), strings.Join(sample, ", "))
+		if more {
+			line += ", ..."
+		}
+		line += ")"
+		lines = append(lines, line)
+	}
+
+	return lines
 }
 
 func (p *EncryptionPlugin) validatePasswordPolicy(password string) error {

--- a/spec/spec/ENCRYPTION.md
+++ b/spec/spec/ENCRYPTION.md
@@ -145,6 +145,17 @@ The following plugins respect `post.Private` to prevent leaking private content 
 
 `EncryptionBuildError` implements the `lifecycle.CriticalError` interface (`IsCritical() bool` returns `true`). This causes the lifecycle manager to halt the build even though the Render stage is normally non-critical.
 
+Encryption key validation MUST run during the Transform stage after private tag/templateKey assignment. This fails the build early before expensive render plugins run when keys are missing or violate policy. Render still re-validates before encryption as a safety check.
+
+When key validation fails, the error output MUST be summarized by key and reason. Each summary entry includes:
+
+- key name
+- policy or missing-key reason
+- total count of affected posts
+- a short sample list (up to 3 paths)
+
+The full list of post paths should not be printed in the error message.
+
 ### Skipped Posts
 
 Posts with `Draft = true` or `Skip = true` are excluded from all encryption processing. They are not subject to key validation and are never encrypted.


### PR DESCRIPTION
## Summary
- validate encryption keys during Transform to fail before expensive render plugins
- summarize key validation errors by key/reason with counts and samples
- document the early validation and new error format in spec and guide

## Issue
Fixes #904

## Testing
- `go test ./pkg/plugins -run TestEncryptionBuildError`