### PR TITLE
fix(feed-cards): render video media in article cards

### DIFF
--- a/pkg/themes/default/templates/partials/cards/article-card.html
+++ b/pkg/themes/default/templates/partials/cards/article-card.html
@@ -6,7 +6,11 @@
 <article class="card card-article h-entry{% if media_src %} has-cover{% endif %}">
 {% if media_src %}
 <a href="{{ post.href }}" class="card-cover u-url">
-<img src="{{ media_src|with_size:"600" }}" alt="{{ post.title | default:post.slug }}" class="card-cover-img u-photo" loading="lazy">
+{% if media_src|is_video %}{% set poster_candidate = post | poster_url:media_src %}<video class="card-cover-img u-video" autoplay muted loop playsinline{% if poster_candidate %} poster="{{ poster_candidate | with_size:"600" }}"{% endif %}>
+<source src="{{ media_src|with_size:"600" }}"{% with media_src|video_mime as mime %}{% if mime %} type="{{ mime }}"{% endif %}{% endwith %}>
+</video>
+{% else %}<img src="{{ media_src|with_size:"600" }}" alt="{{ post.title | default:post.slug }}" class="card-cover-img u-photo" loading="lazy">
+{% endif %}
 </a>
 {% endif %}
 <div class="card-content">


### PR DESCRIPTION
## Summary
- render a <video> element in the default theme article card when frontmatter media resolves to a video URL
- reuse existing media helpers for MIME type and poster handling so image behavior stays unchanged
- fixes the broken <img src="...mp4"> markup seen on tag/feed card pages such as /tags/guide/

Fixes #1015
