### PR TITLE
feat(agent-skill): add analytics storytelling guidance

### DIFF
--- a/pkg/agentskill/bundle/markata-go-site/SKILL.md
+++ b/pkg/agentskill/bundle/markata-go-site/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: markata-go-site
-description: Help agents work effectively in markata-go site repositories. Use this whenever the user is working on a markata-go site or asks about site config, frontmatter or content authoring, templates or layouts, themes or palettes, build or deploy debugging, performance tuning, or deciding whether a change belongs in config, content, templates, CSS, feeds, or plugins.
+description: Help agents work effectively in markata-go site repositories. Use this whenever the user is working on a markata-go site or asks about site config, frontmatter or content authoring, templates or layouts, themes or palettes, analytics or stats pages, chartjs or contribution graphs, build or deploy debugging, performance tuning, or deciding whether a change belongs in config, content, templates, CSS, feeds, or plugins. Use it proactively for tasks like creating an `analytics.md` page, exposing reading time or word count in templates, or helping an author turn site metrics into a publishable story.
 ---
 
 This skill helps an agent work inside a markata-go site repository without needing the markata-go source tree.
@@ -13,6 +13,7 @@ Before making changes:
 - locate the active config file, usually `markata-go.toml`
 - inspect the site's content directories such as `posts/`, `pages/`, `docs/`, and `static/`
 - inspect `templates/` and `palettes/` before inventing new structure
+- inspect existing analytics pages, metrics partials, and chart code blocks before inventing a new data story pattern
 - prefer current command output and files over older examples or assumptions
 - when the site is minimal or brand new, use the topic files in this skill as the default markata-go playbook
 
@@ -34,6 +35,7 @@ Read only the topic files relevant to the task:
 - `topics/faster-builds.md`
 - `topics/theme-creation.md`
 - `topics/template-management.md`
+- `topics/analytics-storytelling.md`
 - `topics/plugin-creation.md`
 
 ## Reference Files
@@ -78,6 +80,7 @@ If the repository is a very small or first-time site and does not yet have clear
 - Template work: `topics/template-management.md`
 - Theme or styling work: `topics/theme-creation.md`
 - Content creation: `topics/writing-frontmatter.md`
+- Analytics pages or metrics storytelling: `topics/analytics-storytelling.md`
 - Config debugging: `topics/configuration.md`
 - Build and CI work: `topics/build-deployment.md`
 - Performance work: `topics/faster-builds.md`
@@ -90,6 +93,7 @@ If the repository is a very small or first-time site and does not yet have clear
 - When something is ambiguous, inspect the actual repo files before changing behavior.
 - Prefer CLI inspection over hand-parsing when `markata-go` already exposes the needed data.
 - If the task is performance-related, compare warm builds before claiming a regression or improvement.
+- For analytics storytelling work, separate computed facts from human narrative: agents should gather metrics, scaffold charts, and suggest story angles, while leaving first-person timeline details for the author unless the user asks for full prose.
 - If the site has no existing conventions yet, use the patterns documented in this skill rather than making up a new structure.
 
 ## Common Repo Areas

--- a/pkg/agentskill/bundle/markata-go-site/evals/evals.json
+++ b/pkg/agentskill/bundle/markata-go-site/evals/evals.json
@@ -30,6 +30,18 @@
       "prompt": "I want each post page to show a small computed reading estimate and a badge when it links to a GitHub repo. Should this live in frontmatter, config, templates, or a plugin? Please reason through the options for a normal markata-go site repo.",
       "expected_output": "Explains the config/content/template/plugin decision clearly, prefers lower-cost options first, and only recommends plugin work when the behavior cannot be expressed with existing fields, templates, or built-in features.",
       "files": []
+    },
+    {
+      "id": 6,
+      "prompt": "Please create an `analytics.md` page for my markata-go site. I want KPI callouts, a chart of publishing activity, and a topic-mix section, but I want to write the timeline story in my own voice. Use built-in stats or chart features when possible and leave me good prompts where I should add interpretation.",
+      "expected_output": "Creates or recommends a Jinja-enabled analytics page pattern, uses built-in stats and chart features instead of inventing a plugin, includes concrete metrics/chart structure, and leaves clear author-facing prompts for the narrative sections.",
+      "files": []
+    },
+    {
+      "id": 7,
+      "prompt": "On my markata-go site I want feed cards and post pages to show word count and reading time, and I also want an about page to show total posts and total reading time for the whole site. What template fields should I use and what is the smallest safe change?",
+      "expected_output": "Points to `post.Extra.word_count`, `post.Extra.reading_time_text`, and `config.Extra.site_stats` fields, keeps the change in templates or partials, and avoids suggesting unnecessary plugin work.",
+      "files": []
     }
   ]
 }

--- a/pkg/agentskill/bundle/markata-go-site/evals/evals.json
+++ b/pkg/agentskill/bundle/markata-go-site/evals/evals.json
@@ -42,6 +42,12 @@
       "prompt": "On my markata-go site I want feed cards and post pages to show word count and reading time, and I also want an about page to show total posts and total reading time for the whole site. What template fields should I use and what is the smallest safe change?",
       "expected_output": "Points to `post.Extra.word_count`, `post.Extra.reading_time_text`, and `config.Extra.site_stats` fields, keeps the change in templates or partials, and avoids suggesting unnecessary plugin work.",
       "files": []
+    },
+    {
+      "id": 8,
+      "prompt": "I want an analytics page on my markata-go second brain that highlights orphan notes, the most-linked notes, and a simple publishing cadence chart. Please stay within built-in data the site already has and tell me what belongs in Jinja markdown versus external analytics.",
+      "expected_output": "Uses built-in or derivable build-side data such as `inlinks`, `outlinks`, post dates, and existing stats fields, clearly separates build-derived analytics from external traffic analytics, and gives a practical `analytics.md` structure for orphan-note and link-graph storytelling.",
+      "files": []
     }
   ]
 }

--- a/pkg/agentskill/bundle/markata-go-site/reference/template-context.md
+++ b/pkg/agentskill/bundle/markata-go-site/reference/template-context.md
@@ -82,6 +82,24 @@ Common site-wide stats in `config.Extra.site_stats`:
 
 Advanced helper access may also be available via `config.Extra.stats` for site and feed KPIs.
 
+Common feed-helper calls when the helper is exposed:
+
+- `config.Extra.stats.ForFeed("blog").PostCount()`
+- `config.Extra.stats.ForFeed("blog").TotalWords()`
+- `config.Extra.stats.ForFeed("blog").TotalReadingTimeText()`
+- `config.Extra.stats.ForFeed("blog").PostsByYear()`
+- `config.Extra.stats.ForFeed("blog").PostsByTag()`
+
+## Link Graph Fields
+
+Common link-analysis fields on `post`:
+
+- `post.hrefs`
+- `post.inlinks`
+- `post.outlinks`
+
+These are useful for backlink sections, related-note sections, hub-note detection, and orphan-note analysis.
+
 ## Common Top-Level Aliases
 
 Markata-go also injects convenient top-level aliases:

--- a/pkg/agentskill/bundle/markata-go-site/reference/template-context.md
+++ b/pkg/agentskill/bundle/markata-go-site/reference/template-context.md
@@ -52,6 +52,36 @@ Usually available in HTML templates:
 - `post.author_objects`
 - `post.Extra`
 
+## Stats And Analytics Fields
+
+Common per-post stats in `post.Extra`:
+
+- `post.Extra.word_count`
+- `post.Extra.char_count`
+- `post.Extra.reading_time`
+- `post.Extra.reading_time_text`
+- `post.Extra.code_lines`
+- `post.Extra.code_blocks`
+- `post.Extra.stats`
+
+Common site-wide stats in `config.Extra.site_stats`:
+
+- `config.Extra.site_stats.total_posts`
+- `config.Extra.site_stats.total_words`
+- `config.Extra.site_stats.total_chars`
+- `config.Extra.site_stats.total_reading_time`
+- `config.Extra.site_stats.total_reading_time_text`
+- `config.Extra.site_stats.average_words`
+- `config.Extra.site_stats.average_reading_time`
+- `config.Extra.site_stats.average_reading_time_text`
+- `config.Extra.site_stats.total_code_lines`
+- `config.Extra.site_stats.total_code_blocks`
+- `config.Extra.site_stats.posts_by_year`
+- `config.Extra.site_stats.words_by_year`
+- `config.Extra.site_stats.posts_by_tag`
+
+Advanced helper access may also be available via `config.Extra.stats` for site and feed KPIs.
+
 ## Common Top-Level Aliases
 
 Markata-go also injects convenient top-level aliases:

--- a/pkg/agentskill/bundle/markata-go-site/topics/analytics-storytelling.md
+++ b/pkg/agentskill/bundle/markata-go-site/topics/analytics-storytelling.md
@@ -1,0 +1,176 @@
+# Analytics And Storytelling
+
+Use this topic when the user wants an `analytics.md` page, a metrics dashboard, chart-driven posts, contribution graphs, or template badges for reading time and content stats.
+
+## What Agents Should Do First
+
+1. Inspect the active config with `markata-go config show`.
+2. Confirm whether the site already enables `stats`, `chartjs`, and `contribution_graph`.
+3. Inspect existing analytics pages, feed pages, and template partials before adding a new pattern.
+4. Decide whether the task belongs in:
+   - a markdown page with `jinja: true`
+   - an existing HTML template or partial
+   - config only
+   - a plugin change
+
+Prefer content, templates, and built-in stats over custom plugin work.
+
+## Built-In Data Surfaces
+
+### Per-post stats
+
+Available on posts after the `stats` plugin runs:
+
+- `post.Extra.word_count`
+- `post.Extra.char_count`
+- `post.Extra.reading_time`
+- `post.Extra.reading_time_text`
+- `post.Extra.code_lines`
+- `post.Extra.code_blocks`
+- `post.Extra.stats`
+
+These are good for post headers, feed cards, article footers, and "long read" badges.
+
+### Site-wide stats
+
+Available in templates and Jinja-enabled markdown via `config.Extra.site_stats`:
+
+- `total_posts`
+- `total_words`
+- `total_chars`
+- `total_reading_time`
+- `total_reading_time_text`
+- `average_words`
+- `average_reading_time`
+- `average_reading_time_text`
+- `total_code_lines`
+- `total_code_blocks`
+- `posts_by_year`
+- `words_by_year`
+- `posts_by_tag`
+
+Use these for analytics pages, about pages, and site summary components.
+
+### Advanced helper
+
+`config.Extra.stats` exposes a helper object for site and feed KPIs. Prefer `config.Extra.site_stats` for straightforward template access. Reach for the helper only when the site already uses it or the task specifically needs helper-driven feed metrics.
+
+## Chart And Graph Options
+
+- Use `chartjs` fenced blocks for bar, line, pie, doughnut, radar, polar area, bubble, and scatter charts.
+- Use `contribution-graph` fenced blocks for calendar-style publishing/activity views.
+- When the repo already has a chart palette or CSS treatment, reuse it instead of inventing a new visual language.
+
+## Recommended `analytics.md` Pattern
+
+Use a normal markdown page with frontmatter like:
+
+```yaml
+---
+title: "Site Analytics"
+description: "Publishing metrics, activity charts, and yearly trends for this site."
+date: 2026-04-09
+published: true
+slug: /analytics/
+jinja: true
+tags:
+  - analytics
+  - meta
+  - writing
+---
+```
+
+Then structure the page in three layers:
+
+1. KPI summary
+2. one or two charts
+3. author-written interpretation
+
+Agents should compute or scaffold the first two layers and leave space for the third.
+
+## Good Analytics Page Structure
+
+Use sections like:
+
+- `## At a glance`
+- `## Publishing activity`
+- `## Topic mix`
+- `## What changed this year`
+- `## Notes from the author`
+
+The first sections can be data-driven. The last sections should invite the author to explain timeline changes, experiments, and tradeoffs in their own voice.
+
+## Safe Authoring Pattern
+
+When asked to create an analytics post, prefer this workflow:
+
+1. Gather site metrics from built-in stats, list commands, and nearby content.
+2. Draft an `analytics.md` page with working charts and KPI callouts.
+3. Add short prompts or placeholders where the human should add interpretation.
+4. Avoid inventing personal history, timelines, or motivations unless the user explicitly asks for prose generation.
+
+Example placeholder style:
+
+```markdown
+## What changed this year
+
+Write about the periods where output increased or dipped.
+Possible prompts:
+- Which projects or life events changed your publishing pace?
+- Which topics became more important?
+- Were there intentional breaks, experiments, or format changes?
+```
+
+## Template Snippets
+
+### Post badge
+
+```django
+<div class="post-meta">
+  <span>{{ post.Extra.reading_time_text }}</span>
+  <span>{{ post.Extra.word_count }} words</span>
+</div>
+```
+
+### Site KPI block
+
+```django
+<section class="site-kpis">
+  <p>{{ config.Extra.site_stats.total_posts }} posts</p>
+  <p>{{ config.Extra.site_stats.total_words }} words</p>
+  <p>{{ config.Extra.site_stats.total_reading_time_text }} total reading time</p>
+</section>
+```
+
+## Markdown Snippets
+
+### KPI summary in `analytics.md`
+
+```markdown
+## At a glance
+
+- {{ config.Extra.site_stats.total_posts }} published posts
+- {{ config.Extra.site_stats.total_words }} total words
+- {{ config.Extra.site_stats.total_reading_time_text }} total reading time
+- {{ config.Extra.site_stats.average_words }} average words per post
+```
+
+### Topic mix chart
+
+Agents may either:
+
+- generate a static `chartjs` block from inspected repo data
+- or wire the page to existing site stats if the repo already has a stable pattern for dynamic Jinja-generated chart data
+
+Keep the chart JSON valid and prefer a small number of clearly labeled datasets.
+
+## Storytelling Guidance
+
+Agents should help authors create stories from their data by:
+
+- identifying notable changes in publishing volume, topic mix, or reading-time distribution
+- suggesting section headings and narrative prompts grounded in the metrics
+- calling out where the data is strong and where it is only directional
+- keeping claims tied to visible charts or explicit metrics
+
+Agents should not overstate causation from site metrics alone.

--- a/pkg/agentskill/bundle/markata-go-site/topics/analytics-storytelling.md
+++ b/pkg/agentskill/bundle/markata-go-site/topics/analytics-storytelling.md
@@ -155,6 +155,64 @@ Possible prompts:
 - {{ config.Extra.site_stats.average_words }} average words per post
 ```
 
+### Injecting variables into markdown
+
+Use `jinja: true` in frontmatter, then render values directly inside normal markdown or inside JSON fenced blocks.
+
+Guidance:
+
+- keep the surrounding JSON valid after Jinja renders
+- prefer simple loops and explicit commas
+- reuse existing repo patterns before inventing more dynamic logic
+- if a page only needs site totals, prefer `config.Extra.site_stats.*`
+
+### Contribution graph from post dates
+
+````markdown
+## Publishing activity
+
+```contribution-graph
+{
+  "data": [
+    {% for post in core.filter("published == true") %}
+    {"date": "{{ post.Date.Format \"2006-01-02\" }}", "value": 1}{% if not loop.last %},{% endif %}
+    {% endfor %}
+  ],
+  "options": {
+    "domain": "year",
+    "subDomain": "day"
+  }
+}
+```
+````
+
+Use this when the author wants a calendar-like view of publishing cadence.
+
+### `chartjs` chart from built-in site stats
+
+````markdown
+## At a glance chart
+
+```chartjs
+{
+  "type": "bar",
+  "data": {
+    "labels": ["Posts", "Words", "Code blocks"],
+    "datasets": [{
+      "label": "Site totals",
+      "data": [
+        {{ config.Extra.site_stats.total_posts }},
+        {{ config.Extra.site_stats.total_words }},
+        {{ config.Extra.site_stats.total_code_blocks }}
+      ]
+    }]
+  }
+}
+```
+````
+
+Use this pattern for simple KPI comparisons where the values already exist in built-in stats.
+
 ### Topic mix chart
 
 Agents may either:

--- a/pkg/agentskill/bundle/markata-go-site/topics/analytics-storytelling.md
+++ b/pkg/agentskill/bundle/markata-go-site/topics/analytics-storytelling.md
@@ -17,6 +17,12 @@ Prefer content, templates, and built-in stats over custom plugin work.
 
 ## Built-In Data Surfaces
 
+This topic should distinguish between three categories:
+
+- built-in today: fields and blocks users can use directly now
+- derivable today: analytics agents can compute from posts, frontmatter, and link data with Jinja/templates
+- external-only: traffic and reader behavior that the build cannot know on its own
+
 ### Per-post stats
 
 Available on posts after the `stats` plugin runs:
@@ -54,6 +60,70 @@ Use these for analytics pages, about pages, and site summary components.
 ### Advanced helper
 
 `config.Extra.stats` exposes a helper object for site and feed KPIs. Prefer `config.Extra.site_stats` for straightforward template access. Reach for the helper only when the site already uses it or the task specifically needs helper-driven feed metrics.
+
+Common helper-driven feed access patterns:
+
+- `config.Extra.stats.ForFeed("blog").PostCount()`
+- `config.Extra.stats.ForFeed("blog").TotalWords()`
+- `config.Extra.stats.ForFeed("blog").TotalReadingTimeText()`
+- `config.Extra.stats.ForFeed("blog").PostsByYear()`
+- `config.Extra.stats.ForFeed("blog").PostsByTag()`
+
+### Link graph data
+
+Available on each post today:
+
+- `post.hrefs`: raw href values found in the post
+- `post.inlinks`: template-friendly links from other posts pointing to this post
+- `post.outlinks`: template-friendly links from this post to other pages
+
+Use these to derive:
+
+- orphan notes or posts with no inlinks
+- hub notes with many inlinks
+- heavily connected posts by total links
+- posts with many outbound references
+- internal link lists and backlink sections
+
+### Common built-ins available today
+
+The easiest analytics pages should start with these built-ins:
+
+- word count
+- reading time
+- code block metrics
+- posts by year
+- words by year
+- posts by tag
+- total site posts
+- total site reading time
+- feed-level totals through `config.Extra.stats.ForFeed(...)`
+- contribution graphs from post dates
+- `chartjs` blocks fed by built-in metrics
+
+### Derivable today with Jinja/templates
+
+These are not first-class dashboard features, but agents can build them with existing data:
+
+- posts per month
+- author contribution mix when author fields are present
+- draft/private/published counts
+- posts by template or layout when frontmatter is consistent
+- stale-content lists using `modified` or `lastmod`
+- inlink/outlink leaderboards
+- orphan notes or orphan posts
+- simple second-brain graph summaries
+
+### External-only analytics
+
+These require outside analytics tools or logs and should not be presented as build-derived facts:
+
+- pageviews
+- unique visitors
+- referrers
+- conversions
+- search queries
+- subscriber counts unless imported from elsewhere
 
 ## Chart And Graph Options
 
@@ -95,6 +165,7 @@ Use sections like:
 - `## At a glance`
 - `## Publishing activity`
 - `## Topic mix`
+- `## Link graph`
 - `## What changed this year`
 - `## Notes from the author`
 
@@ -165,6 +236,7 @@ Guidance:
 - prefer simple loops and explicit commas
 - reuse existing repo patterns before inventing more dynamic logic
 - if a page only needs site totals, prefer `config.Extra.site_stats.*`
+- in HTML templates, prefer lowercase map keys like `post.inlinks`; in Jinja markdown loops over `core.filter(...)`, many sites use object-style fields like `post.Inlinks` and `post.Title`
 
 ### Contribution graph from post dates
 
@@ -222,11 +294,66 @@ Agents may either:
 
 Keep the chart JSON valid and prefer a small number of clearly labeled datasets.
 
+### Feed KPI snippet
+
+````markdown
+## Blog feed totals
+
+- {{ config.Extra.stats.ForFeed("blog").PostCount() }} posts in the blog feed
+- {{ config.Extra.stats.ForFeed("blog").TotalWords() }} words in the blog feed
+- {{ config.Extra.stats.ForFeed("blog").TotalReadingTimeText() }} total reading time
+````
+
+Use this when the site has meaningful feed partitions such as `blog`, `docs`, or `notes`.
+
+### Orphan notes section
+
+An orphan note is usually a post with no `inlinks`. Agents should confirm the site's conventions before presenting this as a strong quality signal, because some sites intentionally publish standalone pages.
+
+````markdown
+## Orphan notes
+
+{% for post in core.filter("published == true") %}
+{% if post.Inlinks|length == 0 %}
+- [{{ post.Title }}]({{ post.Href }})
+{% endif %}
+{% endfor %}
+````
+
+If the site already uses a different field casing pattern in markdown/Jinja, mirror the local convention instead of forcing a rewrite. The important thing is the pattern: filter posts, check the inlink count, and render a list.
+
+### Most-linked posts
+
+````markdown
+## Most linked notes
+
+{% for post in core.filter("published == true") %}
+- [{{ post.Title }}]({{ post.Href }}) has {{ post.Inlinks|length }} inbound links and {{ post.Outlinks|length }} outbound links
+{% endfor %}
+````
+
+Agents should usually sort or pre-filter this in the site's preferred way if the repo already has helper patterns for ordered post collections.
+
+## Link Analytics Ideas
+
+Good build-side link analytics include:
+
+- orphan notes
+- most-linked notes
+- posts with the most outbound references
+- posts with no outbound links
+- dense hub pages for docs or second brains
+- backlink sections for related-post discovery
+- broken-wikilink follow-up lists when the site treats warnings as actionable
+
+For second-brain sites, these are often more valuable than pageview analytics because they describe knowledge structure rather than reader traffic.
+
 ## Storytelling Guidance
 
 Agents should help authors create stories from their data by:
 
 - identifying notable changes in publishing volume, topic mix, or reading-time distribution
+- identifying useful link graph patterns such as isolated notes, strong hubs, and unusually reference-heavy posts
 - suggesting section headings and narrative prompts grounded in the metrics
 - calling out where the data is strong and where it is only directional
 - keeping claims tied to visible charts or explicit metrics


### PR DESCRIPTION
## Summary
- expand the bundled `markata-go-site` skill so it proactively triggers for analytics pages, stats work, and chart-driven storytelling tasks
- add an `analytics-storytelling` topic that teaches agents how to scaffold `analytics.md` pages with built-in stats, charts, and author-written narrative sections
- document the built-in stats surfaces in the bundled template-context reference and add eval coverage for analytics authoring and template stats usage

## Testing
- validated `pkg/agentskill/bundle/markata-go-site/evals/evals.json` with `jq empty`

## Issue
- Refs #995