### PR TITLE
fix: include frontmatter images in OG card output

### DIFF
--- a/docs/guides/post-formats.md
+++ b/docs/guides/post-formats.md
@@ -130,7 +130,7 @@ await page.screenshot({ path: 'og-image.png' });
 
 The default OG card template includes:
 - Post title (large, prominent)
-- Frontmatter media when present (`image` → `cover_image` → `og_image`)
+- Frontmatter media when present (`image` → `cover_image` → `og_image` → `video`, videos render as video tags)
 - Author name and site URL
 - Publication date
 - Theme palette and background styling

--- a/pkg/plugins/publish_html.go
+++ b/pkg/plugins/publish_html.go
@@ -64,6 +64,35 @@ func getPostExtraString(post *models.Post, keys ...string) string {
 	return ""
 }
 
+var ogVideoExtensions = map[string]string{
+	".mp4":  "video/mp4",
+	".m4v":  "video/mp4",
+	".webm": "video/webm",
+	".mov":  "video/quicktime",
+	".ogv":  "video/ogg",
+	".ogg":  "video/ogg",
+}
+
+func isOGVideoURL(url string) bool {
+	if url == "" {
+		return false
+	}
+	ext := strings.ToLower(filepath.Ext(url))
+	_, ok := ogVideoExtensions[ext]
+	return ok
+}
+
+func ogVideoMIMEType(url string) string {
+	if url == "" {
+		return ""
+	}
+	ext := strings.ToLower(filepath.Ext(url))
+	if mime, ok := ogVideoExtensions[ext]; ok {
+		return mime
+	}
+	return ""
+}
+
 // PublishHTMLPlugin writes individual post HTML files during the write stage.
 // It supports multiple output formats: HTML, Markdown source, and OG card HTML.
 type PublishHTMLPlugin struct {
@@ -753,6 +782,16 @@ func (p *PublishHTMLPlugin) renderOGWithBuiltinTemplate(post *models.Post, confi
 	}
 
 	imageURL := getPostExtraString(post, "image", "cover_image", "og_image")
+	videoURL := getPostExtraString(post, "video")
+	mediaURL := imageURL
+	if mediaURL == "" {
+		mediaURL = videoURL
+	}
+	isVideo := isOGVideoURL(mediaURL)
+	mediaType := ""
+	if isVideo {
+		mediaType = ogVideoMIMEType(mediaURL)
+	}
 
 	// Build canonical URL for the original post
 	canonicalURL := siteURL + "/" + post.Slug + "/"
@@ -822,7 +861,8 @@ func (p *PublishHTMLPlugin) renderOGWithBuiltinTemplate(post *models.Post, confi
             box-shadow: 0 14px 35px -16px rgba(0, 0, 0, 0.45);
             flex-shrink: 0;
         }
-        .og-image {
+        .og-image,
+        .og-video {
             width: 100%;
             height: 100%;
             object-fit: cover;
@@ -895,9 +935,15 @@ func (p *PublishHTMLPlugin) renderOGWithBuiltinTemplate(post *models.Post, confi
                     </div>
                     {{end}}
                 </div>
-                {{if .ImageURL}}
+                {{if .HasMedia}}
                 <div class="og-image-wrap">
-                    <img src="{{.ImageURL}}" alt="{{.Title}}" class="og-image">
+                    {{if .IsVideo}}
+                    <video class="og-video" autoplay muted loop playsinline>
+                        <source src="{{.MediaURL}}" type="{{.MediaType}}">
+                    </video>
+                    {{else}}
+                    <img src="{{.MediaURL}}" alt="{{.Title}}" class="og-image">
+                    {{end}}
                 </div>
                 {{end}}
             </div>
@@ -929,7 +975,10 @@ func (p *PublishHTMLPlugin) renderOGWithBuiltinTemplate(post *models.Post, confi
 		DateStr      string
 		Tags         []string
 		TagsDisplay  []string
-		ImageURL     string
+		HasMedia     bool
+		IsVideo      bool
+		MediaType    string
+		MediaURL     string
 		SiteTitle    string
 		CanonicalURL string
 	}{
@@ -938,7 +987,10 @@ func (p *PublishHTMLPlugin) renderOGWithBuiltinTemplate(post *models.Post, confi
 		DateStr:      dateStr,
 		Tags:         post.Tags,
 		TagsDisplay:  tagsDisplay,
-		ImageURL:     imageURL,
+		HasMedia:     mediaURL != "",
+		IsVideo:      isVideo,
+		MediaType:    mediaType,
+		MediaURL:     mediaURL,
 		SiteTitle:    siteTitle,
 		CanonicalURL: canonicalURL,
 	}

--- a/pkg/plugins/publish_html_test.go
+++ b/pkg/plugins/publish_html_test.go
@@ -313,6 +313,54 @@ func TestPublishHTMLPlugin_OGCardWithoutFrontmatterImageOmitsImageTag(t *testing
 	}
 }
 
+func TestPublishHTMLPlugin_OGCardSupportsVideoFrontmatter(t *testing.T) {
+	tempDir := t.TempDir()
+	plugin := NewPublishHTMLPlugin()
+
+	config := &lifecycle.Config{
+		OutputDir: tempDir,
+		Extra: map[string]interface{}{
+			"url":          "https://example.com",
+			"title":        "Test Site",
+			"post_formats": models.PostFormatsConfig{OG: true},
+		},
+	}
+
+	title := "Post With Video"
+	post := &models.Post{
+		Path:        "test.md",
+		Slug:        "test-post",
+		Title:       &title,
+		HTML:        "<html><body>Test content</body></html>",
+		Published:   true,
+		Draft:       false,
+		Skip:        false,
+		ArticleHTML: "<p>Test content</p>",
+		Extra: map[string]interface{}{
+			"video": "https://cdn.example.com/posts/clip.mp4",
+		},
+	}
+
+	m := createTestManager(t, config)
+	if err := plugin.writePost(post, config, nil, m); err != nil {
+		t.Fatalf("writePost() error = %v", err)
+	}
+
+	ogPath := filepath.Join(tempDir, "test-post", "og", "index.html")
+	content, err := os.ReadFile(ogPath)
+	if err != nil {
+		t.Fatalf("failed to read OG card: %v", err)
+	}
+
+	ogHTML := string(content)
+	if !strings.Contains(ogHTML, "<video") {
+		t.Errorf("OG card should include video tag when video frontmatter is set. Got: %s", ogHTML)
+	}
+	if strings.Contains(ogHTML, "<img") {
+		t.Errorf("OG card should not include image tag when video frontmatter is set. Got: %s", ogHTML)
+	}
+}
+
 // TestPublishHTMLPlugin_ShadowPagesDocumentation tests the expected behavior is documented.
 func TestPublishHTMLPlugin_ShadowPagesDocumentation(t *testing.T) {
 	// This test documents the shadow pages behavior:

--- a/pkg/themes/default/templates/og-card.html
+++ b/pkg/themes/default/templates/og-card.html
@@ -78,7 +78,8 @@
             box-shadow: 0 10px 30px rgba(0, 0, 0, 0.28);
         }
 
-        .og-media img {
+        .og-media img,
+        .og-media video {
             display: block;
             width: 100%;
             height: 100%;
@@ -184,8 +185,9 @@
     {% if config.theme.palette %}
     <link rel="stylesheet" href="/css/palette.css">
     {% endif %}
+{% with post.image|media_url:post.cover_image|media_url:post.og_image|media_url:post.video as media_src %}
 </head>
-<body class="{% if post.image or post.cover_image or post.og_image %}has-media {% endif %}{% if post.title|length < 20 %}title-xs{% elif post.title|length < 40 %}title-sm{% elif post.title|length < 60 %}title-md{% elif post.title|length < 100 %}title-lg{% else %}title-xl{% endif %}">
+<body class="{% if media_src %}has-media {% endif %}{% if post.title|length < 20 %}title-xs{% elif post.title|length < 40 %}title-sm{% elif post.title|length < 60 %}title-md{% elif post.title|length < 100 %}title-lg{% else %}title-xl{% endif %}">
     <!-- Background Decorations -->
     {% if config.theme.background.enabled %}
     {% for bg in config.theme.background.backgrounds %}
@@ -197,14 +199,14 @@
         <div class="og-copy">
             <h1 class="og-title">{{ post.title }}</h1>
         </div>
-        {% if post.image or post.cover_image or post.og_image %}
+        {% if media_src %}
         <figure class="og-media">
-            {% if post.image %}
-            <img src="{{ post.image }}" alt="{{ post.title }}">
-            {% elif post.cover_image %}
-            <img src="{{ post.cover_image }}" alt="{{ post.title }}">
+            {% if media_src|is_video %}
+            <video class="og-image" autoplay muted loop playsinline>
+                <source src="{{ media_src }}" type="video/{% with media_src|lower as src_lower %}{% if src_lower|endswith:".mp4" or src_lower|endswith:".m4v" %}mp4{% elif src_lower|endswith:".webm" %}webm{% elif src_lower|endswith:".mov" %}quicktime{% else %}ogg{% endif %}{% endwith %}">
+            </video>
             {% else %}
-            <img src="{{ post.og_image }}" alt="{{ post.title }}">
+            <img src="{{ media_src }}" alt="{{ post.title }}" class="og-image">
             {% endif %}
         </figure>
         {% endif %}
@@ -227,4 +229,5 @@
         {% endif %}
     </footer>
 </body>
+{% endwith %}
 </html>

--- a/spec/spec/TEMPLATES.md
+++ b/spec/spec/TEMPLATES.md
@@ -210,8 +210,9 @@ When an OG card template renders post media, it MUST use this frontmatter fallba
 1. `image`
 2. `cover_image`
 3. `og_image`
+4. `video`
 
-If none of these fields are present, the OG card renders a text-only layout.
+If the resolved media is a video file, the OG template should render a video tag instead of an image tag. If none of these fields are present, the OG card renders a text-only layout.
 
 ### Feed Templates
 


### PR DESCRIPTION
## Summary
- include post frontmatter media in OG cards using fallback order: `image`, `cover_image`, `og_image`, then `video`
- render video tags in OG cards when media resolves to a video file
- add OG rendering test and document video fallback in templates spec and post formats guide

## Testing
- `go test ./pkg/plugins -run TestPublishHTMLPlugin_OGCardSupportsVideoFrontmatter`

Refs #902