### PR TITLE
feat: allow per-post post format overrides

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -1483,6 +1483,17 @@ og = true         # /slug/og/index.html (social card)
 
 **Visible Format Links**: When alternate formats are enabled, posts and feeds display visible links allowing visitors to access content in their preferred format.
 
+**Per-post frontmatter overrides**: A post can override any of these format flags in frontmatter with a `post_formats` object. Overrides merge with the site defaults, so omitted keys continue to inherit from `[markata-go.post_formats]`.
+
+```yaml
+---
+title: "One-off terminal post"
+post_formats:
+  ansi: true
+  og: false
+---
+```
+
 OG card pages automatically include:
 - `<link rel="canonical">` pointing back to the original post
 - `<meta name="robots" content="noindex, nofollow">` to prevent search engine indexing

--- a/docs/guides/post-formats.md
+++ b/docs/guides/post-formats.md
@@ -29,6 +29,26 @@ og = true         # OpenGraph card HTML (default: true)
 
 By default, HTML, Markdown, plain text, and OG formats are enabled. ANSI output is opt-in so you can add rich terminal rendering without introducing escape sequences into existing `.txt` endpoints.
 
+## Per-Post Overrides
+
+Site config sets the defaults, and individual posts can override them in frontmatter:
+
+```yaml
+---
+title: "Release Notes"
+post_formats:
+  markdown: false
+  ansi: true
+  og: false
+---
+```
+
+Merge rules:
+
+- omitted keys inherit the site-wide `[markata-go.post_formats]` setting
+- specified keys override only that post
+- template-visible `config.post_formats` follows the resolved per-post values, so alternate links and format switchers stay in sync with generated files
+
 ## Available Formats
 
 ### HTML (default)

--- a/pkg/agentskill/bundle/markata-go-site/topics/writing-frontmatter.md
+++ b/pkg/agentskill/bundle/markata-go-site/topics/writing-frontmatter.md
@@ -157,7 +157,19 @@ Author IDs are resolved against `[markata-go.authors]` config to produce full `p
 - `template`: selects a specific template file
 - `layout`: selects a layout-driven page shell when the site uses layout config
 - `authors` or `author`: affect bylines and author objects in templates
+- `post_formats`: can override site-level post output formats per post, such as enabling `ansi` for one article or disabling `og`/`markdown` for a specific page
 - custom fields: appear in `post.Extra` for templates and plugin logic
+
+Example per-post output override:
+
+```yaml
+---
+title: "CLI cheat sheet"
+post_formats:
+  ansi: true
+  markdown: false
+---
+```
 
 ## Recommended Content Workflow
 

--- a/pkg/plugins/oembed.go
+++ b/pkg/plugins/oembed.go
@@ -180,7 +180,7 @@ func resolveEmbedHighlightConfig(extra map[string]interface{}) (chromaTheme stri
 
 func renderGistCodeMarkdown(resolver *oembedResolver, language, content string) (string, error) {
 	if language == "" {
-		language = "text"
+		language = formatText
 	}
 	md := resolver.markdown
 	if md == nil {

--- a/pkg/plugins/post_formats.go
+++ b/pkg/plugins/post_formats.go
@@ -1,0 +1,137 @@
+package plugins
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
+	"github.com/WaylonWalker/markata-go/pkg/models"
+	"gopkg.in/yaml.v3"
+)
+
+func resolvePostFormats(post *models.Post, config *lifecycle.Config) models.PostFormatsConfig {
+	resolved := getPostFormatsConfig(config)
+	if post == nil || post.Extra == nil {
+		return resolved
+	}
+
+	overrideValue, ok := post.Extra["post_formats"]
+	if !ok {
+		return resolved
+	}
+
+	override, ok := parsePostFormatsOverride(overrideValue)
+	if !ok {
+		return resolved
+	}
+
+	if override.HTML != nil {
+		resolved.HTML = override.HTML
+	}
+	if hasPostFormatKey(overrideValue, "markdown") {
+		resolved.Markdown = override.Markdown
+	}
+	if hasPostFormatKey(overrideValue, "text") {
+		resolved.Text = override.Text
+	}
+	if hasPostFormatKey(overrideValue, "ansi") {
+		resolved.ANSI = override.ANSI
+	}
+	if hasPostFormatKey(overrideValue, "og") {
+		resolved.OG = override.OG
+	}
+
+	return resolved
+}
+
+func parsePostFormatsOverride(value interface{}) (models.PostFormatsConfig, bool) {
+	if value == nil {
+		return models.PostFormatsConfig{}, false
+	}
+
+	switch v := value.(type) {
+	case models.PostFormatsConfig:
+		return v, true
+	case map[string]interface{}:
+		return postFormatsConfigFromMap(v), true
+	default:
+		return models.PostFormatsConfig{}, false
+	}
+}
+
+func postFormatsConfigFromMap(raw map[string]interface{}) models.PostFormatsConfig {
+	encoded, err := yaml.Marshal(raw)
+	if err != nil {
+		return models.PostFormatsConfig{}
+	}
+
+	var parsed struct {
+		HTML     *bool `yaml:"html"`
+		Markdown *bool `yaml:"markdown"`
+		Text     *bool `yaml:"text"`
+		ANSI     *bool `yaml:"ansi"`
+		OG       *bool `yaml:"og"`
+	}
+	if err := yaml.Unmarshal(encoded, &parsed); err != nil {
+		return models.PostFormatsConfig{}
+	}
+
+	return models.PostFormatsConfig{
+		HTML:     parsed.HTML,
+		Markdown: parsed.Markdown != nil && *parsed.Markdown,
+		Text:     parsed.Text != nil && *parsed.Text,
+		ANSI:     parsed.ANSI != nil && *parsed.ANSI,
+		OG:       parsed.OG != nil && *parsed.OG,
+	}
+}
+
+func hasPostFormatKey(value interface{}, key string) bool {
+	switch v := value.(type) {
+	case map[string]interface{}:
+		_, ok := v[key]
+		return ok
+	case models.PostFormatsConfig:
+		switch key {
+		case "html":
+			return v.HTML != nil
+		case "markdown", "text", "ansi", "og":
+			return true
+		default:
+			return false
+		}
+	default:
+		return false
+	}
+}
+
+func applyPostFormatsToConfig(base *models.Config, postFormats models.PostFormatsConfig) *models.Config {
+	if base == nil {
+		return nil
+	}
+
+	resolvedConfig := *base
+	resolvedConfig.PostFormats = postFormats
+	return &resolvedConfig
+}
+
+func removeDisabledPostOutputs(outputDir, slug string, postFormats models.PostFormatsConfig) {
+	postDir := filepath.Join(outputDir, slug)
+	if !postFormats.IsHTMLEnabled() {
+		_ = os.Remove(filepath.Join(postDir, "index.html"))
+	}
+	if !postFormats.Markdown {
+		_ = os.Remove(filepath.Join(outputDir, slug+".md"))
+		_ = os.RemoveAll(filepath.Join(postDir, "index.md"))
+	}
+	if !postFormats.Text {
+		_ = os.Remove(filepath.Join(outputDir, slug+".txt"))
+		_ = os.RemoveAll(filepath.Join(postDir, "index.txt"))
+	}
+	if !postFormats.ANSI {
+		_ = os.Remove(filepath.Join(outputDir, slug+".ansi"))
+		_ = os.RemoveAll(filepath.Join(postDir, "index.ansi"))
+	}
+	if !postFormats.OG {
+		_ = os.RemoveAll(filepath.Join(postDir, "og"))
+	}
+}

--- a/pkg/plugins/publish_html.go
+++ b/pkg/plugins/publish_html.go
@@ -220,11 +220,12 @@ func (p *PublishHTMLPlugin) writePost(post *models.Post, config *lifecycle.Confi
 		return fmt.Errorf("creating post directory %s: %w", postDir, err)
 	}
 
-	// Get post formats config from Extra
-	postFormats := getPostFormatsConfig(config)
+	// Resolve site defaults plus any per-post frontmatter override.
+	postFormats := resolvePostFormats(post, config)
 
 	// Get build cache for incremental builds
 	cache := GetBuildCache(m)
+	removeDisabledPostOutputs(config.OutputDir, post.Slug, postFormats)
 
 	// Write HTML format (default)
 	if postFormats.IsHTMLEnabled() {
@@ -376,7 +377,7 @@ func (p *PublishHTMLPlugin) buildFormatContent(post *models.Post, config *lifecy
 	// If we have an engine and the template exists, render it
 	if engine != nil && templateName != "" && engine.TemplateExists(templateName) {
 		// Create template context
-		ctx := templates.NewContext(post, post.Content, ToModelsConfig(config))
+		ctx := templates.NewContext(post, post.Content, applyPostFormatsToConfig(ToModelsConfig(config), resolvePostFormats(post, config)))
 		ctx = ctx.WithCore(m)
 
 		// Render the template
@@ -447,7 +448,7 @@ func (p *PublishHTMLPlugin) renderTerminalContent(
 		return post.Content
 	}
 
-	ctx := templates.NewContext(post, body, ToModelsConfig(config))
+	ctx := templates.NewContext(post, body, applyPostFormatsToConfig(ToModelsConfig(config), resolvePostFormats(post, config)))
 	result, err := engine.Render(templateName, ctx)
 	if err != nil {
 		return body
@@ -710,7 +711,7 @@ func (p *PublishHTMLPlugin) generateOGHTML(post *models.Post, config *lifecycle.
 // renderOGWithThemeTemplate renders the OG card using the theme's og-card.html template.
 func (p *PublishHTMLPlugin) renderOGWithThemeTemplate(post *models.Post, config *lifecycle.Config, engine *templates.Engine) string {
 	// Build context for pongo2 template
-	ctx := templates.NewContext(post, "", ToModelsConfig(config))
+	ctx := templates.NewContext(post, "", applyPostFormatsToConfig(ToModelsConfig(config), resolvePostFormats(post, config)))
 
 	result, err := engine.Render("og-card.html", ctx)
 	if err != nil {

--- a/pkg/plugins/publish_html_test.go
+++ b/pkg/plugins/publish_html_test.go
@@ -1210,3 +1210,100 @@ func TestPublishHTMLPlugin_NonPrivatePostGetsAllFormats(t *testing.T) {
 		t.Error("Public post .ansi file should be written")
 	}
 }
+
+func TestResolvePostFormats_MergesFrontmatterOverride(t *testing.T) {
+	htmlEnabled := true
+	config := &lifecycle.Config{
+		Extra: map[string]interface{}{
+			"post_formats": models.PostFormatsConfig{
+				HTML:     &htmlEnabled,
+				Markdown: true,
+				Text:     true,
+				ANSI:     false,
+				OG:       true,
+			},
+		},
+	}
+
+	post := &models.Post{
+		Extra: map[string]interface{}{
+			"post_formats": map[string]interface{}{
+				"ansi": true,
+				"og":   false,
+			},
+		},
+	}
+
+	resolved := resolvePostFormats(post, config)
+
+	if !resolved.IsHTMLEnabled() {
+		t.Fatal("expected html to inherit enabled site default")
+	}
+	if !resolved.Markdown {
+		t.Fatal("expected markdown to inherit enabled site default")
+	}
+	if !resolved.Text {
+		t.Fatal("expected text to inherit enabled site default")
+	}
+	if !resolved.ANSI {
+		t.Fatal("expected ansi to be enabled by post override")
+	}
+	if resolved.OG {
+		t.Fatal("expected og to be disabled by post override")
+	}
+}
+
+func TestPublishHTMLPlugin_PostFrontmatterDisablesInheritedFormats(t *testing.T) {
+	tempDir := t.TempDir()
+	plugin := NewPublishHTMLPlugin()
+
+	htmlEnabled := true
+	config := &lifecycle.Config{
+		OutputDir: tempDir,
+		Extra: map[string]interface{}{
+			"post_formats": models.PostFormatsConfig{
+				HTML:     &htmlEnabled,
+				Markdown: true,
+				Text:     true,
+				ANSI:     false,
+				OG:       false,
+			},
+		},
+	}
+
+	title := "Frontmatter Override"
+	post := &models.Post{
+		Path:        "override.md",
+		Slug:        "override-post",
+		Title:       &title,
+		Content:     "body",
+		HTML:        "<html><body>html</body></html>",
+		Published:   true,
+		ArticleHTML: "<p>body</p>",
+		Extra: map[string]interface{}{
+			"post_formats": map[string]interface{}{
+				"markdown": false,
+				"text":     false,
+				"ansi":     true,
+			},
+		},
+	}
+
+	m := createTestManager(t, config)
+	if err := plugin.writePost(post, config, nil, m); err != nil {
+		t.Fatalf("writePost() error = %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(tempDir, "override-post", "index.html")); os.IsNotExist(err) {
+		t.Fatal("expected html output to be written")
+	}
+	if _, err := os.Stat(filepath.Join(tempDir, "override-post.md")); !os.IsNotExist(err) {
+		t.Fatal("expected markdown output to be suppressed by post override")
+	}
+	if _, err := os.Stat(filepath.Join(tempDir, "override-post.txt")); !os.IsNotExist(err) {
+		t.Fatal("expected text output to be suppressed by post override")
+	}
+	if _, err := os.Stat(filepath.Join(tempDir, "override-post.ansi")); os.IsNotExist(err) {
+		t.Fatal("expected ansi output to be enabled by post override")
+	}
+}

--- a/pkg/plugins/templates.go
+++ b/pkg/plugins/templates.go
@@ -581,7 +581,7 @@ func (p *TemplatesPlugin) renderPost(post *models.Post, config *lifecycle.Config
 	}
 
 	// Create template context
-	modelsConfig := ToModelsConfig(config)
+	modelsConfig := applyPostFormatsToConfig(ToModelsConfig(config), resolvePostFormats(post, config))
 	ctx := templates.NewContext(post, post.ArticleHTML, modelsConfig)
 	ctx = ctx.WithCore(m)
 	ctx.Set("feed_posts", createFeedPostsFunc(m))

--- a/pkg/plugins/templates_test.go
+++ b/pkg/plugins/templates_test.go
@@ -398,6 +398,65 @@ func TestTemplatesPlugin_Render_NoTemplate(t *testing.T) {
 	}
 }
 
+func TestTemplatesPlugin_Render_UsesResolvedPostFormatsInTemplateContext(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "templates-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	templateContent := `{% if config.post_formats.markdown %}md-on{% else %}md-off{% endif %} {% if config.post_formats.ansi %}ansi-on{% else %}ansi-off{% endif %}`
+	templatePath := filepath.Join(tmpDir, "post.html")
+
+	err = os.WriteFile(templatePath, []byte(templateContent), 0o600)
+	if err != nil {
+		t.Fatalf("Failed to write template: %v", err)
+	}
+
+	p := NewTemplatesPlugin()
+	m := lifecycle.NewManager()
+	config := m.Config()
+	config.Extra["templates_dir"] = tmpDir
+	htmlEnabled := true
+	config.Extra["post_formats"] = models.PostFormatsConfig{
+		HTML:     &htmlEnabled,
+		Markdown: true,
+		Text:     true,
+		ANSI:     false,
+	}
+
+	err = p.Configure(m)
+	if err != nil {
+		t.Fatalf("Configure() error = %v", err)
+	}
+	if !p.engine.TemplateExists("post.html") {
+		t.Fatalf("expected post.html template to be available from %s", templatePath)
+	}
+
+	title := "Test Post"
+	post := &models.Post{
+		Title:       &title,
+		Template:    "post.html",
+		ArticleHTML: "<p>Hello World</p>",
+		Extra: map[string]interface{}{
+			"post_formats": map[string]interface{}{
+				"markdown": false,
+				"ansi":     true,
+			},
+		},
+	}
+	m.AddPost(post)
+
+	err = p.Render(m)
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+
+	if !strings.Contains(post.HTML, "md-off ansi-on") {
+		t.Fatalf("expected template context to use resolved per-post post_formats, got %q", post.HTML)
+	}
+}
+
 func TestTemplatesPlugin_Render_SkippedPost(t *testing.T) {
 	p := NewTemplatesPlugin()
 	m := lifecycle.NewManager()

--- a/pkg/templates/context.go
+++ b/pkg/templates/context.go
@@ -635,6 +635,7 @@ func postFormatsToMap(p *models.PostFormatsConfig) map[string]interface{} {
 		"html":     htmlEnabled,
 		"markdown": p.Markdown,
 		"text":     p.Text,
+		"ansi":     p.ANSI,
 		"og":       p.OG,
 	}
 }

--- a/spec/spec/CONFIG.md
+++ b/spec/spec/CONFIG.md
@@ -867,6 +867,19 @@ This section controls what output formats are generated for each post:
 | `ansi` | `false` | `/slug.ansi` | ANSI-styled terminal page output |
 | `og` | `true` | `/slug/og/index.html` | OpenGraph card HTML (1200x630) for social screenshots |
 
+Posts MAY override these site defaults in frontmatter with a `post_formats` mapping. Per-post overrides merge with `[my-ssg.post_formats]` key-by-key; omitted keys inherit the site setting.
+
+```yaml
+---
+title: "Terminal-first post"
+post_formats:
+  ansi: true
+  og: false
+---
+```
+
+In this example, the post inherits the site defaults for `html`, `markdown`, and `text`, enables `.ansi` for this post only, and suppresses OG output for this post only.
+
 `text` and `ansi` are separate explicit variants:
 
 - `text` MUST emit readable plain text with no ANSI escape sequences.


### PR DESCRIPTION
## Summary
- allow posts to override site-level `post_formats` in frontmatter, merging per-key with global defaults
- keep generated files and template-visible `config.post_formats` in sync so alternate links and format UI reflect per-post overrides
- document the new frontmatter behavior in the spec, docs, and bundled site skill, with regression coverage for publish and template rendering

## Issue
- Refs #998

## Validation
- `go test ./pkg/plugins ./pkg/templates`
- `just lint-new`
- pre-commit hooks (`go fmt`, `go vet`, `golangci-lint`, `go test`) passed during commit