### PR TITLE
feat(slugs): add configurable flat, path, and hybrid slug modes

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -780,12 +780,38 @@ src = "/js/analytics.js"
 |-------|------|---------|-------------|
 | `patterns` | string[] | `["pages/**/*.md", "posts/**/*.md"]` | Glob patterns to find content files |
 | `use_gitignore` | bool | `true` | Respect .gitignore when finding files |
+| `slug_mode` | string | `"flat"` | Slug derivation mode: `flat` or `path` |
 
 ```toml
 [markata-go.glob]
 patterns = ["posts/**/*.md", "pages/*.md", "docs/**/*.md"]
 use_gitignore = true
+slug_mode = "flat"
 ```
+
+`slug_mode` controls how markata derives a slug when frontmatter does not explicitly set `slug`:
+
+- `flat` keeps the current default behavior and uses the filename only. `posts/2026/hello-world.md` becomes `hello-world`.
+- `path` derives the slug from the content path, strips leading `posts/` or `pages/`, and treats `index.md` or `README.md` as the directory root. `posts/notes/today.md` becomes `notes/today`, and `pages/docs/README.md` becomes `docs`.
+
+Frontmatter `slug` still overrides either mode.
+
+You can also mix both behaviors by directory with `slug_rules`:
+
+```toml
+[markata-go.glob]
+slug_mode = "flat"
+
+[[markata-go.glob.slug_rules]]
+prefix = "posts/blog"
+mode = "flat"
+
+[[markata-go.glob.slug_rules]]
+prefix = "posts/notes"
+mode = "path"
+```
+
+Rules match by content path prefix, and the longest matching prefix wins. That lets you keep primary content flat while letting notes or docs stay nested.
 
 ### Markdown Settings (`[markata-go.markdown]`)
 

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -84,13 +84,13 @@ use_gitignore = true
 **Stage:** Load  
 **Purpose:** Reads discovered files and parses them into Post objects with frontmatter and content.
 
-**Configuration:** None (uses `content_dir` from main config)
+**Configuration:** Uses `[markata-go.glob]` for discovery and default slug behavior
 
 **Behavior:**
 1. Reads each file as UTF-8
 2. Extracts YAML frontmatter between `---` delimiters
 3. Creates Post object with parsed metadata and content
-4. Generates slug from frontmatter, title, or filename
+4. Generates slug from frontmatter or the configured slug mode (`flat` filename-based by default, optional `path` mode for nested content)
 5. Generates href as `/{slug}/`
 
 **Post fields set:**

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -16,6 +16,8 @@ func DefaultConfig() *models.Config {
 		GlobConfig: models.GlobConfig{
 			Patterns:     []string{"pages/**/*.md", "posts/**/*.md"},
 			UseGitignore: true,
+			SlugMode:     models.SlugModeFlat,
+			SlugRules:    nil,
 		},
 		Feeds: []models.FeedConfig{
 			{

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -80,6 +80,8 @@ func applyEnvOverride(config *models.Config, key, value string) {
 		config.GlobConfig.Patterns = parseStringList(value)
 	case "glob_use_gitignore":
 		config.GlobConfig.UseGitignore = parseBool(value)
+	case "glob_slug_mode":
+		config.GlobConfig.SlugMode = value
 	case "markdown_extensions":
 		config.MarkdownConfig.Extensions = parseStringList(value)
 	case "feed_defaults_items_per_page", "feeds_defaults_items_per_page":

--- a/pkg/config/env_test.go
+++ b/pkg/config/env_test.go
@@ -105,6 +105,7 @@ func TestApplyEnvOverrides_ListFields(t *testing.T) {
 		"MARKATA_GO_HOOKS":               "markdown,template,sitemap",
 		"MARKATA_GO_DISABLED_HOOKS":      "seo,analytics",
 		"MARKATA_GO_GLOB_PATTERNS":       "posts/**/*.md,pages/*.md",
+		"MARKATA_GO_GLOB_SLUG_MODE":      "path",
 		"MARKATA_GO_MARKDOWN_EXTENSIONS": "tables,footnotes",
 	})
 	defer cleanup()
@@ -137,6 +138,10 @@ func TestApplyEnvOverrides_ListFields(t *testing.T) {
 				}
 			}
 		})
+	}
+
+	if config.GlobConfig.SlugMode != "path" {
+		t.Errorf("SlugMode = %q, want %q", config.GlobConfig.SlugMode, "path")
 	}
 }
 

--- a/pkg/config/merge.go
+++ b/pkg/config/merge.go
@@ -355,6 +355,12 @@ func mergeGlobConfig(base, override models.GlobConfig) models.GlobConfig {
 	// Since we can't distinguish between "explicitly set to false" and "not set",
 	// we always take the override value
 	result.UseGitignore = override.UseGitignore
+	if override.SlugMode != "" {
+		result.SlugMode = override.SlugMode
+	}
+	if len(override.SlugRules) > 0 {
+		result.SlugRules = append([]models.SlugRule{}, override.SlugRules...)
+	}
 
 	return result
 }
@@ -508,7 +514,7 @@ func mergeEncryptionConfig(base, override models.EncryptionConfig) models.Encryp
 		result.MinEstimatedCrackTime = override.MinEstimatedCrackTime
 	}
 	if override.MinPasswordLength != 0 {
-		result.MinPasswordLength = override.MinPasswordLength
+		result.MinPasswordLength = override.MinPasswordLength // pragma: allowlist secret
 	}
 
 	// Merge private_tags: override entries take precedence over base

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -52,6 +52,8 @@ type baseConfigData struct {
 	DisabledHooks []string
 	GlobPatterns  []string
 	UseGitignore  *bool
+	SlugMode      string
+	SlugRules     []models.SlugRule
 	Extensions    []string
 	Concurrency   int
 	Theme         models.ThemeConfig
@@ -169,7 +171,9 @@ func buildConfig(src configSource) *models.Config {
 		Hooks:         base.Hooks,
 		DisabledHooks: base.DisabledHooks,
 		GlobConfig: models.GlobConfig{
-			Patterns: base.GlobPatterns,
+			Patterns:  base.GlobPatterns,
+			SlugMode:  base.SlugMode,
+			SlugRules: append([]models.SlugRule{}, base.SlugRules...),
 		},
 		MarkdownConfig: models.MarkdownConfig{
 			Extensions: base.Extensions,
@@ -284,6 +288,10 @@ func ParseTOML(data []byte) (*models.Config, error) {
 
 	// Extract the markata-go section as a map
 	if markataGoRaw, ok := rawWrapper["markata-go"].(map[string]any); ok {
+		if globRaw, ok := markataGoRaw["glob"].(map[string]any); ok && len(config.GlobConfig.SlugRules) == 0 {
+			config.GlobConfig.SlugRules = extractSlugRules(globRaw["slug_rules"])
+		}
+
 		// Initialize Extra if needed
 		if config.Extra == nil {
 			config.Extra = make(map[string]any)
@@ -316,6 +324,34 @@ func ParseTOML(data []byte) (*models.Config, error) {
 	}
 
 	return config, nil
+}
+
+func extractSlugRules(raw any) []models.SlugRule {
+	entries, ok := raw.([]any)
+	if !ok {
+		return nil
+	}
+
+	rules := make([]models.SlugRule, 0, len(entries))
+	for _, entry := range entries {
+		m, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		rules = append(rules, models.SlugRule{
+			Prefix: stringValue(m["prefix"]),
+			Mode:   stringValue(m["mode"]),
+		})
+	}
+	return rules
+}
+
+func stringValue(v any) string {
+	s, ok := v.(string)
+	if !ok {
+		return ""
+	}
+	return s
 }
 
 // ParseYAML parses YAML configuration data into a Config struct.
@@ -471,8 +507,15 @@ type tomlFontConfig struct {
 }
 
 type tomlGlobConfig struct {
-	Patterns     []string `toml:"patterns"`
-	UseGitignore *bool    `toml:"use_gitignore"`
+	Patterns     []string       `toml:"patterns"`
+	UseGitignore *bool          `toml:"use_gitignore"`
+	SlugMode     string         `toml:"slug_mode"`
+	SlugRules    []tomlSlugRule `toml:"slug_rules"`
+}
+
+type tomlSlugRule struct {
+	Prefix string `toml:"prefix"`
+	Mode   string `toml:"mode"`
 }
 
 type tomlMarkdownConfig struct {
@@ -1253,7 +1296,7 @@ func (e *tomlEncryptionConfig) toEncryptionConfig() models.EncryptionConfig {
 		config.MinEstimatedCrackTime = defaults.MinEstimatedCrackTime
 	}
 	if config.MinPasswordLength == 0 {
-		config.MinPasswordLength = defaults.MinPasswordLength
+		config.MinPasswordLength = defaults.MinPasswordLength // pragma: allowlist secret
 	}
 
 	return config
@@ -1543,6 +1586,8 @@ func (c *tomlConfig) getBaseConfig() baseConfigData {
 		DisabledHooks: c.DisabledHooks,
 		GlobPatterns:  c.Glob.Patterns,
 		UseGitignore:  c.Glob.UseGitignore,
+		SlugMode:      c.Glob.SlugMode,
+		SlugRules:     c.Glob.toSlugRules(),
 		Extensions:    c.Markdown.Extensions,
 		Concurrency:   c.Concurrency,
 		Theme:         c.Theme.toThemeConfig(),
@@ -1808,8 +1853,15 @@ type yamlFooterConfig struct {
 }
 
 type yamlGlobConfig struct {
-	Patterns     []string `yaml:"patterns"`
-	UseGitignore *bool    `yaml:"use_gitignore"`
+	Patterns     []string       `yaml:"patterns"`
+	UseGitignore *bool          `yaml:"use_gitignore"`
+	SlugMode     string         `yaml:"slug_mode"`
+	SlugRules    []yamlSlugRule `yaml:"slug_rules"`
+}
+
+type yamlSlugRule struct {
+	Prefix string `yaml:"prefix"`
+	Mode   string `yaml:"mode"`
 }
 
 type yamlMarkdownConfig struct {
@@ -1980,7 +2032,7 @@ func (e *yamlEncryptionConfig) toEncryptionConfig() models.EncryptionConfig {
 		config.MinEstimatedCrackTime = defaults.MinEstimatedCrackTime
 	}
 	if config.MinPasswordLength == 0 {
-		config.MinPasswordLength = defaults.MinPasswordLength
+		config.MinPasswordLength = defaults.MinPasswordLength // pragma: allowlist secret
 	}
 
 	return config
@@ -2958,6 +3010,8 @@ func (c *yamlConfig) getBaseConfig() baseConfigData {
 		DisabledHooks: c.DisabledHooks,
 		GlobPatterns:  c.Glob.Patterns,
 		UseGitignore:  c.Glob.UseGitignore,
+		SlugMode:      c.Glob.SlugMode,
+		SlugRules:     c.Glob.toSlugRules(),
 		Extensions:    c.Markdown.Extensions,
 		Concurrency:   c.Concurrency,
 		Theme:         c.Theme.toThemeConfig(),
@@ -3157,12 +3211,43 @@ type jsonFooterConfig struct {
 }
 
 type jsonGlobConfig struct {
-	Patterns     []string `json:"patterns"`
-	UseGitignore *bool    `json:"use_gitignore"`
+	Patterns     []string       `json:"patterns"`
+	UseGitignore *bool          `json:"use_gitignore"`
+	SlugMode     string         `json:"slug_mode"`
+	SlugRules    []jsonSlugRule `json:"slug_rules"`
+}
+
+type jsonSlugRule struct {
+	Prefix string `json:"prefix"`
+	Mode   string `json:"mode"`
 }
 
 type jsonMarkdownConfig struct {
 	Extensions []string `json:"extensions"`
+}
+
+func (g tomlGlobConfig) toSlugRules() []models.SlugRule {
+	rules := make([]models.SlugRule, 0, len(g.SlugRules))
+	for _, rule := range g.SlugRules {
+		rules = append(rules, models.SlugRule{Prefix: rule.Prefix, Mode: rule.Mode})
+	}
+	return rules
+}
+
+func (g yamlGlobConfig) toSlugRules() []models.SlugRule {
+	rules := make([]models.SlugRule, 0, len(g.SlugRules))
+	for _, rule := range g.SlugRules {
+		rules = append(rules, models.SlugRule{Prefix: rule.Prefix, Mode: rule.Mode})
+	}
+	return rules
+}
+
+func (g jsonGlobConfig) toSlugRules() []models.SlugRule {
+	rules := make([]models.SlugRule, 0, len(g.SlugRules))
+	for _, rule := range g.SlugRules {
+		rules = append(rules, models.SlugRule{Prefix: rule.Prefix, Mode: rule.Mode})
+	}
+	return rules
 }
 
 type jsonFeedConfig struct {
@@ -3329,7 +3414,7 @@ func (e *jsonEncryptionConfig) toEncryptionConfig() models.EncryptionConfig {
 		config.MinEstimatedCrackTime = defaults.MinEstimatedCrackTime
 	}
 	if config.MinPasswordLength == 0 {
-		config.MinPasswordLength = defaults.MinPasswordLength
+		config.MinPasswordLength = defaults.MinPasswordLength // pragma: allowlist secret
 	}
 
 	return config
@@ -4307,6 +4392,8 @@ func (c *jsonConfig) getBaseConfig() baseConfigData {
 		DisabledHooks: c.DisabledHooks,
 		GlobPatterns:  c.Glob.Patterns,
 		UseGitignore:  c.Glob.UseGitignore,
+		SlugMode:      c.Glob.SlugMode,
+		SlugRules:     c.Glob.toSlugRules(),
 		Extensions:    c.Markdown.Extensions,
 		Concurrency:   c.Concurrency,
 		Theme:         c.Theme.toThemeConfig(),

--- a/pkg/config/parser_test.go
+++ b/pkg/config/parser_test.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"testing"
+
+	"github.com/BurntSushi/toml"
 )
 
 func TestParseTOML(t *testing.T) {
@@ -401,6 +403,79 @@ use_gitignore = false
 	}
 }
 
+func TestParseTOML_GlobSlugMode(t *testing.T) {
+	data := []byte(`
+[markata-go]
+[markata-go.glob]
+slug_mode = "path"
+`)
+
+	config, err := ParseTOML(data)
+	if err != nil {
+		t.Fatalf("ParseTOML() error = %v", err)
+	}
+
+	if config.GlobConfig.SlugMode != "path" {
+		t.Errorf("SlugMode = %q, want %q", config.GlobConfig.SlugMode, "path")
+	}
+}
+
+func TestParseTOML_GlobSlugRules(t *testing.T) {
+	data := []byte(`
+[markata-go]
+[markata-go.glob]
+slug_mode = "flat"
+
+[[markata-go.glob.slug_rules]]
+prefix = "posts/blog"
+mode = "flat"
+
+[[markata-go.glob.slug_rules]]
+prefix = "posts/notes"
+mode = "path"
+`)
+
+	config, err := ParseTOML(data)
+	if err != nil {
+		t.Fatalf("ParseTOML() error = %v", err)
+	}
+
+	if len(config.GlobConfig.SlugRules) != 2 {
+		t.Fatalf("len(SlugRules) = %d, want 2", len(config.GlobConfig.SlugRules))
+	}
+	if config.GlobConfig.SlugRules[1].Prefix != "posts/notes" {
+		t.Errorf("Prefix = %q, want %q", config.GlobConfig.SlugRules[1].Prefix, "posts/notes")
+	}
+}
+
+func TestParseTOML_GlobSlugRulesDecoder(t *testing.T) {
+	data := []byte(`
+[markata-go]
+
+[markata-go.glob]
+slug_mode = "flat"
+
+[[markata-go.glob.slug_rules]]
+prefix = "posts/blog"
+mode = "flat"
+
+[[markata-go.glob.slug_rules]]
+prefix = "posts/notes"
+mode = "path"
+`)
+
+	var wrapper struct {
+		MarkataGo tomlConfig `toml:"markata-go"`
+	}
+	if err := toml.Unmarshal(data, &wrapper); err != nil {
+		t.Fatalf("toml.Unmarshal() error = %v", err)
+	}
+
+	if len(wrapper.MarkataGo.Glob.SlugRules) != 2 {
+		t.Fatalf("decoder len(SlugRules) = %d, want 2", len(wrapper.MarkataGo.Glob.SlugRules))
+	}
+}
+
 func TestParseTOML_FeedFormats(t *testing.T) {
 	data := []byte(`
 [markata-go]
@@ -710,7 +785,8 @@ func TestParseJSON_NestedConfig(t *testing.T) {
     "output_dir": "public",
     "glob": {
       "patterns": ["posts/**/*.md", "pages/*.md"],
-      "use_gitignore": true
+	      "use_gitignore": true,
+	      "slug_mode": "path"
     },
     "feed_defaults": {
       "items_per_page": 20,
@@ -733,6 +809,9 @@ func TestParseJSON_NestedConfig(t *testing.T) {
 
 	if len(config.GlobConfig.Patterns) != 2 {
 		t.Errorf("len(Patterns) = %d, want 2", len(config.GlobConfig.Patterns))
+	}
+	if config.GlobConfig.SlugMode != "path" {
+		t.Errorf("SlugMode = %q, want %q", config.GlobConfig.SlugMode, "path")
 	}
 	if config.FeedDefaults.ItemsPerPage != 20 {
 		t.Errorf("ItemsPerPage = %d, want 20", config.FeedDefaults.ItemsPerPage)

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -62,6 +62,27 @@ func ValidateConfig(config *models.Config) []error {
 		})
 	}
 
+	if config.GlobConfig.SlugMode != "" && !models.IsValidSlugMode(config.GlobConfig.SlugMode) {
+		errs = append(errs, ValidationError{
+			Field:   "glob.slug_mode",
+			Message: `must be one of: "flat", "path"`,
+		})
+	}
+	for i, rule := range config.GlobConfig.SlugRules {
+		if strings.TrimSpace(rule.Prefix) == "" {
+			errs = append(errs, ValidationError{
+				Field:   fmt.Sprintf("glob.slug_rules[%d].prefix", i),
+				Message: "must not be empty",
+			})
+		}
+		if !models.IsValidSlugMode(rule.Mode) {
+			errs = append(errs, ValidationError{
+				Field:   fmt.Sprintf("glob.slug_rules[%d].mode", i),
+				Message: `must be one of: "flat", "path"`,
+			})
+		}
+	}
+
 	// Validate license configuration
 	if !config.License.IsDisabled() {
 		if key, ok := config.License.Key(); ok {
@@ -152,6 +173,39 @@ func ValidateConfigWithPositions(config *models.Config, tracker *PositionTracker
 			GetFixSuggestion("empty_patterns", "", ""),
 			true,
 		))
+	}
+
+	if config.GlobConfig.SlugMode != "" && !models.IsValidSlugMode(config.GlobConfig.SlugMode) {
+		configErrors.Add(NewConfigErrorWithFix(
+			tracker,
+			"glob.slug_mode",
+			config.GlobConfig.SlugMode,
+			`must be one of: "flat", "path"`,
+			"Use \"flat\" for filename-based slugs or \"path\" for directory-based slugs.",
+			false,
+		))
+	}
+	for i, rule := range config.GlobConfig.SlugRules {
+		if strings.TrimSpace(rule.Prefix) == "" {
+			configErrors.Add(NewConfigErrorWithFix(
+				tracker,
+				fmt.Sprintf("glob.slug_rules[%d].prefix", i),
+				rule.Prefix,
+				"must not be empty",
+				"Set a content path prefix like \"posts/blog\" or remove the rule.",
+				false,
+			))
+		}
+		if !models.IsValidSlugMode(rule.Mode) {
+			configErrors.Add(NewConfigErrorWithFix(
+				tracker,
+				fmt.Sprintf("glob.slug_rules[%d].mode", i),
+				rule.Mode,
+				`must be one of: "flat", "path"`,
+				"Use \"flat\" or \"path\".",
+				false,
+			))
+		}
 	}
 
 	// Validate feed configurations

--- a/pkg/listcache/listcache.go
+++ b/pkg/listcache/listcache.go
@@ -161,7 +161,7 @@ func buildPostsFromCache(
 		return postsByPath, nil
 	}
 
-	updated, err := loadChangedPosts(contentDir, changed)
+	updated, err := loadChangedPosts(contentDir, changed, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -299,21 +299,33 @@ func diffFiles(files []string, contentDir string, cached map[string]FileInfo) (c
 	return current, changed, nil
 }
 
-func loadChangedPosts(contentDir string, changed map[string]bool) ([]*models.Post, error) {
+func loadChangedPosts(contentDir string, changed map[string]bool, cfg *lifecycle.Config) ([]*models.Post, error) {
 	posts := make([]*models.Post, 0, len(changed))
+	modelsConfig := modelsConfigFromLifecycleConfig(cfg)
 	for path := range changed {
 		fullPath := filepath.Join(contentDir, path)
 		content, err := os.ReadFile(fullPath)
 		if err != nil {
 			return nil, fmt.Errorf("read %s: %w", path, err)
 		}
-		post, err := plugins.ParsePostFromContent(path, string(content))
+		post, err := plugins.ParsePostFromContentWithConfig(path, string(content), modelsConfig)
 		if err != nil {
 			return nil, fmt.Errorf("parse %s: %w", path, err)
 		}
 		posts = append(posts, post)
 	}
 	return posts, nil
+}
+
+func modelsConfigFromLifecycleConfig(cfg *lifecycle.Config) *models.Config {
+	if cfg == nil {
+		return nil
+	}
+	modelsConfig, ok := cfg.Extra["models_config"].(*models.Config)
+	if !ok {
+		return nil
+	}
+	return modelsConfig
 }
 
 func applyTransforms(cfg *lifecycle.Config, posts []*models.Post) error {

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -1151,6 +1151,18 @@ type GlobConfig struct {
 
 	// UseGitignore determines whether to respect .gitignore files
 	UseGitignore bool `json:"use_gitignore" yaml:"use_gitignore" toml:"use_gitignore"`
+
+	// SlugMode controls how slugs are derived from matched source paths.
+	SlugMode string `json:"slug_mode" yaml:"slug_mode" toml:"slug_mode"`
+
+	// SlugRules override slug mode for specific content path prefixes.
+	SlugRules []SlugRule `json:"slug_rules,omitempty" yaml:"slug_rules,omitempty" toml:"slug_rules,omitempty"`
+}
+
+// SlugRule selects a slug mode for files under a content path prefix.
+type SlugRule struct {
+	Prefix string `json:"prefix" yaml:"prefix" toml:"prefix"`
+	Mode   string `json:"mode" yaml:"mode" toml:"mode"`
 }
 
 // MarkdownConfig configures markdown processing.

--- a/pkg/models/post.go
+++ b/pkg/models/post.go
@@ -3,6 +3,7 @@ package models
 import (
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 )
@@ -162,6 +163,54 @@ var slugifyRegex = regexp.MustCompile(`[^a-z0-9\-_]+`)
 // multiHyphenRegex matches multiple consecutive hyphens
 var multiHyphenRegex = regexp.MustCompile(`-+`)
 
+const (
+	SlugModeFlat = "flat"
+	SlugModePath = "path"
+)
+
+var slugModeAliases = map[string]string{
+	SlugModeFlat:   SlugModeFlat,
+	SlugModePath:   SlugModePath,
+	"directory":    SlugModePath,
+	"dir":          SlugModePath,
+	"nested":       SlugModePath,
+	"hierarchical": SlugModePath,
+}
+
+var contentRootDirs = []string{"posts", "pages"}
+
+func NormalizeSlugRulePrefix(prefix string) string {
+	prefix = filepath.Clean(strings.TrimSpace(prefix))
+	prefix = strings.ReplaceAll(prefix, string(filepath.Separator), "/")
+	prefix = strings.TrimPrefix(prefix, "./")
+	if prefix == "." {
+		return ""
+	}
+	return strings.Trim(prefix, "/")
+}
+
+func SlugModeForPath(path, defaultMode string, rules []SlugRule) string {
+	normalizedPath := NormalizeSlugRulePrefix(path)
+	bestMode := NormalizeSlugMode(defaultMode)
+	bestPrefixLen := -1
+
+	for _, rule := range rules {
+		prefix := NormalizeSlugRulePrefix(rule.Prefix)
+		if prefix == "" {
+			continue
+		}
+		if normalizedPath != prefix && !strings.HasPrefix(normalizedPath, prefix+"/") {
+			continue
+		}
+		if len(prefix) > bestPrefixLen {
+			bestPrefixLen = len(prefix)
+			bestMode = NormalizeSlugMode(rule.Mode)
+		}
+	}
+
+	return bestMode
+}
+
 // KnownExtensions contains file extensions that should be stripped from filenames.
 // Extensions not in this list are treated as part of the filename.
 var KnownExtensions = map[string]bool{
@@ -181,48 +230,30 @@ func StripKnownExtension(filename string) string {
 	return filename
 }
 
-// GenerateSlug generates a URL-safe slug from the title or path.
-// If a title is set, it uses the title; otherwise, it derives the slug from the file path.
-//
-// Special handling for index.md files:
-//   - ./index.md → "" (empty slug, becomes homepage)
-//   - docs/index.md → "docs"
-//   - blog/guides/index.md → "blog/guides"
+func IsValidSlugMode(mode string) bool {
+	_, ok := slugModeAliases[strings.ToLower(strings.TrimSpace(mode))]
+	return ok
+}
+
+func NormalizeSlugMode(mode string) string {
+	if normalized, ok := slugModeAliases[strings.ToLower(strings.TrimSpace(mode))]; ok {
+		return normalized
+	}
+	return SlugModeFlat
+}
+
+// GenerateSlug generates a URL-safe slug using the default flat mode.
 func (p *Post) GenerateSlug() {
-	var source string
+	p.GenerateSlugWithMode(SlugModeFlat)
+}
 
-	// Check for index.md special case
-	base := filepath.Base(p.Path)
-	if strings.EqualFold(base, "index.md") {
-		// For index.md files, use the directory path as the slug
-		dir := filepath.Dir(p.Path)
-		// Clean up the directory path
-		dir = filepath.Clean(dir)
-		// Remove leading ./ or just .
-		if dir == "." {
-			p.Slug = "" // Root index.md becomes homepage
-			return
-		}
-		// Use directory path as slug (normalized)
-		slug := strings.ToLower(dir)
-		slug = strings.ReplaceAll(slug, string(filepath.Separator), "/")
-		slug = strings.TrimPrefix(slug, "./")
-		p.Slug = slug
-		return
+func (p *Post) GenerateSlugWithMode(mode string) {
+	switch NormalizeSlugMode(mode) {
+	case SlugModePath:
+		p.Slug = generatePathSlug(p.Path, p.Title)
+	default:
+		p.Slug = generateFlatSlug(p.Path, p.Title)
 	}
-
-	// Priority: basename > title
-	// Use the filename without known extension as the primary source
-	// Only strip recognized file extensions, keeping periods in version numbers etc.
-	basename := StripKnownExtension(base)
-	if basename != "" {
-		source = basename
-	} else if p.Title != nil && *p.Title != "" {
-		// Fallback to title if basename is somehow empty
-		source = *p.Title
-	}
-
-	p.Slug = Slugify(source)
 }
 
 // Slugify converts a string to a URL-safe slug.
@@ -245,6 +276,73 @@ func Slugify(s string) string {
 	slug = strings.Trim(slug, "-")
 
 	return slug
+}
+
+func generateFlatSlug(path string, title *string) string {
+	base := filepath.Base(path)
+	if isDirectoryRootFile(base) {
+		dir := filepath.Clean(filepath.Dir(path))
+		if dir == "." {
+			return ""
+		}
+		dir = strings.ReplaceAll(dir, string(filepath.Separator), "/")
+		dir = strings.TrimPrefix(dir, "./")
+		return strings.ToLower(strings.Trim(dir, "/"))
+	}
+	basename := StripKnownExtension(base)
+	if basename != "" {
+		return Slugify(basename)
+	}
+	if title != nil && *title != "" {
+		return Slugify(*title)
+	}
+	return ""
+}
+
+func generatePathSlug(path string, title *string) string {
+	relPath := filepath.Clean(path)
+	relPath = strings.ReplaceAll(relPath, string(filepath.Separator), "/")
+	relPath = strings.TrimPrefix(relPath, "./")
+	relPath = strings.Trim(relPath, "/")
+	if relPath == "" || relPath == "." {
+		return ""
+	}
+
+	parts := strings.Split(relPath, "/")
+	if len(parts) > 0 && slices.Contains(contentRootDirs, strings.ToLower(parts[0])) {
+		parts = parts[1:]
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+
+	last := parts[len(parts)-1]
+	if isDirectoryRootFile(last) {
+		parts = parts[:len(parts)-1]
+	} else {
+		basename := StripKnownExtension(last)
+		if basename != "" {
+			parts[len(parts)-1] = basename
+		} else if title != nil && *title != "" {
+			parts[len(parts)-1] = *title
+		}
+	}
+
+	slugParts := make([]string, 0, len(parts))
+	for _, part := range parts {
+		slug := Slugify(part)
+		if slug == "" {
+			continue
+		}
+		slugParts = append(slugParts, slug)
+	}
+
+	return strings.Join(slugParts, "/")
+}
+
+func isDirectoryRootFile(path string) bool {
+	name := strings.ToLower(StripKnownExtension(filepath.Base(path)))
+	return name == "index" || name == "readme"
 }
 
 // GenerateHref generates the relative URL path from the slug.

--- a/pkg/models/post_test.go
+++ b/pkg/models/post_test.go
@@ -573,6 +573,74 @@ func TestPost_GenerateSlug_RegularMdNotAffected(t *testing.T) {
 	}
 }
 
+func TestPost_GenerateSlugWithMode_Path(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{name: "posts root file", path: "posts/hello-world.md", expected: "hello-world"},
+		{name: "pages nested file", path: "pages/docs/getting-started.md", expected: "docs/getting-started"},
+		{name: "posts nested index", path: "posts/notes/index.md", expected: "notes"},
+		{name: "pages nested readme", path: "pages/docs/README.md", expected: "docs"},
+		{name: "deep nested path", path: "posts/blog/2026/my-post.md", expected: "blog/2026/my-post"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewPost(tt.path)
+			p.GenerateSlugWithMode(SlugModePath)
+			if p.Slug != tt.expected {
+				t.Errorf("Slug: got %q, want %q", p.Slug, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNormalizeSlugMode(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{input: "flat", want: SlugModeFlat},
+		{input: "path", want: SlugModePath},
+		{input: "directory", want: SlugModePath},
+		{input: "nested", want: SlugModePath},
+		{input: "", want: SlugModeFlat},
+		{input: "unknown", want: SlugModeFlat},
+	}
+
+	for _, tt := range tests {
+		if got := NormalizeSlugMode(tt.input); got != tt.want {
+			t.Errorf("NormalizeSlugMode(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestSlugModeForPath(t *testing.T) {
+	rules := []SlugRule{
+		{Prefix: "posts/blog", Mode: SlugModeFlat},
+		{Prefix: "posts/notes", Mode: SlugModePath},
+		{Prefix: "posts/notes/daily", Mode: SlugModeFlat},
+	}
+
+	tests := []struct {
+		path string
+		want string
+	}{
+		{path: "posts/blog/launch.md", want: SlugModeFlat},
+		{path: "posts/notes/today.md", want: SlugModePath},
+		{path: "posts/notes/daily/entry.md", want: SlugModeFlat},
+		{path: "pages/docs/intro.md", want: SlugModeFlat},
+	}
+
+	for _, tt := range tests {
+		if got := SlugModeForPath(tt.path, SlugModeFlat, rules); got != tt.want {
+			t.Errorf("SlugModeForPath(%q) = %q, want %q", tt.path, got, tt.want)
+		}
+	}
+}
+
 // =============================================================================
 // Slug Generation Issue #433 - Periods replaced with dashes
 // =============================================================================

--- a/pkg/plugins/custom_slugs_test.go
+++ b/pkg/plugins/custom_slugs_test.go
@@ -188,6 +188,67 @@ Content`,
 	}
 }
 
+func TestLoadPlugin_PathSlugMode(t *testing.T) {
+	plugin := NewLoadPlugin()
+	plugin.slugMode = models.SlugModePath
+
+	tests := []struct {
+		name     string
+		path     string
+		wantSlug string
+		wantHref string
+	}{
+		{name: "posts nested file", path: "posts/notes/today.md", wantSlug: "notes/today", wantHref: "/notes/today/"},
+		{name: "posts index file", path: "posts/notes/index.md", wantSlug: "notes", wantHref: "/notes/"},
+		{name: "pages readme file", path: "pages/docs/README.md", wantSlug: "docs", wantHref: "/docs/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			post, err := plugin.parseFile(tt.path, "---\npublished: true\n---\ncontent")
+			if err != nil {
+				t.Fatalf("parseFile() error = %v", err)
+			}
+			if post.Slug != tt.wantSlug {
+				t.Errorf("Slug = %q, want %q", post.Slug, tt.wantSlug)
+			}
+			if post.Href != tt.wantHref {
+				t.Errorf("Href = %q, want %q", post.Href, tt.wantHref)
+			}
+		})
+	}
+}
+
+func TestLoadPlugin_SlugRules(t *testing.T) {
+	plugin := NewLoadPlugin()
+	plugin.slugMode = models.SlugModeFlat
+	plugin.slugRules = []models.SlugRule{
+		{Prefix: "posts/blog", Mode: models.SlugModeFlat},
+		{Prefix: "posts/notes", Mode: models.SlugModePath},
+	}
+
+	tests := []struct {
+		name     string
+		path     string
+		wantSlug string
+	}{
+		{name: "blog stays flat", path: "posts/blog/launch-post.md", wantSlug: "launch-post"},
+		{name: "notes become nested", path: "posts/notes/today.md", wantSlug: "notes/today"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			post, err := plugin.parseFile(tt.path, "---\npublished: true\n---\ncontent")
+			if err != nil {
+				t.Fatalf("parseFile() error = %v", err)
+			}
+			if post.Slug != tt.wantSlug {
+				t.Errorf("Slug = %q, want %q", post.Slug, tt.wantSlug)
+			}
+		})
+	}
+}
+
 func TestOverwriteCheckPlugin_DetectsConflicts(t *testing.T) {
 	// Create posts with explicitly set empty slugs (both would be homepage)
 	posts := []*models.Post{

--- a/pkg/plugins/load.go
+++ b/pkg/plugins/load.go
@@ -29,16 +29,24 @@ var (
 )
 
 // LoadPlugin parses markdown files into Post objects.
-type LoadPlugin struct{}
+type LoadPlugin struct {
+	slugMode  string
+	slugRules []models.SlugRule
+}
 
 // NewLoadPlugin creates a new LoadPlugin.
 func NewLoadPlugin() *LoadPlugin {
-	return &LoadPlugin{}
+	return &LoadPlugin{slugMode: models.SlugModeFlat}
 }
 
 // Name returns the plugin identifier.
 func (p *LoadPlugin) Name() string {
 	return "load"
+}
+
+func (p *LoadPlugin) Configure(m *lifecycle.Manager) error {
+	p.slugMode, p.slugRules = configuredSlugSettings(m.Config())
+	return nil
 }
 
 // Load reads and parses all discovered files into Post objects.
@@ -531,7 +539,15 @@ func (p *LoadPlugin) loadSequential(m *lifecycle.Manager, files []string, baseDi
 // This is a lightweight helper for cache-backed workflows that need
 // frontmatter parsing and slug generation without running the full lifecycle.
 func ParsePostFromContent(path, content string) (*models.Post, error) {
-	loader := &LoadPlugin{}
+	return ParsePostFromContentWithConfig(path, content, nil)
+}
+
+func ParsePostFromContentWithConfig(path, content string, cfg *models.Config) (*models.Post, error) {
+	loader := NewLoadPlugin()
+	if cfg != nil {
+		loader.slugMode = models.NormalizeSlugMode(cfg.GlobConfig.SlugMode)
+		loader.slugRules = append([]models.SlugRule{}, cfg.GlobConfig.SlugRules...)
+	}
 	return loader.parseFile(path, content)
 }
 
@@ -556,7 +572,7 @@ func (p *LoadPlugin) parseFile(path, content string) (*models.Post, error) {
 	// Generate slug if not explicitly set in frontmatter
 	// If slug was explicitly set (even to empty string), respect it
 	if !post.Has("_slug_explicit") && post.Slug == "" {
-		post.GenerateSlug()
+		post.GenerateSlugWithMode(models.SlugModeForPath(path, p.slugMode, p.slugRules))
 	}
 
 	// Generate href from slug
@@ -567,6 +583,24 @@ func (p *LoadPlugin) parseFile(path, content string) (*models.Post, error) {
 	post.InputHash = buildcache.ComputePostInputHash(body, rawFrontmatter, post.Template)
 
 	return post, nil
+}
+
+func configuredSlugSettings(cfg *lifecycle.Config) (string, []models.SlugRule) {
+	if cfg == nil {
+		return models.SlugModeFlat, nil
+	}
+	if modelsConfig, ok := cfg.Extra["models_config"].(*models.Config); ok && modelsConfig != nil {
+		return models.NormalizeSlugMode(modelsConfig.GlobConfig.SlugMode), append([]models.SlugRule{}, modelsConfig.GlobConfig.SlugRules...)
+	}
+	if raw, ok := cfg.Extra["slug_mode"].(string); ok {
+		return models.NormalizeSlugMode(raw), nil
+	}
+	return models.SlugModeFlat, nil
+}
+
+func configuredSlugMode(cfg *lifecycle.Config, path string) string {
+	mode, rules := configuredSlugSettings(cfg)
+	return models.SlugModeForPath(path, mode, rules)
 }
 
 // Date field aliases for publication date (first match wins).

--- a/pkg/plugins/publish_html.go
+++ b/pkg/plugins/publish_html.go
@@ -200,7 +200,7 @@ func (p *PublishHTMLPlugin) writePost(post *models.Post, config *lifecycle.Confi
 	// Determine output path
 	// Use slug to create: output_dir/slug/index.html
 	if !post.Has("_slug_explicit") && post.Slug == "" {
-		post.GenerateSlug()
+		post.GenerateSlugWithMode(configuredSlugMode(config, post.Path))
 	}
 
 	outputDir := config.OutputDir

--- a/spec/spec/CONFIG.md
+++ b/spec/spec/CONFIG.md
@@ -787,6 +787,49 @@ og = true        # Enable social card HTML for screenshot tools
 
 ---
 
+### Glob Settings (`[my-ssg.glob]`)
+
+```toml
+[my-ssg.glob]
+patterns = ["posts/**/*.md", "pages/**/*.md"]
+use_gitignore = true
+slug_mode = "flat"    # "flat" (default) or "path"
+```
+
+The glob section controls both file discovery and the default slug derivation strategy.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `patterns` | string[] | `["pages/**/*.md", "posts/**/*.md"]` | Glob patterns to find content files |
+| `use_gitignore` | bool | `true` | Respect `.gitignore` when discovering content |
+| `slug_mode` | string | `"flat"` | How to derive slugs when frontmatter does not set `slug` |
+
+`slug_mode` values:
+
+- `flat` - Current markata behavior. Slugs come from the filename only. Examples: `posts/2026/hello.md -> hello`, `docs/index.md -> docs`.
+- `path` - Derive slugs from the relative content path. Leading `posts/` and `pages/` path segments are removed. `index.md`, `README.md`, and `readme.md` become the root of their containing directory. Examples: `posts/notes/today.md -> notes/today`, `pages/docs/README.md -> docs`.
+
+Optional path-specific overrides can be declared with `slug_rules`:
+
+```toml
+[my-ssg.glob]
+slug_mode = "flat"
+
+[[my-ssg.glob.slug_rules]]
+prefix = "posts/blog"
+mode = "flat"
+
+[[my-ssg.glob.slug_rules]]
+prefix = "posts/notes"
+mode = "path"
+```
+
+Rules use the longest matching prefix, so more specific directories win.
+
+Explicit frontmatter `slug` always wins over `slug_mode`.
+
+---
+
 ### Well-Known Files (`[my-ssg.well_known]`)
 
 ```toml

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -201,6 +201,90 @@ Content here`)
 	}
 }
 
+func TestOutputStructure_PathSlugModeFromContentPath(t *testing.T) {
+	site := newTestSite(t)
+	site.addPost("posts/notes/today.md", `---
+title: Today
+published: true
+---
+Content here`)
+
+	m := lifecycle.NewManager()
+	cfg := &lifecycle.Config{
+		ContentDir:   site.contentDir,
+		OutputDir:    site.outputDir,
+		GlobPatterns: []string{"**/*.md"},
+		Extra:        make(map[string]interface{}),
+	}
+	modelsConfig := config.DefaultConfig()
+	modelsConfig.GlobConfig.SlugMode = models.SlugModePath
+	cfg.Extra["models_config"] = modelsConfig
+	cfg.Extra["url"] = "https://example.com"
+	cfg.Extra["title"] = "Test Site"
+	m.SetConfig(cfg)
+
+	m.RegisterPlugin(plugins.NewGlobPlugin())
+	m.RegisterPlugin(plugins.NewLoadPlugin())
+	m.RegisterPlugin(plugins.NewRenderMarkdownPlugin())
+	m.RegisterPlugin(plugins.NewPublishHTMLPlugin())
+
+	if err := m.Run(); err != nil {
+		t.Fatalf("build failed: %v", err)
+	}
+
+	if !site.fileExists("notes/today/index.html") {
+		t.Error("expected output/notes/today/index.html to exist")
+	}
+}
+
+func TestOutputStructure_SlugRulesHybridMode(t *testing.T) {
+	site := newTestSite(t)
+	site.addPost("posts/blog/launch-post.md", `---
+title: Launch
+published: true
+---
+Launch content`)
+	site.addPost("posts/notes/today.md", `---
+title: Today
+published: true
+---
+Notes content`)
+
+	m := lifecycle.NewManager()
+	cfg := &lifecycle.Config{
+		ContentDir:   site.contentDir,
+		OutputDir:    site.outputDir,
+		GlobPatterns: []string{"**/*.md"},
+		Extra:        make(map[string]interface{}),
+	}
+	modelsConfig := config.DefaultConfig()
+	modelsConfig.GlobConfig.SlugMode = models.SlugModeFlat
+	modelsConfig.GlobConfig.SlugRules = []models.SlugRule{
+		{Prefix: "posts/blog", Mode: models.SlugModeFlat},
+		{Prefix: "posts/notes", Mode: models.SlugModePath},
+	}
+	cfg.Extra["models_config"] = modelsConfig
+	cfg.Extra["url"] = "https://example.com"
+	cfg.Extra["title"] = "Test Site"
+	m.SetConfig(cfg)
+
+	m.RegisterPlugin(plugins.NewGlobPlugin())
+	m.RegisterPlugin(plugins.NewLoadPlugin())
+	m.RegisterPlugin(plugins.NewRenderMarkdownPlugin())
+	m.RegisterPlugin(plugins.NewPublishHTMLPlugin())
+
+	if err := m.Run(); err != nil {
+		t.Fatalf("build failed: %v", err)
+	}
+
+	if !site.fileExists("launch-post/index.html") {
+		t.Error("expected output/launch-post/index.html to exist")
+	}
+	if !site.fileExists("notes/today/index.html") {
+		t.Error("expected output/notes/today/index.html to exist")
+	}
+}
+
 func TestLinkAvatars_RootAbsoluteAssetsOnNestedPage(t *testing.T) {
 	site := newTestSite(t)
 	site.addPost("instant-pot-chicken-teriyaki.md", `---


### PR DESCRIPTION
## Summary
- add `glob.slug_mode` support for `flat` and `path` slug generation while keeping flat slugs as the default
- add `glob.slug_rules` so specific content directories can override slug behavior, enabling hybrid layouts like flat blog posts and nested notes
- document the new slug configuration and cover it with parser, model, plugin, and integration tests

## Testing
- go test ./...
- just lint-fast

## Related
- Refs #931