### PR TITLE
fix: disable managed Tailwind preflight by default

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -391,6 +391,7 @@ into your theme so you don't need a separate build step.
 ```toml
 [markata-go.tailwind]
 include = "css"                # "css", "js", or false (default: "css")
+preflight = false               # Enable Tailwind Preflight reset styles (default: false)
 input = "tailwind.css"          # Input CSS (relative to assets_dir)
 output = "markata-tailwind.css" # Output CSS (relative to assets_dir)
 config_file = ""                # Optional tailwind.config.js path
@@ -412,8 +413,10 @@ verbose = false                  # Verbose installer/build logs
   you, so basic utility usage works without creating `tailwind.css` first.
 - If `extra_args` is empty and `config_file` is unset, markata-go generates a
   temporary Tailwind config that scans a generated token manifest built from
-  rendered page HTML plus local JS/template sources. The manifest is hashed so
-  Tailwind is skipped when the effective utility set has not changed.
+  rendered page HTML plus local JS/template sources. That generated config
+  disables Tailwind Preflight by default so utilities do not override markata-go's
+  built-in theme styles. Set `preflight = true` to opt back into the reset. The
+  manifest is hashed so Tailwind is skipped when the effective utility set has not changed.
 - `include = "css"` loads the compiled CSS. If `theme.custom_css` is unset, the
   Tailwind output is assigned automatically. Explicit `theme.custom_css` always wins.
 - `include = "js"` injects `https://cdn.tailwindcss.com` in the document head.
@@ -429,6 +432,9 @@ override that behavior.
 
 **Validation warning:** If `include = "css"` and `[markata-go.css_purge].enabled = false`,
 markata-go emits a warning because Tailwind outputs an intentionally large CSS bundle.
+
+For Tailwind-first sites with a custom reset strategy, either set `preflight = true`
+or provide your own `config_file`. User-supplied Tailwind config files are respected as-is.
 
 ### Aesthetic Settings (`[markata-go]`)
 

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -3694,6 +3694,7 @@ compiled CSS or the Tailwind CDN JS script into your site.
 ```toml
 [markata-go.tailwind]
 include = "css"                # "css", "js", or false (default: "css")
+preflight = false               # Enable Tailwind Preflight reset styles (default: false)
 input = "tailwind.css"          # Input CSS (relative to assets_dir)
 output = "markata-tailwind.css" # Output CSS (relative to assets_dir)
 config_file = ""                # Optional tailwind.config.js path
@@ -3710,6 +3711,7 @@ verbose = false                  # Verbose installer/build logs
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `include` | string \| bool | `"css"` | Load the compiled CSS (`"css"`), inject the CDN JS (`"js"`), or disable auto-inclusion (`false`). |
+| `preflight` | bool | `false` | Enable Tailwind Preflight reset styles in markata-go's generated Tailwind config. |
 | `input` | string | `"tailwind.css"` | Tailwind input CSS (relative to `assets_dir`). |
 | `output` | string | `"markata-tailwind.css"` | Output CSS path (relative to `assets_dir`). |
 | `config_file` | string | `""` | Optional path to `tailwind.config.js`. |
@@ -3726,7 +3728,7 @@ verbose = false                  # Verbose installer/build logs
 1. Injects Tailwind includes during Configure, then rebuilds CSS during Cleanup only when the effective utility manifest changes.
 2. Resolves `input`/`output` relative to `assets_dir` (absolute paths are respected).
 3. If `input` is missing, generates a default Tailwind entry CSS file automatically.
-4. If `extra_args` is empty and `config_file` is unset, generates a temporary Tailwind config from a cached token manifest derived from rendered HTML plus local JS/template sources.
+4. If `extra_args` is empty and `config_file` is unset, generates a temporary Tailwind config from a cached token manifest derived from rendered HTML plus local JS/template sources, with `corePlugins.preflight` controlled by `tailwind.preflight`.
 5. `include = "css"` sets `theme.custom_css` to the output if it's empty.
 6. `include = "js"` injects the Tailwind CDN script and respects assets mode for vendoring.
 7. Fast mode skips Tailwind rebuilds when the compiled asset already exists.
@@ -3735,6 +3737,7 @@ verbose = false                  # Verbose installer/build logs
 **Notes:**
 - Tailwind CLI is downloaded with checksum verification (versioned per platform).
 - With default settings, markata-go prefers the managed Tailwind binary for consistency.
+- Preflight defaults to off in markata-go-managed configs so utility classes can be layered onto the built-in theme without resetting post typography.
 - If `auto_install = false`, the plugin uses `binary` or searches `PATH`.
 
 ### Examples

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -177,6 +177,17 @@ func applyEnvOverride(config *models.Config, key, value string) {
 		build := parseBool(value)
 		tailwindConfig.Build = &build
 		config.Extra["tailwind"] = tailwindConfig
+	case "tailwind_preflight":
+		if config.Extra == nil {
+			config.Extra = make(map[string]interface{})
+		}
+		tailwindConfig, ok := config.Extra["tailwind"].(models.TailwindConfig)
+		if !ok {
+			tailwindConfig = models.NewTailwindConfig()
+		}
+		preflight := parseBool(value)
+		tailwindConfig.Preflight = &preflight
+		config.Extra["tailwind"] = tailwindConfig
 	// Encryption settings
 	case "encryption_enabled":
 		config.Encryption.Enabled = parseBool(value)

--- a/pkg/config/env_test.go
+++ b/pkg/config/env_test.go
@@ -241,6 +241,27 @@ func TestApplyEnvOverrides_TailwindBuild(t *testing.T) {
 	}
 }
 
+func TestApplyEnvOverrides_TailwindPreflight(t *testing.T) {
+	cleanup := setEnvVars(t, map[string]string{
+		"MARKATA_GO_TAILWIND_PREFLIGHT": "true",
+	})
+	defer cleanup()
+
+	config := DefaultConfig()
+	config.Extra["tailwind"] = models.NewTailwindConfig()
+	if err := ApplyEnvOverrides(config); err != nil {
+		t.Fatalf("ApplyEnvOverrides() error = %v", err)
+	}
+
+	tailwindConfig, ok := config.Extra["tailwind"].(models.TailwindConfig)
+	if !ok {
+		t.Fatalf("tailwind config missing from Extra: %#v", config.Extra["tailwind"])
+	}
+	if tailwindConfig.Preflight == nil || !*tailwindConfig.Preflight {
+		t.Fatalf("Tailwind.Preflight = %#v, want true", tailwindConfig.Preflight)
+	}
+}
+
 func TestApplyEnvOverrides_CaseInsensitive(t *testing.T) {
 	// Test that keys are case-insensitive
 	cleanup := setEnvVars(t, map[string]string{

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -2020,6 +2020,11 @@ type TailwindConfig struct {
 	// Empty means use the default (css).
 	Include *string `json:"include,omitempty" yaml:"include,omitempty" toml:"include,omitempty"`
 
+	// Preflight controls whether Tailwind's base reset styles are enabled.
+	// Defaults to false for markata-go's built-in theme so utility classes work
+	// without overriding existing theme typography and spacing.
+	Preflight *bool `json:"preflight,omitempty" yaml:"preflight,omitempty" toml:"preflight,omitempty"`
+
 	// Input is the Tailwind input CSS file path. Relative paths are resolved
 	// against assets_dir unless they already start with assets_dir.
 	Input string `json:"input,omitempty" yaml:"input,omitempty" toml:"input,omitempty"`
@@ -2062,8 +2067,10 @@ func NewTailwindConfig() TailwindConfig {
 	autoInstall := true
 	minify := true
 	include := "css"
+	preflight := false
 	return TailwindConfig{
 		Include:     &include,
+		Preflight:   &preflight,
 		Input:       "tailwind.css",
 		Output:      "markata-tailwind.css",
 		ConfigFile:  "",
@@ -2119,6 +2126,15 @@ func (t *TailwindConfig) IncludeMode() string {
 		return "css"
 	}
 	return *t.Include
+}
+
+// IsPreflightEnabled returns whether Tailwind preflight reset styles are enabled.
+// Defaults to false if not explicitly set.
+func (t *TailwindConfig) IsPreflightEnabled() bool {
+	if t.Preflight == nil {
+		return false
+	}
+	return *t.Preflight
 }
 
 // ImageZoomConfig configures the image_zoom plugin for lightbox functionality.

--- a/pkg/plugins/tailwind.go
+++ b/pkg/plugins/tailwind.go
@@ -279,6 +279,10 @@ func (p *TailwindPlugin) parseTailwindConfigBools(raw map[string]interface{}, re
 		value := tailwindConfigBoolean(rawBuild, true)
 		result.Build = &value
 	}
+	if rawPreflight, ok := raw["preflight"]; ok {
+		value := tailwindConfigBoolean(rawPreflight, false)
+		result.Preflight = &value
+	}
 	if rawMinify, ok := raw["minify"]; ok {
 		value := tailwindConfigBoolean(rawMinify, true)
 		result.Minify = &value
@@ -622,7 +626,7 @@ func (p *TailwindPlugin) resolveBuildConfigFile(_ *lifecycle.Config, contentPath
 		content = append(content, fmt.Sprintf("  %q", filepath.ToSlash(pattern)))
 	}
 
-	configJS := "module.exports = {\ncontent: [\n" + strings.Join(content, ",\n") + "\n]\n}\n"
+	configJS := "module.exports = {\ncontent: [\n" + strings.Join(content, ",\n") + "\n],\ncorePlugins: {\n  preflight: " + boolToJS(p.config.IsPreflightEnabled()) + "\n}\n}\n"
 	if _, err := tmpFile.WriteString(configJS); err != nil {
 		cleanup()
 		_ = tmpFile.Close()
@@ -666,6 +670,12 @@ func (p *TailwindPlugin) computeTailwindManifestHash(config *lifecycle.Config, m
 	builder.WriteString(p.tailwindInputHash(config))
 	builder.WriteString("\n--tailwind-minify:")
 	if p.config.IsMinifyEnabled() {
+		builder.WriteString("true")
+	} else {
+		builder.WriteString("false")
+	}
+	builder.WriteString("\n--tailwind-preflight:")
+	if p.config.IsPreflightEnabled() {
 		builder.WriteString("true")
 	} else {
 		builder.WriteString("false")
@@ -719,6 +729,13 @@ func headHasScript(scripts []models.ScriptTag, src string) bool {
 		}
 	}
 	return false
+}
+
+func boolToJS(value bool) string {
+	if value {
+		return BoolTrue
+	}
+	return BoolFalse
 }
 
 func tailwindNormalizeInclude(value string) string {

--- a/pkg/plugins/tailwind_test.go
+++ b/pkg/plugins/tailwind_test.go
@@ -76,6 +76,48 @@ func TestTailwindPlugin_ResolveBuildConfigFile_GeneratesContentConfig(t *testing
 			t.Fatalf("generated config missing %q:\n%s", needle, text)
 		}
 	}
+	if !strings.Contains(text, "preflight: false") {
+		t.Fatalf("generated config should disable preflight by default:\n%s", text)
+	}
+}
+
+func TestTailwindPlugin_ResolveBuildConfigFile_AllowsPreflightOptIn(t *testing.T) {
+	plugin := NewTailwindPlugin()
+	plugin.config = models.NewTailwindConfig()
+	preflight := true
+	plugin.config.Preflight = &preflight
+
+	configPath, cleanup, err := plugin.resolveBuildConfigFile(&lifecycle.Config{}, []string{"/tmp/manifest.txt"})
+	if err != nil {
+		t.Fatalf("resolveBuildConfigFile() error = %v", err)
+	}
+	defer cleanup()
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", configPath, err)
+	}
+	text := string(data)
+	if !strings.Contains(text, "preflight: true") {
+		t.Fatalf("generated config should preserve explicit preflight opt-in:\n%s", text)
+	}
+}
+
+func TestTailwindPlugin_ManifestHashChangesWhenPreflightChanges(t *testing.T) {
+	tmpDir := t.TempDir()
+	plugin := NewTailwindPlugin()
+	plugin.config = models.NewTailwindConfig()
+	config := &lifecycle.Config{Extra: map[string]interface{}{"assets_dir": tmpDir}}
+
+	baseHash := plugin.computeTailwindManifestHash(config, "tokens")
+
+	preflight := true
+	plugin.config.Preflight = &preflight
+	preflightHash := plugin.computeTailwindManifestHash(config, "tokens")
+
+	if baseHash == preflightHash {
+		t.Fatal("expected manifest hash to change when preflight setting changes")
+	}
 }
 
 func TestExtractTailwindTokens(t *testing.T) {

--- a/spec/spec/CONFIG.md
+++ b/spec/spec/CONFIG.md
@@ -716,6 +716,7 @@ pseudo-only selectors like `:root` or `::selection` to avoid dropping base/theme
 ```toml
 [my-ssg.tailwind]
 include = "css"                # "css", "js", or false (default: "css")
+preflight = false               # Enable Tailwind Preflight reset styles (default: false)
 input = "tailwind.css"          # Input CSS (relative to assets_dir)
 output = "markata-tailwind.css" # Output CSS (relative to assets_dir)
 config_file = ""                # Optional tailwind.config.js path
@@ -739,11 +740,15 @@ Behavior:
 
 - `build = true` injects the Tailwind output during configure and performs the
   actual Tailwind rebuild in cleanup when needed.
+- `preflight = false` is the default for markata-go-managed Tailwind configs so
+  Tailwind utilities work without resetting the built-in theme's typography and
+  spacing. Set `preflight = true` for Tailwind-first sites that want the reset.
 - `input`/`output` resolve relative to `assets_dir` (absolute paths are respected).
 - If `extra_args` is empty and `config_file` is unset, markata-go generates a
   temporary Tailwind config that scans a generated token manifest derived from
-  rendered page HTML plus local JS/template sources. The manifest is hashed and
-  cached so Tailwind is skipped when the effective utility set is unchanged.
+  rendered page HTML plus local JS/template sources. The generated config also
+  sets `corePlugins.preflight` from `tailwind.preflight`. The manifest is hashed
+  and cached so Tailwind is skipped when the effective utility set is unchanged.
 - `include = "css"` ensures the output CSS is included in templates. If
   `theme.custom_css` is unset, it is set to the output path. The plugin does not
   override explicit `theme.custom_css` values.

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -454,6 +454,60 @@ This post is long enough to trigger the reading progress indicator.
 	}
 }
 
+func TestTailwindManagedConfig_DisablesPreflightByDefault(t *testing.T) {
+	site := newTestSite(t)
+	site.addPost("tailwind.md", `---
+title: Tailwind Defaults
+published: true
+---
+# Heading
+
+<div class="text-red-500 font-bold">utility text</div>
+`)
+
+	m := lifecycle.NewManager()
+	cfg := &lifecycle.Config{
+		ContentDir:   site.contentDir,
+		OutputDir:    site.outputDir,
+		GlobPatterns: []string{"**/*.md"},
+		Extra:        make(map[string]interface{}),
+	}
+	cfg.Extra["url"] = "https://example.com"
+	cfg.Extra["title"] = "Test Site"
+	cfg.Extra["tailwind"] = models.NewTailwindConfig()
+	m.SetConfig(cfg)
+
+	templatesPlugin := plugins.NewTemplatesPlugin()
+	if err := templatesPlugin.Configure(m); err != nil {
+		t.Fatalf("templates configure failed: %v", err)
+	}
+
+	m.RegisterPlugin(plugins.NewTailwindPlugin())
+	m.RegisterPlugin(plugins.NewStaticAssetsPlugin())
+	m.RegisterPlugin(plugins.NewGlobPlugin())
+	m.RegisterPlugin(plugins.NewLoadPlugin())
+	m.RegisterPlugin(plugins.NewRenderMarkdownPlugin())
+	m.RegisterPlugin(templatesPlugin)
+	m.RegisterPlugin(plugins.NewPublishHTMLPlugin())
+
+	if err := m.Run(); err != nil {
+		t.Fatalf("build failed: %v", err)
+	}
+
+	html := site.readFile("tailwind/index.html")
+	if !strings.Contains(html, "/markata-tailwind.css") {
+		t.Fatalf("expected managed Tailwind CSS to be included, got %s", html)
+	}
+
+	tailwindCSS := site.readFile("markata-tailwind.css")
+	if strings.Contains(tailwindCSS, "h1,h2,h3,h4,h5,h6{font-size:inherit;font-weight:inherit}") {
+		t.Fatal("expected preflight heading reset to be disabled in managed Tailwind CSS")
+	}
+	if !strings.Contains(tailwindCSS, ".text-red-500") {
+		t.Fatal("expected Tailwind utility class to be generated")
+	}
+}
+
 // =============================================================================
 // Feed Format Tests (from tests.yaml feed_formats)
 // =============================================================================


### PR DESCRIPTION
## Summary
- add a `tailwind.preflight` option and default markata-go-managed Tailwind builds to `false`
- generate managed Tailwind config with `corePlugins.preflight` set from config and cover it with regression tests
- document the new default and note that custom `tailwind.config.js` files are still respected

## Testing
- go test ./pkg/plugins ./pkg/config ./tests
- just lint-fast

## Issues
- Fixes #956