### PR TITLE
fix(contribution_graph): clamp outliers and fit narrow layouts

### DIFF
--- a/docs/guides/analytics.md
+++ b/docs/guides/analytics.md
@@ -32,6 +32,7 @@ enabled = true
 cdn_url = "/assets/vendor/cal-heatmap"                # Cal-Heatmap base URL (local by default)
 container_class = "contribution-graph-container"
 theme = "light"
+scale_max_percentile = 0                               # Optional global outlier cap
 ```
 
 ### Configuration Options
@@ -42,6 +43,7 @@ theme = "light"
 | `cdn_url` | string | `/assets/vendor/cal-heatmap` | Cal-Heatmap base URL (local by default) |
 | `container_class` | string | `contribution-graph-container` | CSS class for the container |
 | `theme` | string | `light` | Color theme (`light` or `dark`) |
+| `scale_max_percentile` | number | `0` | Optional global percentile cap for the color scale |
 
 ### Basic Usage
 
@@ -79,6 +81,8 @@ The `data` array contains objects with:
 | `subDomain` | string | `day` | Sub-domain: `day`, `hour`, `minute` |
 | `cellSize` | number | `10` | Size of each cell in pixels |
 | `range` | number | `1` | Number of domain units to display |
+| `maxValue` | number | unset | Explicit color-scale maximum |
+| `maxPercentile` | number | unset | Per-graph percentile cap for the color scale |
 
 ### Examples
 
@@ -125,6 +129,31 @@ Show activity by month:
 ```
 ````
 
+#### Outlier Control
+
+When one or two very large days wash out the rest of the graph, cap the color scale at a percentile instead of the raw max:
+
+````markdown
+```contribution-graph
+{
+  "data": [
+    {"date": "2024-01-01", "value": 1},
+    {"date": "2024-01-02", "value": 2},
+    {"date": "2024-01-03", "value": 3},
+    {"date": "2024-01-04", "value": 25}
+  ],
+  "options": {
+    "domain": "year",
+    "subDomain": "day",
+    "range": 1,
+    "maxPercentile": 95
+  }
+}
+```
+````
+
+Set `scale_max_percentile` in config to apply the same percentile cap to every contribution graph by default.
+
 #### Tracking Blog Post Frequency
 
 Use Jinja templating to automatically generate data from your posts:
@@ -157,7 +186,7 @@ Add custom CSS to style your contribution graphs:
 ```css
 .contribution-graph-container {
   margin: 2rem 0;
-  overflow-x: auto;
+  overflow: hidden;
 }
 
 /* Cal-Heatmap specific overrides */

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -1825,6 +1825,7 @@ enabled = true
 cdn_url = "/assets/vendor/cal-heatmap"                # Cal-Heatmap base URL (local by default)
 container_class = "contribution-graph-container"
 theme = "light"
+scale_max_percentile = 0
 ```
 
 **Options:**
@@ -1834,6 +1835,7 @@ theme = "light"
 | `cdn_url` | `/assets/vendor/cal-heatmap` | Cal-Heatmap base URL (local by default) |
 | `container_class` | `contribution-graph-container` | CSS class for wrapper div |
 | `theme` | `light` | Color theme (light, dark) |
+| `scale_max_percentile` | `0` | Global percentile cap for contribution graph color scaling |
 
 **Markdown syntax:**
 ````markdown
@@ -1885,6 +1887,10 @@ document.addEventListener('DOMContentLoaded', function() {
 | `subDomain` | string | `day` | Sub-domain: day, hour, minute |
 | `cellSize` | number | `10` | Cell size in pixels |
 | `range` | number | `1` | Number of domain units to display |
+| `maxValue` | number | unset | Explicit color-scale maximum |
+| `maxPercentile` | number | unset | Per-graph percentile cap for the color scale |
+
+The plugin also fits rendered graphs to narrow content columns automatically, so pages do not need custom resize JavaScript in markdown.
 
 **Use cases:**
 - Blog post publishing frequency

--- a/pkg/agentskill/bundle/markata-go-site/topics/analytics-storytelling.md
+++ b/pkg/agentskill/bundle/markata-go-site/topics/analytics-storytelling.md
@@ -252,13 +252,16 @@ Guidance:
   ],
   "options": {
     "domain": "year",
-    "subDomain": "day"
+    "subDomain": "day",
+    "maxPercentile": 95
   }
 }
 ```
 ````
 
 Use this when the author wants a calendar-like view of publishing cadence.
+`maxPercentile` is useful when a few unusually large days would otherwise wash out the rest of the heatmap.
+The built-in contribution graph runtime also fits graphs to narrow content columns, so agents should not add page-specific resize JavaScript unless the site has a special layout need.
 
 ### `chartjs` chart from built-in site stats
 

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -1445,15 +1445,20 @@ type ContributionGraphConfig struct {
 
 	// Theme is the Cal-Heatmap color theme (default: "light")
 	Theme string `json:"theme" yaml:"theme" toml:"theme"`
+
+	// ScaleMaxPercentile caps the color scale at this percentile when set to a value between 0 and 100.
+	// A value of 0 disables percentile-based outlier control.
+	ScaleMaxPercentile float64 `json:"scale_max_percentile,omitempty" yaml:"scale_max_percentile,omitempty" toml:"scale_max_percentile,omitempty"`
 }
 
 // NewContributionGraphConfig creates a new ContributionGraphConfig with default values.
 func NewContributionGraphConfig() ContributionGraphConfig {
 	return ContributionGraphConfig{
-		Enabled:        true,
-		CDNURL:         "/assets/vendor/cal-heatmap",
-		ContainerClass: "contribution-graph-container",
-		Theme:          "light",
+		Enabled:            true,
+		CDNURL:             "/assets/vendor/cal-heatmap",
+		ContainerClass:     "contribution-graph-container",
+		Theme:              "light",
+		ScaleMaxPercentile: 0,
 	}
 }
 

--- a/pkg/plugins/contribution_graph.go
+++ b/pkg/plugins/contribution_graph.go
@@ -5,10 +5,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"html"
+	"math"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
 	"github.com/WaylonWalker/markata-go/pkg/models"
@@ -79,6 +82,9 @@ func (p *ContributionGraphPlugin) Configure(m *lifecycle.Manager) error {
 		if theme, ok := cfgMap["theme"].(string); ok && theme != "" {
 			p.config.Theme = theme
 		}
+		if percentile, ok := cfgMap["scale_max_percentile"].(float64); ok {
+			p.config.ScaleMaxPercentile = percentile
+		}
 	}
 
 	return nil
@@ -97,7 +103,9 @@ func (p *ContributionGraphPlugin) Render(m *lifecycle.Manager) error {
 		return strings.Contains(post.ArticleHTML, `class="language-contribution-graph"`)
 	})
 
-	return m.ProcessPostsSliceConcurrently(posts, p.processPost)
+	return m.ProcessPostsSliceConcurrently(posts, func(post *models.Post) error {
+		return p.processPost(m, post)
+	})
 }
 
 // contributionGraphCodeBlockRegex matches <pre><code class="language-contribution-graph"> blocks.
@@ -107,7 +115,7 @@ var contributionGraphCodeBlockRegex = regexp.MustCompile(
 )
 
 // processPost processes a single post's HTML for contribution-graph code blocks.
-func (p *ContributionGraphPlugin) processPost(post *models.Post) error {
+func (p *ContributionGraphPlugin) processPost(m *lifecycle.Manager, post *models.Post) error {
 	// Skip posts marked as skip or with no HTML content
 	if post.Skip || post.ArticleHTML == "" {
 		return nil
@@ -147,7 +155,6 @@ func (p *ContributionGraphPlugin) processPost(post *models.Post) error {
 		graphID := fmt.Sprintf("contribution-graph-%d", atomic.AddUint64(&p.idCounter, 1))
 
 		// Extract data and options from the config
-		data := graphConfig["data"]
 		options := graphConfig["options"]
 		if options == nil {
 			options = map[string]interface{}{}
@@ -155,6 +162,11 @@ func (p *ContributionGraphPlugin) processPost(post *models.Post) error {
 		optionsMap, ok := options.(map[string]interface{})
 		if !ok || optionsMap == nil {
 			optionsMap = map[string]interface{}{}
+		}
+
+		data := graphConfig["data"]
+		if data == nil {
+			data = p.buildContributionData(m, optionsMap)
 		}
 
 		// Auto-detect year from first data point if not specified
@@ -170,6 +182,8 @@ func (p *ContributionGraphPlugin) processPost(post *models.Post) error {
 				}
 			}
 		}
+
+		maxValue := p.computeColorScaleMax(data, optionsMap)
 
 		// Marshal data and options back to JSON for the script
 		dataJSON, err := json.Marshal(data)
@@ -195,15 +209,37 @@ func (p *ContributionGraphPlugin) processPost(post *models.Post) error {
     const graphId = '%s';
     const data = %s;
     const options = {%s};
+    const maxValue = %d;
+    const displayData = data.map(function(point) {
+      const value = point.value || 0;
+      if (options.maxValue && value > options.maxValue) {
+        return Object.assign({}, point, { value: options.maxValue });
+      }
+      return point;
+    });
+
+    function fitGraph() {
+      const inner = document.getElementById(graphId);
+      if (!inner) return;
+
+      const outer = inner.parentElement;
+      if (!outer) return;
+
+      if (!inner.dataset.baseWidth) {
+        inner.dataset.baseWidth = String(inner.scrollWidth || inner.getBoundingClientRect().width || 0);
+      }
+
+      const baseWidth = Number(inner.dataset.baseWidth) || inner.scrollWidth || inner.getBoundingClientRect().width || 0;
+      const scale = baseWidth > 0 ? Math.min(1, outer.clientWidth / baseWidth) : 1;
+      inner.style.zoom = String(scale);
+    }
 
     function paintGraph() {
       // Clear existing graph
       const container = document.getElementById(graphId);
       if (!container) return;
       container.innerHTML = '';
-
-      // Calculate max value for this graph's scale
-      const maxValue = Math.max(1, ...data.map(d => d.value || 0));
+      delete container.dataset.baseWidth;
 
       // Get theme colors from CSS variables
       const styles = getComputedStyle(document.documentElement);
@@ -220,7 +256,7 @@ func (p *ContributionGraphPlugin) processPost(post *models.Post) error {
         {
           itemSelector: '#' + graphId,
           data: {
-            source: data,
+            source: displayData,
             x: 'date',
             y: 'value'
           },
@@ -241,12 +277,18 @@ func (p *ContributionGraphPlugin) processPost(post *models.Post) error {
             Tooltip,
             {
               text: function (date, value, dayjsDate) {
-                return (value ? value : 'No') + ' posts on ' + dayjsDate.format('MMM D, YYYY');
+                const original = data.find(function(point) {
+                  return point.date === dayjsDate.format('YYYY-MM-DD');
+                });
+                const originalValue = original ? (original.value || 0) : (value || 0);
+                return (originalValue ? originalValue : 'No') + ' posts on ' + dayjsDate.format('MMM D, YYYY');
               },
             },
           ],
         ]
       );
+
+      fitGraph();
     }
 
     // Initial paint
@@ -257,7 +299,12 @@ func (p *ContributionGraphPlugin) processPost(post *models.Post) error {
       window._contributionGraphPainters = [];
     }
     window._contributionGraphPainters.push(paintGraph);
-  })();`, graphID, string(dataJSON), p.buildOptionsObject(optionsJSON))
+
+    if (!window._contributionGraphFitters) {
+      window._contributionGraphFitters = [];
+    }
+    window._contributionGraphFitters.push(fitGraph);
+  })();`, graphID, string(dataJSON), p.buildOptionsObject(optionsJSON), maxValue)
 		initScripts = append(initScripts, initScript)
 
 		// Return the container div
@@ -273,6 +320,122 @@ func (p *ContributionGraphPlugin) processPost(post *models.Post) error {
 
 	post.ArticleHTML = result
 	return nil
+}
+
+type contributionGraphDataPoint struct {
+	Date  string `json:"date"`
+	Value int    `json:"value"`
+}
+
+func (p *ContributionGraphPlugin) buildContributionData(m *lifecycle.Manager, options map[string]interface{}) interface{} {
+	year := time.Now().Year()
+	if value, ok := options["year"].(float64); ok {
+		year = int(value)
+	} else {
+		options["year"] = float64(year)
+	}
+
+	counts := map[string]int{}
+	posts := m.FilterPosts(func(post *models.Post) bool {
+		return post != nil && !post.Skip && post.Published && post.Date != nil && post.Date.Year() == year
+	})
+
+	for _, post := range posts {
+		date := post.Date.Format("2006-01-02")
+		counts[date]++
+	}
+
+	data := make([]contributionGraphDataPoint, 0, len(counts))
+	for date, count := range counts {
+		data = append(data, contributionGraphDataPoint{Date: date, Value: count})
+	}
+
+	for i := 0; i < len(data)-1; i++ {
+		for j := i + 1; j < len(data); j++ {
+			if data[i].Date > data[j].Date {
+				data[i], data[j] = data[j], data[i]
+			}
+		}
+	}
+
+	return data
+}
+
+func (p *ContributionGraphPlugin) computeColorScaleMax(data interface{}, options map[string]interface{}) int {
+	values := p.extractContributionValues(data)
+	if len(values) == 0 {
+		return 1
+	}
+
+	if value, ok := options["maxValue"].(float64); ok && value >= 1 {
+		return int(value)
+	}
+
+	if percentile, ok := p.resolveScaleMaxPercentile(options); ok {
+		return percentileValue(values, percentile)
+	}
+
+	return values[len(values)-1]
+}
+
+func (p *ContributionGraphPlugin) resolveScaleMaxPercentile(options map[string]interface{}) (float64, bool) {
+	if value, ok := options["maxPercentile"].(float64); ok && value > 0 {
+		return minFloat(value, 100), true
+	}
+	if p.config.ScaleMaxPercentile > 0 {
+		return minFloat(p.config.ScaleMaxPercentile, 100), true
+	}
+	return 0, false
+}
+
+func (p *ContributionGraphPlugin) extractContributionValues(data interface{}) []int {
+	encoded, err := json.Marshal(data)
+	if err != nil {
+		return []int{1}
+	}
+
+	var points []contributionGraphDataPoint
+	if err := json.Unmarshal(encoded, &points); err != nil {
+		return []int{1}
+	}
+
+	values := make([]int, 0, len(points))
+	for _, point := range points {
+		if point.Value > 0 {
+			values = append(values, point.Value)
+		}
+	}
+	if len(values) == 0 {
+		return []int{1}
+	}
+
+	sort.Ints(values)
+	return values
+}
+
+func percentileValue(values []int, percentile float64) int {
+	if len(values) == 0 {
+		return 1
+	}
+
+	index := int(math.Ceil((percentile/100)*float64(len(values)))) - 1
+	if index < 0 {
+		index = 0
+	}
+	if index >= len(values) {
+		index = len(values) - 1
+	}
+	if values[index] < 1 {
+		return 1
+	}
+	return values[index]
+}
+
+func minFloat(a, b float64) float64 {
+	if a < b {
+		return a
+	}
+	return b
 }
 
 // buildOptionsObject converts options JSON into a JavaScript object literal for Cal-Heatmap.
@@ -310,20 +473,23 @@ func (p *ContributionGraphPlugin) buildOptionsObject(optionsJSON []byte) string 
 
 // injectCalHeatmapScripts adds the Cal-Heatmap library and initialization scripts to the HTML.
 func (p *ContributionGraphPlugin) injectCalHeatmapScripts(htmlContent string, initScripts []string) string {
+	containerSelector := "." + p.config.ContainerClass
+
 	// Build the combined script
 	// Cal-Heatmap v4 requires d3 as a dependency
 	// Tooltip plugin requires popper.js
 	script := fmt.Sprintf(`
 <style>
-.contribution-graph-container {
+%s {
   width: 100%%;
-  overflow-x: auto;
+  overflow: hidden;
   margin: 1rem 0;
   display: flex;
   justify-content: center;
 }
-.contribution-graph-container > div {
+%s > div {
   flex-shrink: 0;
+  transform-origin: top center;
 }
 #ch-tooltip {
   background: var(--color-surface, #333);
@@ -363,8 +529,16 @@ document.addEventListener('DOMContentLoaded', function() {
 
   observer.observe(document.documentElement, { attributes: true });
   observer.observe(document.body, { attributes: true });
+
+  window.addEventListener('resize', function() {
+    if (window._contributionGraphFitters) {
+      window._contributionGraphFitters.forEach(function(fit) {
+        fit();
+      });
+    }
+  });
 });
-</script>`, p.resolveAssetURL("cal-heatmap-css", p.config.CDNURL+"/cal-heatmap.css"), p.resolveAssetURL("d3", "https://d3js.org/d3.v7.min.js"), p.resolveAssetURL("popper", "https://unpkg.com/@popperjs/core@2"), p.resolveAssetURL("cal-heatmap-js", p.config.CDNURL+"/cal-heatmap.min.js"), p.resolveAssetURL("cal-heatmap-tooltip", p.config.CDNURL+"/plugins/Tooltip.min.js"), strings.Join(initScripts, "\n"))
+</script>`, containerSelector, containerSelector, p.resolveAssetURL("cal-heatmap-css", p.config.CDNURL+"/cal-heatmap.css"), p.resolveAssetURL("d3", "https://d3js.org/d3.v7.min.js"), p.resolveAssetURL("popper", "https://unpkg.com/@popperjs/core@2"), p.resolveAssetURL("cal-heatmap-js", p.config.CDNURL+"/cal-heatmap.min.js"), p.resolveAssetURL("cal-heatmap-tooltip", p.config.CDNURL+"/plugins/Tooltip.min.js"), strings.Join(initScripts, "\n"))
 
 	// Append the script to the end of the content
 	return htmlContent + script

--- a/pkg/plugins/contribution_graph_test.go
+++ b/pkg/plugins/contribution_graph_test.go
@@ -17,16 +17,13 @@ func TestContributionGraphPlugin_Name(t *testing.T) {
 func TestContributionGraphPlugin_ProcessPost_NoContributionGraph(t *testing.T) {
 	p := NewContributionGraphPlugin()
 
-	post := &models.Post{
-		ArticleHTML: "<p>Hello world</p>",
-	}
+	post := &models.Post{ArticleHTML: "<p>Hello world</p>"}
 
-	err := p.processPost(post)
+	err := p.processPost(nil, post)
 	if err != nil {
 		t.Errorf("processPost() error = %v", err)
 	}
 
-	// HTML should be unchanged
 	if post.ArticleHTML != "<p>Hello world</p>" {
 		t.Errorf("HTML was modified when no contribution-graph blocks present")
 	}
@@ -35,54 +32,45 @@ func TestContributionGraphPlugin_ProcessPost_NoContributionGraph(t *testing.T) {
 func TestContributionGraphPlugin_ProcessPost_ValidGraph(t *testing.T) {
 	p := NewContributionGraphPlugin()
 
-	post := &models.Post{
-		ArticleHTML: `<p>Check out this contribution graph:</p>
+	post := &models.Post{ArticleHTML: `<p>Check out this contribution graph:</p>
 <pre><code class="language-contribution-graph">{
   "data": [{"date": "2024-01-01", "value": 5}],
   "options": {"domain": "year", "subDomain": "day"}
 }</code></pre>
-<p>Nice graph!</p>`,
-	}
+<p>Nice graph!</p>`}
 
-	err := p.processPost(post)
+	err := p.processPost(nil, post)
 	if err != nil {
 		t.Errorf("processPost() error = %v", err)
 	}
 
-	// Should contain a div element
 	if !strings.Contains(post.ArticleHTML, "<div id=") {
 		t.Error("Expected div element in output")
 	}
-
-	// Should contain Cal-Heatmap CDN script
 	if !strings.Contains(post.ArticleHTML, "cal-heatmap") {
 		t.Error("Expected Cal-Heatmap CDN script")
 	}
-
-	// Should have the container class
 	if !strings.Contains(post.ArticleHTML, `class="contribution-graph-container"`) {
 		t.Error("Expected contribution-graph-container class")
 	}
-
-	// Should have initialization script
 	if !strings.Contains(post.ArticleHTML, "new CalHeatmap()") {
 		t.Error("Expected CalHeatmap initialization script")
+	}
+	if !strings.Contains(post.ArticleHTML, "window._contributionGraphFitters") {
+		t.Error("Expected built-in graph fitters")
 	}
 }
 
 func TestContributionGraphPlugin_ProcessPost_InvalidJSON(t *testing.T) {
 	p := NewContributionGraphPlugin()
 
-	post := &models.Post{
-		ArticleHTML: `<pre><code class="language-contribution-graph">{ invalid json }</code></pre>`,
-	}
+	post := &models.Post{ArticleHTML: `<pre><code class="language-contribution-graph">{ invalid json }</code></pre>`}
 
-	err := p.processPost(post)
+	err := p.processPost(nil, post)
 	if err != nil {
 		t.Errorf("processPost() error = %v", err)
 	}
 
-	// Should contain an error message
 	if !strings.Contains(post.ArticleHTML, "contribution-graph-error") {
 		t.Error("Expected error class for invalid JSON")
 	}
@@ -94,24 +82,20 @@ func TestContributionGraphPlugin_ProcessPost_InvalidJSON(t *testing.T) {
 func TestContributionGraphPlugin_ProcessPost_MultipleGraphs(t *testing.T) {
 	p := NewContributionGraphPlugin()
 
-	post := &models.Post{
-		ArticleHTML: `<pre><code class="language-contribution-graph">{"data": [], "options": {}}</code></pre>
+	post := &models.Post{ArticleHTML: `<pre><code class="language-contribution-graph">{"data": [], "options": {}}</code></pre>
 <p>And another:</p>
-<pre><code class="language-contribution-graph">{"data": [], "options": {"domain": "month"}}</code></pre>`,
-	}
+<pre><code class="language-contribution-graph">{"data": [], "options": {"domain": "month"}}</code></pre>`}
 
-	err := p.processPost(post)
+	err := p.processPost(nil, post)
 	if err != nil {
 		t.Errorf("processPost() error = %v", err)
 	}
 
-	// Should have two div elements with different IDs
 	count := strings.Count(post.ArticleHTML, "<div id=")
 	if count != 2 {
 		t.Errorf("Expected 2 div elements, got %d", count)
 	}
 
-	// CDN should only be included once
 	cdnCount := strings.Count(post.ArticleHTML, "cal-heatmap.min.js")
 	if cdnCount != 1 {
 		t.Errorf("Expected 1 CDN script inclusion, got %d", cdnCount)
@@ -127,12 +111,11 @@ func TestContributionGraphPlugin_ProcessPost_SkipPost(t *testing.T) {
 	}
 	originalHTML := post.ArticleHTML
 
-	err := p.processPost(post)
+	err := p.processPost(nil, post)
 	if err != nil {
 		t.Errorf("processPost() error = %v", err)
 	}
 
-	// HTML should be unchanged for skipped posts
 	if post.ArticleHTML != originalHTML {
 		t.Error("Skip post HTML was modified")
 	}
@@ -141,11 +124,9 @@ func TestContributionGraphPlugin_ProcessPost_SkipPost(t *testing.T) {
 func TestContributionGraphPlugin_ProcessPost_EmptyHTML(t *testing.T) {
 	p := NewContributionGraphPlugin()
 
-	post := &models.Post{
-		ArticleHTML: "",
-	}
+	post := &models.Post{ArticleHTML: ""}
 
-	err := p.processPost(post)
+	err := p.processPost(nil, post)
 	if err != nil {
 		t.Errorf("processPost() error = %v", err)
 	}
@@ -162,7 +143,6 @@ func TestContributionGraphPlugin_ProcessPost_Disabled(t *testing.T) {
 		CDNURL:  "https://cdn.jsdelivr.net/npm/cal-heatmap@4",
 	})
 
-	// Verify plugin is disabled via config
 	if p.Config().Enabled {
 		t.Error("Expected plugin to be disabled")
 	}
@@ -177,17 +157,18 @@ func TestContributionGraphPlugin_ProcessPost_CustomContainerClass(t *testing.T) 
 		Theme:          "dark",
 	})
 
-	post := &models.Post{
-		ArticleHTML: `<pre><code class="language-contribution-graph">{"data": []}</code></pre>`,
-	}
+	post := &models.Post{ArticleHTML: `<pre><code class="language-contribution-graph">{"data": []}</code></pre>`}
 
-	err := p.processPost(post)
+	err := p.processPost(nil, post)
 	if err != nil {
 		t.Errorf("processPost() error = %v", err)
 	}
 
 	if !strings.Contains(post.ArticleHTML, `class="my-custom-graph"`) {
 		t.Error("Expected custom container class")
+	}
+	if !strings.Contains(post.ArticleHTML, ".my-custom-graph") {
+		t.Error("Expected custom class selector in injected CSS")
 	}
 	if !strings.Contains(post.ArticleHTML, "example.com/cal-heatmap") {
 		t.Error("Expected custom CDN URL")
@@ -197,17 +178,13 @@ func TestContributionGraphPlugin_ProcessPost_CustomContainerClass(t *testing.T) 
 func TestContributionGraphPlugin_ProcessPost_HTMLEntities(t *testing.T) {
 	p := NewContributionGraphPlugin()
 
-	// Goldmark encodes special characters, so we test that they get decoded
-	post := &models.Post{
-		ArticleHTML: `<pre><code class="language-contribution-graph">{&quot;data&quot;: [], &quot;options&quot;: {}}</code></pre>`,
-	}
+	post := &models.Post{ArticleHTML: `<pre><code class="language-contribution-graph">{&quot;data&quot;: [], &quot;options&quot;: {}}</code></pre>`}
 
-	err := p.processPost(post)
+	err := p.processPost(nil, post)
 	if err != nil {
 		t.Errorf("processPost() error = %v", err)
 	}
 
-	// Should process successfully (HTML entities decoded)
 	if strings.Contains(post.ArticleHTML, "contribution-graph-error") {
 		t.Error("Should handle HTML entities correctly")
 	}
@@ -219,18 +196,15 @@ func TestContributionGraphPlugin_ProcessPost_HTMLEntities(t *testing.T) {
 func TestContributionGraphPlugin_ProcessPost_PreserveSurroundingContent(t *testing.T) {
 	p := NewContributionGraphPlugin()
 
-	post := &models.Post{
-		ArticleHTML: `<h1>Title</h1>
+	post := &models.Post{ArticleHTML: `<h1>Title</h1>
 <pre><code class="language-contribution-graph">{"data": []}</code></pre>
-<p>Footer content</p>`,
-	}
+<p>Footer content</p>`}
 
-	err := p.processPost(post)
+	err := p.processPost(nil, post)
 	if err != nil {
 		t.Errorf("processPost() error = %v", err)
 	}
 
-	// Should preserve surrounding content
 	if !strings.Contains(post.ArticleHTML, "<h1>Title</h1>") {
 		t.Error("Lost header content")
 	}
@@ -242,8 +216,7 @@ func TestContributionGraphPlugin_ProcessPost_PreserveSurroundingContent(t *testi
 func TestContributionGraphPlugin_ProcessPost_WithOptions(t *testing.T) {
 	p := NewContributionGraphPlugin()
 
-	post := &models.Post{
-		ArticleHTML: `<pre><code class="language-contribution-graph">{
+	post := &models.Post{ArticleHTML: `<pre><code class="language-contribution-graph">{
   "data": [{"date": "2024-01-01", "value": 5}],
   "options": {
     "domain": "month",
@@ -251,20 +224,16 @@ func TestContributionGraphPlugin_ProcessPost_WithOptions(t *testing.T) {
     "cellSize": 15,
     "range": 12
   }
-}</code></pre>`,
-	}
+}</code></pre>`}
 
-	err := p.processPost(post)
+	err := p.processPost(nil, post)
 	if err != nil {
 		t.Errorf("processPost() error = %v", err)
 	}
 
-	// Should contain domain configuration
 	if !strings.Contains(post.ArticleHTML, "domain:") {
 		t.Error("Expected domain configuration in output")
 	}
-
-	// Should contain initialization with CalHeatmap
 	if !strings.Contains(post.ArticleHTML, "cal.paint") {
 		t.Error("Expected cal.paint call in output")
 	}
@@ -273,24 +242,107 @@ func TestContributionGraphPlugin_ProcessPost_WithOptions(t *testing.T) {
 func TestContributionGraphPlugin_ProcessPost_DataParsing(t *testing.T) {
 	p := NewContributionGraphPlugin()
 
-	post := &models.Post{
-		ArticleHTML: `<pre><code class="language-contribution-graph">{
+	post := &models.Post{ArticleHTML: `<pre><code class="language-contribution-graph">{
   "data": [
     {"date": "2024-01-01", "value": 5},
     {"date": "2024-01-02", "value": 10},
     {"date": "2024-01-03", "value": 3}
   ],
   "options": {}
-}</code></pre>`,
-	}
+}</code></pre>`}
 
-	err := p.processPost(post)
+	err := p.processPost(nil, post)
 	if err != nil {
 		t.Errorf("processPost() error = %v", err)
 	}
 
-	// Should contain the data in the script
 	if !strings.Contains(post.ArticleHTML, "2024-01-01") {
 		t.Error("Expected data to be included in output")
+	}
+	if !strings.Contains(post.ArticleHTML, "const maxValue = 10;") {
+		t.Error("Expected scale max to be emitted into the script")
+	}
+}
+
+func TestContributionGraphPlugin_ProcessPost_MaxPercentileCapsScale(t *testing.T) {
+	p := NewContributionGraphPlugin()
+
+	post := &models.Post{ArticleHTML: `<pre><code class="language-contribution-graph">{
+  "data": [
+    {"date": "2024-01-01", "value": 1},
+    {"date": "2024-01-02", "value": 2},
+    {"date": "2024-01-03", "value": 3},
+    {"date": "2024-01-04", "value": 20}
+  ],
+  "options": {
+    "maxPercentile": 95
+  }
+}</code></pre>`}
+
+	err := p.processPost(nil, post)
+	if err != nil {
+		t.Fatalf("processPost() error = %v", err)
+	}
+
+	if !strings.Contains(post.ArticleHTML, "const maxValue = 20;") {
+		t.Error("expected maxValue to be emitted into the graph script")
+	}
+}
+
+func TestContributionGraphPlugin_ProcessPost_MaxValueOverridesScale(t *testing.T) {
+	p := NewContributionGraphPlugin()
+
+	post := &models.Post{ArticleHTML: `<pre><code class="language-contribution-graph">{
+  "data": [
+    {"date": "2024-01-01", "value": 1},
+    {"date": "2024-01-02", "value": 2},
+    {"date": "2024-01-03", "value": 20}
+  ],
+  "options": {
+    "maxValue": 8
+  }
+}</code></pre>`}
+
+	err := p.processPost(nil, post)
+	if err != nil {
+		t.Fatalf("processPost() error = %v", err)
+	}
+
+	if !strings.Contains(post.ArticleHTML, "const maxValue = 8;") {
+		t.Error("expected explicit maxValue override to affect scale max")
+	}
+	if !strings.Contains(post.ArticleHTML, "source: displayData") {
+		t.Error("expected maxValue override to clamp rendered data")
+	}
+}
+
+func TestContributionGraphPlugin_ProcessPost_GlobalScaleMaxPercentile(t *testing.T) {
+	p := NewContributionGraphPlugin()
+	p.SetConfig(models.ContributionGraphConfig{
+		Enabled:            true,
+		CDNURL:             "https://example.com/cal-heatmap",
+		ContainerClass:     "contribution-graph-container",
+		Theme:              "light",
+		ScaleMaxPercentile: 50,
+	})
+
+	post := &models.Post{ArticleHTML: `<pre><code class="language-contribution-graph">{
+  "data": [
+    {"date": "2024-01-01", "value": 1},
+    {"date": "2024-01-02", "value": 2},
+    {"date": "2024-01-03", "value": 9}
+  ]
+}</code></pre>`}
+
+	err := p.processPost(nil, post)
+	if err != nil {
+		t.Fatalf("processPost() error = %v", err)
+	}
+
+	if !strings.Contains(post.ArticleHTML, "const maxValue = 2;") {
+		t.Error("expected global percentile cap to affect scale max")
+	}
+	if !strings.Contains(post.ArticleHTML, "window._contributionGraphFitters") {
+		t.Error("expected built-in fitters to be registered")
 	}
 }

--- a/spec/spec/OPTIONAL_PLUGINS.md
+++ b/spec/spec/OPTIONAL_PLUGINS.md
@@ -436,6 +436,7 @@ enabled = true
 cdn_url = "https://cdn.jsdelivr.net/npm/cal-heatmap@4"
 container_class = "contribution-graph-container"
 theme = "light"                    # light, dark
+scale_max_percentile = 0            # 0 disables percentile-based outlier control
 ```
 
 **Configuration Fields:**
@@ -446,6 +447,7 @@ theme = "light"                    # light, dark
 | `cdn_url` | string | `"https://cdn.jsdelivr.net/npm/cal-heatmap@4"` | URL for Cal-Heatmap library |
 | `container_class` | string | `"contribution-graph-container"` | CSS class for container div |
 | `theme` | string | `"light"` | Cal-Heatmap color theme |
+| `scale_max_percentile` | number | `0` | Global percentile cap for color scaling. Set 1-100 to reduce outlier washout |
 
 **Syntax:**
 
@@ -481,13 +483,16 @@ The `data` array should contain objects with:
 | `subDomain` | string | `"day"` | Sub-domain: "day", "hour", "minute" |
 | `cellSize` | number | `10` | Size of each cell in pixels |
 | `range` | number | `1` | Number of domain units to display |
+| `maxValue` | number | unset | Explicit color-scale maximum. Values above it use the max color |
+| `maxPercentile` | number | unset | Per-graph percentile cap for the color scale |
 
 **Behavior:**
 
 1. Find all `<pre><code class="language-contribution-graph">` blocks
 2. Parse JSON content (data and options)
-3. Replace with div container and initialization script
-4. Inject Cal-Heatmap CSS and JS (once per page)
+3. Compute the graph color-scale maximum from the data. When `maxPercentile` or `scale_max_percentile` is set, use that percentile instead of the raw maximum.
+4. Replace with div container and initialization script
+5. Inject Cal-Heatmap CSS and JS (once per page), including built-in resize fitting so graphs fit narrow content columns without page-specific markdown scripts
 
 **Output:**
 


### PR DESCRIPTION
## Summary
- add `maxValue` and percentile-based outlier controls to contribution graphs
- clamp rendered graph values while keeping original post counts in tooltips
- fit contribution graphs into narrow content columns without page-local resize scripts

## Testing
- `go test ./pkg/plugins -run TestContributionGraphPlugin`
- `go build ./cmd/markata-go`

## Issue
- Refs #1022