### PR TITLE
fix(agent-skill): improve bundled skill quality

### DIFF
--- a/cmd/markata-go/cmd/explain.go
+++ b/cmd/markata-go/cmd/explain.go
@@ -671,6 +671,7 @@ The installed skill is intentionally split into focused topic files:
 - plugin creation
 
 The entrypoint is ` + "`SKILL.md`" + ` and the detailed guidance lives under ` + "`topics/`" + `.
+Reference material lives under ` + "`reference/`" + `, starter files live under ` + "`examples/`" + `, and bundled regression prompts live under ` + "`evals/`" + `.
 
 ## Why a Command Group?
 

--- a/docs/guides/agent-skills.md
+++ b/docs/guides/agent-skills.md
@@ -162,9 +162,11 @@ examples/
     base.html
     post.html
     feed.html
+evals/
+  evals.json
 ```
 
-Topic files provide narrative guidance for common tasks. Reference files give quick-lookup shapes (template variables, feed config patterns). Example files provide starter configs and templates for new sites or agents that need a concrete starting point.
+Topic files provide narrative guidance for common tasks. Reference files give quick-lookup shapes (template variables, feed config patterns). Example files provide starter configs and templates for new sites or agents that need a concrete starting point. `evals/evals.json` provides a starter regression prompt set for reviewing changes to the bundled skill itself.
 
 ## What The Skill Covers
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -186,7 +186,7 @@ markata-go agent remove --target claude
 - `agents` target: `.agents/skills/markata-go-site/`
 - `claude` target: `.claude/skills/markata-go-site/`
 
-The installed skill is split into `SKILL.md` plus focused topic files under `topics/`, reference material under `reference/`, and starter files under `examples/` so agents can read only the sections relevant to the current task. A `.manifest.json` file is written alongside the skill for drift detection via `agent doctor`.
+The installed skill is split into `SKILL.md` plus focused topic files under `topics/`, reference material under `reference/`, starter files under `examples/`, and regression prompts under `evals/` so agents can read only the sections relevant to the current task while maintainers still have a starter eval set for bundled-skill reviews. A `.manifest.json` file is written alongside the skill for drift detection via `agent doctor`.
 
 The `agent` command group is intentionally generic so future subcommands can add export or MCP-oriented integrations without changing the bundled skill format.
 

--- a/pkg/agentskill/bundle/markata-go-site/SKILL.md
+++ b/pkg/agentskill/bundle/markata-go-site/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: markata-go-site
-description: Help agents work effectively in markata-go site repositories. Use this when the task involves site configuration, writing content, templates, themes, builds, deployment, or deciding whether a change belongs in config, content, templates, or plugins.
+description: Help agents work effectively in markata-go site repositories. Use this whenever the user is working on a markata-go site or asks about site config, frontmatter or content authoring, templates or layouts, themes or palettes, build or deploy debugging, performance tuning, or deciding whether a change belongs in config, content, templates, CSS, feeds, or plugins.
 ---
 
 This skill helps an agent work inside a markata-go site repository without needing the markata-go source tree.
@@ -54,6 +54,12 @@ Use these as starter material for first sites or when a repo has no local exampl
 - `examples/templates/base.html`
 - `examples/templates/post.html`
 - `examples/templates/feed.html`
+
+## Eval Files
+
+Use these only when reviewing or improving the bundled skill itself:
+
+- `evals/evals.json`
 
 ## First-Site Defaults
 

--- a/pkg/agentskill/bundle/markata-go-site/evals/evals.json
+++ b/pkg/agentskill/bundle/markata-go-site/evals/evals.json
@@ -1,0 +1,35 @@
+{
+  "skill_name": "markata-go-site",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "My markata-go site has both posts and docs. I want docs pages under `/docs/` to use a docs-style layout with a left sidebar and right table of contents, but I do not want to rewrite all templates. What config should I change and what should it look like?",
+      "expected_output": "Explains that layout config is the right first step, points to `[markata-go.layout]` and `[markata-go.layout.paths]`, and gives a concrete TOML example instead of jumping straight to plugin or full template work.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "Please create a new post about my release notes for version 0.8. I want frontmatter that works well with markata-go, includes tags and description, and keeps me from forgetting the publish date.",
+      "expected_output": "Uses `markata-go new` or current frontmatter conventions, produces practical starter frontmatter, and keeps the guidance focused on content/frontmatter rather than template or plugin changes.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "On my markata-go blog I want feed cards to show the description under the title and use a compact byline. I already have a `templates/` folder. Which file should I inspect first and how would you make the smallest safe change?",
+      "expected_output": "Steers the answer toward the smallest relevant template or partial, preserves existing site conventions, and avoids rebuilding the whole template tree.",
+      "files": []
+    },
+    {
+      "id": 4,
+      "prompt": "My production deploy on GitHub Pages builds, but the feed URLs and some absolute asset URLs still point at localhost. How should I debug this in a markata-go site repo and what config or env values are most likely wrong?",
+      "expected_output": "Focuses on `url`, environment overrides such as `MARKATA_GO_URL`, and build/deploy validation steps before suggesting template rewrites.",
+      "files": []
+    },
+    {
+      "id": 5,
+      "prompt": "I want each post page to show a small computed reading estimate and a badge when it links to a GitHub repo. Should this live in frontmatter, config, templates, or a plugin? Please reason through the options for a normal markata-go site repo.",
+      "expected_output": "Explains the config/content/template/plugin decision clearly, prefers lower-cost options first, and only recommends plugin work when the behavior cannot be expressed with existing fields, templates, or built-in features.",
+      "files": []
+    }
+  ]
+}

--- a/pkg/agentskill/bundle/markata-go-site/reference/template-context.md
+++ b/pkg/agentskill/bundle/markata-go-site/reference/template-context.md
@@ -10,7 +10,9 @@ Correct: `{{ post.title }}`, `{{ post.article_html }}`, `{{ page.has_next }}`
 
 Wrong: `{{ post.Title }}`, `{{ post.ArticleHTML }}`, `{{ page.HasNext }}`
 
-The only PascalCase key is `post.Extra` (and `config.Extra`), which provides access to custom frontmatter and config values.
+Known PascalCase compatibility aliases are limited. `post.Extra` and `config.Extra` provide access to custom frontmatter and config values.
+
+`post.templateKey` may also be present as a compatibility alias. Prefer `post.template` for new work, but expect `post.templateKey` in older content, migrations, and some template/debugging contexts.
 
 ## Core Template Variables
 
@@ -39,7 +41,7 @@ Usually available in HTML templates:
 - `post.skip`
 - `post.tags`
 - `post.template`
-- `post.templateKey`
+- `post.templateKey` (compatibility alias for `post.template`)
 - `post.html`
 - `post.article_html`
 - `post.title`

--- a/pkg/agentskill/bundle/markata-go-site/topics/template-management.md
+++ b/pkg/agentskill/bundle/markata-go-site/topics/template-management.md
@@ -26,7 +26,9 @@ Correct: `{{ post.title }}`, `{{ post.article_html }}`, `{{ config.url }}`, `{{ 
 
 Wrong: `{{ post.Title }}`, `{{ post.ArticleHTML }}`, `{{ page.HasNext }}`
 
-The only PascalCase key is `post.Extra` (and `config.Extra`), which is intentional for the dynamic extras namespace: `{{ post.Extra.image }}`, `{{ config.Extra.custom_key }}`.
+Known PascalCase compatibility aliases are limited. `post.Extra` and `config.Extra` are intentional for the dynamic extras namespace: `{{ post.Extra.image }}`, `{{ config.Extra.custom_key }}`.
+
+`post.templateKey` may also appear as a compatibility alias for older content and migrations. Prefer `post.template` for new template work, but do not assume `post.templateKey` is invalid when reading or debugging an existing site.
 
 ## Search Order
 

--- a/pkg/agentskill/embed_test.go
+++ b/pkg/agentskill/embed_test.go
@@ -101,15 +101,38 @@ func TestSiteSkill_ContainsExampleFiles(t *testing.T) {
 	}
 }
 
+func TestSiteSkill_ContainsEvalFiles(t *testing.T) {
+	requiredEvals := []string{
+		"evals/evals.json",
+	}
+
+	skillFS, err := SiteSkill()
+	if err != nil {
+		t.Fatalf("SiteSkill() error = %v", err)
+	}
+
+	for _, evalFile := range requiredEvals {
+		t.Run(evalFile, func(t *testing.T) {
+			info, err := fs.Stat(skillFS, evalFile)
+			if err != nil {
+				t.Fatalf("missing required eval file %q: %v", evalFile, err)
+			}
+			if info.Size() == 0 {
+				t.Fatalf("eval file %q is empty", evalFile)
+			}
+		})
+	}
+}
+
 func TestListFiles_ReturnsExpectedFiles(t *testing.T) {
 	files, err := ListFiles()
 	if err != nil {
 		t.Fatalf("ListFiles() error = %v", err)
 	}
 
-	// SKILL.md + 8 topic files + 3 reference files + 6 example files = 18 minimum
-	if len(files) < 18 {
-		t.Fatalf("ListFiles() returned %d files, expected at least 18", len(files))
+	// SKILL.md + 8 topic files + 3 reference files + 6 example files + 1 eval file = 19 minimum
+	if len(files) < 19 {
+		t.Fatalf("ListFiles() returned %d files, expected at least 19", len(files))
 	}
 
 	hasSkill := false

--- a/spec/spec/AGENTS.md
+++ b/spec/spec/AGENTS.md
@@ -19,6 +19,7 @@ The bundled skill MUST include:
 - a `topics/` directory with focused guidance files
 - a `reference/` directory with quick-lookup reference material
 - an `examples/` directory with starter config and template files
+- an `evals/` directory with starter regression prompts for the bundled skill itself
 
 The initial required topic files are:
 
@@ -46,7 +47,13 @@ The initial example files are:
 - `templates/post.html`
 - `templates/feed.html`
 
+The initial eval files are:
+
+- `evals/evals.json`
+
 The entrypoint SHOULD tell agents to read only the topic files relevant to the current task. Reference and example files SHOULD be used when agents need exact shapes or starter material rather than narrative guidance.
+
+The `SKILL.md` frontmatter description MUST name concrete site-repository tasks and decision contexts so the bundled skill triggers reliably for real work instead of only broad repository descriptions.
 
 ## Skill Content Requirements
 
@@ -57,6 +64,14 @@ The bundled skill MUST guide agents toward:
 - using built-in CLI inspection commands where possible
 - preserving the site's existing layout and conventions unless the task explicitly changes them
 - using warm-build comparisons for performance work
+
+The bundled skill MUST also include a starter eval set that covers at least:
+
+- config changes or debugging
+- frontmatter or content creation
+- template or layout edits
+- build or deploy debugging
+- deciding whether work belongs in config, templates, feeds, CSS, or plugins
 
 ## Skill Maintenance Requirement
 


### PR DESCRIPTION
## Summary
- strengthen the bundled `markata-go-site` skill description so it triggers for concrete site-repo tasks
- clarify `post.templateKey` as a compatibility alias while steering new template work toward `post.template`
- add bundled eval coverage and document the installed `evals/` layout across spec and user docs

## Testing
- go test ./pkg/agentskill ./cmd/markata-go/cmd
- just lint-fast
- pre-commit hooks on commit: go fmt, go vet, golangci-lint, go test

## Issue
Refs #995
