### PR TITLE
fix(cli): align new command templates and starter content

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,10 +274,10 @@ markata-go serve -v           # Verbose logging
 Create a new post.
 
 ```bash
-markata-go new "My First Post"         # Creates posts/my-first-post.md
+markata-go new "My First Post"         # Creates pages/post/my-first-post.md
 markata-go new "Hello World" --dir blog  # Creates blog/hello-world.md
-markata-go new "Draft" --draft          # Create as draft (default)
-markata-go new "Published" --draft=false # Create as published
+markata-go new "Draft" --draft          # Create as draft
+markata-go new "Published" --draft=false # Create as published (default)
 ```
 
 ### `markata-go config`

--- a/cmd/markata-go/cmd/new.go
+++ b/cmd/markata-go/cmd/new.go
@@ -16,6 +16,18 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+var contentTemplateAliases = map[string][]string{
+	"article": {"blog-post", "essay", "tutorial"},
+	"note":    {"ping", "thought", "status", "tweet"},
+	"photo":   {"shot", "shots", "image", "gallery"},
+	"video":   {"clip", "cast", "stream"},
+	"link":    {"bookmark", "til", "stars"},
+	"quote":   {"quotation"},
+	"guide":   {"series", "step", "chapter"},
+	"inline":  {"gratitude", "micro"},
+	"contact": {"character", "person"},
+}
+
 var (
 	// newDir is the directory for new posts (overrides template placement).
 	newDir string
@@ -305,6 +317,57 @@ func loadTemplates() map[string]ContentTemplate {
 	return templates
 }
 
+func formatTemplateName(name string) string {
+	aliases := contentTemplateAliases[name]
+	if len(aliases) == 0 {
+		return name
+	}
+
+	return fmt.Sprintf("%s (aka: %s)", name, strings.Join(aliases, ", "))
+}
+
+func formatTemplateEntry(name string, template ContentTemplate) string {
+	return fmt.Sprintf("%s -> %s/ (%s)", formatTemplateName(name), template.Directory, template.Source)
+}
+
+func resolveTemplateAlias(name string) (string, bool) {
+	for canonical, aliases := range contentTemplateAliases {
+		for _, alias := range aliases {
+			if alias == name {
+				return canonical, true
+			}
+		}
+	}
+
+	return "", false
+}
+
+func resolveTemplateSelection(name string, templates map[string]ContentTemplate) (ContentTemplate, string, bool) {
+	if template, exists := templates[name]; exists {
+		return template, name, true
+	}
+
+	canonical, ok := resolveTemplateAlias(name)
+	if !ok {
+		return ContentTemplate{}, "", false
+	}
+
+	template, exists := templates[canonical]
+	if !exists {
+		return ContentTemplate{}, "", false
+	}
+
+	frontmatter := make(map[string]interface{}, len(template.Frontmatter))
+	for k, v := range template.Frontmatter {
+		frontmatter[k] = v
+	}
+	frontmatter["template"] = name
+	frontmatter["templateKey"] = name
+	template.Frontmatter = frontmatter
+
+	return template, canonical, true
+}
+
 // loadTemplatesFromDir loads templates from markdown files in a directory.
 func loadTemplatesFromDir(dir string, templates map[string]ContentTemplate) {
 	entries, err := os.ReadDir(dir)
@@ -452,7 +515,10 @@ func runInteractiveMode(cmd *cobra.Command, templates map[string]ContentTemplate
 		return nil, fmt.Errorf("title is required")
 	}
 
-	template := templates[newTemplate]
+	template, _, ok := resolveTemplateSelection(newTemplate, templates)
+	if !ok {
+		return nil, fmt.Errorf("unknown template %q", newTemplate)
+	}
 
 	// Get template (only prompt if not explicitly set via flag)
 	if !cmd.Flags().Changed("template") {
@@ -461,9 +527,12 @@ func runInteractiveMode(cmd *cobra.Command, templates map[string]ContentTemplate
 			templateNames = append(templateNames, name)
 		}
 		sort.Strings(templateNames)
-		errlnf("Available templates: %s", strings.Join(templateNames, ", "))
+		errln("Available templates:")
+		for _, name := range templateNames {
+			errlnf("  %s", formatTemplateEntry(name, templates[name]))
+		}
 		templateInput := promptNew(reader, "Template", "post")
-		if t, ok := templates[templateInput]; ok {
+		if t, _, ok := resolveTemplateSelection(templateInput, templates); ok {
 			newTemplate = templateInput
 			template = t
 		}
@@ -488,7 +557,7 @@ func runInteractiveMode(cmd *cobra.Command, templates map[string]ContentTemplate
 
 	// Get draft status (only prompt if not explicitly set via flag)
 	if !cmd.Flags().Changed("draft") {
-		newDraft = promptYesNoNew(reader, "Create as draft?", true)
+		newDraft = promptYesNoNew(reader, "Create as draft?", false)
 	}
 
 	errln()
@@ -550,7 +619,7 @@ func runNewCommand(cmd *cobra.Command, args []string) error {
 	templates := loadTemplates()
 
 	// Validate template exists
-	template, exists := templates[newTemplate]
+	template, _, exists := resolveTemplateSelection(newTemplate, templates)
 	if !exists {
 		availableNames := make([]string, 0, len(templates))
 		for name := range templates {
@@ -559,7 +628,6 @@ func runNewCommand(cmd *cobra.Command, args []string) error {
 		sort.Strings(availableNames)
 		return fmt.Errorf("unknown template %q; available templates: %s", newTemplate, strings.Join(availableNames, ", "))
 	}
-
 	var title string
 	var tags []string
 
@@ -630,7 +698,7 @@ func listTemplates() error {
 	outln()
 	for _, name := range names {
 		t := templates[name]
-		outlnf("  %-12s -> %s/  (%s)", name, t.Directory, t.Source)
+		outlnf("  %s", formatTemplateEntry(name, t))
 	}
 	outln()
 	outln("Use --template <name> or -t <name> to select a template.")
@@ -680,9 +748,6 @@ func generateTemplatedContent(title, slug string, date time.Time, draft bool, ta
 	sb.WriteString("---\n")
 	sb.Write(fmBytes)
 	sb.WriteString("---\n\n")
-	sb.WriteString("# ")
-	sb.WriteString(title)
-	sb.WriteString("\n\n")
 
 	// Use template body or default
 	body := template.Body
@@ -746,10 +811,8 @@ tags: %s
 description: ""
 ---
 
-# %s
-
 Write your content here...
-`, title, slug, date.Format("2006-01-02"), published, draft, tagsYAML, title)
+`, title, slug, date.Format("2006-01-02"), published, draft, tagsYAML)
 }
 
 // promptNew displays a question and returns the user's response or a default value.

--- a/cmd/markata-go/cmd/new_huh.go
+++ b/cmd/markata-go/cmd/new_huh.go
@@ -211,7 +211,10 @@ func runHuhNewWizard(templates map[string]ContentTemplate) (*newWizardState, err
 	theme := createHuhTheme(paletteName)
 
 	state := &newWizardState{
-		Template: newTemplate,
+		Template: "post",
+	}
+	if _, resolvedName, ok := resolveTemplateSelection(newTemplate, templates); ok {
+		state.Template = resolvedName
 	}
 
 	// Build all groups for a single form with back navigation.
@@ -567,7 +570,7 @@ func buildTemplateOptions(templates map[string]ContentTemplate) []huh.Option[str
 	options := make([]huh.Option[string], 0, len(names))
 	for _, name := range names {
 		t := templates[name]
-		label := fmt.Sprintf("%s -> %s/ (%s)", name, t.Directory, t.Source)
+		label := formatTemplateEntry(name, t)
 		options = append(options, huh.NewOption(label, name))
 	}
 	return options
@@ -720,7 +723,10 @@ func containsString(slice []string, val string) bool {
 
 // applyNewWizardState generates and writes the content file from wizard state.
 func applyNewWizardState(state *newWizardState, templates map[string]ContentTemplate) error {
-	template := templates[state.Template]
+	template, _, ok := resolveTemplateSelection(state.Template, templates)
+	if !ok {
+		return fmt.Errorf("unknown template %q", state.Template)
+	}
 
 	// Override directory from wizard state
 	outputDir := state.Directory

--- a/cmd/markata-go/cmd/new_test.go
+++ b/cmd/markata-go/cmd/new_test.go
@@ -7,7 +7,18 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/spf13/cobra"
 )
+
+func resetNewCommandFlags() {
+	newDir = ""
+	newDraft = false
+	newTags = ""
+	newTemplate = "post"
+	newList = false
+	newPlain = false
+}
 
 func TestGenerateSlug(t *testing.T) {
 	tests := []struct {
@@ -58,6 +69,7 @@ func TestGenerateSlug(t *testing.T) {
 }
 
 func TestRunNewCommand_NoInputRequiresTitle(t *testing.T) {
+	resetNewCommandFlags()
 	originalNoInput := noInput
 	defer func() { noInput = originalNoInput }()
 
@@ -73,6 +85,41 @@ func TestRunNewCommand_NoInputRequiresTitle(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "title is required when --no-input is set") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunInteractiveMode_TemplateAlias(t *testing.T) {
+	resetNewCommandFlags()
+	newTemplate = "ping"
+
+	cmd := &cobra.Command{}
+	cmd.SetIn(strings.NewReader("My Ping\nnotes\n\nn\n"))
+	cmd.SetOut(bytes.NewBuffer(nil))
+	cmd.SetErr(bytes.NewBuffer(nil))
+	currentCmd = cmd
+	defer func() { currentCmd = nil }()
+
+	input, err := runInteractiveMode(cmd, builtinTemplates())
+	if err != nil {
+		t.Fatalf("runInteractiveMode returned error: %v", err)
+	}
+	if got := input.template.Frontmatter["template"]; got != "ping" {
+		t.Fatalf("template frontmatter = %v, want ping", got)
+	}
+	if got := input.template.Frontmatter["templateKey"]; got != "ping" {
+		t.Fatalf("templateKey frontmatter = %v, want ping", got)
+	}
+	if input.template.Directory != "pages/note" {
+		t.Fatalf("directory = %q, want %q", input.template.Directory, "pages/note")
+	}
+	if newDir != "pages/note" {
+		t.Fatalf("newDir = %q, want %q", newDir, "pages/note")
+	}
+	if newDraft {
+		t.Fatal("expected draft prompt to leave newDraft false")
+	}
+	if input.title != "My Ping" {
+		t.Fatalf("title = %q, want %q", input.title, "My Ping")
 	}
 }
 
@@ -304,14 +351,46 @@ func TestGenerateTemplatedContent(t *testing.T) {
 		t.Error("content should contain tags")
 	}
 
-	// Check heading
-	if !strings.Contains(content, "# My Test Post") {
-		t.Error("content should contain heading")
+	if strings.Contains(content, "# My Test Post") {
+		t.Error("content should not contain an H1 heading")
 	}
 
 	// Check body
 	if !strings.Contains(content, "Start writing here...") {
 		t.Error("content should contain template body")
+	}
+}
+
+func TestResolveTemplateSelection_Alias(t *testing.T) {
+	templates := builtinTemplates()
+
+	template, resolvedName, ok := resolveTemplateSelection("ping", templates)
+	if !ok {
+		t.Fatal("expected alias template resolution to succeed")
+	}
+	if resolvedName != "note" {
+		t.Fatalf("resolvedName = %q, want %q", resolvedName, "note")
+	}
+	if got := template.Frontmatter["template"]; got != "ping" {
+		t.Fatalf("template frontmatter = %v, want ping", got)
+	}
+	if got := template.Frontmatter["templateKey"]; got != "ping" {
+		t.Fatalf("templateKey frontmatter = %v, want ping", got)
+	}
+	if template.Directory != templates["note"].Directory {
+		t.Fatalf("directory = %q, want %q", template.Directory, templates["note"].Directory)
+	}
+}
+
+func TestFormatTemplateEntry_IncludesAliases(t *testing.T) {
+	template := builtinTemplates()["note"]
+	entry := formatTemplateEntry("note", template)
+
+	if !strings.Contains(entry, "note (aka: ping, thought, status, tweet)") {
+		t.Fatalf("entry = %q, expected aliases", entry)
+	}
+	if !strings.Contains(entry, "-> pages/note/") {
+		t.Fatalf("entry = %q, expected directory", entry)
 	}
 }
 
@@ -392,6 +471,9 @@ func TestGeneratePostContentWithTags(t *testing.T) {
 	contentNoTags := generatePostContentWithTags("No Tags", "no-tags", date, true, nil)
 	if !strings.Contains(contentNoTags, "tags: []") {
 		t.Error("should contain empty tags array")
+	}
+	if strings.Contains(content, "# Test Post") {
+		t.Error("should not contain an H1 heading")
 	}
 }
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -160,7 +160,7 @@ Create a new post with the `new` command:
 
 ```bash
 markata-go new "My First Post"
-# Creates: posts/my-first-post.md
+# Creates: pages/post/my-first-post.md
 ```
 
 This generates a markdown file with YAML frontmatter:
@@ -170,13 +170,12 @@ This generates a markdown file with YAML frontmatter:
 title: "My First Post"
 slug: "my-first-post"
 date: 2026-01-21
-published: false
-draft: true
+published: true
+draft: false
 tags: []
-template: "post.html"
+description: ""
+template: post
 ---
-
-# My First Post
 
 Write your content here...
 ```
@@ -188,11 +187,11 @@ Write your content here...
 | `title` | string | - | Post title |
 | `slug` | string | auto | URL-safe identifier (auto-generated from title) |
 | `date` | date | - | Publication date |
-| `published` | bool | `false` | Whether the post is publicly visible |
+| `published` | bool | `true` | Whether the post is publicly visible |
 | `draft` | bool | `false` | Mark as work-in-progress |
 | `tags` | []string | `[]` | List of tags for categorization |
-| `description` | string | auto | Meta description (auto-generated if not set) |
-| `template` | string | `post.html` | Template file to use |
+| `description` | string | `""` | Meta description placeholder |
+| `template` | string | `post` | Content template to use |
 
 Any additional fields are stored in `Extra` and accessible in templates.
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -1480,7 +1480,7 @@ Content templates configure the `markata-go new` command, controlling default fr
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `directory` | string | `"content-templates"` | Directory for user-defined template files |
-| `placement` | object | `{post:"posts",page:"pages",docs:"docs"}` | Map of template names to output directories |
+| `placement` | object | `{post:"pages/post",page:"pages",docs:"docs"}` | Map of template names to output directories |
 | `templates` | array | `[]` | Custom template definitions |
 
 ```toml
@@ -1544,6 +1544,10 @@ markata-go new "My Post"                  # Use default (post) template
 markata-go new "Tutorial" -t tutorial     # Use custom template
 markata-go new "Recipe" -t recipe --dir custom  # Override directory
 ```
+
+Built-in content templates are listed with aliases in `markata-go new --list`, such as `note (aka: ping, thought, status, tweet)`. Built-in aliases are also accepted directly with `--template`.
+
+Generated files include frontmatter plus the configured body template, but they do not include a starter `# H1` heading. markata-go already renders the page title from frontmatter, so starter content should begin with body text or `##` sections.
 
 See [[cli-reference|CLI Reference]] for complete `new` command documentation.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -457,7 +457,7 @@ Creating project structure...
 Create your first post? (Y/n): y
 Post title [Hello World]: My First Post
 
-  ✓ Created posts/my-first-post.md
+  ✓ Created pages/post/my-first-post.md
 
 Done! Run 'markata-go serve' to start.
 ```
@@ -504,14 +504,24 @@ markata-go new [title] [flags]
 
 | Template | Directory | Description |
 |----------|-----------|-------------|
-| `post` | `posts/` | Blog posts with standard frontmatter |
+| `post` | `pages/post/` | Blog posts with standard frontmatter |
 | `page` | `pages/` | Static pages |
 | `docs` | `docs/` | Documentation pages |
+| `article` (`blog-post`, `essay`, `tutorial`) | `pages/article/` | Long-form article content |
+| `note` (`ping`, `thought`, `status`, `tweet`) | `pages/note/` | Short note and micro-post content |
+| `photo` (`shot`, `shots`, `image`, `gallery`) | `pages/photo/` | Image-focused posts |
+| `video` (`clip`, `cast`, `stream`) | `pages/video/` | Video posts |
+| `link` (`bookmark`, `til`, `stars`) | `pages/link/` | Link and bookmark posts |
+| `quote` (`quotation`) | `pages/quote/` | Quote posts with attribution |
+| `guide` (`series`, `step`, `chapter`) | `pages/guide/` | Guides and multi-part content |
+| `inline` (`gratitude`, `micro`) | `pages/inline/` | Inline feed-first content |
+| `contact` (`character`, `person`) | `pages/contact/` | Profile/contact pages |
+| `author` | `pages/author/` | Author profile pages |
 
 #### Examples
 
 ```bash
-# Create a new post (creates posts/my-first-post.md)
+# Create a new post (creates pages/post/my-first-post.md)
 markata-go new "My First Post"
 
 # Use a different template
@@ -530,15 +540,15 @@ markata-go new "Hello World" --template post --dir blog
 
 # Create as a draft (opt-in, default is published)
 markata-go new "Work in Progress" --draft
-# Creates: posts/work-in-progress.md with draft: true
+# Creates: pages/post/work-in-progress.md with draft: true
 
 # Create as published (default behavior)
 markata-go new "Ready to Publish"
-# Creates: posts/ready-to-publish.md with draft: false, published: true
+# Creates: pages/post/ready-to-publish.md with draft: false, published: true
 
 # Create with tags
 markata-go new "Go Tutorial" --tags "go,tutorial,programming"
-# Creates: posts/go-tutorial.md with tags: ["go", "tutorial", "programming"]
+# Creates: pages/post/go-tutorial.md with tags: ["go", "tutorial", "programming"]
 
 # Interactive mode (no arguments) - launches TUI wizard
 markata-go new
@@ -554,9 +564,11 @@ Templates control the default frontmatter and output directory for new content.
 
 **Template Discovery:**
 
-1. **Built-in templates** - `post`, `page`, `docs` are always available
+1. **Built-in templates** - `post`, `page`, `docs`, `article`, `note`, `photo`, `video`, `link`, `quote`, `guide`, `inline`, `contact`, and `author` are always available
 2. **Config templates** - Defined in `markata-go.toml` under `[content_templates]`
 3. **File templates** - Markdown files in `content-templates/` directory
+
+Built-in content types with aliases are shown in `markata-go new --list` as `type (aka: alias1, alias2)`. You can also pass those aliases directly to `--template`; for example, `--template ping` resolves to the built-in `note` template while preserving `template: ping` in frontmatter.
 
 **Configuration Example:**
 
@@ -622,17 +634,17 @@ The wizard guides you through:
 $ markata-go new
 
 ? Select a template
-  > post - Blog post (posts/)
+  > post - Blog post (pages/post/)
     page - Static page (pages/)
     docs - Documentation (docs/)
 
 ? Title: My New Post
-? Select a directory: posts (default)
+? Select a directory: pages/post (default)
 ? Select tags: [go, tutorial]
 ? Make this post private? No
-? Create my-new-post.md in posts/? Yes
+? Create my-new-post.md in pages/post/? Yes
 
-Created: posts/my-new-post.md
+Created: pages/post/my-new-post.md
 ```
 
 **Plain text mode:** Use `--plain` or pipe input to get simple text prompts instead of the TUI.
@@ -656,10 +668,10 @@ tags:
 description: ""
 ---
 
-# My First Post
-
 Write your content here...
 ```
+
+The generated body does not include a starter H1. markata-go renders the page title from frontmatter, so content should start with regular body text or an `##` heading.
 
 The slug is automatically generated from the title by:
 - Converting to lowercase

--- a/spec/spec/CLI_NEW.md
+++ b/spec/spec/CLI_NEW.md
@@ -77,7 +77,9 @@ the title argument.
 - `huh.Select` showing all available templates
 - Default: `post` (or value from `--template` flag)
 - Templates sourced from: builtins, config, content-templates/ directory
-- Each option shows: `name -> directory/ (source)`
+- Built-in supported content types are shown with aliases when available, for example `note (aka: ping, thought, status, tweet)`
+- Each option shows: `name (aka: aliases) -> directory/ (source)` when aliases exist, otherwise `name -> directory/ (source)`
+- The command accepts either the canonical built-in type or any built-in alias via `--template`; aliases are written back to frontmatter as the selected `template`/`templateKey` value
 
 #### 3. Directory Selection
 
@@ -141,10 +143,10 @@ authors:              # Only if multi-author configured
   - author-id
 ---
 
-# The Post Title
-
 Write your content here...
 ```
+
+The generated markdown body MUST NOT include a default H1 heading. Page templates already render the post title as the document H1, so generated starter content begins directly with the template body.
 
 ### Defaults
 
@@ -163,7 +165,7 @@ Write your content here...
 
 ```toml
 [content_templates.placement]
-post = "posts"
+post = "pages/post"
 page = "pages"
 docs = "docs"
 article = "pages/article"


### PR DESCRIPTION
## Summary
- add built-in template alias labels and alias resolution for `markata-go new` across list, plain prompts, and the TUI flow
- stop generating a duplicate H1 in new starter content and default plain interactive creation to `draft: false`
- align the spec and docs with current `pages/post` placement and published-by-default behavior

## Testing
- `go test ./cmd/markata-go/cmd`
- `just lint-new`

## Issue
- Fixes #952