### PR TITLE
fix: speed up and wire view transition navigation

### DIFF
--- a/cmd/markata-go/cmd/benchmark.go
+++ b/cmd/markata-go/cmd/benchmark.go
@@ -418,6 +418,9 @@ func createBenchmarkManager(cfgPath, workDir string) (*lifecycle.Manager, error)
 	// Pass mentions configuration
 	lcConfig.Extra["mentions"] = cfg.Mentions
 
+	// Pass view transitions configuration
+	lcConfig.Extra["view_transitions"] = cfg.ViewTransitions
+
 	m.SetConfig(lcConfig)
 
 	if cfg.Concurrency > 0 {

--- a/cmd/markata-go/cmd/core.go
+++ b/cmd/markata-go/cmd/core.go
@@ -107,6 +107,9 @@ func createManager(cfgPath string) (*lifecycle.Manager, error) {
 	// Pass tags configuration
 	lcConfig.Extra["tags"] = cfg.Tags
 
+	// Pass view transitions configuration
+	lcConfig.Extra["view_transitions"] = cfg.ViewTransitions
+
 	// Pass garden configuration
 	lcConfig.Extra["garden"] = cfg.Garden
 

--- a/docs/guides/view-transitions.md
+++ b/docs/guides/view-transitions.md
@@ -82,8 +82,9 @@ The browser animates between old and new content:
 
 ```javascript
 document.startViewTransition(() => {
-  // Update DOM
-  document.body.innerHTML = newDoc.body.innerHTML;
+  // Update the changing layout regions
+  document.querySelector('#view-transition-page').innerHTML =
+    newDoc.querySelector('#view-transition-page').innerHTML;
   document.title = newDoc.title;
   history.pushState(null, '', url);
 });
@@ -256,6 +257,7 @@ Now cards will morph smoothly when navigating!
 2. **Optimize images** - Images in new content delay transition
 3. **Minimize inline scripts** - Scripts need re-initialization
 4. **Use caching** - Browser caches reduce fetch time
+5. **Swap smaller regions** - Replacing the page wrapper is usually cheaper than replacing the entire `body`
 
 ## Accessibility
 

--- a/docs/reference/view-transitions-config.md
+++ b/docs/reference/view-transitions-config.md
@@ -19,28 +19,30 @@ View Transitions can be configured via your `markata.toml` or YAML config file. 
 
 ## Configuration Options
 
-Add a `[view_transitions]` section to your config:
+Add a `[markata-go.view_transitions]` section to your config:
 
 ```toml
-[view_transitions]
+[markata-go.view_transitions]
 enabled = true              # Enable/disable view transitions globally
 debug = false               # Log debug messages to console
-duration = 300              # Default transition duration in ms
+duration = 120              # Default transition duration in ms
 update_meta = true          # Update meta tags on navigation
 scroll_to_top = true        # Scroll to top on navigation (unless hash present)
 skip_classes = []           # Additional CSS classes to skip
 skip_selectors = []         # Additional selectors to skip
 ```
 
+In TOML, nest this under `[markata-go.view_transitions]` because markata-go loads site config from the top-level `[markata-go]` table.
+
 ## Quick Examples
 
 ### TOML (`markata.toml`)
 
 ```toml
-[view_transitions]
+[markata-go.view_transitions]
 enabled = true
 debug = false
-duration = 300
+duration = 120
 update_meta = true
 scroll_to_top = true
 skip_classes = ["no-transition", "external-link"]
@@ -50,18 +52,19 @@ skip_selectors = ["[data-skip-transition]", ".modal a"]
 ### YAML (`markata.yaml`)
 
 ```yaml
-view_transitions:
-  enabled: true
-  debug: false
-  duration: 300
-  update_meta: true
-  scroll_to_top: true
-  skip_classes:
-    - no-transition
-    - external-link
-  skip_selectors:
-    - "[data-skip-transition]"
-    - ".modal a"
+markata-go:
+  view_transitions:
+    enabled: true
+    debug: false
+    duration: 120
+    update_meta: true
+    scroll_to_top: true
+    skip_classes:
+      - no-transition
+      - external-link
+    skip_selectors:
+      - "[data-skip-transition]"
+      - ".modal a"
 ```
 
 ## Option Reference
@@ -74,7 +77,7 @@ view_transitions:
 Enable or disable view transitions globally.
 
 ```toml
-[view_transitions]
+[markata-go.view_transitions]
 enabled = false  # Disable view transitions completely
 ```
 
@@ -92,7 +95,7 @@ When disabled, all navigation uses standard browser behavior (no transitions).
 Enable debug logging to browser console.
 
 ```toml
-[view_transitions]
+[markata-go.view_transitions]
 debug = true
 ```
 
@@ -118,13 +121,13 @@ Skipping link with class: no-transition
 ### `duration`
 
 **Type**: Integer (milliseconds)  
-**Default**: `300`
+**Default**: `120`
 
 Default transition duration in milliseconds. Used as a reference value.
 
 ```toml
-[view_transitions]
-duration = 500  # Slower transitions
+[markata-go.view_transitions]
+duration = 220  # Slower transitions
 ```
 
 **Note**: The actual animation duration is controlled by CSS:
@@ -355,10 +358,10 @@ location.reload();
 If you don't add `[view_transitions]` to your config, these defaults apply:
 
 ```toml
-[view_transitions]
+[markata-go.view_transitions]
 enabled = true              # View transitions ON by default
 debug = false               # No console logging
-duration = 300              # 300ms reference duration
+duration = 120              # 120ms reference duration
 update_meta = true          # Update meta tags
 scroll_to_top = true        # Scroll to top on navigation
 skip_classes = []           # No custom skip classes
@@ -398,6 +401,7 @@ Or just omit the section entirely - view transitions are enabled by default!
 2. Check whether the transition was prefetched (`prefetched: true`)
 3. Use the browser Network tab to confirm HTML responses are served from cache when expected
 4. Profile re-initialization listeners after `view-transition-complete` if `reinitMs` is consistently high
+5. If `swapMs` is high, check whether the page is replacing more DOM than necessary
 
 ### "Scripts not working after transition"
 

--- a/pkg/config/merge.go
+++ b/pkg/config/merge.go
@@ -114,6 +114,9 @@ func MergeConfigs(base, override *models.Config) *models.Config {
 	// Mentions - merge
 	result.Mentions = mergeMentionsConfig(base.Mentions, override.Mentions)
 
+	// ViewTransitions - merge
+	result.ViewTransitions = mergeViewTransitionsConfig(base.ViewTransitions, override.ViewTransitions)
+
 	// Authors - merge
 	result.Authors = mergeAuthorsConfig(base.Authors, override.Authors)
 
@@ -122,6 +125,35 @@ func MergeConfigs(base, override *models.Config) *models.Config {
 
 	// Extra (plugin configs) - merge
 	result.Extra = mergeExtra(base.Extra, override.Extra)
+
+	return result
+}
+
+// mergeViewTransitionsConfig merges ViewTransitionsConfig, preferring explicit override values.
+func mergeViewTransitionsConfig(base, override models.ViewTransitionsConfig) models.ViewTransitionsConfig {
+	result := base
+
+	if override.Enabled != nil {
+		result.Enabled = override.Enabled
+	}
+	if override.Debug != nil {
+		result.Debug = override.Debug
+	}
+	if override.Duration != 0 {
+		result.Duration = override.Duration
+	}
+	if override.UpdateMeta != nil {
+		result.UpdateMeta = override.UpdateMeta
+	}
+	if override.ScrollToTop != nil {
+		result.ScrollToTop = override.ScrollToTop
+	}
+	if len(override.SkipClasses) > 0 {
+		result.SkipClasses = override.SkipClasses
+	}
+	if len(override.SkipSelectors) > 0 {
+		result.SkipSelectors = override.SkipSelectors
+	}
 
 	return result
 }

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -33,6 +33,7 @@ type configSource interface {
 	getMentions() mentionsConverter
 	getWebSub() webSubConverter
 	getShortcuts() shortcutsConverter
+	getViewTransitions() viewTransitionsConverter
 	getAuthors() authorsConverter
 	getGarden() gardenConverter
 	getTemplates() templatesConverter
@@ -142,6 +143,10 @@ type webSubConverter interface {
 
 type shortcutsConverter interface {
 	toShortcutsConfig() models.ShortcutsConfig
+}
+
+type viewTransitionsConverter interface {
+	toViewTransitionsConfig() models.ViewTransitionsConfig
 }
 
 type authorsConverter interface {
@@ -254,6 +259,9 @@ func buildConfig(src configSource) *models.Config {
 	// Convert Shortcuts config
 	config.Shortcuts = src.getShortcuts().toShortcutsConfig()
 
+	// Convert ViewTransitions config
+	config.ViewTransitions = src.getViewTransitions().toViewTransitionsConfig()
+
 	// Convert Authors config
 	config.Authors = src.getAuthors().toAuthorsConfig()
 
@@ -311,7 +319,7 @@ func ParseTOML(data []byte) (*models.Config, error) {
 			"default_templates": true, "auto_feeds": true, "head": true,
 			"content_templates": true, "footer_layout": true, "search": true,
 			"plugins": true, "thoughts": true, "wikilinks": true, "tags": true,
-			"tag_aggregator": true, "websub": true, "shortcuts": true, "encryption": true,
+			"tag_aggregator": true, "websub": true, "shortcuts": true, "view_transitions": true, "encryption": true,
 			"authors": true, "garden": true, "tailwind": false, "css_purge": false,
 		}
 
@@ -386,45 +394,46 @@ func ParseJSON(data []byte) (*models.Config, error) {
 
 // tomlConfig is an internal struct for parsing TOML configuration.
 type tomlConfig struct {
-	OutputDir     string                  `toml:"output_dir"`
-	URL           string                  `toml:"url"`
-	Title         string                  `toml:"title"`
-	Description   string                  `toml:"description"`
-	Author        string                  `toml:"author"`
-	License       interface{}             `toml:"license"`
-	AssetsDir     string                  `toml:"assets_dir"`
-	TemplatesDir  string                  `toml:"templates_dir"`
-	Nav           []tomlNavItem           `toml:"nav"`
-	Footer        tomlFooterConfig        `toml:"footer"`
-	Hooks         []string                `toml:"hooks"`
-	DisabledHooks []string                `toml:"disabled_hooks"`
-	Glob          tomlGlobConfig          `toml:"glob"`
-	Markdown      tomlMarkdownConfig      `toml:"markdown"`
-	Feeds         []tomlFeedConfig        `toml:"feeds"`
-	FeedDefaults  tomlFeedDefaults        `toml:"feed_defaults"`
-	Concurrency   int                     `toml:"concurrency"`
-	Theme         tomlThemeConfig         `toml:"theme"`
-	PostFormats   tomlPostFormatsConfig   `toml:"post_formats"`
-	WellKnown     tomlWellKnownConfig     `toml:"well_known"`
-	SEO           tomlSEOConfig           `toml:"seo"`
-	IndieAuth     tomlIndieAuthConfig     `toml:"indieauth"`
-	Webmention    tomlWebmentionConfig    `toml:"webmention"`
-	Components    tomlComponentsConfig    `toml:"components"`
-	Layout        tomlLayoutConfig        `toml:"layout"`
-	Sidebar       tomlSidebarConfig       `toml:"sidebar"`
-	Toc           tomlTocConfig           `toml:"toc"`
-	Header        tomlHeaderLayoutConfig  `toml:"header"`
-	Blogroll      tomlBlogrollConfig      `toml:"blogroll"`
-	Tags          tomlTagsConfig          `toml:"tags"`
-	Encryption    tomlEncryptionConfig    `toml:"encryption"`
-	TagAggregator tomlTagAggregatorConfig `toml:"tag_aggregator"`
-	Mentions      tomlMentionsConfig      `toml:"mentions"`
-	WebSub        tomlWebSubConfig        `toml:"websub"`
-	Shortcuts     tomlShortcutsConfig     `toml:"shortcuts"`
-	Authors       tomlAuthorsConfig       `toml:"authors"`
-	Garden        tomlGardenConfig        `toml:"garden"`
-	Templates     tomlTemplatesConfig     `toml:"templates"`
-	UnknownFields map[string]any          `toml:"-"`
+	OutputDir       string                    `toml:"output_dir"`
+	URL             string                    `toml:"url"`
+	Title           string                    `toml:"title"`
+	Description     string                    `toml:"description"`
+	Author          string                    `toml:"author"`
+	License         interface{}               `toml:"license"`
+	AssetsDir       string                    `toml:"assets_dir"`
+	TemplatesDir    string                    `toml:"templates_dir"`
+	Nav             []tomlNavItem             `toml:"nav"`
+	Footer          tomlFooterConfig          `toml:"footer"`
+	Hooks           []string                  `toml:"hooks"`
+	DisabledHooks   []string                  `toml:"disabled_hooks"`
+	Glob            tomlGlobConfig            `toml:"glob"`
+	Markdown        tomlMarkdownConfig        `toml:"markdown"`
+	Feeds           []tomlFeedConfig          `toml:"feeds"`
+	FeedDefaults    tomlFeedDefaults          `toml:"feed_defaults"`
+	Concurrency     int                       `toml:"concurrency"`
+	Theme           tomlThemeConfig           `toml:"theme"`
+	PostFormats     tomlPostFormatsConfig     `toml:"post_formats"`
+	WellKnown       tomlWellKnownConfig       `toml:"well_known"`
+	SEO             tomlSEOConfig             `toml:"seo"`
+	IndieAuth       tomlIndieAuthConfig       `toml:"indieauth"`
+	Webmention      tomlWebmentionConfig      `toml:"webmention"`
+	Components      tomlComponentsConfig      `toml:"components"`
+	Layout          tomlLayoutConfig          `toml:"layout"`
+	Sidebar         tomlSidebarConfig         `toml:"sidebar"`
+	Toc             tomlTocConfig             `toml:"toc"`
+	Header          tomlHeaderLayoutConfig    `toml:"header"`
+	Blogroll        tomlBlogrollConfig        `toml:"blogroll"`
+	Tags            tomlTagsConfig            `toml:"tags"`
+	Encryption      tomlEncryptionConfig      `toml:"encryption"`
+	TagAggregator   tomlTagAggregatorConfig   `toml:"tag_aggregator"`
+	Mentions        tomlMentionsConfig        `toml:"mentions"`
+	WebSub          tomlWebSubConfig          `toml:"websub"`
+	Shortcuts       tomlShortcutsConfig       `toml:"shortcuts"`
+	ViewTransitions tomlViewTransitionsConfig `toml:"view_transitions"`
+	Authors         tomlAuthorsConfig         `toml:"authors"`
+	Garden          tomlGardenConfig          `toml:"garden"`
+	Templates       tomlTemplatesConfig       `toml:"templates"`
+	UnknownFields   map[string]any            `toml:"-"`
 }
 
 type tomlNavItem struct {
@@ -697,12 +706,57 @@ type tomlShortcutsConfig struct {
 	Navigation map[string]string `toml:"navigation"`
 }
 
+type tomlViewTransitionsConfig struct {
+	Enabled       *bool    `toml:"enabled"`
+	Debug         *bool    `toml:"debug"`
+	Duration      int      `toml:"duration"`
+	UpdateMeta    *bool    `toml:"update_meta"`
+	ScrollToTop   *bool    `toml:"scroll_to_top"`
+	SkipClasses   []string `toml:"skip_classes"`
+	SkipSelectors []string `toml:"skip_selectors"`
+}
+
 func (s *tomlShortcutsConfig) toShortcutsConfig() models.ShortcutsConfig {
 	config := models.ShortcutsConfig{
 		Navigation: s.Navigation,
 	}
 	if config.Navigation == nil {
 		config.Navigation = make(map[string]string)
+	}
+	return config
+}
+
+func (v *tomlViewTransitionsConfig) toViewTransitionsConfig() models.ViewTransitionsConfig {
+	defaults := models.NewViewTransitionsConfig()
+	config := models.ViewTransitionsConfig{
+		Enabled:       v.Enabled,
+		Debug:         v.Debug,
+		Duration:      v.Duration,
+		UpdateMeta:    v.UpdateMeta,
+		ScrollToTop:   v.ScrollToTop,
+		SkipClasses:   v.SkipClasses,
+		SkipSelectors: v.SkipSelectors,
+	}
+	if config.Enabled == nil {
+		config.Enabled = defaults.Enabled
+	}
+	if config.Debug == nil {
+		config.Debug = defaults.Debug
+	}
+	if config.Duration == 0 {
+		config.Duration = defaults.Duration
+	}
+	if config.UpdateMeta == nil {
+		config.UpdateMeta = defaults.UpdateMeta
+	}
+	if config.ScrollToTop == nil {
+		config.ScrollToTop = defaults.ScrollToTop
+	}
+	if config.SkipClasses == nil {
+		config.SkipClasses = defaults.SkipClasses
+	}
+	if config.SkipSelectors == nil {
+		config.SkipSelectors = defaults.SkipSelectors
 	}
 	return config
 }
@@ -1613,27 +1667,28 @@ func (c *tomlConfig) getFeeds() []feedConfigConverter {
 	return feeds
 }
 
-func (c *tomlConfig) getFeedDefaults() feedDefaultsConverter   { return &c.FeedDefaults }
-func (c *tomlConfig) getPostFormats() postFormatsConverter     { return &c.PostFormats }
-func (c *tomlConfig) getWellKnown() wellKnownConverter         { return &c.WellKnown }
-func (c *tomlConfig) getSEO() seoConverter                     { return &c.SEO }
-func (c *tomlConfig) getIndieAuth() indieAuthConverter         { return &c.IndieAuth }
-func (c *tomlConfig) getWebmention() webmentionConverter       { return &c.Webmention }
-func (c *tomlConfig) getComponents() componentsConverter       { return &c.Components }
-func (c *tomlConfig) getLayout() layoutConverter               { return &c.Layout }
-func (c *tomlConfig) getSidebar() sidebarConverter             { return &c.Sidebar }
-func (c *tomlConfig) getToc() tocConverter                     { return &c.Toc }
-func (c *tomlConfig) getHeader() headerConverter               { return &c.Header }
-func (c *tomlConfig) getBlogroll() blogrollConverter           { return &c.Blogroll }
-func (c *tomlConfig) getTags() tagsConverter                   { return &c.Tags }
-func (c *tomlConfig) getEncryption() encryptionConverter       { return &c.Encryption }
-func (c *tomlConfig) getTagAggregator() tagAggregatorConverter { return &c.TagAggregator }
-func (c *tomlConfig) getWebSub() webSubConverter               { return &c.WebSub }
-func (c *tomlConfig) getMentions() mentionsConverter           { return &c.Mentions }
-func (c *tomlConfig) getShortcuts() shortcutsConverter         { return &c.Shortcuts }
-func (c *tomlConfig) getAuthors() authorsConverter             { return &c.Authors }
-func (c *tomlConfig) getGarden() gardenConverter               { return &c.Garden }
-func (c *tomlConfig) getTemplates() templatesConverter         { return &c.Templates }
+func (c *tomlConfig) getFeedDefaults() feedDefaultsConverter       { return &c.FeedDefaults }
+func (c *tomlConfig) getPostFormats() postFormatsConverter         { return &c.PostFormats }
+func (c *tomlConfig) getWellKnown() wellKnownConverter             { return &c.WellKnown }
+func (c *tomlConfig) getSEO() seoConverter                         { return &c.SEO }
+func (c *tomlConfig) getIndieAuth() indieAuthConverter             { return &c.IndieAuth }
+func (c *tomlConfig) getWebmention() webmentionConverter           { return &c.Webmention }
+func (c *tomlConfig) getComponents() componentsConverter           { return &c.Components }
+func (c *tomlConfig) getLayout() layoutConverter                   { return &c.Layout }
+func (c *tomlConfig) getSidebar() sidebarConverter                 { return &c.Sidebar }
+func (c *tomlConfig) getToc() tocConverter                         { return &c.Toc }
+func (c *tomlConfig) getHeader() headerConverter                   { return &c.Header }
+func (c *tomlConfig) getBlogroll() blogrollConverter               { return &c.Blogroll }
+func (c *tomlConfig) getTags() tagsConverter                       { return &c.Tags }
+func (c *tomlConfig) getEncryption() encryptionConverter           { return &c.Encryption }
+func (c *tomlConfig) getTagAggregator() tagAggregatorConverter     { return &c.TagAggregator }
+func (c *tomlConfig) getWebSub() webSubConverter                   { return &c.WebSub }
+func (c *tomlConfig) getMentions() mentionsConverter               { return &c.Mentions }
+func (c *tomlConfig) getShortcuts() shortcutsConverter             { return &c.Shortcuts }
+func (c *tomlConfig) getViewTransitions() viewTransitionsConverter { return &c.ViewTransitions }
+func (c *tomlConfig) getAuthors() authorsConverter                 { return &c.Authors }
+func (c *tomlConfig) getGarden() gardenConverter                   { return &c.Garden }
+func (c *tomlConfig) getTemplates() templatesConverter             { return &c.Templates }
 
 func (c *tomlConfig) toConfig() *models.Config {
 	return buildConfig(c)
@@ -1787,44 +1842,45 @@ func (d *tomlFeedDefaults) toFeedDefaults() models.FeedDefaults {
 
 // yamlConfig is an internal struct for parsing YAML configuration.
 type yamlConfig struct {
-	OutputDir     string                  `yaml:"output_dir"`
-	URL           string                  `yaml:"url"`
-	Title         string                  `yaml:"title"`
-	Description   string                  `yaml:"description"`
-	Author        string                  `yaml:"author"`
-	License       interface{}             `yaml:"license"`
-	AssetsDir     string                  `yaml:"assets_dir"`
-	TemplatesDir  string                  `yaml:"templates_dir"`
-	Nav           []yamlNavItem           `yaml:"nav"`
-	Footer        yamlFooterConfig        `yaml:"footer"`
-	Hooks         []string                `yaml:"hooks"`
-	DisabledHooks []string                `yaml:"disabled_hooks"`
-	Glob          yamlGlobConfig          `yaml:"glob"`
-	Markdown      yamlMarkdownConfig      `yaml:"markdown"`
-	Feeds         []yamlFeedConfig        `yaml:"feeds"`
-	FeedDefaults  yamlFeedDefaults        `yaml:"feed_defaults"`
-	Concurrency   int                     `yaml:"concurrency"`
-	Theme         yamlThemeConfig         `yaml:"theme"`
-	PostFormats   yamlPostFormatsConfig   `yaml:"post_formats"`
-	WellKnown     yamlWellKnownConfig     `yaml:"well_known"`
-	IndieAuth     yamlIndieAuthConfig     `yaml:"indieauth"`
-	Webmention    yamlWebmentionConfig    `yaml:"webmention"`
-	SEO           yamlSEOConfig           `yaml:"seo"`
-	Components    yamlComponentsConfig    `yaml:"components"`
-	Layout        yamlLayoutConfig        `yaml:"layout"`
-	Sidebar       yamlSidebarConfig       `yaml:"sidebar"`
-	Toc           yamlTocConfig           `yaml:"toc"`
-	Header        yamlHeaderLayoutConfig  `yaml:"header"`
-	Blogroll      yamlBlogrollConfig      `yaml:"blogroll"`
-	Tags          yamlTagsConfig          `yaml:"tags"`
-	Encryption    yamlEncryptionConfig    `yaml:"encryption"`
-	TagAggregator yamlTagAggregatorConfig `yaml:"tag_aggregator"`
-	Mentions      yamlMentionsConfig      `yaml:"mentions"`
-	WebSub        yamlWebSubConfig        `yaml:"websub"`
-	Shortcuts     yamlShortcutsConfig     `yaml:"shortcuts"`
-	Authors       yamlAuthorsConfig       `yaml:"authors"`
-	Garden        yamlGardenConfig        `yaml:"garden"`
-	Templates     yamlTemplatesConfig     `yaml:"templates"`
+	OutputDir       string                    `yaml:"output_dir"`
+	URL             string                    `yaml:"url"`
+	Title           string                    `yaml:"title"`
+	Description     string                    `yaml:"description"`
+	Author          string                    `yaml:"author"`
+	License         interface{}               `yaml:"license"`
+	AssetsDir       string                    `yaml:"assets_dir"`
+	TemplatesDir    string                    `yaml:"templates_dir"`
+	Nav             []yamlNavItem             `yaml:"nav"`
+	Footer          yamlFooterConfig          `yaml:"footer"`
+	Hooks           []string                  `yaml:"hooks"`
+	DisabledHooks   []string                  `yaml:"disabled_hooks"`
+	Glob            yamlGlobConfig            `yaml:"glob"`
+	Markdown        yamlMarkdownConfig        `yaml:"markdown"`
+	Feeds           []yamlFeedConfig          `yaml:"feeds"`
+	FeedDefaults    yamlFeedDefaults          `yaml:"feed_defaults"`
+	Concurrency     int                       `yaml:"concurrency"`
+	Theme           yamlThemeConfig           `yaml:"theme"`
+	PostFormats     yamlPostFormatsConfig     `yaml:"post_formats"`
+	WellKnown       yamlWellKnownConfig       `yaml:"well_known"`
+	IndieAuth       yamlIndieAuthConfig       `yaml:"indieauth"`
+	Webmention      yamlWebmentionConfig      `yaml:"webmention"`
+	SEO             yamlSEOConfig             `yaml:"seo"`
+	Components      yamlComponentsConfig      `yaml:"components"`
+	Layout          yamlLayoutConfig          `yaml:"layout"`
+	Sidebar         yamlSidebarConfig         `yaml:"sidebar"`
+	Toc             yamlTocConfig             `yaml:"toc"`
+	Header          yamlHeaderLayoutConfig    `yaml:"header"`
+	Blogroll        yamlBlogrollConfig        `yaml:"blogroll"`
+	Tags            yamlTagsConfig            `yaml:"tags"`
+	Encryption      yamlEncryptionConfig      `yaml:"encryption"`
+	TagAggregator   yamlTagAggregatorConfig   `yaml:"tag_aggregator"`
+	Mentions        yamlMentionsConfig        `yaml:"mentions"`
+	WebSub          yamlWebSubConfig          `yaml:"websub"`
+	Shortcuts       yamlShortcutsConfig       `yaml:"shortcuts"`
+	ViewTransitions yamlViewTransitionsConfig `yaml:"view_transitions"`
+	Authors         yamlAuthorsConfig         `yaml:"authors"`
+	Garden          yamlGardenConfig          `yaml:"garden"`
+	Templates       yamlTemplatesConfig       `yaml:"templates"`
 }
 
 type yamlNavItem struct {
@@ -2163,12 +2219,57 @@ type yamlShortcutsConfig struct {
 	Navigation map[string]string `yaml:"navigation"`
 }
 
+type yamlViewTransitionsConfig struct {
+	Enabled       *bool    `yaml:"enabled"`
+	Debug         *bool    `yaml:"debug"`
+	Duration      int      `yaml:"duration"`
+	UpdateMeta    *bool    `yaml:"update_meta"`
+	ScrollToTop   *bool    `yaml:"scroll_to_top"`
+	SkipClasses   []string `yaml:"skip_classes"`
+	SkipSelectors []string `yaml:"skip_selectors"`
+}
+
 func (s *yamlShortcutsConfig) toShortcutsConfig() models.ShortcutsConfig {
 	config := models.ShortcutsConfig{
 		Navigation: s.Navigation,
 	}
 	if config.Navigation == nil {
 		config.Navigation = make(map[string]string)
+	}
+	return config
+}
+
+func (v *yamlViewTransitionsConfig) toViewTransitionsConfig() models.ViewTransitionsConfig {
+	defaults := models.NewViewTransitionsConfig()
+	config := models.ViewTransitionsConfig{
+		Enabled:       v.Enabled,
+		Debug:         v.Debug,
+		Duration:      v.Duration,
+		UpdateMeta:    v.UpdateMeta,
+		ScrollToTop:   v.ScrollToTop,
+		SkipClasses:   v.SkipClasses,
+		SkipSelectors: v.SkipSelectors,
+	}
+	if config.Enabled == nil {
+		config.Enabled = defaults.Enabled
+	}
+	if config.Debug == nil {
+		config.Debug = defaults.Debug
+	}
+	if config.Duration == 0 {
+		config.Duration = defaults.Duration
+	}
+	if config.UpdateMeta == nil {
+		config.UpdateMeta = defaults.UpdateMeta
+	}
+	if config.ScrollToTop == nil {
+		config.ScrollToTop = defaults.ScrollToTop
+	}
+	if config.SkipClasses == nil {
+		config.SkipClasses = defaults.SkipClasses
+	}
+	if config.SkipSelectors == nil {
+		config.SkipSelectors = defaults.SkipSelectors
 	}
 	return config
 }
@@ -3039,27 +3140,28 @@ func (c *yamlConfig) getFeeds() []feedConfigConverter {
 	return feeds
 }
 
-func (c *yamlConfig) getFeedDefaults() feedDefaultsConverter   { return &c.FeedDefaults }
-func (c *yamlConfig) getPostFormats() postFormatsConverter     { return &c.PostFormats }
-func (c *yamlConfig) getWellKnown() wellKnownConverter         { return &c.WellKnown }
-func (c *yamlConfig) getSEO() seoConverter                     { return &c.SEO }
-func (c *yamlConfig) getIndieAuth() indieAuthConverter         { return &c.IndieAuth }
-func (c *yamlConfig) getWebmention() webmentionConverter       { return &c.Webmention }
-func (c *yamlConfig) getComponents() componentsConverter       { return &c.Components }
-func (c *yamlConfig) getLayout() layoutConverter               { return &c.Layout }
-func (c *yamlConfig) getSidebar() sidebarConverter             { return &c.Sidebar }
-func (c *yamlConfig) getToc() tocConverter                     { return &c.Toc }
-func (c *yamlConfig) getHeader() headerConverter               { return &c.Header }
-func (c *yamlConfig) getBlogroll() blogrollConverter           { return &c.Blogroll }
-func (c *yamlConfig) getTags() tagsConverter                   { return &c.Tags }
-func (c *yamlConfig) getEncryption() encryptionConverter       { return &c.Encryption }
-func (c *yamlConfig) getTagAggregator() tagAggregatorConverter { return &c.TagAggregator }
-func (c *yamlConfig) getWebSub() webSubConverter               { return &c.WebSub }
-func (c *yamlConfig) getMentions() mentionsConverter           { return &c.Mentions }
-func (c *yamlConfig) getShortcuts() shortcutsConverter         { return &c.Shortcuts }
-func (c *yamlConfig) getAuthors() authorsConverter             { return &c.Authors }
-func (c *yamlConfig) getGarden() gardenConverter               { return &c.Garden }
-func (c *yamlConfig) getTemplates() templatesConverter         { return &c.Templates }
+func (c *yamlConfig) getFeedDefaults() feedDefaultsConverter       { return &c.FeedDefaults }
+func (c *yamlConfig) getPostFormats() postFormatsConverter         { return &c.PostFormats }
+func (c *yamlConfig) getWellKnown() wellKnownConverter             { return &c.WellKnown }
+func (c *yamlConfig) getSEO() seoConverter                         { return &c.SEO }
+func (c *yamlConfig) getIndieAuth() indieAuthConverter             { return &c.IndieAuth }
+func (c *yamlConfig) getWebmention() webmentionConverter           { return &c.Webmention }
+func (c *yamlConfig) getComponents() componentsConverter           { return &c.Components }
+func (c *yamlConfig) getLayout() layoutConverter                   { return &c.Layout }
+func (c *yamlConfig) getSidebar() sidebarConverter                 { return &c.Sidebar }
+func (c *yamlConfig) getToc() tocConverter                         { return &c.Toc }
+func (c *yamlConfig) getHeader() headerConverter                   { return &c.Header }
+func (c *yamlConfig) getBlogroll() blogrollConverter               { return &c.Blogroll }
+func (c *yamlConfig) getTags() tagsConverter                       { return &c.Tags }
+func (c *yamlConfig) getEncryption() encryptionConverter           { return &c.Encryption }
+func (c *yamlConfig) getTagAggregator() tagAggregatorConverter     { return &c.TagAggregator }
+func (c *yamlConfig) getWebSub() webSubConverter                   { return &c.WebSub }
+func (c *yamlConfig) getMentions() mentionsConverter               { return &c.Mentions }
+func (c *yamlConfig) getShortcuts() shortcutsConverter             { return &c.Shortcuts }
+func (c *yamlConfig) getViewTransitions() viewTransitionsConverter { return &c.ViewTransitions }
+func (c *yamlConfig) getAuthors() authorsConverter                 { return &c.Authors }
+func (c *yamlConfig) getGarden() gardenConverter                   { return &c.Garden }
+func (c *yamlConfig) getTemplates() templatesConverter             { return &c.Templates }
 
 func (c *yamlConfig) toConfig() *models.Config {
 	return buildConfig(c)
@@ -3147,44 +3249,45 @@ func (d *yamlFeedDefaults) toFeedDefaults() models.FeedDefaults {
 
 // jsonConfig is an internal struct for parsing JSON configuration.
 type jsonConfig struct {
-	OutputDir     string                  `json:"output_dir"`
-	URL           string                  `json:"url"`
-	Title         string                  `json:"title"`
-	Description   string                  `json:"description"`
-	Author        string                  `json:"author"`
-	License       interface{}             `json:"license"`
-	AssetsDir     string                  `json:"assets_dir"`
-	TemplatesDir  string                  `json:"templates_dir"`
-	Nav           []jsonNavItem           `json:"nav"`
-	Footer        jsonFooterConfig        `json:"footer"`
-	Hooks         []string                `json:"hooks"`
-	DisabledHooks []string                `json:"disabled_hooks"`
-	Glob          jsonGlobConfig          `json:"glob"`
-	Markdown      jsonMarkdownConfig      `json:"markdown"`
-	Feeds         []jsonFeedConfig        `json:"feeds"`
-	FeedDefaults  jsonFeedDefaults        `json:"feed_defaults"`
-	Concurrency   int                     `json:"concurrency"`
-	Theme         jsonThemeConfig         `json:"theme"`
-	PostFormats   jsonPostFormatsConfig   `json:"post_formats"`
-	WellKnown     jsonWellKnownConfig     `json:"well_known"`
-	IndieAuth     jsonIndieAuthConfig     `json:"indieauth"`
-	Webmention    jsonWebmentionConfig    `json:"webmention"`
-	SEO           jsonSEOConfig           `json:"seo"`
-	Components    jsonComponentsConfig    `json:"components"`
-	Layout        jsonLayoutConfig        `json:"layout"`
-	Sidebar       jsonSidebarConfig       `json:"sidebar"`
-	Toc           jsonTocConfig           `json:"toc"`
-	Header        jsonHeaderLayoutConfig  `json:"header"`
-	Blogroll      jsonBlogrollConfig      `json:"blogroll"`
-	Tags          jsonTagsConfig          `json:"tags"`
-	Encryption    jsonEncryptionConfig    `json:"encryption"`
-	TagAggregator jsonTagAggregatorConfig `json:"tag_aggregator"`
-	Mentions      jsonMentionsConfig      `json:"mentions"`
-	WebSub        jsonWebSubConfig        `json:"websub"`
-	Shortcuts     jsonShortcutsConfig     `json:"shortcuts"`
-	Authors       jsonAuthorsConfig       `json:"authors"`
-	Garden        jsonGardenConfig        `json:"garden"`
-	Templates     jsonTemplatesConfig     `json:"templates"`
+	OutputDir       string                    `json:"output_dir"`
+	URL             string                    `json:"url"`
+	Title           string                    `json:"title"`
+	Description     string                    `json:"description"`
+	Author          string                    `json:"author"`
+	License         interface{}               `json:"license"`
+	AssetsDir       string                    `json:"assets_dir"`
+	TemplatesDir    string                    `json:"templates_dir"`
+	Nav             []jsonNavItem             `json:"nav"`
+	Footer          jsonFooterConfig          `json:"footer"`
+	Hooks           []string                  `json:"hooks"`
+	DisabledHooks   []string                  `json:"disabled_hooks"`
+	Glob            jsonGlobConfig            `json:"glob"`
+	Markdown        jsonMarkdownConfig        `json:"markdown"`
+	Feeds           []jsonFeedConfig          `json:"feeds"`
+	FeedDefaults    jsonFeedDefaults          `json:"feed_defaults"`
+	Concurrency     int                       `json:"concurrency"`
+	Theme           jsonThemeConfig           `json:"theme"`
+	PostFormats     jsonPostFormatsConfig     `json:"post_formats"`
+	WellKnown       jsonWellKnownConfig       `json:"well_known"`
+	IndieAuth       jsonIndieAuthConfig       `json:"indieauth"`
+	Webmention      jsonWebmentionConfig      `json:"webmention"`
+	SEO             jsonSEOConfig             `json:"seo"`
+	Components      jsonComponentsConfig      `json:"components"`
+	Layout          jsonLayoutConfig          `json:"layout"`
+	Sidebar         jsonSidebarConfig         `json:"sidebar"`
+	Toc             jsonTocConfig             `json:"toc"`
+	Header          jsonHeaderLayoutConfig    `json:"header"`
+	Blogroll        jsonBlogrollConfig        `json:"blogroll"`
+	Tags            jsonTagsConfig            `json:"tags"`
+	Encryption      jsonEncryptionConfig      `json:"encryption"`
+	TagAggregator   jsonTagAggregatorConfig   `json:"tag_aggregator"`
+	Mentions        jsonMentionsConfig        `json:"mentions"`
+	WebSub          jsonWebSubConfig          `json:"websub"`
+	Shortcuts       jsonShortcutsConfig       `json:"shortcuts"`
+	ViewTransitions jsonViewTransitionsConfig `json:"view_transitions"`
+	Authors         jsonAuthorsConfig         `json:"authors"`
+	Garden          jsonGardenConfig          `json:"garden"`
+	Templates       jsonTemplatesConfig       `json:"templates"`
 }
 
 type jsonNavItem struct {
@@ -3547,12 +3650,57 @@ type jsonShortcutsConfig struct {
 	Navigation map[string]string `json:"navigation"`
 }
 
+type jsonViewTransitionsConfig struct {
+	Enabled       *bool    `json:"enabled"`
+	Debug         *bool    `json:"debug"`
+	Duration      int      `json:"duration"`
+	UpdateMeta    *bool    `json:"update_meta"`
+	ScrollToTop   *bool    `json:"scroll_to_top"`
+	SkipClasses   []string `json:"skip_classes"`
+	SkipSelectors []string `json:"skip_selectors"`
+}
+
 func (s *jsonShortcutsConfig) toShortcutsConfig() models.ShortcutsConfig {
 	config := models.ShortcutsConfig{
 		Navigation: s.Navigation,
 	}
 	if config.Navigation == nil {
 		config.Navigation = make(map[string]string)
+	}
+	return config
+}
+
+func (v *jsonViewTransitionsConfig) toViewTransitionsConfig() models.ViewTransitionsConfig {
+	defaults := models.NewViewTransitionsConfig()
+	config := models.ViewTransitionsConfig{
+		Enabled:       v.Enabled,
+		Debug:         v.Debug,
+		Duration:      v.Duration,
+		UpdateMeta:    v.UpdateMeta,
+		ScrollToTop:   v.ScrollToTop,
+		SkipClasses:   v.SkipClasses,
+		SkipSelectors: v.SkipSelectors,
+	}
+	if config.Enabled == nil {
+		config.Enabled = defaults.Enabled
+	}
+	if config.Debug == nil {
+		config.Debug = defaults.Debug
+	}
+	if config.Duration == 0 {
+		config.Duration = defaults.Duration
+	}
+	if config.UpdateMeta == nil {
+		config.UpdateMeta = defaults.UpdateMeta
+	}
+	if config.ScrollToTop == nil {
+		config.ScrollToTop = defaults.ScrollToTop
+	}
+	if config.SkipClasses == nil {
+		config.SkipClasses = defaults.SkipClasses
+	}
+	if config.SkipSelectors == nil {
+		config.SkipSelectors = defaults.SkipSelectors
 	}
 	return config
 }
@@ -4423,27 +4571,28 @@ func (c *jsonConfig) getFeeds() []feedConfigConverter {
 	return feeds
 }
 
-func (c *jsonConfig) getFeedDefaults() feedDefaultsConverter   { return &c.FeedDefaults }
-func (c *jsonConfig) getPostFormats() postFormatsConverter     { return &c.PostFormats }
-func (c *jsonConfig) getWellKnown() wellKnownConverter         { return &c.WellKnown }
-func (c *jsonConfig) getSEO() seoConverter                     { return &c.SEO }
-func (c *jsonConfig) getIndieAuth() indieAuthConverter         { return &c.IndieAuth }
-func (c *jsonConfig) getWebmention() webmentionConverter       { return &c.Webmention }
-func (c *jsonConfig) getComponents() componentsConverter       { return &c.Components }
-func (c *jsonConfig) getLayout() layoutConverter               { return &c.Layout }
-func (c *jsonConfig) getSidebar() sidebarConverter             { return &c.Sidebar }
-func (c *jsonConfig) getToc() tocConverter                     { return &c.Toc }
-func (c *jsonConfig) getHeader() headerConverter               { return &c.Header }
-func (c *jsonConfig) getBlogroll() blogrollConverter           { return &c.Blogroll }
-func (c *jsonConfig) getTags() tagsConverter                   { return &c.Tags }
-func (c *jsonConfig) getEncryption() encryptionConverter       { return &c.Encryption }
-func (c *jsonConfig) getTagAggregator() tagAggregatorConverter { return &c.TagAggregator }
-func (c *jsonConfig) getMentions() mentionsConverter           { return &c.Mentions }
-func (c *jsonConfig) getWebSub() webSubConverter               { return &c.WebSub }
-func (c *jsonConfig) getShortcuts() shortcutsConverter         { return &c.Shortcuts }
-func (c *jsonConfig) getAuthors() authorsConverter             { return &c.Authors }
-func (c *jsonConfig) getGarden() gardenConverter               { return &c.Garden }
-func (c *jsonConfig) getTemplates() templatesConverter         { return &c.Templates }
+func (c *jsonConfig) getFeedDefaults() feedDefaultsConverter       { return &c.FeedDefaults }
+func (c *jsonConfig) getPostFormats() postFormatsConverter         { return &c.PostFormats }
+func (c *jsonConfig) getWellKnown() wellKnownConverter             { return &c.WellKnown }
+func (c *jsonConfig) getSEO() seoConverter                         { return &c.SEO }
+func (c *jsonConfig) getIndieAuth() indieAuthConverter             { return &c.IndieAuth }
+func (c *jsonConfig) getWebmention() webmentionConverter           { return &c.Webmention }
+func (c *jsonConfig) getComponents() componentsConverter           { return &c.Components }
+func (c *jsonConfig) getLayout() layoutConverter                   { return &c.Layout }
+func (c *jsonConfig) getSidebar() sidebarConverter                 { return &c.Sidebar }
+func (c *jsonConfig) getToc() tocConverter                         { return &c.Toc }
+func (c *jsonConfig) getHeader() headerConverter                   { return &c.Header }
+func (c *jsonConfig) getBlogroll() blogrollConverter               { return &c.Blogroll }
+func (c *jsonConfig) getTags() tagsConverter                       { return &c.Tags }
+func (c *jsonConfig) getEncryption() encryptionConverter           { return &c.Encryption }
+func (c *jsonConfig) getTagAggregator() tagAggregatorConverter     { return &c.TagAggregator }
+func (c *jsonConfig) getMentions() mentionsConverter               { return &c.Mentions }
+func (c *jsonConfig) getWebSub() webSubConverter                   { return &c.WebSub }
+func (c *jsonConfig) getShortcuts() shortcutsConverter             { return &c.Shortcuts }
+func (c *jsonConfig) getViewTransitions() viewTransitionsConverter { return &c.ViewTransitions }
+func (c *jsonConfig) getAuthors() authorsConverter                 { return &c.Authors }
+func (c *jsonConfig) getGarden() gardenConverter                   { return &c.Garden }
+func (c *jsonConfig) getTemplates() templatesConverter             { return &c.Templates }
 
 func (c *jsonConfig) toConfig() *models.Config {
 	return buildConfig(c)

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -557,6 +557,9 @@ type Config struct {
 	// Shortcuts configures user-defined keyboard shortcuts
 	Shortcuts ShortcutsConfig `json:"shortcuts" yaml:"shortcuts" toml:"shortcuts"`
 
+	// ViewTransitions configures client-side animated page navigation.
+	ViewTransitions ViewTransitionsConfig `json:"view_transitions" yaml:"view_transitions" toml:"view_transitions"`
+
 	// Tags configures the tags listing page at /tags
 	Tags TagsConfig `json:"tags" yaml:"tags" toml:"tags"`
 
@@ -2445,6 +2448,48 @@ func NewShortcutsConfig() ShortcutsConfig {
 	}
 }
 
+// ViewTransitionsConfig configures client-side page transition behavior.
+type ViewTransitionsConfig struct {
+	// Enabled controls whether the transition script is injected.
+	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty" toml:"enabled,omitempty"`
+
+	// Debug enables browser console logging and timing output.
+	Debug *bool `json:"debug,omitempty" yaml:"debug,omitempty" toml:"debug,omitempty"`
+
+	// Duration is the reference transition duration in milliseconds.
+	Duration int `json:"duration,omitempty" yaml:"duration,omitempty" toml:"duration,omitempty"`
+
+	// UpdateMeta controls whether head meta tags are synchronized on navigation.
+	UpdateMeta *bool `json:"update_meta,omitempty" yaml:"update_meta,omitempty" toml:"update_meta,omitempty"`
+
+	// ScrollToTop controls whether navigation scrolls to the top unless a hash is present.
+	ScrollToTop *bool `json:"scroll_to_top,omitempty" yaml:"scroll_to_top,omitempty" toml:"scroll_to_top,omitempty"`
+
+	// SkipClasses are additional CSS classes that should bypass transitions.
+	SkipClasses []string `json:"skip_classes,omitempty" yaml:"skip_classes,omitempty" toml:"skip_classes,omitempty"`
+
+	// SkipSelectors are additional selectors that should bypass transitions.
+	SkipSelectors []string `json:"skip_selectors,omitempty" yaml:"skip_selectors,omitempty" toml:"skip_selectors,omitempty"`
+}
+
+// NewViewTransitionsConfig creates a new ViewTransitionsConfig with default values.
+func NewViewTransitionsConfig() ViewTransitionsConfig {
+	enabled := true
+	debug := false
+	updateMeta := true
+	scrollToTop := true
+
+	return ViewTransitionsConfig{
+		Enabled:       &enabled,
+		Debug:         &debug,
+		Duration:      300,
+		UpdateMeta:    &updateMeta,
+		ScrollToTop:   &scrollToTop,
+		SkipClasses:   []string{},
+		SkipSelectors: []string{},
+	}
+}
+
 // HasCustomShortcuts returns true if any custom shortcuts are defined.
 func (s *ShortcutsConfig) HasCustomShortcuts() bool {
 	return len(s.Navigation) > 0
@@ -3049,6 +3094,7 @@ func NewConfig() *Config {
 		ResourceHints:    NewResourceHintsConfig(),
 		Encryption:       NewEncryptionConfig(),
 		Shortcuts:        NewShortcutsConfig(),
+		ViewTransitions:  NewViewTransitionsConfig(),
 		Tags:             NewTagsConfig(),
 		Garden:           NewGardenConfig(),
 		Assets:           NewAssetsConfig(),

--- a/pkg/plugins/templates.go
+++ b/pkg/plugins/templates.go
@@ -913,6 +913,12 @@ func toModelsConfigUncached(config *lifecycle.Config) *models.Config {
 		modelsConfig.Search = models.NewSearchConfig()
 	}
 
+	if viewTransitions, ok := config.Extra["view_transitions"].(models.ViewTransitionsConfig); ok {
+		modelsConfig.ViewTransitions = viewTransitions
+	} else {
+		modelsConfig.ViewTransitions = models.NewViewTransitionsConfig()
+	}
+
 	// Copy remaining plugin configs
 	copyPluginConfigs(config, modelsConfig)
 

--- a/pkg/themes/default/static/css/components.css
+++ b/pkg/themes/default/static/css/components.css
@@ -1867,11 +1867,11 @@ article.post {
 
 /* Default cross-fade for everything (fixes old+new overlap flash). */
 ::view-transition-old(root) {
-   animation: fade-out 160ms ease both;
+   animation: fade-out 80ms ease both;
 }
 
 ::view-transition-new(root) {
-   animation: fade-in 200ms ease both;
+   animation: fade-in 100ms ease both;
 }
 
 /* Root transition container */
@@ -1894,32 +1894,32 @@ article.post {
 
 @keyframes slide-up {
    from {
-      transform: translateY(20px);
+      transform: translateY(8px);
    }
 }
 
 @keyframes slide-down {
    from {
-      transform: translateY(-20px);
+      transform: translateY(-8px);
    }
 }
 
 /* Main content gets a slightly more directional motion. */
 ::view-transition-old(main-content) {
-   animation: fade-out 140ms ease both;
+   animation: fade-out 70ms ease both;
 }
 
 ::view-transition-new(main-content) {
-   animation: fade-in 220ms ease both, slide-up 260ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+   animation: fade-in 110ms ease both, slide-up 120ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
 }
 
 /* Lists feel snappier than full article transitions. */
 ::view-transition-old(posts-list) {
-   animation: fade-out 120ms ease both;
+   animation: fade-out 60ms ease both;
 }
 
 ::view-transition-new(posts-list) {
-   animation: fade-in 180ms ease both, slide-down 220ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+   animation: fade-in 90ms ease both, slide-down 100ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
 }
 
 /* ==========================================================================

--- a/pkg/themes/default/static/js/navigation-shortcuts.js
+++ b/pkg/themes/default/static/js/navigation-shortcuts.js
@@ -330,12 +330,12 @@
       return;
     }
 
-    var nextLink = document.querySelector('a.pagination-next');
+    var nextLink = document.querySelector('[data-action="next"], a.pagination-next');
     if (nextLink && nextLink.href) {
       window.prefetchViewTransitionUrl(nextLink.href);
     }
 
-    var prevLink = document.querySelector('a.pagination-prev');
+    var prevLink = document.querySelector('[data-action="prev"], a.pagination-prev');
     if (prevLink && prevLink.href) {
       window.prefetchViewTransitionUrl(prevLink.href);
     }

--- a/pkg/themes/default/static/js/view-transitions.js
+++ b/pkg/themes/default/static/js/view-transitions.js
@@ -31,7 +31,7 @@
     debug: false,
     skipClasses: [],
     skipSelectors: [],
-    transitionDuration: 150,
+    transitionDuration: 120,
     updateMeta: true,
     scrollToTop: true,
   };
@@ -303,11 +303,63 @@
     return fetchDocument(url, { metrics: metrics });
   }
 
+  function syncBodyAttributes(newDoc) {
+    if (!newDoc || !newDoc.body) return;
+
+    const currentAttributes = Array.from(document.body.attributes);
+    for (const attribute of currentAttributes) {
+      if (!newDoc.body.hasAttribute(attribute.name)) {
+        document.body.removeAttribute(attribute.name);
+      }
+    }
+
+    Array.from(newDoc.body.attributes).forEach((attribute) => {
+      document.body.setAttribute(attribute.name, attribute.value);
+    });
+  }
+
+  function replaceElementContents(selector, newDoc) {
+    const currentElement = document.querySelector(selector);
+    const nextElement = newDoc.querySelector(selector);
+
+    if (!currentElement || !nextElement) {
+      return false;
+    }
+
+    currentElement.innerHTML = nextElement.innerHTML;
+    return true;
+  }
+
+  function replaceElement(selector, newDoc) {
+    const currentElement = document.querySelector(selector);
+    const nextElement = newDoc.querySelector(selector);
+
+    if (!currentElement || !nextElement) {
+      return false;
+    }
+
+    currentElement.replaceWith(nextElement.cloneNode(true));
+    return true;
+  }
+
+  function updateLayoutRegions(newDoc) {
+    const replacedPage = replaceElementContents('#view-transition-page', newDoc);
+    if (!replacedPage) {
+      document.body.innerHTML = newDoc.body.innerHTML;
+      return false;
+    }
+
+    replaceElement('#view-transition-progress', newDoc);
+    return true;
+  }
+
   /**
    * Update the current document with content from new document
    */
   function updateDocument(newDoc, metrics) {
     const swapStartedAt = getNow();
+
+    syncBodyAttributes(newDoc);
 
     // Update title
     document.title = newDoc.title;
@@ -317,11 +369,11 @@
       updateMetaTags(newDoc);
     }
 
-    // Replace body content
-    document.body.innerHTML = newDoc.body.innerHTML;
+    // Replace the main layout region instead of the entire body when possible.
+    updateLayoutRegions(newDoc);
 
     // Re-execute inline module scripts (e.g. mermaid, chartjs).
-    // innerHTML assignment does not run <script> tags, so we clone them
+    // Replaced fragments do not run <script> tags, so we clone module scripts
     // into fresh elements which the browser will evaluate.
     document.body.querySelectorAll('script[type="module"]').forEach(old => {
       const fresh = document.createElement('script');

--- a/pkg/themes/default/templates/base.html
+++ b/pkg/themes/default/templates/base.html
@@ -195,9 +195,11 @@
   </header>
   {% endblock %}
 
-  {% block progress %}{% endblock %}
+  <div id="view-transition-progress">
+    {% block progress %}{% endblock %}
+  </div>
 
-  <div class="page-wrapper">
+  <div class="page-wrapper" id="view-transition-page">
     {% block main %}
       {# Left sidebar for feed navigation (if enabled) #}
       {% if config.components.feed_sidebar.enabled and config.components.feed_sidebar.position == 'left' %}
@@ -385,6 +387,12 @@
           placeholder: '{{ config.search.placeholder | default:"Search…" }}'
         }
       });
+
+      var pagefindInput = root.querySelector('.pagefind-ui__search-input');
+      if (pagefindInput) {
+        if (!pagefindInput.id) pagefindInput.id = 'pagefind-search-input';
+        if (!pagefindInput.name) pagefindInput.name = 'search';
+      }
     };
 
     // Lazy-load pagefind: only fetch CSS + JS on first interaction

--- a/spec/spec/THEMES.md
+++ b/spec/spec/THEMES.md
@@ -1196,7 +1196,7 @@ The base template (`base.html`) uses these flags to conditionally load CSS:
 
 ### View-Transition Safety Net
 
-Because view transitions (SPA-like navigation) currently swap `document.body.innerHTML` and NOT `<head>`, CSS `<link>` tags persist from the original page. When navigating from a page without conditional CSS (e.g., a plain text post) to a page that needs it (e.g., a post with code blocks), the CSS would be missing.
+Because view transitions (SPA-like navigation) preserve `<head>` across navigations, CSS `<link>` tags persist from the original page. When navigating from a page without conditional CSS (e.g., a plain text post) to a page that needs it (e.g., a post with code blocks), the CSS would be missing unless the runtime adds it.
 
 The `conditional-css.js` script solves this by:
 1. Listening for `view-transition-complete` events dispatched by `view-transitions.js`
@@ -1207,6 +1207,8 @@ The `conditional-css.js` script solves this by:
 Any JS-driven theme controls rendered in `<body>` (palette family selector, dark/light toggle, and aesthetic selector) MUST also re-initialize on `view-transition-complete` so controls and option lists remain interactive after navigation.
 
 View-transition navigations SHOULD fetch and parse the destination document before calling `document.startViewTransition()` so the current page is not visually frozen during network I/O. Implementations SHOULD allow normal browser caching for HTML navigations and MAY prefetch likely next destinations (for example hovered links or pagination targets) to reduce latency for keyboard-driven page jumps.
+
+When possible, implementations SHOULD replace only the primary view-transition regions (for example the progress area and page wrapper) instead of replacing the entire `<body>`. The runtime MUST still synchronize `<body>` attributes such as classes so page-specific layout state remains correct after navigation.
 
 ### CSS File Categories
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -177,9 +177,11 @@
   </header>
   {% endblock %}
 
-  {% block progress %}{% endblock %}
+  <div id="view-transition-progress">
+    {% block progress %}{% endblock %}
+  </div>
 
-  <div class="page-wrapper">
+  <div class="page-wrapper" id="view-transition-page">
     {% block main %}
       {# Left sidebar for feed navigation (if enabled) #}
       {% if config.components.feed_sidebar.enabled and config.components.feed_sidebar.position == 'left' %}
@@ -364,6 +366,12 @@
           placeholder: '{{ config.search.placeholder | default:"Search…" }}'
         }
       });
+
+      var pagefindInput = root.querySelector('.pagefind-ui__search-input');
+      if (pagefindInput) {
+        if (!pagefindInput.id) pagefindInput.id = 'pagefind-search-input';
+        if (!pagefindInput.name) pagefindInput.name = 'search';
+      }
     };
 
     // Lazy-load pagefind: only fetch CSS + JS on first interaction


### PR DESCRIPTION
## Summary
- fetch and parse destination documents before starting view transitions, prefetch likely next pages, and reduce default transition timings so keyboard page jumps feel snappier
- preserve more layout during navigation by swapping the view-transition page regions instead of replacing the full body
- wire `view_transitions` config through parsing, merge, runtime, and templates, and patch Pagefind search inputs with stable `id`/`name` attributes after re-init

## Testing
- go fmt ./...
- go vet ./...
- golangci-lint run --timeout=2m --fast
- go test ./...

## Related
- Refs #958