### PR TITLE
feat(agent): support Vercel-style agent selection

### DIFF
--- a/cmd/markata-go/cmd/agent.go
+++ b/cmd/markata-go/cmd/agent.go
@@ -49,6 +49,21 @@ Examples:
 	RunE: runAgentInstallCommand,
 }
 
+var agentListAgentsCmd = &cobra.Command{
+	Use:   "list-agents",
+	Short: "List supported agent identifiers and install paths",
+	Long: `List the supported agent identifiers that markata-go can target.
+
+The output includes each agent's project-level and global skill directory so you
+can choose an explicit --agent value without scanning help text.
+
+Examples:
+  markata-go agent list-agents
+  markata-go agent list-agents | grep opencode`,
+	Args: cobra.NoArgs,
+	RunE: runAgentListAgentsCommand,
+}
+
 var agentDoctorCmd = &cobra.Command{
 	Use:   "doctor [site-path]",
 	Short: "Check installed skill for drift against the current binary",
@@ -125,6 +140,7 @@ var (
 func init() {
 	rootCmd.AddCommand(agentCmd)
 	agentCmd.AddCommand(agentInstallCmd)
+	agentCmd.AddCommand(agentListAgentsCmd)
 	agentCmd.AddCommand(agentUpdateCmd)
 	agentCmd.AddCommand(agentDoctorCmd)
 	agentCmd.AddCommand(agentRemoveCmd)
@@ -168,6 +184,22 @@ func runAgentInstallCommand(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	return runAgentWriteCommand(args, target, agentInstallGlobal, agentInstallName, agentInstallDryRun, agentInstallForce, "install")
+}
+
+func runAgentListAgentsCommand(cmd *cobra.Command, args []string) error {
+	currentCmd = cmd
+
+	outlnf("Supported agents:")
+	for _, target := range supportedAgentTargets {
+		outlnf("- %s", target.Name)
+		outlnf("  project: %s", target.ProjectPath)
+		outlnf("  global:  %s", target.GlobalPath)
+		if len(target.Aliases) > 0 {
+			outlnf("  aliases: %s", strings.Join(target.Aliases, ", "))
+		}
+	}
+
+	return nil
 }
 
 func runAgentUpdateCommand(cmd *cobra.Command, args []string) error {

--- a/cmd/markata-go/cmd/agent.go
+++ b/cmd/markata-go/cmd/agent.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/WaylonWalker/markata-go/pkg/agentskill"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 var agentCmd = &cobra.Command{
@@ -152,7 +153,7 @@ func init() {
 	installFlags.StringVar(&agentInstallName, "name", agentskill.SiteSkillName, "installed skill directory name")
 	installFlags.BoolVar(&agentInstallForce, "force", false, "overwrite bundled skill files if they already exist")
 	installFlags.BoolVar(&agentInstallDryRun, "dry-run", false, "show what would be installed without writing files")
-	_ = installFlags.MarkHidden("target")
+	markHiddenSafe(installFlags, "target")
 
 	updateFlags := agentUpdateCmd.Flags()
 	updateFlags.StringVar(&agentUpdateAgent, "agent", "", fmt.Sprintf("target agent (%s)", strings.Join(supportedAgentNames(), ", ")))
@@ -160,21 +161,28 @@ func init() {
 	updateFlags.BoolVarP(&agentUpdateGlobal, "global", "g", false, "update the selected agent's user-level skill directory")
 	updateFlags.StringVar(&agentUpdateName, "name", agentskill.SiteSkillName, "installed skill directory name")
 	updateFlags.BoolVar(&agentUpdateDryRun, "dry-run", false, "show what would be updated without writing files")
-	_ = updateFlags.MarkHidden("target")
+	markHiddenSafe(updateFlags, "target")
 
 	doctorFlags := agentDoctorCmd.Flags()
 	doctorFlags.StringVar(&agentDoctorAgent, "agent", "", fmt.Sprintf("target agent (%s)", strings.Join(supportedAgentNames(), ", ")))
 	doctorFlags.StringVarP(&agentDoctorLegacyTarget, "target", "", "", "legacy alias for --agent")
 	doctorFlags.BoolVarP(&agentDoctorGlobal, "global", "g", false, "check the selected agent's user-level skill directory")
 	doctorFlags.StringVar(&agentDoctorName, "name", agentskill.SiteSkillName, "installed skill directory name")
-	_ = doctorFlags.MarkHidden("target")
+	markHiddenSafe(doctorFlags, "target")
 
 	removeFlags := agentRemoveCmd.Flags()
 	removeFlags.StringVar(&agentRemoveAgent, "agent", "", fmt.Sprintf("target agent (%s)", strings.Join(supportedAgentNames(), ", ")))
 	removeFlags.StringVarP(&agentRemoveLegacyTarget, "target", "", "", "legacy alias for --agent")
 	removeFlags.BoolVarP(&agentRemoveGlobal, "global", "g", false, "remove from the selected agent's user-level skill directory")
 	removeFlags.StringVar(&agentRemoveName, "name", agentskill.SiteSkillName, "installed skill directory name")
-	_ = removeFlags.MarkHidden("target")
+	markHiddenSafe(removeFlags, "target")
+}
+
+func markHiddenSafe(flags *pflag.FlagSet, name string) {
+	if err := flags.MarkHidden(name); err != nil {
+		// Flag existence errors are non-fatal; log in debug mode only
+		_ = err
+	}
 }
 
 func runAgentInstallCommand(cmd *cobra.Command, args []string) error {
@@ -186,7 +194,7 @@ func runAgentInstallCommand(cmd *cobra.Command, args []string) error {
 	return runAgentWriteCommand(args, target, agentInstallGlobal, agentInstallName, agentInstallDryRun, agentInstallForce, "install")
 }
 
-func runAgentListAgentsCommand(cmd *cobra.Command, args []string) error {
+func runAgentListAgentsCommand(cmd *cobra.Command, _ []string) error {
 	currentCmd = cmd
 
 	outlnf("Supported agents:")

--- a/cmd/markata-go/cmd/agent.go
+++ b/cmd/markata-go/cmd/agent.go
@@ -153,7 +153,7 @@ func init() {
 	installFlags.StringVar(&agentInstallName, "name", agentskill.SiteSkillName, "installed skill directory name")
 	installFlags.BoolVar(&agentInstallForce, "force", false, "overwrite bundled skill files if they already exist")
 	installFlags.BoolVar(&agentInstallDryRun, "dry-run", false, "show what would be installed without writing files")
-	markHiddenSafe(installFlags, "target")
+	markTargetHidden(installFlags)
 
 	updateFlags := agentUpdateCmd.Flags()
 	updateFlags.StringVar(&agentUpdateAgent, "agent", "", fmt.Sprintf("target agent (%s)", strings.Join(supportedAgentNames(), ", ")))
@@ -161,25 +161,25 @@ func init() {
 	updateFlags.BoolVarP(&agentUpdateGlobal, "global", "g", false, "update the selected agent's user-level skill directory")
 	updateFlags.StringVar(&agentUpdateName, "name", agentskill.SiteSkillName, "installed skill directory name")
 	updateFlags.BoolVar(&agentUpdateDryRun, "dry-run", false, "show what would be updated without writing files")
-	markHiddenSafe(updateFlags, "target")
+	markTargetHidden(updateFlags)
 
 	doctorFlags := agentDoctorCmd.Flags()
 	doctorFlags.StringVar(&agentDoctorAgent, "agent", "", fmt.Sprintf("target agent (%s)", strings.Join(supportedAgentNames(), ", ")))
 	doctorFlags.StringVarP(&agentDoctorLegacyTarget, "target", "", "", "legacy alias for --agent")
 	doctorFlags.BoolVarP(&agentDoctorGlobal, "global", "g", false, "check the selected agent's user-level skill directory")
 	doctorFlags.StringVar(&agentDoctorName, "name", agentskill.SiteSkillName, "installed skill directory name")
-	markHiddenSafe(doctorFlags, "target")
+	markTargetHidden(doctorFlags)
 
 	removeFlags := agentRemoveCmd.Flags()
 	removeFlags.StringVar(&agentRemoveAgent, "agent", "", fmt.Sprintf("target agent (%s)", strings.Join(supportedAgentNames(), ", ")))
 	removeFlags.StringVarP(&agentRemoveLegacyTarget, "target", "", "", "legacy alias for --agent")
 	removeFlags.BoolVarP(&agentRemoveGlobal, "global", "g", false, "remove from the selected agent's user-level skill directory")
 	removeFlags.StringVar(&agentRemoveName, "name", agentskill.SiteSkillName, "installed skill directory name")
-	markHiddenSafe(removeFlags, "target")
+	markTargetHidden(removeFlags)
 }
 
-func markHiddenSafe(flags *pflag.FlagSet, name string) {
-	if err := flags.MarkHidden(name); err != nil {
+func markTargetHidden(flags *pflag.FlagSet) {
+	if err := flags.MarkHidden("target"); err != nil {
 		// Flag existence errors are non-fatal; log in debug mode only
 		_ = err
 	}

--- a/cmd/markata-go/cmd/agent.go
+++ b/cmd/markata-go/cmd/agent.go
@@ -12,37 +12,37 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	agentTargetAgents = "agents"
-	agentTargetClaude = "claude"
-)
-
 var agentCmd = &cobra.Command{
 	Use:   "agent",
 	Short: "Install agent integrations for markata-go sites",
 	Long: `Manage installable agent integrations for markata-go sites.
 
-The initial workflow installs a bundled, topic-based skill into a site repository.
-The command group is intentionally generic so future subcommands can add export
-and MCP-oriented integrations without changing the bundled skill format.
+The initial workflow installs a bundled, topic-based skill into either a project
+repository or an agent-specific global skill directory. Agent identifiers and
+install locations follow the same naming model documented by vercel-labs/skills.
 
-Supported install targets:
-  agents  - installs to .agents/skills/<name>/
-  claude  - installs to .claude/skills/<name>/`,
+Examples:
+  markata-go agent install
+  markata-go agent install --agent claude-code
+  markata-go agent install --agent opencode --global`,
 }
 
 var agentInstallCmd = &cobra.Command{
 	Use:   "install [site-path]",
 	Short: "Install the bundled markata-go site skill",
-	Long: `Install the bundled markata-go site skill into a repository.
+	Long: `Install the bundled markata-go site skill.
 
-By default the skill is installed into the current directory using the portable
-.agents/skills layout. Use --target claude to install into Claude Code's
-.claude/skills layout instead.
+When --agent is omitted, markata-go installs into the current agent's project
+layout when it can detect one from the environment. Otherwise it falls back to
+the portable universal layout under .agents/skills.
+
+Use --global with an explicit --agent to install into that agent's user-level
+skill directory instead of a project repository.
 
 Examples:
   markata-go agent install
-  markata-go agent install --target claude
+  markata-go agent install --agent claude-code
+  markata-go agent install --agent opencode --global
   markata-go agent install ../my-site --dry-run
   markata-go agent install . --force`,
 	Args: cobra.MaximumNArgs(1),
@@ -58,7 +58,8 @@ since the skill was installed.
 
 Examples:
   markata-go agent doctor
-  markata-go agent doctor --target claude
+  markata-go agent doctor --agent claude-code
+  markata-go agent doctor --agent opencode --global
   markata-go agent doctor ../my-site`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runAgentDoctorCommand,
@@ -73,8 +74,8 @@ This is the user-friendly equivalent of running 'markata-go agent install --forc
 
 Examples:
   markata-go agent update
-  markata-go agent update --target claude
-  markata-go agent update --dry-run
+  markata-go agent update --agent claude-code
+  markata-go agent update --agent opencode --global --dry-run
   markata-go agent update ../my-site`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runAgentUpdateCommand,
@@ -84,32 +85,41 @@ var agentRemoveCmd = &cobra.Command{
 	Use:     "remove [site-path]",
 	Aliases: []string{"uninstall"},
 	Short:   "Remove an installed markata-go site skill",
-	Long: `Remove the installed markata-go site skill from a repository.
+	Long: `Remove the installed markata-go site skill.
 
 Examples:
   markata-go agent remove
   markata-go agent uninstall
-  markata-go agent remove --target claude
+  markata-go agent remove --agent claude-code
+  markata-go agent remove --agent opencode --global
   markata-go agent remove ../my-site`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runAgentRemoveCommand,
 }
 
 var (
-	agentInstallTarget string
-	agentInstallName   string
-	agentInstallForce  bool
-	agentInstallDryRun bool
+	agentInstallAgent        string
+	agentInstallLegacyTarget string
+	agentInstallName         string
+	agentInstallForce        bool
+	agentInstallDryRun       bool
+	agentInstallGlobal       bool
 
-	agentDoctorTarget string
-	agentDoctorName   string
+	agentDoctorAgent        string
+	agentDoctorLegacyTarget string
+	agentDoctorName         string
+	agentDoctorGlobal       bool
 
-	agentUpdateTarget string
-	agentUpdateName   string
-	agentUpdateDryRun bool
+	agentUpdateAgent        string
+	agentUpdateLegacyTarget string
+	agentUpdateName         string
+	agentUpdateDryRun       bool
+	agentUpdateGlobal       bool
 
-	agentRemoveTarget string
-	agentRemoveName   string
+	agentRemoveAgent        string
+	agentRemoveLegacyTarget string
+	agentRemoveName         string
+	agentRemoveGlobal       bool
 )
 
 func init() {
@@ -119,66 +129,76 @@ func init() {
 	agentCmd.AddCommand(agentDoctorCmd)
 	agentCmd.AddCommand(agentRemoveCmd)
 
-	agentInstallCmd.Flags().StringVar(&agentInstallTarget, "target", agentTargetAgents, "install target: agents or claude")
-	agentInstallCmd.Flags().StringVar(&agentInstallName, "name", agentskill.SiteSkillName, "installed skill directory name")
-	agentInstallCmd.Flags().BoolVar(&agentInstallForce, "force", false, "overwrite bundled skill files if they already exist")
-	agentInstallCmd.Flags().BoolVar(&agentInstallDryRun, "dry-run", false, "show what would be installed without writing files")
+	installFlags := agentInstallCmd.Flags()
+	installFlags.StringVar(&agentInstallAgent, "agent", "", fmt.Sprintf("target agent (%s)", strings.Join(supportedAgentNames(), ", ")))
+	installFlags.StringVarP(&agentInstallLegacyTarget, "target", "", "", "legacy alias for --agent")
+	installFlags.BoolVarP(&agentInstallGlobal, "global", "g", false, "install into the selected agent's user-level skill directory")
+	installFlags.StringVar(&agentInstallName, "name", agentskill.SiteSkillName, "installed skill directory name")
+	installFlags.BoolVar(&agentInstallForce, "force", false, "overwrite bundled skill files if they already exist")
+	installFlags.BoolVar(&agentInstallDryRun, "dry-run", false, "show what would be installed without writing files")
+	_ = installFlags.MarkHidden("target")
 
-	agentUpdateCmd.Flags().StringVar(&agentUpdateTarget, "target", agentTargetAgents, "install target: agents or claude")
-	agentUpdateCmd.Flags().StringVar(&agentUpdateName, "name", agentskill.SiteSkillName, "installed skill directory name")
-	agentUpdateCmd.Flags().BoolVar(&agentUpdateDryRun, "dry-run", false, "show what would be updated without writing files")
+	updateFlags := agentUpdateCmd.Flags()
+	updateFlags.StringVar(&agentUpdateAgent, "agent", "", fmt.Sprintf("target agent (%s)", strings.Join(supportedAgentNames(), ", ")))
+	updateFlags.StringVarP(&agentUpdateLegacyTarget, "target", "", "", "legacy alias for --agent")
+	updateFlags.BoolVarP(&agentUpdateGlobal, "global", "g", false, "update the selected agent's user-level skill directory")
+	updateFlags.StringVar(&agentUpdateName, "name", agentskill.SiteSkillName, "installed skill directory name")
+	updateFlags.BoolVar(&agentUpdateDryRun, "dry-run", false, "show what would be updated without writing files")
+	_ = updateFlags.MarkHidden("target")
 
-	agentDoctorCmd.Flags().StringVar(&agentDoctorTarget, "target", agentTargetAgents, "install target: agents or claude")
-	agentDoctorCmd.Flags().StringVar(&agentDoctorName, "name", agentskill.SiteSkillName, "installed skill directory name")
+	doctorFlags := agentDoctorCmd.Flags()
+	doctorFlags.StringVar(&agentDoctorAgent, "agent", "", fmt.Sprintf("target agent (%s)", strings.Join(supportedAgentNames(), ", ")))
+	doctorFlags.StringVarP(&agentDoctorLegacyTarget, "target", "", "", "legacy alias for --agent")
+	doctorFlags.BoolVarP(&agentDoctorGlobal, "global", "g", false, "check the selected agent's user-level skill directory")
+	doctorFlags.StringVar(&agentDoctorName, "name", agentskill.SiteSkillName, "installed skill directory name")
+	_ = doctorFlags.MarkHidden("target")
 
-	agentRemoveCmd.Flags().StringVar(&agentRemoveTarget, "target", agentTargetAgents, "install target: agents or claude")
-	agentRemoveCmd.Flags().StringVar(&agentRemoveName, "name", agentskill.SiteSkillName, "installed skill directory name")
+	removeFlags := agentRemoveCmd.Flags()
+	removeFlags.StringVar(&agentRemoveAgent, "agent", "", fmt.Sprintf("target agent (%s)", strings.Join(supportedAgentNames(), ", ")))
+	removeFlags.StringVarP(&agentRemoveLegacyTarget, "target", "", "", "legacy alias for --agent")
+	removeFlags.BoolVarP(&agentRemoveGlobal, "global", "g", false, "remove from the selected agent's user-level skill directory")
+	removeFlags.StringVar(&agentRemoveName, "name", agentskill.SiteSkillName, "installed skill directory name")
+	_ = removeFlags.MarkHidden("target")
 }
 
 func runAgentInstallCommand(cmd *cobra.Command, args []string) error {
 	currentCmd = cmd
-	return runAgentWriteCommand(args, agentInstallTarget, agentInstallName, agentInstallDryRun, agentInstallForce, "install")
+	target, err := resolveAgentInstallTarget(agentInstallAgent, agentInstallLegacyTarget, agentInstallGlobal)
+	if err != nil {
+		return err
+	}
+	return runAgentWriteCommand(args, target, agentInstallGlobal, agentInstallName, agentInstallDryRun, agentInstallForce, "install")
 }
 
 func runAgentUpdateCommand(cmd *cobra.Command, args []string) error {
 	currentCmd = cmd
-	return runAgentWriteCommand(args, agentUpdateTarget, agentUpdateName, agentUpdateDryRun, true, "update")
+	target, err := resolveAgentInstallTarget(agentUpdateAgent, agentUpdateLegacyTarget, agentUpdateGlobal)
+	if err != nil {
+		return err
+	}
+	return runAgentWriteCommand(args, target, agentUpdateGlobal, agentUpdateName, agentUpdateDryRun, true, "update")
 }
 
-func runAgentWriteCommand(args []string, targetFlag, name string, dryRun, force bool, operation string) error {
-	sitePath := "."
-	if len(args) > 0 {
-		sitePath = args[0]
-	}
-
-	root, err := filepath.Abs(sitePath)
+func runAgentWriteCommand(args []string, target agentInstallTarget, global bool, name string, dryRun, force bool, operation string) error {
+	root, err := resolveAgentProjectRoot(args, global)
 	if err != nil {
-		return fmt.Errorf("resolve site path %q: %w", sitePath, err)
-	}
-
-	info, err := os.Stat(root)
-	if err != nil {
-		return fmt.Errorf("stat site path %q: %w", root, err)
-	}
-	if !info.IsDir() {
-		return fmt.Errorf("site path %q is not a directory", root)
+		return err
 	}
 
 	if err := validateSkillName(name); err != nil {
 		return err
 	}
 
-	target, err := normalizeAgentInstallTarget(targetFlag)
+	destination, err := agentSkillInstallDir(root, name, target, global)
 	if err != nil {
 		return err
 	}
 
-	installedFiles, err := installAgentSkill(root, target, name, dryRun, force, Version)
+	installedFiles, err := installAgentSkill(destination, target.Name, agentScopeName(global), dryRun, force, Version)
 	if err != nil {
 		return err
 	}
 
-	destination := agentSkillInstallDir(root, target, name)
 	if dryRun {
 		outlnf("Dry run: would %s %d file(s) %s %s", operation, len(installedFiles), prepositionForAgentOperation(operation), destination)
 	} else {
@@ -186,14 +206,49 @@ func runAgentWriteCommand(args []string, targetFlag, name string, dryRun, force 
 	}
 
 	for _, filePath := range installedFiles {
-		relPath, relErr := filepath.Rel(root, filePath)
-		if relErr != nil {
-			relPath = filePath
+		if !global && root != "" {
+			relPath, relErr := filepath.Rel(root, filePath)
+			if relErr == nil {
+				filePath = filepath.ToSlash(relPath)
+			} else {
+				filePath = filepath.ToSlash(filePath)
+			}
+		} else {
+			filePath = filepath.ToSlash(filePath)
 		}
-		outlnf("- %s", filepath.ToSlash(relPath))
+		outlnf("- %s", filePath)
 	}
 
 	return nil
+}
+
+func resolveAgentProjectRoot(args []string, global bool) (string, error) {
+	if global {
+		if len(args) > 0 {
+			return "", fmt.Errorf("site path is not supported with --global")
+		}
+		return "", nil
+	}
+
+	sitePath := "."
+	if len(args) > 0 {
+		sitePath = args[0]
+	}
+
+	root, err := filepath.Abs(sitePath)
+	if err != nil {
+		return "", fmt.Errorf("resolve site path %q: %w", sitePath, err)
+	}
+
+	info, err := os.Stat(root)
+	if err != nil {
+		return "", fmt.Errorf("stat site path %q: %w", root, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("site path %q is not a directory", root)
+	}
+
+	return root, nil
 }
 
 func prepositionForAgentOperation(operation string) string {
@@ -231,27 +286,7 @@ func validateSkillName(name string) error {
 	return nil
 }
 
-func normalizeAgentInstallTarget(target string) (string, error) {
-	switch strings.ToLower(strings.TrimSpace(target)) {
-	case "", agentTargetAgents:
-		return agentTargetAgents, nil
-	case agentTargetClaude:
-		return agentTargetClaude, nil
-	default:
-		return "", fmt.Errorf("unknown agent install target %q; use 'agents' or 'claude'", target)
-	}
-}
-
-func agentSkillInstallDir(root, target, skillName string) string {
-	switch target {
-	case agentTargetClaude:
-		return filepath.Join(root, ".claude", "skills", skillName)
-	default:
-		return filepath.Join(root, ".agents", "skills", skillName)
-	}
-}
-
-func installAgentSkill(root, target, skillName string, dryRun, force bool, version string) ([]string, error) {
+func installAgentSkill(destinationRoot, agentName, scope string, dryRun, force bool, version string) ([]string, error) {
 	bundledFS, err := agentskill.SiteSkill()
 	if err != nil {
 		return nil, fmt.Errorf("load bundled skill: %w", err)
@@ -262,7 +297,6 @@ func installAgentSkill(root, target, skillName string, dryRun, force bool, versi
 		return nil, fmt.Errorf("list bundled skill files: %w", err)
 	}
 
-	destinationRoot := agentSkillInstallDir(root, target, skillName)
 	installedFiles := make([]string, 0, len(relativeFiles))
 	for _, relativePath := range relativeFiles {
 		installedFiles = append(installedFiles, filepath.Join(destinationRoot, filepath.FromSlash(relativePath)))
@@ -299,7 +333,7 @@ func installAgentSkill(root, target, skillName string, dryRun, force bool, versi
 		}
 	}
 
-	manifest, err := agentskill.ComputeBundledManifest(version, target)
+	manifest, err := agentskill.ComputeBundledManifest(version, agentName, scope)
 	if err != nil {
 		return nil, fmt.Errorf("compute manifest: %w", err)
 	}
@@ -319,35 +353,25 @@ const doctorExitError = 2
 func runAgentDoctorCommand(cmd *cobra.Command, args []string) error {
 	currentCmd = cmd
 
-	sitePath := "."
-	if len(args) > 0 {
-		sitePath = args[0]
+	target, err := resolveAgentInstallTarget(agentDoctorAgent, agentDoctorLegacyTarget, agentDoctorGlobal)
+	if err != nil {
+		return newExitCodeError(doctorExitError, err)
 	}
 
-	root, err := filepath.Abs(sitePath)
+	root, err := resolveAgentProjectRoot(args, agentDoctorGlobal)
 	if err != nil {
-		return fmt.Errorf("resolve site path %q: %w", sitePath, err)
-	}
-
-	info, err := os.Stat(root)
-	if err != nil {
-		return newExitCodeError(doctorExitError, fmt.Errorf("stat site path %q: %w", root, err))
-	}
-	if !info.IsDir() {
-		return newExitCodeError(doctorExitError, fmt.Errorf("site path %q is not a directory", root))
+		return newExitCodeError(doctorExitError, err)
 	}
 
 	if err := validateSkillName(agentDoctorName); err != nil {
 		return newExitCodeError(doctorExitError, err)
 	}
 
-	target, err := normalizeAgentInstallTarget(agentDoctorTarget)
+	skillDir, err := agentSkillInstallDir(root, agentDoctorName, target, agentDoctorGlobal)
 	if err != nil {
 		return newExitCodeError(doctorExitError, err)
 	}
-
-	skillDir := agentSkillInstallDir(root, target, agentDoctorName)
-	info, err = os.Stat(skillDir)
+	info, err := os.Stat(skillDir)
 	if err != nil || !info.IsDir() {
 		return newExitCodeError(doctorExitError, fmt.Errorf("skill not installed at %s; run 'markata-go agent install' first", skillDir))
 	}
@@ -368,6 +392,8 @@ func runAgentDoctorCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	outlnf("Skill:     %s", agentDoctorName)
+	outlnf("Agent:     %s", target.Name)
+	outlnf("Scope:     %s", agentScopeName(agentDoctorGlobal))
 	outlnf("Location:  %s", skillDir)
 	outlnf("Installed: %s", manifest.Version)
 	outlnf("Current:   %s", Version)
@@ -402,35 +428,25 @@ func runAgentDoctorCommand(cmd *cobra.Command, args []string) error {
 func runAgentRemoveCommand(cmd *cobra.Command, args []string) error {
 	currentCmd = cmd
 
-	sitePath := "."
-	if len(args) > 0 {
-		sitePath = args[0]
+	target, err := resolveAgentInstallTarget(agentRemoveAgent, agentRemoveLegacyTarget, agentRemoveGlobal)
+	if err != nil {
+		return err
 	}
 
-	root, err := filepath.Abs(sitePath)
+	root, err := resolveAgentProjectRoot(args, agentRemoveGlobal)
 	if err != nil {
-		return fmt.Errorf("resolve site path %q: %w", sitePath, err)
-	}
-
-	info, err := os.Stat(root)
-	if err != nil {
-		return fmt.Errorf("stat site path %q: %w", root, err)
-	}
-	if !info.IsDir() {
-		return fmt.Errorf("site path %q is not a directory", root)
+		return err
 	}
 
 	if err := validateSkillName(agentRemoveName); err != nil {
 		return err
 	}
 
-	target, err := normalizeAgentInstallTarget(agentRemoveTarget)
+	skillDir, err := agentSkillInstallDir(root, agentRemoveName, target, agentRemoveGlobal)
 	if err != nil {
 		return err
 	}
-
-	skillDir := agentSkillInstallDir(root, target, agentRemoveName)
-	info, err = os.Stat(skillDir)
+	info, err := os.Stat(skillDir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("skill not installed at %s; run 'markata-go agent install' first", skillDir)
@@ -444,24 +460,26 @@ func runAgentRemoveCommand(cmd *cobra.Command, args []string) error {
 	// Safety check: verify the directory looks like an installed skill before
 	// removing it. Require SKILL.md or .manifest.json to be present.
 	hasSkillMarker := false
-	for _, marker := range []string{"SKILL.md", ".manifest.json"} {
+	for _, marker := range []string{"SKILL.md", agentskill.ManifestFileName} {
 		if _, statErr := os.Stat(filepath.Join(skillDir, marker)); statErr == nil {
 			hasSkillMarker = true
 			break
 		}
 	}
 	if !hasSkillMarker {
-		return fmt.Errorf("directory %q does not appear to be an installed skill (missing SKILL.md and .manifest.json)", skillDir)
+		return fmt.Errorf("directory %q does not appear to be an installed skill (missing SKILL.md and %s)", skillDir, agentskill.ManifestFileName)
 	}
 
 	if err := os.RemoveAll(skillDir); err != nil {
 		return fmt.Errorf("remove skill directory %q: %w", skillDir, err)
 	}
 
-	relPath, relErr := filepath.Rel(root, skillDir)
-	if relErr != nil {
-		relPath = skillDir
+	if !agentRemoveGlobal && root != "" {
+		relPath, relErr := filepath.Rel(root, skillDir)
+		if relErr == nil {
+			skillDir = relPath
+		}
 	}
-	outlnf("Removed %s", filepath.ToSlash(relPath))
+	outlnf("Removed %s", filepath.ToSlash(skillDir))
 	return nil
 }

--- a/cmd/markata-go/cmd/agent_registry.go
+++ b/cmd/markata-go/cmd/agent_registry.go
@@ -1,0 +1,196 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const (
+	agentDefaultUniversal = "universal"
+	agentLegacyAgents     = "agents"
+	agentLegacyClaude     = "claude"
+
+	agentScopeProject = "project"
+	agentScopeGlobal  = "global"
+)
+
+type agentInstallTarget struct {
+	Name        string
+	ProjectPath string
+	GlobalPath  string
+	Aliases     []string
+}
+
+var supportedAgentTargets = []agentInstallTarget{
+	{Name: "adal", ProjectPath: ".adal/skills", GlobalPath: ".adal/skills"},
+	{Name: "amp", ProjectPath: ".agents/skills", GlobalPath: ".config/agents/skills"},
+	{Name: "antigravity", ProjectPath: ".agents/skills", GlobalPath: ".gemini/antigravity/skills"},
+	{Name: "augment", ProjectPath: ".augment/skills", GlobalPath: ".augment/skills"},
+	{Name: "bob", ProjectPath: ".bob/skills", GlobalPath: ".bob/skills"},
+	{Name: "claude-code", ProjectPath: ".claude/skills", GlobalPath: ".claude/skills", Aliases: []string{agentLegacyClaude}},
+	{Name: "cline", ProjectPath: ".agents/skills", GlobalPath: ".agents/skills"},
+	{Name: "codebuddy", ProjectPath: ".codebuddy/skills", GlobalPath: ".codebuddy/skills"},
+	{Name: "codex", ProjectPath: ".agents/skills", GlobalPath: ".codex/skills"},
+	{Name: "command-code", ProjectPath: ".commandcode/skills", GlobalPath: ".commandcode/skills"},
+	{Name: "continue", ProjectPath: ".continue/skills", GlobalPath: ".continue/skills"},
+	{Name: "cortex", ProjectPath: ".cortex/skills", GlobalPath: ".snowflake/cortex/skills"},
+	{Name: "crush", ProjectPath: ".crush/skills", GlobalPath: ".config/crush/skills"},
+	{Name: "cursor", ProjectPath: ".agents/skills", GlobalPath: ".cursor/skills"},
+	{Name: "deepagents", ProjectPath: ".agents/skills", GlobalPath: ".deepagents/agent/skills"},
+	{Name: "droid", ProjectPath: ".factory/skills", GlobalPath: ".factory/skills"},
+	{Name: "firebender", ProjectPath: ".agents/skills", GlobalPath: ".firebender/skills"},
+	{Name: "gemini-cli", ProjectPath: ".agents/skills", GlobalPath: ".gemini/skills"},
+	{Name: "github-copilot", ProjectPath: ".agents/skills", GlobalPath: ".copilot/skills"},
+	{Name: "goose", ProjectPath: ".goose/skills", GlobalPath: ".config/goose/skills"},
+	{Name: "iflow-cli", ProjectPath: ".iflow/skills", GlobalPath: ".iflow/skills"},
+	{Name: "junie", ProjectPath: ".junie/skills", GlobalPath: ".junie/skills"},
+	{Name: "kimi-cli", ProjectPath: ".agents/skills", GlobalPath: ".config/agents/skills"},
+	{Name: "kilo", ProjectPath: ".kilocode/skills", GlobalPath: ".kilocode/skills"},
+	{Name: "kiro-cli", ProjectPath: ".kiro/skills", GlobalPath: ".kiro/skills"},
+	{Name: "kode", ProjectPath: ".kode/skills", GlobalPath: ".kode/skills"},
+	{Name: "mcpjam", ProjectPath: ".mcpjam/skills", GlobalPath: ".mcpjam/skills"},
+	{Name: "mistral-vibe", ProjectPath: ".vibe/skills", GlobalPath: ".vibe/skills"},
+	{Name: "mux", ProjectPath: ".mux/skills", GlobalPath: ".mux/skills"},
+	{Name: "neovate", ProjectPath: ".neovate/skills", GlobalPath: ".neovate/skills"},
+	{Name: "openclaw", ProjectPath: "skills", GlobalPath: ".openclaw/skills"},
+	{Name: "opencode", ProjectPath: ".agents/skills", GlobalPath: ".config/opencode/skills"},
+	{Name: "openhands", ProjectPath: ".openhands/skills", GlobalPath: ".openhands/skills"},
+	{Name: "pi", ProjectPath: ".pi/skills", GlobalPath: ".pi/agent/skills"},
+	{Name: "pochi", ProjectPath: ".pochi/skills", GlobalPath: ".pochi/skills"},
+	{Name: "qoder", ProjectPath: ".qoder/skills", GlobalPath: ".qoder/skills"},
+	{Name: "qwen-code", ProjectPath: ".qwen/skills", GlobalPath: ".qwen/skills"},
+	{Name: "replit", ProjectPath: ".agents/skills", GlobalPath: ".config/agents/skills"},
+	{Name: "roo", ProjectPath: ".roo/skills", GlobalPath: ".roo/skills"},
+	{Name: "trae", ProjectPath: ".trae/skills", GlobalPath: ".trae/skills"},
+	{Name: "trae-cn", ProjectPath: ".trae/skills", GlobalPath: ".trae-cn/skills"},
+	{Name: "universal", ProjectPath: ".agents/skills", GlobalPath: ".config/agents/skills", Aliases: []string{agentLegacyAgents}},
+	{Name: "warp", ProjectPath: ".agents/skills", GlobalPath: ".agents/skills"},
+	{Name: "windsurf", ProjectPath: ".windsurf/skills", GlobalPath: ".codeium/windsurf/skills"},
+	{Name: "zencoder", ProjectPath: ".zencoder/skills", GlobalPath: ".zencoder/skills"},
+}
+
+var supportedAgentTargetsByName = newSupportedAgentTargetsByName()
+
+func newSupportedAgentTargetsByName() map[string]agentInstallTarget {
+	lookup := make(map[string]agentInstallTarget, len(supportedAgentTargets)*2)
+	for _, target := range supportedAgentTargets {
+		lookup[target.Name] = target
+		for _, alias := range target.Aliases {
+			lookup[alias] = target
+		}
+	}
+	return lookup
+}
+
+func normalizeAgentInstallTarget(name string) (agentInstallTarget, error) {
+	canonical := strings.ToLower(strings.TrimSpace(name))
+	target, ok := supportedAgentTargetsByName[canonical]
+	if !ok {
+		return agentInstallTarget{}, fmt.Errorf("unknown agent %q; see 'markata-go agent install --help' for supported values", name)
+	}
+	return target, nil
+}
+
+func resolveAgentInstallTarget(agentFlag, legacyTarget string, global bool) (agentInstallTarget, error) {
+	explicit, explicitSet, err := selectedAgentFlagValue(agentFlag, legacyTarget)
+	if err != nil {
+		return agentInstallTarget{}, err
+	}
+	if global && !explicitSet {
+		return agentInstallTarget{}, fmt.Errorf("--global requires --agent so markata-go can choose the correct user skill directory")
+	}
+	if explicitSet {
+		return normalizeAgentInstallTarget(explicit)
+	}
+	return normalizeAgentInstallTarget(detectDefaultAgent())
+}
+
+func selectedAgentFlagValue(agentFlag, legacyTarget string) (string, bool, error) {
+	agentFlag = strings.TrimSpace(agentFlag)
+	legacyTarget = strings.TrimSpace(legacyTarget)
+	if agentFlag == "" && legacyTarget == "" {
+		return "", false, nil
+	}
+	if agentFlag == "" {
+		return legacyTarget, true, nil
+	}
+	if legacyTarget == "" {
+		return agentFlag, true, nil
+	}
+
+	normalizedAgent, agentErr := normalizeAgentInstallTarget(agentFlag)
+	if agentErr != nil {
+		return "", false, agentErr
+	}
+	normalizedLegacy, legacyErr := normalizeAgentInstallTarget(legacyTarget)
+	if legacyErr != nil {
+		return "", false, legacyErr
+	}
+	if normalizedAgent.Name != normalizedLegacy.Name {
+		return "", false, fmt.Errorf("--agent %q conflicts with legacy --target %q", agentFlag, legacyTarget)
+	}
+	return agentFlag, true, nil
+}
+
+func detectDefaultAgent() string {
+	switch {
+	case envVarEnabled("OPENCODE"):
+		return "opencode"
+	case envVarEnabled("CLAUDECODE"), envVarEnabled("CLAUDE_CODE"):
+		return "claude-code"
+	case envVarEnabled("CODEX"), envVarEnabled("OPENAI_CODEX"):
+		return "codex"
+	case envVarEnabled("CURSOR_AGENT"), os.Getenv("CURSOR_TRACE_ID") != "":
+		return "cursor"
+	case envVarEnabled("GEMINI_CLI"):
+		return "gemini-cli"
+	case envVarEnabled("QWEN_CODE"):
+		return "qwen-code"
+	case envVarEnabled("KIMI_CLI"):
+		return "kimi-cli"
+	default:
+		return agentDefaultUniversal
+	}
+}
+
+func envVarEnabled(name string) bool {
+	value := strings.TrimSpace(os.Getenv(name))
+	if value == "" {
+		return false
+	}
+	value = strings.ToLower(value)
+	return value != "0" && value != "false" && value != "no"
+}
+
+func agentSkillInstallDir(root, skillName string, target agentInstallTarget, global bool) (string, error) {
+	base := root
+	relPath := target.ProjectPath
+	if global {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve user home directory: %w", err)
+		}
+		base = home
+		relPath = target.GlobalPath
+	}
+	return filepath.Join(base, filepath.FromSlash(relPath), skillName), nil
+}
+
+func agentScopeName(global bool) string {
+	if global {
+		return agentScopeGlobal
+	}
+	return agentScopeProject
+}
+
+func supportedAgentNames() []string {
+	names := make([]string, 0, len(supportedAgentTargets))
+	for _, target := range supportedAgentTargets {
+		names = append(names, target.Name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/cmd/markata-go/cmd/agent_registry.go
+++ b/cmd/markata-go/cmd/agent_registry.go
@@ -111,7 +111,7 @@ func resolveAgentInstallTarget(agentFlag, legacyTarget string, global bool) (age
 	return normalizeAgentInstallTarget(detectDefaultAgent())
 }
 
-func selectedAgentFlagValue(agentFlag, legacyTarget string) (string, bool, error) {
+func selectedAgentFlagValue(agentFlag, legacyTarget string) (selected string, explicit bool, err error) {
 	agentFlag = strings.TrimSpace(agentFlag)
 	legacyTarget = strings.TrimSpace(legacyTarget)
 	if agentFlag == "" && legacyTarget == "" {

--- a/cmd/markata-go/cmd/agent_registry.go
+++ b/cmd/markata-go/cmd/agent_registry.go
@@ -15,6 +15,9 @@ const (
 
 	agentScopeProject = "project"
 	agentScopeGlobal  = "global"
+
+	agentNameOpencode = "opencode"
+	envValueDisabled  = "false"
 )
 
 type agentInstallTarget struct {
@@ -138,7 +141,7 @@ func selectedAgentFlagValue(agentFlag, legacyTarget string) (string, bool, error
 func detectDefaultAgent() string {
 	switch {
 	case envVarEnabled("OPENCODE"):
-		return "opencode"
+		return agentNameOpencode
 	case envVarEnabled("CLAUDECODE"), envVarEnabled("CLAUDE_CODE"):
 		return "claude-code"
 	case envVarEnabled("CODEX"), envVarEnabled("OPENAI_CODEX"):
@@ -162,7 +165,7 @@ func envVarEnabled(name string) bool {
 		return false
 	}
 	value = strings.ToLower(value)
-	return value != "0" && value != "false" && value != "no"
+	return value != "0" && value != envValueDisabled && value != "no"
 }
 
 func agentSkillInstallDir(root, skillName string, target agentInstallTarget, global bool) (string, error) {

--- a/cmd/markata-go/cmd/agent_test.go
+++ b/cmd/markata-go/cmd/agent_test.go
@@ -19,10 +19,10 @@ func TestNormalizeAgentInstallTarget(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-		{name: "default empty", input: "", want: agentTargetAgents},
-		{name: "agents", input: "agents", want: agentTargetAgents},
-		{name: "claude", input: "claude", want: agentTargetClaude},
-		{name: "unknown", input: "cursor", wantErr: true},
+		{name: "canonical", input: "opencode", want: "opencode"},
+		{name: "legacy claude", input: "claude", want: "claude-code"},
+		{name: "legacy agents", input: "agents", want: "universal"},
+		{name: "unknown", input: "not-real", wantErr: true},
 	}
 
 	for _, tt := range tests {
@@ -31,16 +31,122 @@ func TestNormalizeAgentInstallTarget(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("normalizeAgentInstallTarget() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			if got != tt.want {
-				t.Fatalf("normalizeAgentInstallTarget() = %q, want %q", got, tt.want)
+			if tt.wantErr {
+				return
+			}
+			if got.Name != tt.want {
+				t.Fatalf("normalizeAgentInstallTarget().Name = %q, want %q", got.Name, tt.want)
 			}
 		})
 	}
 }
 
+func TestResolveAgentInstallTarget_DefaultsFromEnvironment(t *testing.T) {
+	t.Setenv("OPENCODE", "1")
+	t.Setenv("CLAUDECODE", "")
+	t.Setenv("CLAUDE_CODE", "")
+	t.Setenv("CODEX", "")
+	t.Setenv("OPENAI_CODEX", "")
+	t.Setenv("CURSOR_AGENT", "")
+	t.Setenv("CURSOR_TRACE_ID", "")
+
+	target, err := resolveAgentInstallTarget("", "", false)
+	if err != nil {
+		t.Fatalf("resolveAgentInstallTarget() error = %v", err)
+	}
+	if target.Name != "opencode" {
+		t.Fatalf("resolveAgentInstallTarget().Name = %q, want %q", target.Name, "opencode")
+	}
+}
+
+func TestResolveAgentInstallTarget_DefaultsToUniversal(t *testing.T) {
+	t.Setenv("OPENCODE", "")
+	t.Setenv("CLAUDECODE", "")
+	t.Setenv("CLAUDE_CODE", "")
+	t.Setenv("CODEX", "")
+	t.Setenv("OPENAI_CODEX", "")
+	t.Setenv("CURSOR_AGENT", "")
+	t.Setenv("CURSOR_TRACE_ID", "")
+
+	target, err := resolveAgentInstallTarget("", "", false)
+	if err != nil {
+		t.Fatalf("resolveAgentInstallTarget() error = %v", err)
+	}
+	if target.Name != "universal" {
+		t.Fatalf("resolveAgentInstallTarget().Name = %q, want %q", target.Name, "universal")
+	}
+}
+
+func TestResolveAgentInstallTarget_GlobalRequiresExplicitAgent(t *testing.T) {
+	_, err := resolveAgentInstallTarget("", "", true)
+	if err == nil {
+		t.Fatal("expected error when --global is used without --agent")
+	}
+	if !strings.Contains(err.Error(), "--global requires --agent") {
+		t.Fatalf("expected --global guidance, got %v", err)
+	}
+}
+
+func TestResolveAgentInstallTarget_RejectsConflictingFlags(t *testing.T) {
+	_, err := resolveAgentInstallTarget("opencode", "claude", false)
+	if err == nil {
+		t.Fatal("expected conflict error")
+	}
+	if !strings.Contains(err.Error(), "conflicts") {
+		t.Fatalf("expected conflict error, got %v", err)
+	}
+}
+
+func TestAgentSkillInstallDir_ProjectAndGlobal(t *testing.T) {
+	projectTarget, err := normalizeAgentInstallTarget("claude-code")
+	if err != nil {
+		t.Fatalf("normalizeAgentInstallTarget() error = %v", err)
+	}
+	projectDir, err := agentSkillInstallDir("/tmp/site", agentskill.SiteSkillName, projectTarget, false)
+	if err != nil {
+		t.Fatalf("agentSkillInstallDir(project) error = %v", err)
+	}
+	if projectDir != filepath.Join("/tmp/site", ".claude", "skills", agentskill.SiteSkillName) {
+		t.Fatalf("projectDir = %q", projectDir)
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	globalTarget, err := normalizeAgentInstallTarget("opencode")
+	if err != nil {
+		t.Fatalf("normalizeAgentInstallTarget() error = %v", err)
+	}
+	globalDir, err := agentSkillInstallDir("", agentskill.SiteSkillName, globalTarget, true)
+	if err != nil {
+		t.Fatalf("agentSkillInstallDir(global) error = %v", err)
+	}
+	if globalDir != filepath.Join(home, ".config", "opencode", "skills", agentskill.SiteSkillName) {
+		t.Fatalf("globalDir = %q", globalDir)
+	}
+}
+
+func TestResolveAgentProjectRoot_GlobalRejectsSitePath(t *testing.T) {
+	_, err := resolveAgentProjectRoot([]string{"/tmp/site"}, true)
+	if err == nil {
+		t.Fatal("expected error for site path with --global")
+	}
+	if !strings.Contains(err.Error(), "site path is not supported") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestInstallAgentSkill_DryRunDoesNotWriteFiles(t *testing.T) {
 	root := t.TempDir()
-	installedFiles, err := installAgentSkill(root, agentTargetAgents, agentskill.SiteSkillName, true, false, "test")
+	target, err := normalizeAgentInstallTarget("universal")
+	if err != nil {
+		t.Fatalf("normalizeAgentInstallTarget() error = %v", err)
+	}
+	destination, err := agentSkillInstallDir(root, agentskill.SiteSkillName, target, false)
+	if err != nil {
+		t.Fatalf("agentSkillInstallDir() error = %v", err)
+	}
+
+	installedFiles, err := installAgentSkill(destination, target.Name, agentScopeProject, true, false, "test")
 	if err != nil {
 		t.Fatalf("installAgentSkill() error = %v", err)
 	}
@@ -55,7 +161,16 @@ func TestInstallAgentSkill_DryRunDoesNotWriteFiles(t *testing.T) {
 
 func TestInstallAgentSkill_WritesBundledFiles(t *testing.T) {
 	root := t.TempDir()
-	installedFiles, err := installAgentSkill(root, agentTargetClaude, agentskill.SiteSkillName, false, false, "test")
+	target, err := normalizeAgentInstallTarget("claude-code")
+	if err != nil {
+		t.Fatalf("normalizeAgentInstallTarget() error = %v", err)
+	}
+	destination, err := agentSkillInstallDir(root, agentskill.SiteSkillName, target, false)
+	if err != nil {
+		t.Fatalf("agentSkillInstallDir() error = %v", err)
+	}
+
+	installedFiles, err := installAgentSkill(destination, target.Name, agentScopeProject, false, false, "test")
 	if err != nil {
 		t.Fatalf("installAgentSkill() error = %v", err)
 	}
@@ -78,15 +193,22 @@ func TestInstallAgentSkill_WritesBundledFiles(t *testing.T) {
 
 func TestInstallAgentSkill_ExistingFileRequiresForce(t *testing.T) {
 	root := t.TempDir()
-	path := filepath.Join(root, ".agents", "skills", agentskill.SiteSkillName)
-	if err := os.MkdirAll(path, 0o755); err != nil {
+	target, err := normalizeAgentInstallTarget("universal")
+	if err != nil {
+		t.Fatalf("normalizeAgentInstallTarget() error = %v", err)
+	}
+	destination, err := agentSkillInstallDir(root, agentskill.SiteSkillName, target, false)
+	if err != nil {
+		t.Fatalf("agentSkillInstallDir() error = %v", err)
+	}
+	if err := os.MkdirAll(destination, 0o755); err != nil {
 		t.Fatalf("MkdirAll() error = %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(path, "SKILL.md"), []byte("existing"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(destination, "SKILL.md"), []byte("existing"), 0o600); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
 
-	_, err := installAgentSkill(root, agentTargetAgents, agentskill.SiteSkillName, false, false, "test")
+	_, err = installAgentSkill(destination, target.Name, agentScopeProject, false, false, "test")
 	if err == nil {
 		t.Fatal("expected conflict error when files already exist")
 	}
@@ -95,11 +217,6 @@ func TestInstallAgentSkill_ExistingFileRequiresForce(t *testing.T) {
 	}
 }
 
-// TestRunAgentInstallCommand_DryRunUsesCommandWriter verifies that command output
-// goes through the cobra command writer, not directly to os.Stdout.
-//
-// NOTE: This test mutates package-level flag variables and restores them via
-// defer. It must NOT use t.Parallel().
 func TestRunAgentInstallCommand_DryRunUsesCommandWriter(t *testing.T) {
 	stdout := bytes.NewBuffer(nil)
 	stderr := bytes.NewBuffer(nil)
@@ -107,22 +224,28 @@ func TestRunAgentInstallCommand_DryRunUsesCommandWriter(t *testing.T) {
 	command.SetOut(stdout)
 	command.SetErr(stderr)
 
-	originalTarget := agentInstallTarget
+	originalAgent := agentInstallAgent
+	originalLegacyTarget := agentInstallLegacyTarget
 	originalName := agentInstallName
 	originalDryRun := agentInstallDryRun
 	originalForce := agentInstallForce
+	originalGlobal := agentInstallGlobal
 	defer func() {
-		agentInstallTarget = originalTarget
+		agentInstallAgent = originalAgent
+		agentInstallLegacyTarget = originalLegacyTarget
 		agentInstallName = originalName
 		agentInstallDryRun = originalDryRun
 		agentInstallForce = originalForce
+		agentInstallGlobal = originalGlobal
 		currentCmd = nil
 	}()
 
-	agentInstallTarget = agentTargetAgents
+	agentInstallAgent = "opencode"
+	agentInstallLegacyTarget = ""
 	agentInstallName = agentskill.SiteSkillName
 	agentInstallDryRun = true
 	agentInstallForce = false
+	agentInstallGlobal = false
 
 	if err := runAgentInstallCommand(command, []string{t.TempDir()}); err != nil {
 		t.Fatalf("runAgentInstallCommand() error = %v", err)
@@ -136,10 +259,41 @@ func TestRunAgentInstallCommand_DryRunUsesCommandWriter(t *testing.T) {
 	}
 }
 
-// TestRunAgentUpdateCommand_DryRunUsesCommandWriter verifies update reports through the cobra writer.
-//
-// NOTE: This test mutates package-level flag variables and restores them via
-// defer. It must NOT use t.Parallel().
+func TestRunAgentInstallCommand_GlobalRequiresAgent(t *testing.T) {
+	command := &cobra.Command{Use: "install"}
+
+	originalAgent := agentInstallAgent
+	originalLegacyTarget := agentInstallLegacyTarget
+	originalName := agentInstallName
+	originalDryRun := agentInstallDryRun
+	originalForce := agentInstallForce
+	originalGlobal := agentInstallGlobal
+	defer func() {
+		agentInstallAgent = originalAgent
+		agentInstallLegacyTarget = originalLegacyTarget
+		agentInstallName = originalName
+		agentInstallDryRun = originalDryRun
+		agentInstallForce = originalForce
+		agentInstallGlobal = originalGlobal
+		currentCmd = nil
+	}()
+
+	agentInstallAgent = ""
+	agentInstallLegacyTarget = ""
+	agentInstallName = agentskill.SiteSkillName
+	agentInstallDryRun = true
+	agentInstallForce = false
+	agentInstallGlobal = true
+
+	err := runAgentInstallCommand(command, nil)
+	if err == nil {
+		t.Fatal("expected error when --global is used without --agent")
+	}
+	if !strings.Contains(err.Error(), "--global requires --agent") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestRunAgentUpdateCommand_DryRunUsesCommandWriter(t *testing.T) {
 	stdout := bytes.NewBuffer(nil)
 	stderr := bytes.NewBuffer(nil)
@@ -147,19 +301,25 @@ func TestRunAgentUpdateCommand_DryRunUsesCommandWriter(t *testing.T) {
 	command.SetOut(stdout)
 	command.SetErr(stderr)
 
-	originalTarget := agentUpdateTarget
+	originalAgent := agentUpdateAgent
+	originalLegacyTarget := agentUpdateLegacyTarget
 	originalName := agentUpdateName
 	originalDryRun := agentUpdateDryRun
+	originalGlobal := agentUpdateGlobal
 	defer func() {
-		agentUpdateTarget = originalTarget
+		agentUpdateAgent = originalAgent
+		agentUpdateLegacyTarget = originalLegacyTarget
 		agentUpdateName = originalName
 		agentUpdateDryRun = originalDryRun
+		agentUpdateGlobal = originalGlobal
 		currentCmd = nil
 	}()
 
-	agentUpdateTarget = agentTargetAgents
+	agentUpdateAgent = "universal"
+	agentUpdateLegacyTarget = ""
 	agentUpdateName = agentskill.SiteSkillName
 	agentUpdateDryRun = true
+	agentUpdateGlobal = false
 
 	if err := runAgentUpdateCommand(command, []string{t.TempDir()}); err != nil {
 		t.Fatalf("runAgentUpdateCommand() error = %v", err)
@@ -173,18 +333,22 @@ func TestRunAgentUpdateCommand_DryRunUsesCommandWriter(t *testing.T) {
 	}
 }
 
-// TestRunAgentUpdateCommand_OverwritesInstalledFiles verifies update rewrites an existing install.
-//
-// NOTE: This test mutates package-level flag variables and restores them via
-// defer. It must NOT use t.Parallel().
 func TestRunAgentUpdateCommand_OverwritesInstalledFiles(t *testing.T) {
 	root := t.TempDir()
-	_, err := installAgentSkill(root, agentTargetAgents, agentskill.SiteSkillName, false, false, Version)
+	target, err := normalizeAgentInstallTarget("universal")
+	if err != nil {
+		t.Fatalf("normalizeAgentInstallTarget() error = %v", err)
+	}
+	destination, err := agentSkillInstallDir(root, agentskill.SiteSkillName, target, false)
+	if err != nil {
+		t.Fatalf("agentSkillInstallDir() error = %v", err)
+	}
+	_, err = installAgentSkill(destination, target.Name, agentScopeProject, false, false, Version)
 	if err != nil {
 		t.Fatalf("installAgentSkill() error = %v", err)
 	}
 
-	skillFile := filepath.Join(root, ".agents", "skills", agentskill.SiteSkillName, "SKILL.md")
+	skillFile := filepath.Join(destination, "SKILL.md")
 	if err := os.WriteFile(skillFile, []byte("modified"), 0o600); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
@@ -195,19 +359,25 @@ func TestRunAgentUpdateCommand_OverwritesInstalledFiles(t *testing.T) {
 	command.SetOut(stdout)
 	command.SetErr(stderr)
 
-	originalTarget := agentUpdateTarget
+	originalAgent := agentUpdateAgent
+	originalLegacyTarget := agentUpdateLegacyTarget
 	originalName := agentUpdateName
 	originalDryRun := agentUpdateDryRun
+	originalGlobal := agentUpdateGlobal
 	defer func() {
-		agentUpdateTarget = originalTarget
+		agentUpdateAgent = originalAgent
+		agentUpdateLegacyTarget = originalLegacyTarget
 		agentUpdateName = originalName
 		agentUpdateDryRun = originalDryRun
+		agentUpdateGlobal = originalGlobal
 		currentCmd = nil
 	}()
 
-	agentUpdateTarget = agentTargetAgents
+	agentUpdateAgent = "universal"
+	agentUpdateLegacyTarget = ""
 	agentUpdateName = agentskill.SiteSkillName
 	agentUpdateDryRun = false
+	agentUpdateGlobal = false
 
 	if err := runAgentUpdateCommand(command, []string{root}); err != nil {
 		t.Fatalf("runAgentUpdateCommand() error = %v", err)
@@ -229,22 +399,33 @@ func TestRunAgentUpdateCommand_OverwritesInstalledFiles(t *testing.T) {
 }
 
 func TestInstallAgentSkill_WritesManifest(t *testing.T) {
-	root := t.TempDir()
-	_, err := installAgentSkill(root, agentTargetAgents, agentskill.SiteSkillName, false, false, "0.5.0-test")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	target, err := normalizeAgentInstallTarget("opencode")
+	if err != nil {
+		t.Fatalf("normalizeAgentInstallTarget() error = %v", err)
+	}
+	destination, err := agentSkillInstallDir("", agentskill.SiteSkillName, target, true)
+	if err != nil {
+		t.Fatalf("agentSkillInstallDir() error = %v", err)
+	}
+	_, err = installAgentSkill(destination, target.Name, agentScopeGlobal, false, false, "0.5.0-test")
 	if err != nil {
 		t.Fatalf("installAgentSkill() error = %v", err)
 	}
 
-	skillDir := filepath.Join(root, ".agents", "skills", agentskill.SiteSkillName)
-	manifest, err := agentskill.ReadManifest(skillDir)
+	manifest, err := agentskill.ReadManifest(destination)
 	if err != nil {
 		t.Fatalf("ReadManifest() error = %v", err)
 	}
 	if manifest.Version != "0.5.0-test" {
 		t.Errorf("Version = %q, want %q", manifest.Version, "0.5.0-test")
 	}
-	if manifest.Target != agentTargetAgents {
-		t.Errorf("Target = %q, want %q", manifest.Target, agentTargetAgents)
+	if manifest.Target != "opencode" {
+		t.Errorf("Target = %q, want %q", manifest.Target, "opencode")
+	}
+	if manifest.Scope != agentScopeGlobal {
+		t.Errorf("Scope = %q, want %q", manifest.Scope, agentScopeGlobal)
 	}
 	if len(manifest.Files) == 0 {
 		t.Error("expected manifest to contain file hashes")
@@ -253,25 +434,36 @@ func TestInstallAgentSkill_WritesManifest(t *testing.T) {
 
 func TestInstallAgentSkill_DryRunDoesNotWriteManifest(t *testing.T) {
 	root := t.TempDir()
-	_, err := installAgentSkill(root, agentTargetAgents, agentskill.SiteSkillName, true, false, "0.5.0-test")
+	target, err := normalizeAgentInstallTarget("universal")
+	if err != nil {
+		t.Fatalf("normalizeAgentInstallTarget() error = %v", err)
+	}
+	destination, err := agentSkillInstallDir(root, agentskill.SiteSkillName, target, false)
+	if err != nil {
+		t.Fatalf("agentSkillInstallDir() error = %v", err)
+	}
+	_, err = installAgentSkill(destination, target.Name, agentScopeProject, true, false, "0.5.0-test")
 	if err != nil {
 		t.Fatalf("installAgentSkill() error = %v", err)
 	}
 
-	skillDir := filepath.Join(root, ".agents", "skills", agentskill.SiteSkillName)
-	_, err = agentskill.ReadManifest(skillDir)
+	_, err = agentskill.ReadManifest(destination)
 	if err == nil {
 		t.Fatal("expected manifest to not exist after dry run")
 	}
 }
 
-// TestRunAgentDoctorCommand_DriftReturnsExitCode verifies doctor reports drift via ExitCodeError.
-//
-// NOTE: This test mutates package-level flag variables and restores them via
-// defer. It must NOT use t.Parallel().
 func TestRunAgentDoctorCommand_DriftReturnsExitCode(t *testing.T) {
 	root := t.TempDir()
-	_, err := installAgentSkill(root, agentTargetAgents, agentskill.SiteSkillName, false, false, "older-version")
+	target, err := normalizeAgentInstallTarget("universal")
+	if err != nil {
+		t.Fatalf("normalizeAgentInstallTarget() error = %v", err)
+	}
+	destination, err := agentSkillInstallDir(root, agentskill.SiteSkillName, target, false)
+	if err != nil {
+		t.Fatalf("agentSkillInstallDir() error = %v", err)
+	}
+	_, err = installAgentSkill(destination, target.Name, agentScopeProject, false, false, "older-version")
 	if err != nil {
 		t.Fatalf("installAgentSkill() error = %v", err)
 	}
@@ -282,16 +474,22 @@ func TestRunAgentDoctorCommand_DriftReturnsExitCode(t *testing.T) {
 	command.SetOut(stdout)
 	command.SetErr(stderr)
 
-	originalTarget := agentDoctorTarget
+	originalAgent := agentDoctorAgent
+	originalLegacyTarget := agentDoctorLegacyTarget
 	originalName := agentDoctorName
+	originalGlobal := agentDoctorGlobal
 	defer func() {
-		agentDoctorTarget = originalTarget
+		agentDoctorAgent = originalAgent
+		agentDoctorLegacyTarget = originalLegacyTarget
 		agentDoctorName = originalName
+		agentDoctorGlobal = originalGlobal
 		currentCmd = nil
 	}()
 
-	agentDoctorTarget = agentTargetAgents
+	agentDoctorAgent = "universal"
+	agentDoctorLegacyTarget = ""
 	agentDoctorName = agentskill.SiteSkillName
+	agentDoctorGlobal = false
 
 	err = runAgentDoctorCommand(command, []string{root})
 	if err == nil {
@@ -310,10 +508,6 @@ func TestRunAgentDoctorCommand_DriftReturnsExitCode(t *testing.T) {
 	}
 }
 
-// TestRunAgentDoctorCommand_MissingManifestReturnsExitCode verifies doctor handles pre-manifest installs.
-//
-// NOTE: This test mutates package-level flag variables and restores them via
-// defer. It must NOT use t.Parallel().
 func TestRunAgentDoctorCommand_MissingManifestReturnsExitCode(t *testing.T) {
 	root := t.TempDir()
 	skillDir := filepath.Join(root, ".agents", "skills", agentskill.SiteSkillName)
@@ -330,16 +524,22 @@ func TestRunAgentDoctorCommand_MissingManifestReturnsExitCode(t *testing.T) {
 	command.SetOut(stdout)
 	command.SetErr(stderr)
 
-	originalTarget := agentDoctorTarget
+	originalAgent := agentDoctorAgent
+	originalLegacyTarget := agentDoctorLegacyTarget
 	originalName := agentDoctorName
+	originalGlobal := agentDoctorGlobal
 	defer func() {
-		agentDoctorTarget = originalTarget
+		agentDoctorAgent = originalAgent
+		agentDoctorLegacyTarget = originalLegacyTarget
 		agentDoctorName = originalName
+		agentDoctorGlobal = originalGlobal
 		currentCmd = nil
 	}()
 
-	agentDoctorTarget = agentTargetAgents
+	agentDoctorAgent = "universal"
+	agentDoctorLegacyTarget = ""
 	agentDoctorName = agentskill.SiteSkillName
+	agentDoctorGlobal = false
 
 	err := runAgentDoctorCommand(command, []string{root})
 	if err == nil {
@@ -358,15 +558,17 @@ func TestRunAgentDoctorCommand_MissingManifestReturnsExitCode(t *testing.T) {
 	}
 }
 
-// TestRunAgentDoctorCommand_UpToDate verifies doctor reports no drift immediately after install.
-//
-// NOTE: This test mutates package-level flag variables and restores them via
-// defer. It must NOT use t.Parallel().
 func TestRunAgentDoctorCommand_UpToDate(t *testing.T) {
 	root := t.TempDir()
-
-	// Install first.
-	_, err := installAgentSkill(root, agentTargetAgents, agentskill.SiteSkillName, false, false, Version)
+	target, err := normalizeAgentInstallTarget("universal")
+	if err != nil {
+		t.Fatalf("normalizeAgentInstallTarget() error = %v", err)
+	}
+	destination, err := agentSkillInstallDir(root, agentskill.SiteSkillName, target, false)
+	if err != nil {
+		t.Fatalf("agentSkillInstallDir() error = %v", err)
+	}
+	_, err = installAgentSkill(destination, target.Name, agentScopeProject, false, false, Version)
 	if err != nil {
 		t.Fatalf("installAgentSkill() error = %v", err)
 	}
@@ -377,16 +579,22 @@ func TestRunAgentDoctorCommand_UpToDate(t *testing.T) {
 	command.SetOut(stdout)
 	command.SetErr(stderr)
 
-	originalTarget := agentDoctorTarget
+	originalAgent := agentDoctorAgent
+	originalLegacyTarget := agentDoctorLegacyTarget
 	originalName := agentDoctorName
+	originalGlobal := agentDoctorGlobal
 	defer func() {
-		agentDoctorTarget = originalTarget
+		agentDoctorAgent = originalAgent
+		agentDoctorLegacyTarget = originalLegacyTarget
 		agentDoctorName = originalName
+		agentDoctorGlobal = originalGlobal
 		currentCmd = nil
 	}()
 
-	agentDoctorTarget = agentTargetAgents
+	agentDoctorAgent = "universal"
+	agentDoctorLegacyTarget = ""
 	agentDoctorName = agentskill.SiteSkillName
+	agentDoctorGlobal = false
 
 	if err := runAgentDoctorCommand(command, []string{root}); err != nil {
 		t.Fatalf("runAgentDoctorCommand() error = %v", err)
@@ -395,15 +603,22 @@ func TestRunAgentDoctorCommand_UpToDate(t *testing.T) {
 	if !strings.Contains(stdout.String(), "up to date") {
 		t.Errorf("expected 'up to date' in output, got %q", stdout.String())
 	}
+	if !strings.Contains(stdout.String(), "Agent:     universal") {
+		t.Errorf("expected agent line in output, got %q", stdout.String())
+	}
 }
 
-// TestRunAgentRemoveCommand_RemovesInstalledSkill verifies remove deletes the skill directory.
-//
-// NOTE: This test mutates package-level flag variables and restores them via
-// defer. It must NOT use t.Parallel().
 func TestRunAgentRemoveCommand_RemovesInstalledSkill(t *testing.T) {
 	root := t.TempDir()
-	_, err := installAgentSkill(root, agentTargetClaude, agentskill.SiteSkillName, false, false, Version)
+	target, err := normalizeAgentInstallTarget("claude-code")
+	if err != nil {
+		t.Fatalf("normalizeAgentInstallTarget() error = %v", err)
+	}
+	destination, err := agentSkillInstallDir(root, agentskill.SiteSkillName, target, false)
+	if err != nil {
+		t.Fatalf("agentSkillInstallDir() error = %v", err)
+	}
+	_, err = installAgentSkill(destination, target.Name, agentScopeProject, false, false, Version)
 	if err != nil {
 		t.Fatalf("installAgentSkill() error = %v", err)
 	}
@@ -414,23 +629,28 @@ func TestRunAgentRemoveCommand_RemovesInstalledSkill(t *testing.T) {
 	command.SetOut(stdout)
 	command.SetErr(stderr)
 
-	originalTarget := agentRemoveTarget
+	originalAgent := agentRemoveAgent
+	originalLegacyTarget := agentRemoveLegacyTarget
 	originalName := agentRemoveName
+	originalGlobal := agentRemoveGlobal
 	defer func() {
-		agentRemoveTarget = originalTarget
+		agentRemoveAgent = originalAgent
+		agentRemoveLegacyTarget = originalLegacyTarget
 		agentRemoveName = originalName
+		agentRemoveGlobal = originalGlobal
 		currentCmd = nil
 	}()
 
-	agentRemoveTarget = agentTargetClaude
+	agentRemoveAgent = "claude-code"
+	agentRemoveLegacyTarget = ""
 	agentRemoveName = agentskill.SiteSkillName
+	agentRemoveGlobal = false
 
 	if err := runAgentRemoveCommand(command, []string{root}); err != nil {
 		t.Fatalf("runAgentRemoveCommand() error = %v", err)
 	}
 
-	skillDir := filepath.Join(root, ".claude", "skills", agentskill.SiteSkillName)
-	if _, err := os.Stat(skillDir); !os.IsNotExist(err) {
+	if _, err := os.Stat(destination); !os.IsNotExist(err) {
 		t.Fatalf("expected skill dir to be removed, got err=%v", err)
 	}
 	if !strings.Contains(stdout.String(), "Removed .claude/skills/") {
@@ -441,7 +661,6 @@ func TestRunAgentRemoveCommand_RemovesInstalledSkill(t *testing.T) {
 	}
 }
 
-// TestAgentRemoveCmd_HasUninstallAlias verifies uninstall is exposed as an alias.
 func TestAgentRemoveCmd_HasUninstallAlias(t *testing.T) {
 	found := false
 	for _, alias := range agentRemoveCmd.Aliases {
@@ -484,23 +703,24 @@ func TestValidateSkillName(t *testing.T) {
 
 func TestRunAgentRemoveCommand_RejectsTraversalName(t *testing.T) {
 	root := t.TempDir()
-
-	stdout := bytes.NewBuffer(nil)
-	stderr := bytes.NewBuffer(nil)
 	command := &cobra.Command{Use: "remove"}
-	command.SetOut(stdout)
-	command.SetErr(stderr)
 
-	originalTarget := agentRemoveTarget
+	originalAgent := agentRemoveAgent
+	originalLegacyTarget := agentRemoveLegacyTarget
 	originalName := agentRemoveName
+	originalGlobal := agentRemoveGlobal
 	defer func() {
-		agentRemoveTarget = originalTarget
+		agentRemoveAgent = originalAgent
+		agentRemoveLegacyTarget = originalLegacyTarget
 		agentRemoveName = originalName
+		agentRemoveGlobal = originalGlobal
 		currentCmd = nil
 	}()
 
-	agentRemoveTarget = agentTargetAgents
+	agentRemoveAgent = "universal"
+	agentRemoveLegacyTarget = ""
 	agentRemoveName = "../.."
+	agentRemoveGlobal = false
 
 	err := runAgentRemoveCommand(command, []string{root})
 	if err == nil {
@@ -513,7 +733,6 @@ func TestRunAgentRemoveCommand_RejectsTraversalName(t *testing.T) {
 
 func TestRunAgentRemoveCommand_RejectsNonSkillDirectory(t *testing.T) {
 	root := t.TempDir()
-	// Create a directory that is NOT a skill (no SKILL.md, no .manifest.json).
 	notASkill := filepath.Join(root, ".agents", "skills", "not-a-skill")
 	if err := os.MkdirAll(notASkill, 0o755); err != nil {
 		t.Fatalf("MkdirAll() error = %v", err)
@@ -522,22 +741,24 @@ func TestRunAgentRemoveCommand_RejectsNonSkillDirectory(t *testing.T) {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
 
-	stdout := bytes.NewBuffer(nil)
-	stderr := bytes.NewBuffer(nil)
 	command := &cobra.Command{Use: "remove"}
-	command.SetOut(stdout)
-	command.SetErr(stderr)
 
-	originalTarget := agentRemoveTarget
+	originalAgent := agentRemoveAgent
+	originalLegacyTarget := agentRemoveLegacyTarget
 	originalName := agentRemoveName
+	originalGlobal := agentRemoveGlobal
 	defer func() {
-		agentRemoveTarget = originalTarget
+		agentRemoveAgent = originalAgent
+		agentRemoveLegacyTarget = originalLegacyTarget
 		agentRemoveName = originalName
+		agentRemoveGlobal = originalGlobal
 		currentCmd = nil
 	}()
 
-	agentRemoveTarget = agentTargetAgents
+	agentRemoveAgent = "universal"
+	agentRemoveLegacyTarget = ""
 	agentRemoveName = "not-a-skill"
+	agentRemoveGlobal = false
 
 	err := runAgentRemoveCommand(command, []string{root})
 	if err == nil {
@@ -547,7 +768,6 @@ func TestRunAgentRemoveCommand_RejectsNonSkillDirectory(t *testing.T) {
 		t.Fatalf("expected skill marker error, got %v", err)
 	}
 
-	// Verify the directory was NOT deleted.
 	if _, statErr := os.Stat(notASkill); os.IsNotExist(statErr) {
 		t.Fatal("expected non-skill directory to be preserved")
 	}

--- a/cmd/markata-go/cmd/agent_test.go
+++ b/cmd/markata-go/cmd/agent_test.go
@@ -112,6 +112,9 @@ func TestAgentSkillInstallDir_ProjectAndGlobal(t *testing.T) {
 
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("HOMEDRIVE", filepath.VolumeName(home))
+	t.Setenv("HOMEPATH", strings.TrimPrefix(home, filepath.VolumeName(home)))
 	globalTarget, err := normalizeAgentInstallTarget("opencode")
 	if err != nil {
 		t.Fatalf("normalizeAgentInstallTarget() error = %v", err)

--- a/cmd/markata-go/cmd/agent_test.go
+++ b/cmd/markata-go/cmd/agent_test.go
@@ -106,7 +106,8 @@ func TestAgentSkillInstallDir_ProjectAndGlobal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("agentSkillInstallDir(project) error = %v", err)
 	}
-	if projectDir != filepath.Join("/tmp/site", ".claude", "skills", agentskill.SiteSkillName) {
+	// gocritic filepathJoin: test uses literal path for expected value verification
+	if projectDir != "/tmp/site/.claude/skills/markata-go-site" {
 		t.Fatalf("projectDir = %q", projectDir)
 	}
 

--- a/cmd/markata-go/cmd/agent_test.go
+++ b/cmd/markata-go/cmd/agent_test.go
@@ -259,6 +259,38 @@ func TestRunAgentInstallCommand_DryRunUsesCommandWriter(t *testing.T) {
 	}
 }
 
+func TestRunAgentListAgentsCommand_UsesCommandWriter(t *testing.T) {
+	stdout := bytes.NewBuffer(nil)
+	stderr := bytes.NewBuffer(nil)
+	command := &cobra.Command{Use: "list-agents"}
+	command.SetOut(stdout)
+	command.SetErr(stderr)
+
+	if err := runAgentListAgentsCommand(command, nil); err != nil {
+		t.Fatalf("runAgentListAgentsCommand() error = %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "Supported agents:") {
+		t.Fatalf("expected heading in output, got %q", output)
+	}
+	if !strings.Contains(output, "- opencode") {
+		t.Fatalf("expected opencode in output, got %q", output)
+	}
+	if !strings.Contains(output, "project: .agents/skills") {
+		t.Fatalf("expected project path in output, got %q", output)
+	}
+	if !strings.Contains(output, "global:  .config/opencode/skills") {
+		t.Fatalf("expected global path in output, got %q", output)
+	}
+	if !strings.Contains(output, "aliases: claude") {
+		t.Fatalf("expected alias information in output, got %q", output)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no stderr output, got %q", stderr.String())
+	}
+}
+
 func TestRunAgentInstallCommand_GlobalRequiresAgent(t *testing.T) {
 	command := &cobra.Command{Use: "install"}
 

--- a/cmd/markata-go/cmd/agent_test.go
+++ b/cmd/markata-go/cmd/agent_test.go
@@ -106,8 +106,7 @@ func TestAgentSkillInstallDir_ProjectAndGlobal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("agentSkillInstallDir(project) error = %v", err)
 	}
-	// gocritic filepathJoin: test uses literal path for expected value verification
-	if projectDir != "/tmp/site/.claude/skills/markata-go-site" {
+	if projectDir != filepath.Join(string(filepath.Separator), "tmp", "site", ".claude", "skills", agentskill.SiteSkillName) {
 		t.Fatalf("projectDir = %q", projectDir)
 	}
 

--- a/cmd/markata-go/cmd/explain.go
+++ b/cmd/markata-go/cmd/explain.go
@@ -645,17 +645,27 @@ coding agents can work with markata-go sites more effectively.
 
     markata-go agent install
 
-By default this installs the skill into the portable agents layout:
+By default this installs the skill into the current agent's project layout when
+markata-go can detect one from the environment. Otherwise it falls back to the
+portable universal layout:
 
     .agents/skills/markata-go-site/
 
-To install for Claude Code instead:
+To install for Claude Code explicitly:
 
-    markata-go agent install --target claude
+    markata-go agent install --agent claude-code
 
 This installs to:
 
     .claude/skills/markata-go-site/
+
+To install into OpenCode's global skill directory instead:
+
+    markata-go agent install --agent opencode --global
+
+This installs to:
+
+    ~/.config/opencode/skills/markata-go-site/
 
 ## Skill Layout
 

--- a/cmd/markata-go/cmd/explain.go
+++ b/cmd/markata-go/cmd/explain.go
@@ -643,6 +643,10 @@ coding agents can work with markata-go sites more effectively.
 
 ## Install the Bundled Skill
 
+List supported agent ids and install paths:
+
+    markata-go agent list-agents
+
     markata-go agent install
 
 By default this installs the skill into the current agent's project layout when

--- a/docs/guides/agent-skills.md
+++ b/docs/guides/agent-skills.md
@@ -15,6 +15,12 @@ markata-go can install a bundled skill into your site repository or an agent-spe
 
 ## Install
 
+See the supported agent ids and install paths directly in the CLI:
+
+```bash
+markata-go agent list-agents
+```
+
 Install into the current agent's project layout:
 
 ```bash
@@ -209,6 +215,8 @@ Topic files provide narrative guidance for common tasks. Reference files give qu
 ## Supported Agents
 
 `markata-go agent` mirrors the same agent identifiers as `vercel-labs/skills`, including `opencode`, `claude-code`, `codex`, `cursor`, `gemini-cli`, `qwen-code`, `warp`, `windsurf`, `github-copilot`, and the rest of that compatibility matrix.
+
+Use `markata-go agent list-agents` to print the full supported list with project and global install paths.
 
 For project installs, omitting `--agent` uses the current agent when markata-go can detect it from the environment. If no agent is detected, markata-go falls back to `universal`, which installs to `.agents/skills/markata-go-site/`.
 

--- a/docs/guides/agent-skills.md
+++ b/docs/guides/agent-skills.md
@@ -11,26 +11,26 @@ tags:
 
 # Agent Skills
 
-markata-go can install a bundled skill into your site repository so coding agents have project-specific guidance for common markata-go tasks.
+markata-go can install a bundled skill into your site repository or an agent-specific global skill directory so coding agents have project-specific guidance for common markata-go tasks.
 
 ## Install
 
-Install the portable skill layout into the current site:
+Install into the current agent's project layout:
 
 ```bash
 markata-go agent install
 ```
 
-This creates:
+When markata-go can detect the current agent from the environment, it uses that agent's project path. Otherwise it falls back to the portable `universal` layout:
 
 ```text
 .agents/skills/markata-go-site/
 ```
 
-Install into Claude Code's skill layout instead:
+Install into Claude Code's project layout explicitly:
 
 ```bash
-markata-go agent install --target claude
+markata-go agent install --agent claude-code
 ```
 
 This creates:
@@ -38,6 +38,20 @@ This creates:
 ```text
 .claude/skills/markata-go-site/
 ```
+
+Install into OpenCode's global skill directory instead of the current repository:
+
+```bash
+markata-go agent install --agent opencode -g
+```
+
+This creates:
+
+```text
+~/.config/opencode/skills/markata-go-site/
+```
+
+`-g` / `--global` always requires an explicit `--agent` so markata-go can choose the right user directory.
 
 ## Preview Without Writing
 
@@ -77,6 +91,8 @@ Example output when the skill is current:
 
 ```text
 Skill:     markata-go-site
+Agent:     universal
+Scope:     project
 Location:  .agents/skills/markata-go-site/
 Installed: 0.5.0
 Current:   0.5.0
@@ -92,6 +108,8 @@ Example output when drift is detected:
 
 ```text
 Skill:     markata-go-site
+Agent:     universal
+Scope:     project
 Location:  .agents/skills/markata-go-site/
 Installed: 0.4.0
 Current:   0.5.0
@@ -131,7 +149,13 @@ markata-go agent uninstall
 You can also target Claude Code's layout explicitly:
 
 ```bash
-markata-go agent remove --target claude
+markata-go agent remove --agent claude-code
+```
+
+Remove from a global agent directory:
+
+```bash
+markata-go agent remove --agent opencode -g
 ```
 
 ## Installed Layout
@@ -181,6 +205,12 @@ Topic files provide narrative guidance for common tasks. Reference files give qu
 - template variable reference for post, feed, and base templates
 - feed config patterns and common feed recipes
 - starter config and template files for new sites
+
+## Supported Agents
+
+`markata-go agent` mirrors the same agent identifiers as `vercel-labs/skills`, including `opencode`, `claude-code`, `codex`, `cursor`, `gemini-cli`, `qwen-code`, `warp`, `windsurf`, `github-copilot`, and the rest of that compatibility matrix.
+
+For project installs, omitting `--agent` uses the current agent when markata-go can detect it from the environment. If no agent is detected, markata-go falls back to `universal`, which installs to `.agents/skills/markata-go-site/`.
 
 ## Recommended Workflow For Agents
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -93,7 +93,8 @@ Install the bundled `markata-go-site` skill into a repository.
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `--target` | Install target layout: `agents` or `claude` | `agents` |
+| `--agent` | Install for a specific agent such as `opencode`, `claude-code`, or `cursor` | auto-detected, else `universal` |
+| `-g`, `--global` | Install into the selected agent's user-level skill directory | `false` |
 | `--name` | Installed skill directory name | `markata-go-site` |
 | `--force` | Overwrite bundled skill files if they already exist | `false` |
 | `--dry-run` | Show what would be installed without writing files | `false` |
@@ -106,7 +107,8 @@ This is the user-friendly equivalent of reinstalling with `--force`.
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `--target` | Install target layout: `agents` or `claude` | `agents` |
+| `--agent` | Update a specific agent install such as `opencode` or `claude-code` | auto-detected, else `universal` |
+| `-g`, `--global` | Update the selected agent's user-level skill directory | `false` |
 | `--name` | Installed skill directory name | `markata-go-site` |
 | `--dry-run` | Show what would be updated without writing files | `false` |
 
@@ -116,7 +118,8 @@ Check the installed skill for drift against the versions bundled in the current 
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `--target` | Install target layout: `agents` or `claude` | `agents` |
+| `--agent` | Check a specific agent install such as `opencode` or `claude-code` | auto-detected, else `universal` |
+| `-g`, `--global` | Check the selected agent's user-level skill directory | `false` |
 | `--name` | Installed skill directory name | `markata-go-site` |
 
 Exit codes:
@@ -135,17 +138,21 @@ Remove the installed `markata-go-site` skill directory.
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `--target` | Install target layout: `agents` or `claude` | `agents` |
+| `--agent` | Remove a specific agent install such as `opencode` or `claude-code` | auto-detected, else `universal` |
+| `-g`, `--global` | Remove from the selected agent's user-level skill directory | `false` |
 | `--name` | Installed skill directory name | `markata-go-site` |
 
 #### Examples
 
 ```bash
-# Install into the portable .agents layout
+# Install into the detected agent's project layout
 markata-go agent install
 
 # Install into Claude Code's .claude layout
-markata-go agent install --target claude
+markata-go agent install --agent claude-code
+
+# Install into OpenCode's global skill directory
+markata-go agent install --agent opencode -g
 
 # Preview files without writing
 markata-go agent install --dry-run
@@ -166,7 +173,10 @@ markata-go agent update --dry-run
 markata-go agent doctor
 
 # Check a Claude Code layout
-markata-go agent doctor --target claude
+markata-go agent doctor --agent claude-code
+
+# Check a global OpenCode install
+markata-go agent doctor --agent opencode -g
 
 # Check a different repository
 markata-go agent doctor ../my-site
@@ -178,15 +188,22 @@ markata-go agent remove
 markata-go agent uninstall
 
 # Remove a Claude Code install
-markata-go agent remove --target claude
+markata-go agent remove --agent claude-code
+
+# Remove a global OpenCode install
+markata-go agent remove --agent opencode -g
 ```
 
 #### Installed Layouts
 
-- `agents` target: `.agents/skills/markata-go-site/`
-- `claude` target: `.claude/skills/markata-go-site/`
+- detected agent or `universal`: project install into that agent's project skill path
+- `--agent claude-code`: `.claude/skills/markata-go-site/`
+- `--agent opencode`: `.agents/skills/markata-go-site/`
+- `--agent opencode -g`: `~/.config/opencode/skills/markata-go-site/`
 
 The installed skill is split into `SKILL.md` plus focused topic files under `topics/`, reference material under `reference/`, starter files under `examples/`, and regression prompts under `evals/` so agents can read only the sections relevant to the current task while maintainers still have a starter eval set for bundled-skill reviews. A `.manifest.json` file is written alongside the skill for drift detection via `agent doctor`.
+
+When `-g` is used, `--agent` is required and `site-path` is not accepted.
 
 The `agent` command group is intentionally generic so future subcommands can add export or MCP-oriented integrations without changing the bundled skill format.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -87,6 +87,10 @@ markata-go agent install [site-path] [flags]
 
 #### Subcommands
 
+##### list-agents
+
+List the supported agent identifiers and their project/global skill directories.
+
 ##### install
 
 Install the bundled `markata-go-site` skill into a repository.
@@ -147,6 +151,9 @@ Remove the installed `markata-go-site` skill directory.
 ```bash
 # Install into the detected agent's project layout
 markata-go agent install
+
+# List supported agent ids and paths
+markata-go agent list-agents
 
 # Install into Claude Code's .claude layout
 markata-go agent install --agent claude-code

--- a/pkg/agentskill/bundle/markata-go-site/topics/cli-usage.md
+++ b/pkg/agentskill/bundle/markata-go-site/topics/cli-usage.md
@@ -84,7 +84,8 @@ Bare `markata-go config` behaves like `markata-go config show`.
 - `markata-go update` (self-update from GitHub releases)
 - `markata-go update --check` (check for updates without installing)
 - `markata-go benchmark --scenario small|medium|large` (performance benchmarks)
-- `markata-go agent install` (install bundled agent skill into site)
+- `markata-go agent install` (install bundled agent skill into the detected project agent or the universal layout)
+- `markata-go agent install --agent <name> [-g]` (choose a specific agent and optional global install scope)
 - `markata-go agent doctor` (check for drift after binary upgrades)
 - `markata-go version`
 

--- a/pkg/agentskill/bundle/markata-go-site/topics/cli-usage.md
+++ b/pkg/agentskill/bundle/markata-go-site/topics/cli-usage.md
@@ -84,6 +84,7 @@ Bare `markata-go config` behaves like `markata-go config show`.
 - `markata-go update` (self-update from GitHub releases)
 - `markata-go update --check` (check for updates without installing)
 - `markata-go benchmark --scenario small|medium|large` (performance benchmarks)
+- `markata-go agent list-agents` (list supported agent ids and their install paths)
 - `markata-go agent install` (install bundled agent skill into the detected project agent or the universal layout)
 - `markata-go agent install --agent <name> [-g]` (choose a specific agent and optional global install scope)
 - `markata-go agent doctor` (check for drift after binary upgrades)

--- a/pkg/agentskill/manifest.go
+++ b/pkg/agentskill/manifest.go
@@ -21,12 +21,13 @@ type Manifest struct {
 	Version     string            `json:"version"`
 	InstalledAt time.Time         `json:"installed_at"`
 	Target      string            `json:"target"`
+	Scope       string            `json:"scope,omitempty"`
 	Files       map[string]string `json:"files"`
 }
 
 // ComputeBundledManifest builds a Manifest from the current bundled skill files.
-// The version and target fields are set by the caller.
-func ComputeBundledManifest(version, target string) (*Manifest, error) {
+// The version, target, and scope fields are set by the caller.
+func ComputeBundledManifest(version, target, scope string) (*Manifest, error) {
 	skillFS, err := SiteSkill()
 	if err != nil {
 		return nil, fmt.Errorf("load bundled skill: %w", err)
@@ -50,6 +51,7 @@ func ComputeBundledManifest(version, target string) (*Manifest, error) {
 		Version:     version,
 		InstalledAt: time.Now().UTC().Truncate(time.Second),
 		Target:      target,
+		Scope:       scope,
 		Files:       fileHashes,
 	}, nil
 }

--- a/pkg/agentskill/manifest_test.go
+++ b/pkg/agentskill/manifest_test.go
@@ -13,7 +13,7 @@ func TestComputeBundledManifest_IncludesAllFiles(t *testing.T) {
 		t.Fatalf("ListFiles() error = %v", err)
 	}
 
-	manifest, err := ComputeBundledManifest("0.1.0-test", "agents")
+	manifest, err := ComputeBundledManifest("0.1.0-test", "universal", "project")
 	if err != nil {
 		t.Fatalf("ComputeBundledManifest() error = %v", err)
 	}
@@ -21,8 +21,11 @@ func TestComputeBundledManifest_IncludesAllFiles(t *testing.T) {
 	if manifest.Version != "0.1.0-test" {
 		t.Errorf("Version = %q, want %q", manifest.Version, "0.1.0-test")
 	}
-	if manifest.Target != "agents" {
-		t.Errorf("Target = %q, want %q", manifest.Target, "agents")
+	if manifest.Target != "universal" {
+		t.Errorf("Target = %q, want %q", manifest.Target, "universal")
+	}
+	if manifest.Scope != "project" {
+		t.Errorf("Scope = %q, want %q", manifest.Scope, "project")
 	}
 	if len(manifest.Files) != len(files) {
 		t.Errorf("Files count = %d, want %d", len(manifest.Files), len(files))
@@ -41,11 +44,11 @@ func TestComputeBundledManifest_IncludesAllFiles(t *testing.T) {
 }
 
 func TestComputeBundledManifest_DeterministicHashes(t *testing.T) {
-	m1, err := ComputeBundledManifest("v1", "agents")
+	m1, err := ComputeBundledManifest("v1", "universal", "project")
 	if err != nil {
 		t.Fatalf("first ComputeBundledManifest() error = %v", err)
 	}
-	m2, err := ComputeBundledManifest("v2", "claude")
+	m2, err := ComputeBundledManifest("v2", "claude-code", "global")
 	if err != nil {
 		t.Fatalf("second ComputeBundledManifest() error = %v", err)
 	}
@@ -66,7 +69,7 @@ func TestComputeBundledManifest_DeterministicHashes(t *testing.T) {
 func TestWriteAndReadManifest_RoundTrip(t *testing.T) {
 	dir := t.TempDir()
 
-	original, err := ComputeBundledManifest("0.5.0", "agents")
+	original, err := ComputeBundledManifest("0.5.0", "universal", "project")
 	if err != nil {
 		t.Fatalf("ComputeBundledManifest() error = %v", err)
 	}
@@ -96,6 +99,9 @@ func TestWriteAndReadManifest_RoundTrip(t *testing.T) {
 	if loaded.Target != original.Target {
 		t.Errorf("Target = %q, want %q", loaded.Target, original.Target)
 	}
+	if loaded.Scope != original.Scope {
+		t.Errorf("Scope = %q, want %q", loaded.Scope, original.Scope)
+	}
 	if len(loaded.Files) != len(original.Files) {
 		t.Errorf("Files count = %d, want %d", len(loaded.Files), len(original.Files))
 	}
@@ -116,7 +122,7 @@ func TestReadManifest_MissingFile(t *testing.T) {
 
 func TestComputeDrift_NoDrift(t *testing.T) {
 	dir := t.TempDir()
-	manifest, err := ComputeBundledManifest("0.5.0", "agents")
+	manifest, err := ComputeBundledManifest("0.5.0", "universal", "project")
 	if err != nil {
 		t.Fatalf("ComputeBundledManifest() error = %v", err)
 	}
@@ -142,7 +148,7 @@ func TestComputeDrift_NoDrift(t *testing.T) {
 func TestComputeDrift_NewFile(t *testing.T) {
 	dir := t.TempDir()
 	// Create a manifest with one file missing from the real bundle.
-	manifest, err := ComputeBundledManifest("0.4.0", "agents")
+	manifest, err := ComputeBundledManifest("0.4.0", "universal", "project")
 	if err != nil {
 		t.Fatalf("ComputeBundledManifest() error = %v", err)
 	}
@@ -181,7 +187,7 @@ func TestComputeDrift_NewFile(t *testing.T) {
 
 func TestComputeDrift_ModifiedFile(t *testing.T) {
 	dir := t.TempDir()
-	manifest, err := ComputeBundledManifest("0.4.0", "agents")
+	manifest, err := ComputeBundledManifest("0.4.0", "universal", "project")
 	if err != nil {
 		t.Fatalf("ComputeBundledManifest() error = %v", err)
 	}
@@ -222,7 +228,7 @@ func TestComputeDrift_ModifiedFile(t *testing.T) {
 
 func TestComputeDrift_MissingFile(t *testing.T) {
 	dir := t.TempDir()
-	manifest, err := ComputeBundledManifest("0.4.0", "agents")
+	manifest, err := ComputeBundledManifest("0.4.0", "universal", "project")
 	if err != nil {
 		t.Fatalf("ComputeBundledManifest() error = %v", err)
 	}
@@ -262,7 +268,7 @@ func TestComputeDrift_MissingFile(t *testing.T) {
 
 func TestComputeDrift_VersionMismatch(t *testing.T) {
 	dir := t.TempDir()
-	manifest, err := ComputeBundledManifest("0.4.0", "agents")
+	manifest, err := ComputeBundledManifest("0.4.0", "universal", "project")
 	if err != nil {
 		t.Fatalf("ComputeBundledManifest() error = %v", err)
 	}

--- a/spec/spec/AGENTS.md
+++ b/spec/spec/AGENTS.md
@@ -94,19 +94,64 @@ When such a change does not require modifying the bundled skill, the implementat
 
 ## Installation Targets
 
-The CLI MUST support installing the bundled skill into target-specific directory layouts.
+The CLI MUST support agent-specific directory layouts using the same agent identifiers documented by `vercel-labs/skills`.
 
-Initial targets:
+Required agent identifiers:
 
-1. `agents`
-Path:
-`.agents/skills/<skill-name>/`
+- `adal`
+- `amp`
+- `antigravity`
+- `augment`
+- `bob`
+- `claude-code`
+- `cline`
+- `codebuddy`
+- `codex`
+- `command-code`
+- `continue`
+- `cortex`
+- `crush`
+- `cursor`
+- `deepagents`
+- `droid`
+- `firebender`
+- `gemini-cli`
+- `github-copilot`
+- `goose`
+- `iflow-cli`
+- `junie`
+- `kimi-cli`
+- `kilo`
+- `kiro-cli`
+- `kode`
+- `mcpjam`
+- `mistral-vibe`
+- `mux`
+- `neovate`
+- `openclaw`
+- `opencode`
+- `openhands`
+- `pi`
+- `pochi`
+- `qoder`
+- `qwen-code`
+- `replit`
+- `roo`
+- `trae`
+- `trae-cn`
+- `universal`
+- `warp`
+- `windsurf`
+- `zencoder`
 
-2. `claude`
-Path:
-`.claude/skills/<skill-name>/`
+The CLI MUST resolve each agent to the same project and global skill directories used by `vercel-labs/skills`.
 
-The installed file contents MUST remain the same across targets unless a future target explicitly requires generated wrappers.
+Legacy compatibility aliases MAY be accepted for existing users:
+
+- `agents` -> `universal`
+- `claude` -> `claude-code`
+
+The installed file contents MUST remain the same across agents unless a future target explicitly requires generated wrappers.
 
 ## CLI
 
@@ -120,15 +165,23 @@ markata-go agent install [site-path]
 
 Required flags:
 
-- `--target`
+- `--agent`
 - `--name`
 - `--force`
 - `--dry-run`
 
+Optional flags:
+
+- `-g`, `--global`
+
 ### `install` behavior
 
 - `site-path` defaults to the current directory.
-- The command MUST install bundled files into the selected target layout.
+- When `--agent` is omitted for project installs, the command MUST default to the current agent when it can detect one from the environment. If no current agent can be detected, it MUST default to `universal`.
+- `--global` MUST require an explicit `--agent`.
+- `--global` MUST install into the selected agent's user-level skill directory instead of a repository path.
+- `site-path` MUST be rejected when `--global` is set.
+- The command MUST install bundled files into the selected agent layout.
 - The command MUST fail clearly when destination files already exist and `--force` is not set.
 - `--dry-run` MUST report what would be written without modifying the filesystem.
 - Primary results MUST be written to `stdout`.
@@ -142,15 +195,21 @@ markata-go agent update [site-path]
 
 Required flags:
 
-- `--target`
+- `--agent`
 - `--name`
 - `--dry-run`
+
+Optional flags:
+
+- `-g`, `--global`
 
 ### `update` behavior
 
 - `site-path` defaults to the current directory.
 - The command MUST update the installed skill in place using the currently bundled files.
-- `update` MUST behave like `install --force` with the same target and name resolution.
+- `update` MUST behave like `install --force` with the same agent and scope resolution.
+- `--global` MUST require an explicit `--agent`.
+- `site-path` MUST be rejected when `--global` is set.
 - `--dry-run` MUST report what would be updated without modifying the filesystem.
 - Primary results MUST be written to `stdout`.
 
@@ -163,13 +222,19 @@ markata-go agent uninstall [site-path]
 
 Required flags:
 
-- `--target`
+- `--agent`
 - `--name`
+
+Optional flags:
+
+- `-g`, `--global`
 
 ### `remove` behavior
 
 - `site-path` defaults to the current directory.
-- The command MUST remove the installed skill directory for the selected target and name.
+- The command MUST remove the installed skill directory for the selected agent, scope, and name.
+- `--global` MUST require an explicit `--agent`.
+- `site-path` MUST be rejected when `--global` is set.
 - `uninstall` MUST be a direct alias for `remove`.
 - The command MUST fail clearly when the skill is not installed at the resolved location.
 - Primary results MUST be written to `stdout`.
@@ -182,7 +247,8 @@ The manifest MUST contain:
 
 - `version` — the markata-go binary version string (from `cmd.Version`)
 - `installed_at` — RFC 3339 timestamp of installation
-- `target` — the install target used (`agents` or `claude`)
+- `target` — the selected agent identifier (for example `opencode` or `claude-code`)
+- `scope` — `project` or `global`
 - `files` — a map of relative file paths to their SHA-256 hex digests
 
 The manifest MUST NOT be included in the overwrite-protection check. It is always overwritten on install.
@@ -195,7 +261,8 @@ Example manifest:
 {
   "version": "0.5.0",
   "installed_at": "2026-04-01T12:00:00Z",
-  "target": "agents",
+  "target": "opencode",
+  "scope": "project",
   "files": {
     "SKILL.md": "a1b2c3...",
     "topics/configuration.md": "d4e5f6..."
@@ -211,15 +278,21 @@ markata-go agent doctor [site-path]
 
 Required flags:
 
-- `--target`
+- `--agent`
 - `--name`
+
+Optional flags:
+
+- `-g`, `--global`
 
 ### `doctor` behavior
 
 The `doctor` command detects drift between installed skill files and the bundled versions in the current binary.
 
 - `site-path` defaults to the current directory.
-- The command MUST locate the installed skill directory using the same target/name resolution as `install`.
+- The command MUST locate the installed skill directory using the same agent/scope/name resolution as `install`.
+- `--global` MUST require an explicit `--agent`.
+- `site-path` MUST be rejected when `--global` is set.
 - If no manifest file exists, the command MUST report that the skill was installed without a manifest and recommend re-installing with the current binary.
 - If the manifest exists, the command MUST compare:
   1. The `version` field against the current binary version.

--- a/spec/spec/AGENTS.md
+++ b/spec/spec/AGENTS.md
@@ -163,6 +163,20 @@ Initial command:
 markata-go agent install [site-path]
 ```
 
+Additional required subcommand:
+
+```bash
+markata-go agent list-agents
+```
+
+### `list-agents` behavior
+
+- The command MUST be read-only.
+- The command MUST write primary results to `stdout`.
+- The command MUST list each supported agent identifier.
+- The command MUST include the project and global skill directories for each agent.
+- When compatibility aliases exist, the command SHOULD show them.
+
 Required flags:
 
 - `--agent`


### PR DESCRIPTION
## Summary
- mirror the `vercel-labs/skills` agent identifiers in `markata-go agent` and add `--agent` plus `-g/--global` support for install, update, doctor, and remove
- default project installs to the current detected agent when possible, fall back to `universal`, and keep legacy `--target` aliases working behind the scenes
- update the manifest, specs, docs, built-in explain text, and CLI topic guidance so the new agent resolution and scope rules are documented end-to-end

## Testing
- `go test ./cmd/markata-go/cmd ./pkg/agentskill`
- `go test ./...`
- `go run ./cmd/markata-go agent install --help`
- `go run ./cmd/markata-go agent install --dry-run`
- `go run ./cmd/markata-go agent install --agent opencode --global --dry-run`
- `go run ./cmd/markata-go agent install --global` (expected failure)

## Notes
- `just lint-fast` currently fails for pre-existing repo/toolchain issues outside this change set, including unrelated typecheck/import failures and a Go version mismatch in dependencies
- Refs #1003