### PR TITLE
fix build cache persistence in fast mode

### DIFF
--- a/cmd/markata-go/cmd/core.go
+++ b/cmd/markata-go/cmd/core.go
@@ -250,7 +250,6 @@ func applyFastMode(m *lifecycle.Manager) {
 	m.Config().Extra["blogroll_disabled"] = true
 	m.Config().Extra["mentions_disabled"] = true
 	m.Config().Extra["feeds_incremental"] = true
-	m.Config().Extra["cache_cleanup_async"] = true
 	verbosef("Fast mode: skipping minification, CSS purging, tailwind rebuilds, pagefind indexing, blogroll, and mentions")
 }
 

--- a/cmd/markata-go/cmd/serve.go
+++ b/cmd/markata-go/cmd/serve.go
@@ -204,6 +204,7 @@ func runServeCommand(cmd *cobra.Command, _ []string) error {
 	// Apply fast mode if requested
 	if serveFast {
 		applyFastMode(m)
+		m.Config().Extra["cache_cleanup_async"] = true
 	}
 
 	if !serveFast {
@@ -1488,6 +1489,7 @@ func doRebuild(ctx context.Context, rebuildCh chan<- struct{}) {
 		}
 		m.Config().Extra["feeds_async"] = true
 		applyFastMode(m)
+		m.Config().Extra["cache_cleanup_async"] = true
 	}
 
 	if serveFast {

--- a/pkg/plugins/build_cache.go
+++ b/pkg/plugins/build_cache.go
@@ -3,6 +3,7 @@ package plugins
 
 import (
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/WaylonWalker/markata-go/pkg/buildcache"
@@ -85,7 +86,7 @@ func (p *BuildCachePlugin) Configure(m *lifecycle.Manager) error {
 			configFiles = []string{path}
 		}
 	}
-	configHash := buildcache.ContentHash(configFilesHash(configFiles))
+	configHash := buildcache.ContentHash(configHashInput(config, configFiles))
 	if configHash != "" && cache.SetConfigHash(configHash) {
 		// Config changed - cache was invalidated
 		buildCacheLog.Phase("configure").Printf("Config changed, full rebuild required")
@@ -135,14 +136,41 @@ func configFilesHash(paths []string) string {
 		return ""
 	}
 
-	hashes := make([]string, 0, len(paths))
+	normalized := make([]string, 0, len(paths))
 	for _, path := range paths {
+		if path == "" {
+			continue
+		}
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			absPath = filepath.Clean(path)
+		}
+		normalized = append(normalized, absPath)
+	}
+
+	sort.Strings(normalized)
+
+	hashes := make([]string, 0, len(normalized))
+	for _, path := range normalized {
 		if hash, err := buildcache.HashFile(path); err == nil && hash != "" {
 			hashes = append(hashes, path+":"+hash)
 		}
 	}
 
 	return strings.Join(hashes, "\n")
+}
+
+func configHashInput(config *lifecycle.Config, paths []string) string {
+	components := make([]string, 0, 3)
+	if pathHash := configFilesHash(paths); pathHash != "" {
+		components = append(components, pathHash)
+	}
+	if config != nil {
+		components = append(components, config.OutputDir)
+		components = append(components, config.ContentDir)
+		components = append(components, strings.Join(config.GlobPatterns, "\x00"))
+	}
+	return strings.Join(components, "\n")
 }
 
 func (p *BuildCachePlugin) configureIncrementalServe(m *lifecycle.Manager, cache *buildcache.Cache) error {

--- a/pkg/plugins/build_cache.go
+++ b/pkg/plugins/build_cache.go
@@ -166,9 +166,7 @@ func configHashInput(config *lifecycle.Config, paths []string) string {
 		components = append(components, pathHash)
 	}
 	if config != nil {
-		components = append(components, config.OutputDir)
-		components = append(components, config.ContentDir)
-		components = append(components, strings.Join(config.GlobPatterns, "\x00"))
+		components = append(components, config.OutputDir, config.ContentDir, strings.Join(config.GlobPatterns, "\x00"))
 	}
 	return strings.Join(components, "\n")
 }

--- a/pkg/plugins/build_cache_test.go
+++ b/pkg/plugins/build_cache_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/WaylonWalker/markata-go/pkg/buildcache"
+	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
 )
 
 func TestConfigFilesHash_ChangesWhenOverlayChanges(t *testing.T) {
@@ -29,5 +30,54 @@ func TestConfigFilesHash_ChangesWhenOverlayChanges(t *testing.T) {
 	second := buildcache.ContentHash(configFilesHash([]string{base, overlay}))
 	if first == second {
 		t.Fatal("expected config hash to change when overlay config changes")
+	}
+}
+
+func TestConfigFilesHash_IsStableAcrossPathFormsAndOrder(t *testing.T) {
+	dir := t.TempDir()
+	base := filepath.Join(dir, "markata-go.toml")
+	overlay := filepath.Join(dir, "tailwind.toml")
+
+	if err := os.WriteFile(base, []byte("title = 'base'\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(base) error = %v", err)
+	}
+	if err := os.WriteFile(overlay, []byte("[markata-go.tailwind]\nbuild = true\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(overlay) error = %v", err)
+	}
+
+	first := buildcache.ContentHash(configFilesHash([]string{overlay, base, ""}))
+	second := buildcache.ContentHash(configFilesHash([]string{filepath.Clean(base), filepath.Clean(overlay)}))
+	third := buildcache.ContentHash(configFilesHash([]string{base, overlay}))
+
+	if first != second || second != third {
+		t.Fatalf("expected config hash to be stable across path forms and ordering: %q %q %q", first, second, third)
+	}
+}
+
+func TestConfigHashInput_IsStableForEquivalentConfig(t *testing.T) {
+	dir := t.TempDir()
+	base := filepath.Join(dir, "markata-go.toml")
+	if err := os.WriteFile(base, []byte("title = 'base'\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(base) error = %v", err)
+	}
+
+	config := &lifecycle.Config{
+		ContentDir:   ".",
+		OutputDir:    "output",
+		GlobPatterns: []string{"**/*.md"},
+		Extra: map[string]interface{}{
+			"title":       "Test Site",
+			"url":         "https://example.com",
+			"config_path": base,
+			"config_paths": []string{
+				base,
+			},
+		},
+	}
+
+	first := buildcache.ContentHash(configHashInput(config, []string{base}))
+	second := buildcache.ContentHash(configHashInput(config, []string{filepath.Clean(base)}))
+	if first != second {
+		t.Fatalf("expected effective config hash to be stable for equivalent config: %q != %q", first, second)
 	}
 }


### PR DESCRIPTION
## Summary
- keep build cache cleanup synchronous for one-shot `build --fast` runs so `.markata/build-cache.json` is written before process exit
- keep async cleanup for `serve --fast`, where background cleanup is still safe and useful
- normalize config hash inputs by sorting and absolutizing config file paths and add regression coverage for stable back-to-back hashing

## Verification
- `go test ./pkg/plugins ./pkg/buildcache`
- sequentially ran `/tmp/markata-go-fixed build --fast -m config/no-tailwind.toml` twice from `/home/waylon/git/waylonwalker.com`
- first run saved a fresh `.markata/build-cache.json`
- second run did not log `Config changed, full rebuild required`
- second run showed incremental reuse: `publish_feeds Incremental: 395 feeds skipped, 0 rebuilt` and `Incremental build: 3193 skipped, 4 rebuilt`

## Performance
- first run after the fix: `28.82s`
- second back-to-back run after the fix: `18.22s`
- improvement: `10.60s` faster, about `36.8%` faster, roughly `1.58x` as fast as the first run
- compared to the broken back-to-back case before the fix (`~65-72s`), the second run dropped to `18.22s`, roughly a `3.6x-4x` speedup

Fixes #1026