### PR TITLE
fix(theme): keep fullscreen video backdrops blur-free

### DIFF
--- a/docs/guides/themes.md
+++ b/docs/guides/themes.md
@@ -1270,18 +1270,28 @@ css = '''
 | `backgrounds[].z_index` | integer | Stacking order (-1 is default, behind content) |
 | `scripts` | array | Script URLs to load for background functionality |
 | `css` | string | Custom CSS for styling background elements |
+| `article_bg` | string | Background applied to post/feed content when decorations are enabled |
+| `article_blur_enabled` | boolean | Opt in to backdrop blur on content containers (default: false) |
+| `article_blur` | string | Blur amount used only when `article_blur_enabled = true` |
+| `article_shadow` | string | Box shadow for post/feed content wrappers |
+| `article_border` | string | Border for post/feed content wrappers |
+| `article_radius` | string | Border radius for post/feed content wrappers |
 
 ### Tips for Background Decorations
 
 1. **Performance**: Complex animations can impact performance. Test on lower-powered devices.
 
-2. **Accessibility**: Ensure backgrounds don't interfere with content readability. Use `pointer-events: none` (applied automatically).
+2. **Fullscreen video**: Keep `article_blur_enabled = false` unless you specifically want frosted-glass content. Even a no-op blur can hurt fullscreen video playback on some browsers.
 
-3. **Z-Index**: Use negative values to place backgrounds behind content. Positive values overlay content.
+   Also avoid adding global `::backdrop` blur, since that affects fullscreen media as well as dialogs.
 
-4. **Web Components**: Custom elements like `<snow-fall>` provide encapsulated, reusable effects.
+3. **Accessibility**: Ensure backgrounds don't interfere with content readability. Use `pointer-events: none` (applied automatically).
 
-5. **Reduced Motion**: Consider respecting `prefers-reduced-motion` in your CSS:
+4. **Z-Index**: Use negative values to place backgrounds behind content. Positive values overlay content.
+
+5. **Web Components**: Custom elements like `<snow-fall>` provide encapsulated, reusable effects.
+
+6. **Reduced Motion**: Consider respecting `prefers-reduced-motion` in your CSS:
 
 ```css
 @media (prefers-reduced-motion: reduce) {
@@ -1289,6 +1299,33 @@ css = '''
     animation: none !important;
   }
 }
+```
+
+### Readable Content Over Decorations
+
+Use article wrapper styling to keep content readable without forcing blur:
+
+```toml
+[markata-go.theme.background]
+enabled = true
+article_bg = "color-mix(in srgb, var(--color-background) 88%, transparent)"
+article_shadow = "0 12px 32px rgba(0, 0, 0, 0.12)"
+article_border = "1px solid color-mix(in srgb, var(--color-border) 60%, transparent)"
+article_radius = "1rem"
+
+backgrounds = [
+  { html = '<div class="stars"></div>', z_index = -10 },
+]
+```
+
+If you do want a frosted-glass effect, enable it explicitly:
+
+```toml
+[markata-go.theme.background]
+enabled = true
+article_bg = "rgba(255, 255, 255, 0.72)"
+article_blur_enabled = true
+article_blur = "12px"
 ```
 
 ### Example: Particle Background

--- a/pkg/themes/css_test.go
+++ b/pkg/themes/css_test.go
@@ -236,3 +236,29 @@ func TestCSSSpacingVariables(t *testing.T) {
 		}
 	})
 }
+
+// TestCSSBackdropFilterOptIn validates that expensive backdrop filters stay opt-in.
+func TestCSSBackdropFilterOptIn(t *testing.T) {
+	cssContent, err := ReadStatic("css/main.css")
+	if err != nil {
+		t.Fatalf("Failed to read main.css: %v", err)
+	}
+	css := string(cssContent)
+
+	t.Run("background containers default to no backdrop filter", func(t *testing.T) {
+		if strings.Contains(css, "backdrop-filter: blur(var(--article-blur, 0px))") {
+			t.Error("content containers should not apply blur(0px); use an opt-in filter variable instead")
+		}
+
+		if !strings.Contains(css, "backdrop-filter: var(--article-backdrop-filter, none)") {
+			t.Error("content containers should default backdrop-filter to none unless explicitly enabled")
+		}
+	})
+
+	t.Run("shared backdrop avoids blur for fullscreen media", func(t *testing.T) {
+		sharedBackdrop := regexp.MustCompile(`::backdrop\s*\{[^}]*backdrop-filter:`)
+		if sharedBackdrop.MatchString(css) {
+			t.Error("shared ::backdrop styling should not blur fullscreen media backgrounds")
+		}
+	})
+}

--- a/pkg/themes/default/static/css/main.css
+++ b/pkg/themes/default/static/css/main.css
@@ -189,10 +189,9 @@ input[type="search"]::-webkit-search-cancel-button:hover {
   opacity: 1;
 }
 
-/* Dialog backdrop (for future use) */
+/* Shared backdrop styling; keep blur off for fullscreen media performance */
 ::backdrop {
   background-color: rgba(0, 0, 0, 0.5);
-  backdrop-filter: blur(4px);
 }
 
 /* High contrast mode overrides */
@@ -612,7 +611,7 @@ main.content-bg {
   background: var(--article-bg, var(--color-background));
   border-radius: var(--radius-lg);
   box-shadow: var(--article-shadow);
-  backdrop-filter: blur(var(--article-blur, 0px));
+  backdrop-filter: var(--article-backdrop-filter, none);
 }
 
 /* Header */
@@ -706,7 +705,7 @@ article.post {
 body:has(.background-layer) article.post,
 body:has(.background-decoration) article.post {
   background: var(--article-bg, var(--color-background));
-  backdrop-filter: blur(var(--article-blur, 0px));
+  backdrop-filter: var(--article-backdrop-filter, none);
 }
 
 .post-header {
@@ -1072,7 +1071,7 @@ body:has(.background-layer) div.feed,
 body:has(.background-decoration) section.feed,
 body:has(.background-decoration) div.feed {
   background: var(--article-bg, var(--color-background));
-  backdrop-filter: blur(var(--article-blur, 0px));
+  backdrop-filter: var(--article-backdrop-filter, none);
 }
 
 .feed-header {

--- a/pkg/themes/default/templates/partials/background-css.html
+++ b/pkg/themes/default/templates/partials/background-css.html
@@ -11,6 +11,7 @@
     :root {
       {% if config.theme.background.article_bg %}--article-bg: {{ config.theme.background.article_bg }};{% endif %}
       {% if config.theme.background.article_blur %}--article-blur: {{ config.theme.background.article_blur }};{% endif %}
+      {% if config.theme.background.article_blur_enabled and config.theme.background.article_blur %}--article-backdrop-filter: blur(var(--article-blur));{% endif %}
       {% if config.theme.background.article_shadow %}--article-shadow: {{ config.theme.background.article_shadow }};{% endif %}
       {% if config.theme.background.article_border %}--article-border: {{ config.theme.background.article_border }};{% endif %}
       {% if config.theme.background.article_radius %}--article-radius: {{ config.theme.background.article_radius }};{% endif %}

--- a/spec/spec/THEMES.md
+++ b/spec/spec/THEMES.md
@@ -1408,6 +1408,25 @@ video {
 }
 ```
 
+### Fullscreen Media Performance
+
+Themes MUST keep fullscreen video playback smooth when decorative backgrounds are enabled.
+
+- Content containers MUST NOT apply `backdrop-filter: blur(0px)` or an equivalent no-op filter by default.
+- Backdrop blur for article, feed, or main content wrappers MUST be opt-in via configuration.
+- Theme-level `::backdrop` styling MUST NOT apply blur globally because it also affects fullscreen media backdrops.
+- When blur is disabled, the computed backdrop filter for those wrappers SHOULD be `none` so browsers can promote fullscreen video without repeated page recompositing.
+
+Recommended background configuration fields:
+
+```toml
+[markata-go.theme.background]
+enabled = true
+article_bg = "color-mix(in srgb, var(--color-background) 88%, transparent)"
+article_blur_enabled = false  # default; safer for fullscreen video
+article_blur = "12px"        # only used when article_blur_enabled = true
+```
+
 ### Full-Width Media
 
 Support for edge-to-edge media display:

--- a/templates/partials/background-css.html
+++ b/templates/partials/background-css.html
@@ -11,6 +11,7 @@
     :root {
       {% if config.theme.background.article_bg %}--article-bg: {{ config.theme.background.article_bg }};{% endif %}
       {% if config.theme.background.article_blur %}--article-blur: {{ config.theme.background.article_blur }};{% endif %}
+      {% if config.theme.background.article_blur_enabled and config.theme.background.article_blur %}--article-backdrop-filter: blur(var(--article-blur));{% endif %}
       {% if config.theme.background.article_shadow %}--article-shadow: {{ config.theme.background.article_shadow }};{% endif %}
       {% if config.theme.background.article_border %}--article-border: {{ config.theme.background.article_border }};{% endif %}
       {% if config.theme.background.article_radius %}--article-radius: {{ config.theme.background.article_radius }};{% endif %}


### PR DESCRIPTION
## Summary
- make decorative background blur opt-in for article and feed wrappers so fullscreen video does not inherit costly no-op backdrop filters
- remove global `::backdrop` blur so fullscreen media keeps a dimmed backdrop without blur-induced recompositing
- add regression coverage plus spec and theme guide updates for the new fullscreen performance expectations

## Testing
- `go test ./pkg/themes/...`
- `go test ./pkg/plugins/...`