### PR TITLE
fix(cli): align config UX and exit handling

### DIFF
--- a/cmd/markata-go/cmd/config.go
+++ b/cmd/markata-go/cmd/config.go
@@ -35,11 +35,12 @@ var configCmd = &cobra.Command{
 	Long: `Commands for managing markata-go configuration.
 
 Subcommands:
-  show     - Display the resolved configuration
-  get      - Get a specific configuration value
-  set      - Set a configuration value
-  validate - Validate the configuration file
-  init     - Create a new configuration file`,
+	  show     - Display the resolved configuration
+	  get      - Get a specific configuration value
+	  set      - Set a configuration value
+	  validate - Validate the configuration file
+	  init     - Create a new configuration file`,
+	RunE: runConfigCommand,
 }
 
 // configShowCmd shows the resolved configuration.
@@ -174,38 +175,36 @@ func init() {
 	configSetCmd.Flags().BoolVar(&configSetBackup, "backup", false, "create backup before modifying")
 }
 
+func runConfigCommand(cmd *cobra.Command, _ []string) error {
+	currentCmd = cmd
+	return runConfigShowCommand(configShowCmd, nil)
+}
+
 func runConfigShowCommand(cmd *cobra.Command, _ []string) error {
-	// Handle format shorthands
-	jsonFlag, err := cmd.Flags().GetBool(formatJSON)
+	format, err := resolveConfigShowFormat(cmd)
 	if err != nil {
-		return fmt.Errorf("failed to get json flag: %w", err)
-	}
-	if jsonFlag {
-		configFormat = formatJSON
-	}
-	tomlFlag, err := cmd.Flags().GetBool(formatTOML)
-	if err != nil {
-		return fmt.Errorf("failed to get toml flag: %w", err)
-	}
-	if tomlFlag {
-		configFormat = formatTOML
+		return err
 	}
 
-	// Handle --annotate and --diff modes
-	if configShowAnnotate || configShowDiff {
-		return runConfigShowWithSources(cfgFile)
-	}
-
-	// Load configuration
-	cfg, err := config.Load(cfgFile)
+	cfg, _, configPaths, err := loadManagerConfig(cfgFile)
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
 
+	// Handle --annotate and --diff modes
+	if configShowAnnotate || configShowDiff {
+		return runConfigShowWithSources(cfg, configPaths)
+	}
+
+	displayMap, err := configToMap(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to convert config to map: %w", err)
+	}
+
 	// Output in requested format
-	switch strings.ToLower(configFormat) {
+	switch format {
 	case formatJSON:
-		data, err := json.MarshalIndent(cfg, "", "  ")
+		data, err := json.MarshalIndent(displayMap, "", "  ")
 		if err != nil {
 			return fmt.Errorf("failed to marshal JSON: %w", err)
 		}
@@ -217,67 +216,82 @@ func runConfigShowCommand(cmd *cobra.Command, _ []string) error {
 		}
 
 	case formatYAML:
-		data, err := yaml.Marshal(cfg)
+		data, err := yaml.Marshal(displayMap)
 		if err != nil {
 			return fmt.Errorf("failed to marshal YAML: %w", err)
 		}
 		outText(string(data))
 
 	default:
-		data, err := yaml.Marshal(cfg)
-		if err != nil {
-			return fmt.Errorf("failed to marshal YAML: %w", err)
-		}
-		outText(string(data))
+		return newUsageError(fmt.Errorf("invalid format %q (expected yaml, json, or toml)", format))
 	}
 
 	return nil
 }
 
+func resolveConfigShowFormat(cmd *cobra.Command) (string, error) {
+	format := strings.ToLower(strings.TrimSpace(configFormat))
+	if format == "" {
+		format = formatYAML
+	}
+
+	jsonFlag, err := cmd.Flags().GetBool(formatJSON)
+	if err != nil {
+		return "", fmt.Errorf("failed to get json flag: %w", err)
+	}
+	tomlFlag, err := cmd.Flags().GetBool(formatTOML)
+	if err != nil {
+		return "", fmt.Errorf("failed to get toml flag: %w", err)
+	}
+
+	if cmd.Flags().Changed(formatJSON) && cmd.Flags().Changed(formatTOML) && jsonFlag && tomlFlag {
+		return "", newUsageError(fmt.Errorf("cannot use --json and --toml together"))
+	}
+
+	if cmd.Flags().Changed("format") {
+		if jsonFlag && format != formatJSON {
+			return "", newUsageError(fmt.Errorf("cannot use --format=%s with --json", format))
+		}
+		if tomlFlag && format != formatTOML {
+			return "", newUsageError(fmt.Errorf("cannot use --format=%s with --toml", format))
+		}
+	}
+
+	if jsonFlag {
+		format = formatJSON
+	}
+	if tomlFlag {
+		format = formatTOML
+	}
+
+	switch format {
+	case formatJSON, formatTOML, formatYAML:
+		return format, nil
+	default:
+		return "", newUsageError(fmt.Errorf("invalid format %q (expected yaml, json, or toml)", format))
+	}
+}
+
 // runConfigShowWithSources handles --annotate and --diff flags.
 // It compares user config with defaults to show value sources.
-func runConfigShowWithSources(configPath string) error {
-	// Get merged config as a map
-	merged, err := config.Load(configPath)
-	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
-	}
+func runConfigShowWithSources(merged *models.Config, configPaths []string) error {
 	mergedMap, err := configToMap(merged)
 	if err != nil {
 		return fmt.Errorf("failed to convert config to map: %w", err)
 	}
 
-	// Load user config file directly (without merging with defaults)
-	var userMap map[string]interface{}
-	var userConfigFile string
-
-	if configPath != "" {
-		userConfigFile = configPath
-	} else {
-		userConfigFile, _ = config.Discover() //nolint:errcheck // discovery failure is ok, we'll handle empty string
-	}
-
-	if userConfigFile != "" {
-		data, err := os.ReadFile(userConfigFile)
-		if err == nil {
-			format := formatFromPath(userConfigFile)
-			wrapper, err := parseConfigToMap(data, format)
-			if err == nil {
-				// Extract the inner markata-go config
-				if inner, ok := wrapper["markata-go"].(map[string]interface{}); ok {
-					userMap = inner
-				}
-			}
-		}
+	userMap, err := loadUserConfigMap(configPaths)
+	if err != nil {
+		return err
 	}
 
 	if configShowDiff {
 		// Show only values that differ from defaults
-		return showDiffConfig(userMap, userConfigFile)
+		return showDiffConfig(userMap, configPaths)
 	}
 
 	// Show annotated config
-	return showAnnotatedConfig(mergedMap, userMap, userConfigFile)
+	return showAnnotatedConfig(mergedMap, userMap, configPaths)
 }
 
 // configToMap converts a Config struct to a map[string]interface{}.
@@ -294,15 +308,18 @@ func configToMap(cfg *models.Config) (map[string]interface{}, error) {
 }
 
 // showDiffConfig prints only user-provided values that differ from defaults.
-func showDiffConfig(userMap map[string]interface{}, userConfigFile string) error {
+func showDiffConfig(userMap map[string]interface{}, configPaths []string) error {
 	if len(userMap) == 0 {
 		outln("# No user configuration found")
 		outln("# All values are defaults")
 		return nil
 	}
 
-	if userConfigFile != "" {
-		outlnf("# User configuration from: %s", userConfigFile)
+	if len(configPaths) > 0 {
+		outln("# User configuration from:")
+		for _, path := range configPaths {
+			outlnf("#   - %s", path)
+		}
 	}
 	outln("# Values below differ from defaults:")
 	outln()
@@ -318,11 +335,16 @@ func showDiffConfig(userMap map[string]interface{}, userConfigFile string) error
 }
 
 // showAnnotatedConfig prints the merged config with source annotations.
-func showAnnotatedConfig(merged, user map[string]interface{}, userConfigFile string) error {
+func showAnnotatedConfig(merged, user map[string]interface{}, configPaths []string) error {
+	userSource := userSourceLabel(configPaths)
+
 	// Print header
 	outln("# Configuration with source annotations")
-	if userConfigFile != "" {
-		outlnf("# User config: %s", userConfigFile)
+	if len(configPaths) > 0 {
+		outln("# User config files:")
+		for _, path := range configPaths {
+			outlnf("#   - %s", path)
+		}
 	} else {
 		outln("# User config: (none found, using defaults)")
 	}
@@ -333,6 +355,13 @@ func showAnnotatedConfig(merged, user map[string]interface{}, userConfigFile str
 	if err != nil {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
+
+	type yamlPathFrame struct {
+		indent int
+		key    string
+	}
+
+	var stack []yamlPathFrame
 
 	// Split into lines and annotate each
 	lines := strings.Split(string(data), "\n")
@@ -360,14 +389,20 @@ func showAnnotatedConfig(merged, user map[string]interface{}, userConfigFile str
 		key := trimmed[:colonIdx]
 		indent := len(line) - len(trimmed)
 
+		for len(stack) > 0 && indent <= stack[len(stack)-1].indent {
+			stack = stack[:len(stack)-1]
+		}
+
+		path := make([]string, 0, len(stack)+1)
+		for _, frame := range stack {
+			path = append(path, frame.key)
+		}
+		path = append(path, key)
+
 		// Determine source based on whether it's in user config
 		source := sourceDefault
-		if isKeyInMap(user, key) {
-			if userConfigFile != "" {
-				source = "user: " + filepath.Base(userConfigFile)
-			} else {
-				source = "user"
-			}
+		if hasPath(user, path) {
+			source = userSource
 		}
 
 		// Calculate padding for alignment
@@ -382,25 +417,98 @@ func showAnnotatedConfig(merged, user map[string]interface{}, userConfigFile str
 		if valueAfterColon != "" && !strings.HasPrefix(valueAfterColon, "|") && !strings.HasPrefix(valueAfterColon, ">") {
 			outlnf("%s%s# %s", line, strings.Repeat(" ", padding), source)
 		} else {
-			// It's a parent key (object/map) - check if any child is from user
-			if indent == 0 && isKeyInMap(user, key) {
-				outlnf("%s%s# %s (partial)", line, strings.Repeat(" ", padding), source)
+			if hasPath(user, path) {
+				outlnf("%s%s# %s", line, strings.Repeat(" ", padding), source)
 			} else {
 				outln(line)
 			}
+			stack = append(stack, yamlPathFrame{indent: indent, key: key})
 		}
 	}
 
 	return nil
 }
 
-// isKeyInMap checks if a key exists in the map (handles nested maps).
-func isKeyInMap(m map[string]interface{}, key string) bool {
-	if m == nil {
-		return false
+func loadUserConfigMap(configPaths []string) (map[string]interface{}, error) {
+	var userMap map[string]interface{}
+
+	for _, configPath := range configPaths {
+		data, err := os.ReadFile(configPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read config file %s: %w", configPath, err)
+		}
+
+		wrapper, err := parseConfigToMap(data, formatFromPath(configPath))
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse config file %s: %w", configPath, err)
+		}
+
+		inner, ok := wrapper["markata-go"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		userMap = mergeConfigMaps(userMap, inner)
 	}
-	_, exists := m[key]
-	return exists
+
+	return userMap, nil
+}
+
+func mergeConfigMaps(base, override map[string]interface{}) map[string]interface{} {
+	if base == nil {
+		base = make(map[string]interface{})
+	}
+
+	for key, value := range override {
+		overrideMap, ok := value.(map[string]interface{})
+		if !ok {
+			base[key] = value
+			continue
+		}
+
+		baseMap, ok := base[key].(map[string]interface{})
+		if !ok {
+			baseMap = make(map[string]interface{})
+		}
+		base[key] = mergeConfigMaps(baseMap, overrideMap)
+	}
+
+	return base
+}
+
+func userSourceLabel(configPaths []string) string {
+	if len(configPaths) == 0 {
+		return "user"
+	}
+	if len(configPaths) == 1 {
+		return "user: " + filepath.Base(configPaths[0])
+	}
+	return fmt.Sprintf("user: merged config (%d files)", len(configPaths))
+}
+
+func hasPath(m map[string]interface{}, path []string) bool {
+	_, ok := getPathValue(m, path)
+	return ok
+}
+
+func getPathValue(m map[string]interface{}, path []string) (interface{}, bool) {
+	if m == nil || len(path) == 0 {
+		return nil, false
+	}
+
+	var current interface{} = m
+	for _, key := range path {
+		currentMap, ok := current.(map[string]interface{})
+		if !ok {
+			return nil, false
+		}
+		current, ok = currentMap[key]
+		if !ok {
+			return nil, false
+		}
+	}
+
+	return current, true
 }
 
 func runConfigGetCommand(_ *cobra.Command, args []string) error {
@@ -442,13 +550,27 @@ func runConfigGetCommand(_ *cobra.Command, args []string) error {
 
 func runConfigValidateCommand(_ *cobra.Command, _ []string) error {
 	// Load and validate configuration
-	cfg, validationErrs, err := config.LoadAndValidate(cfgFile)
+	cfg, _, _, err := loadManagerConfig(cfgFile)
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
-
-	// Split errors and warnings
+	validationErrs := config.ValidateConfig(cfg)
 	actualErrors, warnings := config.SplitErrorsAndWarnings(validationErrs)
+
+	configPath := cfgFile
+	if configPath == "" {
+		if len(mergeConfigFiles) > 0 {
+			configPath = fmt.Sprintf("(merged config: %s)", strings.Join(mergeConfigFiles, ", "))
+		} else if discovered, discoverErr := config.Discover(); discoverErr == nil {
+			configPath = discovered
+		}
+	}
+	if configPath == "" && len(mergeConfigFiles) > 0 {
+		configPath = fmt.Sprintf("(merged config: %s)", strings.Join(mergeConfigFiles, ", "))
+	}
+	if configPath == "" {
+		configPath = "(defaults)"
+	}
 
 	// Print warnings
 	if len(warnings) > 0 {
@@ -469,18 +591,6 @@ func runConfigValidateCommand(_ *cobra.Command, _ []string) error {
 	}
 
 	// Print success
-	configPath := cfgFile
-	if configPath == "" {
-		var discoverErr error
-		configPath, discoverErr = config.Discover()
-		if discoverErr != nil {
-			configPath = ""
-		}
-	}
-	if configPath == "" {
-		configPath = "(defaults)"
-	}
-
 	outlnf("Configuration is valid: %s", configPath)
 
 	if verbose {

--- a/cmd/markata-go/cmd/config_test.go
+++ b/cmd/markata-go/cmd/config_test.go
@@ -1,12 +1,16 @@
 package cmd
 
 import (
+	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/WaylonWalker/markata-go/pkg/config"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 func TestParseValue(t *testing.T) {
@@ -257,44 +261,58 @@ func TestConfigToMap(t *testing.T) {
 	}
 }
 
-func TestIsKeyInMap(t *testing.T) {
+func TestHasPath(t *testing.T) {
 	tests := []struct {
 		name   string
 		m      map[string]interface{}
-		key    string
+		path   []string
 		expect bool
 	}{
 		{
 			name:   "nil map",
 			m:      nil,
-			key:    "foo",
+			path:   []string{"foo"},
 			expect: false,
 		},
 		{
-			name:   "key exists",
+			name:   "top level key exists",
 			m:      map[string]interface{}{"title": "Test"},
-			key:    "title",
+			path:   []string{"title"},
+			expect: true,
+		},
+		{
+			name: "nested key exists",
+			m: map[string]interface{}{
+				"glob": map[string]interface{}{"patterns": []interface{}{"posts/**/*.md"}},
+			},
+			path:   []string{"glob", "patterns"},
 			expect: true,
 		},
 		{
 			name:   "key does not exist",
 			m:      map[string]interface{}{"title": "Test"},
-			key:    "description",
+			path:   []string{"description"},
+			expect: false,
+		},
+		{
+			name:   "missing nested key",
+			m:      map[string]interface{}{"glob": map[string]interface{}{}},
+			path:   []string{"glob", "patterns"},
 			expect: false,
 		},
 		{
 			name:   "empty map",
 			m:      map[string]interface{}{},
-			key:    "title",
+			path:   []string{"title"},
 			expect: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := isKeyInMap(tt.m, tt.key)
+			got := hasPath(tt.m, tt.path)
 			if got != tt.expect {
-				t.Errorf("isKeyInMap() = %v, want %v", got, tt.expect)
+				t.Errorf("hasPath() = %v, want %v", got, tt.expect)
 			}
 		})
 	}
@@ -304,54 +322,44 @@ func TestShowDiffConfig(t *testing.T) {
 	tests := []struct {
 		name           string
 		userMap        map[string]interface{}
-		userConfigFile string
+		configPaths    []string
 		expectContains []string
 	}{
 		{
 			name:           "nil user map",
 			userMap:        nil,
-			userConfigFile: "",
+			configPaths:    nil,
 			expectContains: []string{"No user configuration found", "All values are defaults"},
 		},
 		{
 			name:           "empty user map",
 			userMap:        map[string]interface{}{},
-			userConfigFile: "",
+			configPaths:    nil,
 			expectContains: []string{"No user configuration found"},
 		},
 		{
 			name:           "user config with values",
 			userMap:        map[string]interface{}{"title": "My Site", "url": "https://example.com"},
-			userConfigFile: "/path/to/markata-go.toml",
+			configPaths:    []string{"/path/to/markata-go.toml"},
 			expectContains: []string{"User configuration from:", "title: My Site"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Capture stdout
-			oldStdout := os.Stdout
-			r, w, err := os.Pipe()
-			if err != nil {
-				t.Fatalf("Failed to create pipe: %v", err)
-			}
-			os.Stdout = w
+			stdout := bytes.NewBuffer(nil)
+			command := &cobra.Command{Use: "config"}
+			command.SetOut(stdout)
+			currentCmd = command
+			defer func() { currentCmd = nil }()
 
-			err = showDiffConfig(tt.userMap, tt.userConfigFile)
-
-			w.Close()
-			os.Stdout = oldStdout
+			err := showDiffConfig(tt.userMap, tt.configPaths)
 
 			if err != nil {
 				t.Fatalf("showDiffConfig() error = %v", err)
 			}
 
-			buf := make([]byte, 4096)
-			n, err := r.Read(buf)
-			if err != nil && n == 0 {
-				t.Fatalf("Failed to read output: %v", err)
-			}
-			output := string(buf[:n])
+			output := stdout.String()
 
 			for _, expect := range tt.expectContains {
 				if !strings.Contains(output, expect) {
@@ -394,8 +402,11 @@ output_dir = "dist"
 		}
 	}()
 
-	// Test that runConfigShowWithSources works without errors
-	// We'll test in --diff mode since it's easier to verify
+	merged, _, configPaths, err := loadManagerConfig("")
+	if err != nil {
+		t.Fatalf("loadManagerConfig() error = %v", err)
+	}
+
 	configShowDiff = true
 	configShowAnnotate = false
 	defer func() {
@@ -403,29 +414,19 @@ output_dir = "dist"
 		configShowAnnotate = false
 	}()
 
-	// Capture stdout
-	oldStdout := os.Stdout
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("Failed to create pipe: %v", err)
-	}
-	os.Stdout = w
+	stdout := bytes.NewBuffer(nil)
+	command := &cobra.Command{Use: "config"}
+	command.SetOut(stdout)
+	currentCmd = command
+	defer func() { currentCmd = nil }()
 
-	err = runConfigShowWithSources("")
-
-	w.Close()
-	os.Stdout = oldStdout
+	err = runConfigShowWithSources(merged, configPaths)
 
 	if err != nil {
 		t.Fatalf("runConfigShowWithSources() error = %v", err)
 	}
 
-	buf := make([]byte, 8192)
-	n, err := r.Read(buf)
-	if err != nil && n == 0 {
-		t.Fatalf("Failed to read output: %v", err)
-	}
-	output := string(buf[:n])
+	output := stdout.String()
 
 	// Should contain user values
 	if !strings.Contains(output, "title") {
@@ -433,5 +434,92 @@ output_dir = "dist"
 	}
 	if !strings.Contains(output, "My Test Site") {
 		t.Errorf("Output should contain 'My Test Site', got:\n%s", output)
+	}
+}
+
+func TestResolveConfigShowFormat_RejectsConflictingFlags(t *testing.T) {
+	command := &cobra.Command{Use: "show"}
+	command.Flags().String("format", "yaml", "")
+	command.Flags().Bool("json", false, "")
+	command.Flags().Bool("toml", false, "")
+
+	if err := command.Flags().Set("json", "true"); err != nil {
+		t.Fatalf("set json flag: %v", err)
+	}
+	if err := command.Flags().Set("toml", "true"); err != nil {
+		t.Fatalf("set toml flag: %v", err)
+	}
+
+	configFormat = "yaml"
+	_, err := resolveConfigShowFormat(command)
+	if err == nil {
+		t.Fatal("expected conflicting flag error")
+	}
+
+	var exitErr *ExitCodeError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected ExitCodeError, got %T", err)
+	}
+	if exitErr.ExitCode() != exitCodeUsage {
+		t.Fatalf("exit code = %d, want %d", exitErr.ExitCode(), exitCodeUsage)
+	}
+}
+
+func TestConfigToMap_YAMLSafeKeys(t *testing.T) {
+	cfg := config.DefaultConfig()
+	m, err := configToMap(cfg)
+	if err != nil {
+		t.Fatalf("configToMap() error = %v", err)
+	}
+
+	if _, err := yaml.Marshal(m); err != nil {
+		t.Fatalf("yaml.Marshal(configToMap()) error = %v", err)
+	}
+}
+
+func TestLoadUserConfigMap_MergesConfigPaths(t *testing.T) {
+	tmpDir := t.TempDir()
+	basePath := filepath.Join(tmpDir, "markata-go.toml")
+	overridePath := filepath.Join(tmpDir, "fast.toml")
+
+	base := `[markata-go]
+title = "Base"
+
+[markata-go.glob]
+patterns = ["posts/**/*.md"]
+`
+	override := `[markata-go]
+url = "https://example.com"
+
+[markata-go.glob]
+use_gitignore = false
+`
+
+	if err := os.WriteFile(basePath, []byte(base), 0o600); err != nil {
+		t.Fatalf("write base config: %v", err)
+	}
+	if err := os.WriteFile(overridePath, []byte(override), 0o600); err != nil {
+		t.Fatalf("write override config: %v", err)
+	}
+
+	userMap, err := loadUserConfigMap([]string{basePath, overridePath})
+	if err != nil {
+		t.Fatalf("loadUserConfigMap() error = %v", err)
+	}
+
+	if got, ok := getPathValue(userMap, []string{"title"}); !ok || got != "Base" {
+		t.Fatalf("title = %v, %v; want Base, true", got, ok)
+	}
+	if got, ok := getPathValue(userMap, []string{"url"}); !ok || got != "https://example.com" {
+		t.Fatalf("url = %v, %v; want https://example.com, true", got, ok)
+	}
+	if got, ok := getPathValue(userMap, []string{"glob", "use_gitignore"}); !ok || got != false {
+		t.Fatalf("glob.use_gitignore = %v, %v; want false, true", got, ok)
+	}
+}
+
+func TestExitCodeForError_UsageErrorReturnsTwo(t *testing.T) {
+	if got := ExitCodeForError(errors.New("accepts 1 arg(s), received 0")); got != exitCodeUsage {
+		t.Fatalf("ExitCodeForError() = %d, want %d", got, exitCodeUsage)
 	}
 }

--- a/cmd/markata-go/cmd/exit_code.go
+++ b/cmd/markata-go/cmd/exit_code.go
@@ -1,5 +1,12 @@
 package cmd
 
+import (
+	"errors"
+	"strings"
+)
+
+const exitCodeUsage = 2
+
 // ExitCodeError carries a process exit code without forcing command handlers to
 // call os.Exit directly.
 type ExitCodeError struct {
@@ -33,4 +40,59 @@ func newExitCodeError(code int, err error) error {
 		return nil
 	}
 	return &ExitCodeError{code: code, err: err}
+}
+
+func newUsageError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return newExitCodeError(exitCodeUsage, err)
+}
+
+func ExitCodeForError(err error) int {
+	if err == nil {
+		return 0
+	}
+
+	exitCode := 1
+	var exitErr interface{ ExitCode() int }
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	if isUsageError(err) {
+		return exitCodeUsage
+	}
+	return exitCode
+}
+
+func isUsageError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	message := strings.TrimSpace(err.Error())
+	if message == "" {
+		return false
+	}
+
+	usagePrefixes := []string{
+		"accepts ",
+		"unknown flag:",
+		"unknown shorthand flag:",
+		"unknown command ",
+		"required flag(s) ",
+		"flag needs an argument:",
+		"requires at least ",
+		"requires at most ",
+		"requires between ",
+		"invalid argument ",
+	}
+
+	for _, prefix := range usagePrefixes {
+		if strings.HasPrefix(message, prefix) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/cmd/markata-go/cmd/root.go
+++ b/cmd/markata-go/cmd/root.go
@@ -146,6 +146,9 @@ func Execute() error {
 
 func init() {
 	cobra.OnInitialize(initConfig)
+	rootCmd.SetFlagErrorFunc(func(_ *cobra.Command, err error) error {
+		return newUsageError(err)
+	})
 
 	// Global flags
 	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file path (default: auto-discover)")

--- a/cmd/markata-go/main.go
+++ b/cmd/markata-go/main.go
@@ -2,7 +2,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -12,11 +11,7 @@ import (
 
 func main() {
 	if err := cmd.Execute(); err != nil {
-		exitCode := 1
-		var exitErr interface{ ExitCode() int }
-		if errors.As(err, &exitErr) {
-			exitCode = exitErr.ExitCode()
-		}
+		exitCode := cmd.ExitCodeForError(err)
 		if message := strings.TrimSpace(err.Error()); message != "" {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		}

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -1939,6 +1939,9 @@ enabled = false
 Display the resolved configuration:
 
 ```bash
+# Same as `markata-go config show`
+markata-go config
+
 # Show as YAML (default)
 markata-go config show
 
@@ -1947,7 +1950,14 @@ markata-go config show --json
 
 # Show as TOML
 markata-go config show --toml
+
+# Include merged override files
+markata-go config show -m fast-markata-go.toml
 ```
+
+`config show` uses the same config resolution path as `build` and `serve`, including any `--merge-config` overrides.
+
+Conflicting format requests such as `markata-go config show --json --toml` fail with usage exit code `2`.
 
 ### `config get`
 
@@ -1987,7 +1997,12 @@ markata-go config validate
 
 # Validate specific config file
 markata-go config validate -c custom.toml
+
+# Validate with merged overrides
+markata-go config validate -m fast-markata-go.toml
 ```
+
+`config validate` uses the same merged configuration resolution as `build` and `serve`.
 
 Example output:
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -933,11 +933,15 @@ Configuration management commands for viewing, validating, and initializing conf
 markata-go config <subcommand> [flags]
 ```
 
+Running `markata-go config` with no subcommand behaves like `markata-go config show`.
+
 #### Subcommands
 
 ##### show
 
 Display the resolved configuration after merging defaults, config file, and environment variables.
+
+`config show` honors the root `--config` and `--merge-config` flags, so it reports the same effective configuration used by `build` and `serve`.
 
 ```bash
 markata-go config show [flags]
@@ -945,6 +949,7 @@ markata-go config show [flags]
 
 | Flag | Description | Default |
 |------|-------------|---------|
+| `--format` | Output format: `yaml`, `json`, or `toml` | `yaml` |
 | `--json` | Output as JSON | `false` |
 | `--toml` | Output as TOML | `false` |
 | (none) | Output as YAML | default |
@@ -963,7 +968,16 @@ markata-go config show --toml
 
 # Show config from specific file
 markata-go config show -c production.toml
+
+# Show config with merged overrides
+markata-go config show -m fast.toml
 ```
+
+Notes:
+
+- `markata-go config` is equivalent to `markata-go config show`
+- `--json` and `--toml` are shorthands for `--format json` and `--format toml`
+- conflicting combinations such as `--json --toml` fail with usage error exit code `2`
 
 ##### get
 
@@ -1032,6 +1046,8 @@ Notes:
 
 Validate the configuration file and report any errors or warnings.
 
+`config validate` honors the root `--config` and `--merge-config` flags.
+
 ```bash
 markata-go config validate [flags]
 ```
@@ -1049,6 +1065,9 @@ markata-go config validate
 # Validate specific config file
 markata-go config validate -c production.toml
 markata-go config validate -c custom.yaml
+
+# Validate with merged overrides
+markata-go config validate -m fast.toml
 ```
 
 **Output:**
@@ -1348,14 +1367,13 @@ Configuration values are resolved in this order (later sources override earlier)
 
 ## Exit Codes
 
-All markata-go commands use standard exit codes:
+markata-go uses these common exit code patterns:
 
 | Code | Name | Description |
 |------|------|-------------|
 | `0` | Success | Command completed successfully |
 | `1` | Error | General error (configuration, plugin, I/O, etc.) |
-| `2` | No Content | No content files found matching glob patterns |
-| `3` | Validation Error | Configuration validation failed |
+| `2` | Usage / Command-specific | Invalid CLI usage such as unknown flags or missing args, or command-specific non-success states documented by that command |
 | `130` | Interrupted | Command interrupted by user (Ctrl+C) |
 
 ### Using Exit Codes in Scripts

--- a/pkg/agentskill/bundle/markata-go-site/topics/cli-usage.md
+++ b/pkg/agentskill/bundle/markata-go-site/topics/cli-usage.md
@@ -23,6 +23,8 @@ Use this topic for everyday site work and safe project inspection.
 - `markata-go config show --diff`
 - `markata-go config get <key>`
 - `markata-go config validate`
+
+Bare `markata-go config` behaves like `markata-go config show`.
 - `markata-go list posts`
 - `markata-go list feeds`
 - `markata-go list tags`
@@ -136,6 +138,7 @@ markata-go lint --fix
 ## Operator Patterns
 
 - use `-m fast.toml` when you want a lighter dev build without rewriting main config
+- use the same `-m` overrides with `config show` and `config validate` when you need to inspect or verify the exact config that `build` or `serve` will use
 - use `-c` when a repo has multiple configs or examples and you need the exact active one
 - use `-o dist` in CI or preview contexts when you want a temporary artifact path
 - use `--no-input` for automation or when the agent must avoid prompts

--- a/pkg/agentskill/bundle/markata-go-site/topics/configuration.md
+++ b/pkg/agentskill/bundle/markata-go-site/topics/configuration.md
@@ -26,6 +26,8 @@ When `--config` is not passed, markata-go looks for config in this order:
 - `markata-go config get <key>`
 - `markata-go config validate`
 
+Bare `markata-go config` behaves like `markata-go config show`.
+
 ## Core Namespace
 
 Most settings live under `[markata-go]` and nested namespaces like `[markata-go.glob]` and `[markata-go.theme]`.
@@ -188,6 +190,8 @@ Local override files like `markata-go.local.toml` are NOT auto-discovered. They 
 ```bash
 markata-go build -m markata-go.local.toml
 markata-go serve -m markata-go.local.toml
+markata-go config show -m markata-go.local.toml
+markata-go config validate -m markata-go.local.toml
 ```
 
 Multiple merge files can be specified and are applied in order on top of the base config.

--- a/pkg/models/layout.go
+++ b/pkg/models/layout.go
@@ -565,7 +565,7 @@ type TocConfig struct {
 	MinDepth int `json:"min_depth,omitempty" yaml:"min_depth,omitempty" toml:"min_depth,omitempty"`
 
 	// MaxDepth is the maximum heading level to include (default: 4)
-	MaxDepth int `json:"max_depth,omitempty" yaml:"min_depth,omitempty" toml:"max_depth,omitempty"`
+	MaxDepth int `json:"max_depth,omitempty" yaml:"max_depth,omitempty" toml:"max_depth,omitempty"`
 
 	// Title is the TOC section title (default: "On this page")
 	Title string `json:"title,omitempty" yaml:"title,omitempty" toml:"title,omitempty"`

--- a/spec/spec/CLI_UX.md
+++ b/spec/spec/CLI_UX.md
@@ -145,6 +145,15 @@ Running `markata-go` with no arguments MUST display help.
 
 Commands SHOULD return errors instead of calling `os.Exit()` directly.
 
+Command invocation and usage errors MUST return exit code `2`.
+
+Examples:
+
+- unknown commands
+- unknown flags
+- conflicting flags
+- missing required positional arguments
+
 Error messages SHOULD:
 
 - explain what went wrong

--- a/spec/spec/CONFIG.md
+++ b/spec/spec/CONFIG.md
@@ -474,6 +474,10 @@ patterns_append = ["pages/*.md"]
 
 Display resolved configuration:
 
+- bare `my-ssg config` MUST behave like `my-ssg config show`
+- `config show` MUST honor the same config resolution path as build commands, including `--config` and `--merge-config`
+- conflicting output flags such as `--json` with `--toml` MUST fail with a usage error (exit code `2`)
+
 ```bash
 $ my-ssg config show
 output_dir = "public"
@@ -582,6 +586,8 @@ Created my-ssg.toml with all options documented
 ### `config validate`
 
 Validate configuration:
+
+- `config validate` MUST honor the same config resolution path as build commands, including `--config` and `--merge-config`
 
 ```bash
 $ my-ssg config validate


### PR DESCRIPTION
## Summary
- make `config show` and `config validate` honor merged config resolution so they match `build` and `serve`
- make bare `markata-go config` behave like `config show`, reject conflicting config format flags, and normalize usage errors to exit code `2`
- fix nested config source annotations and the `TocConfig` YAML tag bug that could break YAML config output

## Testing
- `go test ./cmd/markata-go/cmd`
- `go test ./pkg/models -run Test`
- `just lint-fast`
- built binary checks for `config show --json --toml` and `config get` exit code `2`

Fixes #994