### PR TITLE
fix: reset pre line height for code blocks

### DIFF
--- a/pkg/themes/default/static/css/code.css
+++ b/pkg/themes/default/static/css/code.css
@@ -16,7 +16,7 @@ code {
 pre {
   font-family: var(--font-mono);
   font-size: var(--text-sm);
-  line-height: var(--leading-relaxed);
+  line-height: normal;
   padding: var(--space-4);
   background: var(--color-surface);
   border-radius: var(--radius-lg);

--- a/spec/spec/THEMES.md
+++ b/spec/spec/THEMES.md
@@ -2023,7 +2023,7 @@ code {
 pre {
   font-family: var(--font-mono);
   font-size: var(--text-sm);
-  line-height: var(--leading-relaxed);
+  line-height: normal;
   padding: var(--space-4);
   background: var(--color-surface);
   border-radius: var(--radius-lg);


### PR DESCRIPTION
## Summary
- reset default theme `pre` blocks to `line-height: normal` so ASCII box drawing and other monospace layouts stay aligned
- update the theme spec snippet to match the implementation
- closes #950

## Testing
- `go test ./...` (timed out after partial progress in this environment)
- `just lint-fast` (timed out in this environment)