### PR TITLE
fix(feeds): honor template aliases in feed filters

### DIFF
--- a/docs/guides/feeds.md
+++ b/docs/guides/feeds.md
@@ -206,6 +206,8 @@ json = "feed.json"                 # Template for JSON
 
 The `filter` field uses a Python-like expression syntax to select which posts appear in a feed.
 
+For template-based filters, `template` and `templateKey` are interchangeable. Equality checks also respect built-in template aliases, so `templateKey == "shots"` matches posts using `shot`, `shots`, or `photo`.
+
 ### Filter Operators
 
 | Operator | Description | Example |
@@ -243,6 +245,9 @@ filter = "date >= '2024-01-01' and date < '2025-01-01'"
 
 # By slug
 filter = "slug != 'about'"
+
+# Template aliases
+filter = "templateKey == 'shots' and 'family' in tags"
 
 # Complex filter
 filter = "published == True and ('python' in tags or 'go' in tags) and featured == True"

--- a/pkg/filter/evaluator.go
+++ b/pkg/filter/evaluator.go
@@ -471,7 +471,7 @@ func getFieldFromValue(obj interface{}, field string) (interface{}, error) {
 	}
 }
 
-func compareTemplateAliasExprs(leftExpr, rightExpr Expr, left, right interface{}) (bool, bool) {
+func compareTemplateAliasExprs(leftExpr, rightExpr Expr, left, right interface{}) (result, ok bool) {
 	if !isTemplateIdentifier(leftExpr) && !isTemplateIdentifier(rightExpr) {
 		return false, false
 	}

--- a/pkg/filter/evaluator.go
+++ b/pkg/filter/evaluator.go
@@ -15,6 +15,52 @@ const (
 	opOr  = "or"
 )
 
+var templateFilterAliases = map[string]string{
+	"article":   "article",
+	"blog-post": "article",
+	"essay":     "article",
+	"post":      "article",
+	"tutorial":  "article",
+
+	"note":    "note",
+	"ping":    "note",
+	"status":  "note",
+	"thought": "note",
+	"tweet":   "note",
+
+	"gallery": "photo",
+	"image":   "photo",
+	"photo":   "photo",
+	"shot":    "photo",
+	"shots":   "photo",
+
+	"cast":   "video",
+	"clip":   "video",
+	"stream": "video",
+	"video":  "video",
+
+	"bookmark": "link",
+	"link":     "link",
+	"stars":    "link",
+	"til":      "link",
+
+	"quotation": "quote",
+	"quote":     "quote",
+
+	"chapter": "guide",
+	"guide":   "guide",
+	"series":  "guide",
+	"step":    "guide",
+
+	"gratitude": "inline",
+	"inline":    "inline",
+	"micro":     "inline",
+
+	"character": "contact",
+	"contact":   "contact",
+	"person":    "contact",
+}
+
 // EvalContext contains the context for evaluating filter expressions
 type EvalContext struct {
 	Today time.Time
@@ -140,8 +186,14 @@ func evalBinaryExpr(e *BinaryExpr, post *models.Post, ctx *EvalContext) (interfa
 	// Handle comparison operators
 	switch e.Op {
 	case "==":
+		if result, ok := compareTemplateAliasExprs(e.Left, e.Right, left, right); ok {
+			return result, nil
+		}
 		return compare(left, right) == 0, nil
 	case "!=":
+		if result, ok := compareTemplateAliasExprs(e.Left, e.Right, left, right); ok {
+			return !result, nil
+		}
 		return compare(left, right) != 0, nil
 	case "<":
 		cmp := compare(left, right)
@@ -350,6 +402,8 @@ func getKnownField(post *models.Post, name string) (interface{}, bool) {
 			return nil, true
 		}
 		return *post.Description, true
+	case "templateKey", "templatekey", "TemplateKey":
+		return post.Template, true
 	case "template", "Template":
 		return post.Template, true
 	case "html", "HTML":
@@ -415,6 +469,53 @@ func getFieldFromValue(obj interface{}, field string) (interface{}, error) {
 	default:
 		return nil, fmt.Errorf("cannot access field '%s' on type %T", field, obj)
 	}
+}
+
+func compareTemplateAliasExprs(leftExpr, rightExpr Expr, left, right interface{}) (bool, bool) {
+	if !isTemplateIdentifier(leftExpr) && !isTemplateIdentifier(rightExpr) {
+		return false, false
+	}
+
+	leftTemplate, ok := normalizeTemplateFilterValue(left)
+	if !ok {
+		return false, false
+	}
+	rightTemplate, ok := normalizeTemplateFilterValue(right)
+	if !ok {
+		return false, false
+	}
+
+	return leftTemplate == rightTemplate, true
+}
+
+func isTemplateIdentifier(expr Expr) bool {
+	ident, ok := expr.(*Identifier)
+	if !ok {
+		return false
+	}
+
+	switch strings.ToLower(strings.TrimSpace(ident.Name)) {
+	case "template", "templatekey":
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeTemplateFilterValue(value interface{}) (string, bool) {
+	template, ok := value.(string)
+	if !ok {
+		return "", false
+	}
+
+	normalized := strings.ToLower(strings.TrimSpace(template))
+	if normalized == "" {
+		return "", true
+	}
+	if canonical, ok := templateFilterAliases[normalized]; ok {
+		return canonical, true
+	}
+	return normalized, true
 }
 
 // toBool converts a value to a boolean

--- a/pkg/filter/evaluator_test.go
+++ b/pkg/filter/evaluator_test.go
@@ -63,6 +63,12 @@ func withDate(date time.Time) func(*models.Post) {
 	}
 }
 
+func withTemplate(template string) func(*models.Post) {
+	return func(p *models.Post) {
+		p.Template = template
+	}
+}
+
 func withExtra(key string, value interface{}) func(*models.Post) {
 	return func(p *models.Post) {
 		p.Set(key, value)
@@ -111,6 +117,24 @@ func TestEvaluate_BooleanComparison(t *testing.T) {
 			expr:     "author == 'waylon'",
 			post:     makePost(withAuthor("waylon")),
 			expected: true,
+		},
+		{
+			name:     "templateKey aliases template",
+			expr:     `templateKey == "photo"`,
+			post:     makePost(withTemplate("shots")),
+			expected: true,
+		},
+		{
+			name:     "template equality respects aliases",
+			expr:     `template == "shots"`,
+			post:     makePost(withTemplate("photo")),
+			expected: true,
+		},
+		{
+			name:     "template inequality respects aliases",
+			expr:     `template != "shots"`,
+			post:     makePost(withTemplate("photo")),
+			expected: false,
 		},
 	}
 

--- a/pkg/plugins/feeds_test.go
+++ b/pkg/plugins/feeds_test.go
@@ -806,9 +806,9 @@ func TestFilterPosts(t *testing.T) {
 	date := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
 
 	posts := []*models.Post{
-		{Slug: "post1", Tags: []string{"python"}, Date: &date},
-		{Slug: "post2", Tags: []string{"go"}, Date: &date},
-		{Slug: "post3", Tags: []string{"python", "go"}, Date: &date},
+		{Slug: "post1", Tags: []string{"python"}, Date: &date, Template: "photo"},
+		{Slug: "post2", Tags: []string{"go"}, Date: &date, Template: "video"},
+		{Slug: "post3", Tags: []string{"python", "go"}, Date: &date, Template: "shot"},
 	}
 
 	tests := []struct {
@@ -826,6 +826,12 @@ func TestFilterPosts(t *testing.T) {
 		{
 			name:      "filter by tag",
 			filter:    `'python' in tags`,
+			wantCount: 2,
+			wantSlugs: []string{"post1", "post3"},
+		},
+		{
+			name:      "filter by templateKey alias",
+			filter:    `templateKey == "shots"`,
 			wantCount: 2,
 			wantSlugs: []string{"post1", "post3"},
 		},

--- a/spec/spec/FEEDS.md
+++ b/spec/spec/FEEDS.md
@@ -927,6 +927,8 @@ With custom template:
 │                                                                      │
 │  2. FILTER                                                           │
 │     - For each feed, run filter expression against all posts        │
+│     - `template` and `templateKey` MUST behave as the same field    │
+│     - Template equality checks MUST respect built-in aliases        │
 │     - Store matching posts in feed.posts                             │
 │                                                                      │
 │  3. SORT                                                             │


### PR DESCRIPTION
## Summary
- make `template` and `templateKey` behave the same in feed filter evaluation
- normalize built-in template aliases for `==` and `!=` checks so values like `shots`, `shot`, and `photo` match consistently
- add coverage in filter and feed tests, and document the behavior in the feed spec and guide

## Issue
Fixes #1008

## Testing
- `go test ./pkg/filter ./pkg/plugins`
- `just lint-fast` *(currently fails due to unrelated repo-wide typecheck issues in existing files and dependencies)*