### PR TITLE
fix(css): fix z-index for Copy this post dropdown

### DIFF
--- a/pkg/themes/default/static/css/components.css
+++ b/pkg/themes/default/static/css/components.css
@@ -1646,7 +1646,7 @@
   position: absolute;
   top: calc(100% + 0.45rem);
   left: 0;
-  z-index: 5;
+  z-index: 100;
   min-width: 12rem;
   display: grid;
   gap: 0.35rem;


### PR DESCRIPTION
## Summary

Fixes #1028

The "Copy this post" dropdown menu was rendering behind sidebar elements due to a z-index conflict. Changed `.post-copy__menu` z-index from `5` to `100` to ensure it appears above the sidebar (`z-index: 90`).

## Changes

- **File:** `pkg/themes/default/static/css/components.css`
- **Line:** 1649
- **Change:** `z-index: 5` → `z-index: 100`

## Root Cause

The sidebar uses `--z-sidebar: 90`, which created a stacking context higher than the dropdown's `z-index: 5`. This caused the dropdown menu to be partially obscured by sidebar content.

## Screenshots

Screenshots available locally for reproduction verification:
- `/tmp/pi-clipboard-35d61ca6-a7d5-4949-bed6-7814edc00f54.png` - Before fix (bug)
- `/tmp/copy-dropdown-fixed.png` - After fix (resolved)

## Testing

1. Build the site with the fix
2. Navigate to a post page
3. Click "Copy this post" button
4. Verify dropdown appears above all content including sidebar

## Checklist

- [x] Bug identified and reproduced
- [x] Fix implemented
- [x] Site builds successfully
- [x] Visual verification completed
