### PR TITLE
fix: canonical sidebar variant URLs

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -1519,6 +1519,9 @@ og = true         # /slug/og/index.html (social card)
 
 **Visible Format Links**: When alternate formats are enabled, posts and feeds display visible links allowing visitors to access content in their preferred format.
 
+Feed sidebar variant links use the same canonical short URLs (`/slug.md`, `/slug.txt`, `/slug.ansi`) rather than nested `/slug/index.<ext>` paths.
+If a post format is disabled, its sidebar link is omitted.
+
 **Per-post frontmatter overrides**: A post can override any of these format flags in frontmatter with a `post_formats` object. Overrides merge with the site defaults, so omitted keys continue to inherit from `[markata-go.post_formats]`.
 
 ```yaml

--- a/pkg/agentskill/bundle/markata-go-site/topics/template-management.md
+++ b/pkg/agentskill/bundle/markata-go-site/topics/template-management.md
@@ -327,6 +327,8 @@ Markata-go can output posts in multiple formats beyond HTML. Alternate format te
 
 Use the `plaintext` filter to strip HTML tags when producing text output. Hardcoded fallbacks: `default.txt` (text), `default.ansi` (ANSI), `raw.txt` (markdown), `og-card.html` (OG).
 
+Feed sidebar variant links should point at the canonical short URLs for enabled formats (`/slug.md`, `/slug.txt`, `/slug.ansi`) instead of nested `/slug/index.<ext>` paths.
+
 ## Common Tasks
 
 - customize post or feed cards

--- a/pkg/plugins/publish_html.go
+++ b/pkg/plugins/publish_html.go
@@ -460,7 +460,7 @@ func (p *PublishHTMLPlugin) resolveTerminalTemplate(post *models.Post, engine *t
 	format := formatTxt
 	defaultTemplateName := defaultTxtTemplate
 	rawTemplateName := rawTxtTemplate
-	formatTemplateKey := "txt"
+	formatTemplateKey := formatTxt
 	shorthandTemplateKey := "txt_template"
 	if ansi {
 		format = formatANSI

--- a/pkg/plugins/templates.go
+++ b/pkg/plugins/templates.go
@@ -1046,7 +1046,7 @@ type sidebarFeedsDataJSON struct {
 // 4 priority levels. Unlike getFeedSidebarPosts which returns the first match,
 // this collects ALL matches so the user can cycle between them with {/}.
 func (p *TemplatesPlugin) getAllCandidateFeeds(
-	post *models.Post, config *lifecycle.Config, m *lifecycle.Manager,
+	post *models.Post, config *lifecycle.Config, m *lifecycle.Manager, postFormats models.PostFormatsConfig,
 ) []sidebarFeedJSON {
 	if post == nil {
 		return nil
@@ -1061,7 +1061,7 @@ func (p *TemplatesPlugin) getAllCandidateFeeds(
 			return
 		}
 		seen[fc.Slug] = true
-		feeds = append(feeds, p.buildSidebarFeedEntry(post, fc, posts, priority, syndication))
+		feeds = append(feeds, p.buildSidebarFeedEntry(post, fc, posts, priority, syndication, postFormats))
 	}
 
 	// 1. Series
@@ -1091,7 +1091,7 @@ func (p *TemplatesPlugin) getAllCandidateFeeds(
 // windowing the post list around the current post for large feeds.
 func (p *TemplatesPlugin) buildSidebarFeedEntry(
 	currentPost *models.Post, fc *models.FeedConfig,
-	posts []*models.Post, priority string, syndication models.SyndicationConfig,
+	posts []*models.Post, priority string, syndication models.SyndicationConfig, postFormats models.PostFormatsConfig,
 ) sidebarFeedJSON {
 	const maxWindowPosts = 50
 
@@ -1132,7 +1132,7 @@ func (p *TemplatesPlugin) buildSidebarFeedEntry(
 		Priority:            priority,
 		Primary:             fc.Primary,
 		ContainsCurrentPost: currentPos >= 0,
-		Variants:            buildSidebarVariants(fc, syndication),
+		Variants:            buildSidebarVariants(fc, syndication, postFormats),
 		TotalPosts:          len(posts),
 		Posts:               make([]sidebarPostJSON, 0, len(windowedPosts)),
 	}
@@ -1153,7 +1153,7 @@ func (p *TemplatesPlugin) buildSidebarFeedEntry(
 	return feed
 }
 
-func buildSidebarVariants(fc *models.FeedConfig, syndication models.SyndicationConfig) []sidebarVariant {
+func buildSidebarVariants(fc *models.FeedConfig, syndication models.SyndicationConfig, postFormats models.PostFormatsConfig) []sidebarVariant {
 	if fc == nil {
 		return nil
 	}
@@ -1167,9 +1167,15 @@ func buildSidebarVariants(fc *models.FeedConfig, syndication models.SyndicationC
 	add := func(key, label, href string) {
 		variants = append(variants, sidebarVariant{Key: key, Label: label, Href: href})
 	}
+	canonicalVariantHref := func(ext string) string {
+		if fc.Slug == "" {
+			return "/index." + ext
+		}
+		return "/" + strings.Trim(fc.Slug, "/") + "." + ext
+	}
 
-	if fc.Formats.Markdown {
-		add("md", "md", baseHref+"index.md")
+	if fc.Formats.Markdown && postFormats.Markdown {
+		add("md", "md", canonicalVariantHref("md"))
 	}
 	if fc.Formats.JSON {
 		add("json", "json", baseHref+"feed.json")
@@ -1183,14 +1189,14 @@ func buildSidebarVariants(fc *models.FeedConfig, syndication models.SyndicationC
 	if fc.Formats.Atom {
 		add("atom", "atom", baseHref+"atom.xml")
 	}
-	if fc.Formats.HTML {
+	if fc.Formats.HTML && postFormats.IsHTMLEnabled() {
 		add("html", "html", baseHref)
 	}
 	if fc.Formats.SimpleHTML {
 		add("simple", "simple", baseHref+"simple/")
 	}
-	if fc.Formats.Text {
-		add("txt", "txt", baseHref+"index.txt")
+	if fc.Formats.Text && postFormats.Text {
+		add("txt", "txt", canonicalVariantHref("txt"))
 	}
 
 	return variants
@@ -1371,10 +1377,11 @@ func (p *TemplatesPlugin) buildSidebarFeedsJSON(
 	post *models.Post, config *lifecycle.Config, m *lifecycle.Manager,
 	primaryFeed *models.FeedConfig,
 ) string {
-	feeds := p.getAllCandidateFeeds(post, config, m)
+	postFormats := resolvePostFormats(post, config)
+	feeds := p.getAllCandidateFeeds(post, config, m, postFormats)
 	feeds = filterPublicSidebarFeeds(feeds)
 	seen := makeSidebarFeedSet(feeds)
-	feeds = p.appendMissingPrimarySidebarFeeds(feeds, seen, post, config, m)
+	feeds = p.appendMissingPrimarySidebarFeeds(feeds, seen, post, config, m, postFormats)
 
 	if len(feeds) <= 1 {
 		// No point in cycling with only 0 or 1 feed
@@ -1429,7 +1436,7 @@ func makeSidebarFeedSet(feeds []sidebarFeedJSON) map[string]bool {
 
 func (p *TemplatesPlugin) appendMissingPrimarySidebarFeeds(
 	feeds []sidebarFeedJSON, seen map[string]bool, post *models.Post,
-	config *lifecycle.Config, m *lifecycle.Manager,
+	config *lifecycle.Config, m *lifecycle.Manager, postFormats models.PostFormatsConfig,
 ) []sidebarFeedJSON {
 	cached, ok := m.Cache().Get("feed_configs")
 	if !ok {
@@ -1446,7 +1453,7 @@ func (p *TemplatesPlugin) appendMissingPrimarySidebarFeeds(
 		if seen[fc.Slug] || !fc.Primary || fc.IncludePrivate {
 			continue
 		}
-		feeds = append(feeds, p.buildSidebarFeedEntry(post, fc, fc.Posts, "primary", syndication))
+		feeds = append(feeds, p.buildSidebarFeedEntry(post, fc, fc.Posts, "primary", syndication, postFormats))
 		seen[fc.Slug] = true
 	}
 

--- a/pkg/plugins/templates_test.go
+++ b/pkg/plugins/templates_test.go
@@ -197,7 +197,7 @@ func TestTemplatesPlugin_BuildSidebarFeedEntry_AppendsFeedParamToLinks(t *testin
 		Posts: []*models.Post{prev, current},
 	}
 
-	entry := p.buildSidebarFeedEntry(current, feed, feed.Posts, "primary", models.NewFeedDefaults().Syndication)
+	entry := p.buildSidebarFeedEntry(current, feed, feed.Posts, "primary", models.NewFeedDefaults().Syndication, models.NewPostFormatsConfig())
 	if len(entry.Posts) != 2 {
 		t.Fatalf("expected 2 posts, got %d", len(entry.Posts))
 	}
@@ -229,7 +229,7 @@ func TestTemplatesPlugin_BuildSidebarFeedEntry_IncludesEnabledVariants(t *testin
 		Posts: []*models.Post{current},
 	}
 
-	entry := p.buildSidebarFeedEntry(current, feed, feed.Posts, "primary", models.NewFeedDefaults().Syndication)
+	entry := p.buildSidebarFeedEntry(current, feed, feed.Posts, "primary", models.NewFeedDefaults().Syndication, models.NewPostFormatsConfig())
 	got := make([]string, 0, len(entry.Variants))
 	for _, variant := range entry.Variants {
 		got = append(got, variant.Key)
@@ -242,6 +242,98 @@ func TestTemplatesPlugin_BuildSidebarFeedEntry_IncludesEnabledVariants(t *testin
 	for i := range want {
 		if got[i] != want[i] {
 			t.Fatalf("variant order = %#v, want %#v", got, want)
+		}
+	}
+}
+
+func TestTemplatesPlugin_BuildSidebarFeedEntry_UsesCanonicalVariantURLs(t *testing.T) {
+	p := NewTemplatesPlugin()
+	title := "Current"
+	current := &models.Post{Slug: "current", Title: &title, Href: "/current/"}
+	feed := &models.FeedConfig{
+		Slug:  "til-feed",
+		Title: "Today I Learned",
+		Formats: models.FeedFormats{
+			HTML:       true,
+			SimpleHTML: true,
+			RSS:        true,
+			Atom:       true,
+			JSON:       true,
+			Markdown:   true,
+			Text:       true,
+		},
+		Posts: []*models.Post{current},
+	}
+
+	entry := p.buildSidebarFeedEntry(current, feed, feed.Posts, "primary", models.NewFeedDefaults().Syndication, models.NewPostFormatsConfig())
+	for _, variant := range entry.Variants {
+		switch variant.Key {
+		case "md":
+			if variant.Href != "/til-feed.md" {
+				t.Fatalf("md href = %q, want %q", variant.Href, "/til-feed.md")
+			}
+		case "txt":
+			if variant.Href != "/til-feed.txt" {
+				t.Fatalf("txt href = %q, want %q", variant.Href, "/til-feed.txt")
+			}
+		}
+	}
+}
+
+func TestTemplatesPlugin_BuildSidebarFeedEntry_UsesCanonicalVariantURLsForRootFeed(t *testing.T) {
+	p := NewTemplatesPlugin()
+	title := "Current"
+	current := &models.Post{Slug: "current", Title: &title, Href: "/current/"}
+	feed := &models.FeedConfig{
+		Title: "Posts",
+		Formats: models.FeedFormats{
+			Markdown: true,
+			Text:     true,
+		},
+		Posts: []*models.Post{current},
+	}
+
+	entry := p.buildSidebarFeedEntry(current, feed, feed.Posts, "primary", models.NewFeedDefaults().Syndication, models.NewPostFormatsConfig())
+	for _, variant := range entry.Variants {
+		switch variant.Key {
+		case "md":
+			if variant.Href != "/index.md" {
+				t.Fatalf("md href = %q, want %q", variant.Href, "/index.md")
+			}
+		case "txt":
+			if variant.Href != "/index.txt" {
+				t.Fatalf("txt href = %q, want %q", variant.Href, "/index.txt")
+			}
+		}
+	}
+}
+
+func TestTemplatesPlugin_BuildSidebarFeedEntry_HidesDisabledPostFormats(t *testing.T) {
+	p := NewTemplatesPlugin()
+	title := "Current"
+	current := &models.Post{Slug: "current", Title: &title, Href: "/current/"}
+	feed := &models.FeedConfig{
+		Slug:  "til-feed",
+		Title: "Today I Learned",
+		Formats: models.FeedFormats{
+			HTML:       true,
+			SimpleHTML: true,
+			RSS:        true,
+			Atom:       true,
+			JSON:       true,
+			Markdown:   true,
+			Text:       true,
+		},
+		Posts: []*models.Post{current},
+	}
+	postFormats := models.NewPostFormatsConfig()
+	postFormats.Markdown = false
+	postFormats.Text = false
+
+	entry := p.buildSidebarFeedEntry(current, feed, feed.Posts, "primary", models.NewFeedDefaults().Syndication, postFormats)
+	for _, variant := range entry.Variants {
+		if variant.Key == "md" || variant.Key == "txt" {
+			t.Fatalf("unexpected variant %q in %#v", variant.Key, entry.Variants)
 		}
 	}
 }

--- a/spec/spec/CONFIG.md
+++ b/spec/spec/CONFIG.md
@@ -911,6 +911,9 @@ Theme-aware ANSI rendering MUST derive colors from the active site palette when 
 
 For `.txt`, `.md`, and `.ansi` formats, content is placed at the canonical short URL (`/slug.txt`, `/slug.md`, `/slug.ansi`). Redirects are provided at `/slug.<ext>/index.html` (for hosts that serve `index.html` in a directory) and `/slug/index.<ext>/index.html` (for backwards compatibility).
 
+Rendered feed/sidebar variant links MUST use the same canonical short URLs rather than nested `/slug/index.<ext>` paths.
+If a post format is disabled in the resolved config, the corresponding sidebar link MUST be omitted.
+
 **Special Files (robots, llms, humans, security, ads):**
 
 Special web files have an inverted structure to serve content at their expected root-level locations:


### PR DESCRIPTION
## Summary
- use canonical short URLs for feed sidebar markdown and text variants
- hide sidebar variant links when the corresponding post format is disabled
- document the sidebar variant URL behavior in spec, docs, and the bundled site skill

## Testing
- go test ./pkg/plugins -run 'TestTemplatesPlugin_BuildSidebarFeedEntry'

Fixes #1031
Fixes #1033