### PR TITLE
fix(video): downsize inline post posters

### DIFF
--- a/pkg/plugins/feed_helpers.go
+++ b/pkg/plugins/feed_helpers.go
@@ -534,9 +534,10 @@ func renderPhotoFigure(post map[string]interface{}) string {
 		return ""
 	}
 	caption := firstNonEmpty(post, "description", "title", "slug")
+	image = templates.WithSize(image, 1200, 675)
 	builder := &strings.Builder{}
 	builder.WriteString("<figure class=\"photo-figure h-entry\">")
-	fmt.Fprintf(builder, "<a href=\"%s\"><img src=\"%s\" alt=\"%s\" loading=\"lazy\"></a>", html.EscapeString(href), html.EscapeString(image), html.EscapeString(caption))
+	fmt.Fprintf(builder, "<a href=\"%s\"><img src=\"%s\" alt=\"%s\" loading=\"lazy\" width=\"1200\" height=\"675\"></a>", html.EscapeString(href), html.EscapeString(image), html.EscapeString(caption))
 	fmt.Fprintf(builder, "<figcaption class=\"p-summary\">%s</figcaption>", html.EscapeString(caption))
 	builder.WriteString("</figure>")
 	return builder.String()

--- a/pkg/plugins/md_video.go
+++ b/pkg/plugins/md_video.go
@@ -251,6 +251,7 @@ func (p *MDVideoPlugin) buildVideoTag(post *models.Post, src, alt string) string
 	}
 
 	if poster := templates.PosterURLFromMap(templates.GetPostMap(post), src); poster != "" {
+		poster = templates.WithSize(poster, 1200, 675)
 		attrs = append(attrs, `poster="`+poster+`"`)
 	}
 

--- a/pkg/plugins/md_video_test.go
+++ b/pkg/plugins/md_video_test.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/WaylonWalker/markata-go/pkg/models"
@@ -111,6 +112,26 @@ func TestMDVideoPlugin_ProcessPost_WithQueryParams(t *testing.T) {
 	}
 	if !contains(post.ArticleHTML, "kickflip") {
 		t.Error("Expected alt text preserved as fallback")
+	}
+}
+
+func TestMDVideoPlugin_ProcessPost_DownsizesPosterOnly(t *testing.T) {
+	p := NewMDVideoPlugin()
+
+	post := &models.Post{
+		ArticleHTML: `<img src="https://dropper.waylonwalker.com/file/6f042a91.mp4?width=500" alt="kickflip">`,
+	}
+
+	err := p.processPost(post)
+	if err != nil {
+		t.Fatalf("processPost() error = %v", err)
+	}
+
+	if !strings.Contains(post.ArticleHTML, `src="https://dropper.waylonwalker.com/file/6f042a91.mp4?width=500"`) {
+		t.Errorf("Expected full video source preserved, got: %s", post.ArticleHTML)
+	}
+	if !strings.Contains(post.ArticleHTML, `poster="https://dropper.waylonwalker.com/file/6f042a91.webp?h=675`) || !strings.Contains(post.ArticleHTML, `w=1200`) {
+		t.Errorf("Expected downsized poster URL, got: %s", post.ArticleHTML)
 	}
 }
 


### PR DESCRIPTION
## Summary
- keep inline post video sources at full size while downsizing trusted poster images
- preserve the feed helper poster sizing change that was already staged
- add a regression test to verify the video `src` stays untouched while the poster gets `w=1200&h=675`

## Testing
- go test ./pkg/plugins/... -run \"TestMDVideoPlugin_ProcessPost_DownsizesPosterOnly|TestMDVideoPlugin_ProcessPost_WithQueryParams|OGCard\" -count=1