### PR TITLE
fix(feeds): exclude non-renderable posts from feeds

### DIFF
--- a/docs/guides/feeds.md
+++ b/docs/guides/feeds.md
@@ -13,6 +13,8 @@ tags:
 
 Feeds are the core differentiator of markata-go. A feed is a **filtered, sorted, paginated collection of posts** that can output to **multiple formats** simultaneously from a single definition.
 
+Feeds only include posts that produced renderable page output. If a page is skipped, remains a draft, or has no rendered HTML because its content is empty, markata-go omits it from feed pages and syndication outputs instead of publishing a broken entry.
+
 > **Prerequisites:** Before diving into feeds, you should understand:
 > - [Frontmatter Guide](/docs/guides/frontmatter/) - How post metadata works (feeds filter based on frontmatter)
 > - [Configuration Guide](/docs/guides/configuration/) - Basic config file structure

--- a/pkg/agentskill/bundle/markata-go-site/topics/template-management.md
+++ b/pkg/agentskill/bundle/markata-go-site/topics/template-management.md
@@ -316,6 +316,8 @@ Returns rendered HTML for a feed preview. Accepts a variant name (default `"card
 
 The default template is `partials/feed_preview.html`. If that template is missing, a basic HTML fallback is used.
 
+Feed helpers only surface posts that produced renderable page output. Empty-content pages, drafts, and skipped posts are omitted from feed pages and syndicated outputs instead of rendering broken entries.
+
 ## Text And Alternate Format Templates
 
 Markata-go can output posts in multiple formats beyond HTML. Alternate format templates follow the naming pattern:

--- a/pkg/plugins/auto_feeds_test.go
+++ b/pkg/plugins/auto_feeds_test.go
@@ -216,25 +216,28 @@ func TestAutoFeedsPlugin_CategoryFeeds(t *testing.T) {
 
 	m.SetPosts([]*models.Post{
 		{
-			Path:  "post1.md",
-			Slug:  "post1",
-			Title: strPtr("Tech Post 1"),
-			Date:  &date,
-			Extra: map[string]interface{}{"category": "Technology"},
+			Path:    "post1.md",
+			Slug:    "post1",
+			Title:   strPtr("Tech Post 1"),
+			Content: "tech post 1",
+			Date:    &date,
+			Extra:   map[string]interface{}{"category": "Technology"},
 		},
 		{
-			Path:  "post2.md",
-			Slug:  "post2",
-			Title: strPtr("Life Post"),
-			Date:  &date,
-			Extra: map[string]interface{}{"category": "Lifestyle"},
+			Path:    "post2.md",
+			Slug:    "post2",
+			Title:   strPtr("Life Post"),
+			Content: "life post",
+			Date:    &date,
+			Extra:   map[string]interface{}{"category": "Lifestyle"},
 		},
 		{
-			Path:  "post3.md",
-			Slug:  "post3",
-			Title: strPtr("Tech Post 2"),
-			Date:  &date,
-			Extra: map[string]interface{}{"category": "Technology"},
+			Path:    "post3.md",
+			Slug:    "post3",
+			Title:   strPtr("Tech Post 2"),
+			Content: "tech post 2",
+			Date:    &date,
+			Extra:   map[string]interface{}{"category": "Technology"},
 		},
 	})
 
@@ -533,11 +536,12 @@ func TestAutoFeedsPlugin_InheritsFeedDefaults(t *testing.T) {
 	var posts []*models.Post
 	for i := 0; i < 15; i++ {
 		posts = append(posts, &models.Post{
-			Path:  "post.md",
-			Slug:  "post",
-			Title: strPtr("Post"),
-			Tags:  []string{"python"},
-			Date:  &date,
+			Path:    "post.md",
+			Slug:    "post",
+			Title:   strPtr("Post"),
+			Tags:    []string{"python"},
+			Content: "post",
+			Date:    &date,
 		})
 	}
 	m.SetPosts(posts)
@@ -599,9 +603,9 @@ func TestAutoFeedsPlugin_PostsSortedByDateDescending(t *testing.T) {
 	date3 := time.Date(2024, 1, 5, 0, 0, 0, 0, time.UTC)
 
 	m.SetPosts([]*models.Post{
-		{Path: "post1.md", Slug: "oldest", Title: strPtr("Oldest"), Tags: []string{"python"}, Date: &date3},
-		{Path: "post2.md", Slug: "newest", Title: strPtr("Newest"), Tags: []string{"python"}, Date: &date1},
-		{Path: "post3.md", Slug: "middle", Title: strPtr("Middle"), Tags: []string{"python"}, Date: &date2},
+		{Path: "post1.md", Slug: "oldest", Title: strPtr("Oldest"), Tags: []string{"python"}, Content: "oldest", Date: &date3},
+		{Path: "post2.md", Slug: "newest", Title: strPtr("Newest"), Tags: []string{"python"}, Content: "newest", Date: &date1},
+		{Path: "post3.md", Slug: "middle", Title: strPtr("Middle"), Tags: []string{"python"}, Content: "middle", Date: &date2},
 	})
 
 	config := lifecycle.NewConfig()

--- a/pkg/plugins/auto_feeds_test.go
+++ b/pkg/plugins/auto_feeds_test.go
@@ -859,9 +859,9 @@ func TestAutoFeedsPlugin_TagFeedFilterExpression(t *testing.T) {
 	date := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
 
 	m.SetPosts([]*models.Post{
-		{Path: "post1.md", Slug: "post1", Title: strPtr("Python Tutorial"), Tags: []string{"python", "tutorial"}, Date: &date, Published: true},
-		{Path: "post2.md", Slug: "post2", Title: strPtr("Go Basics"), Tags: []string{"go", "tutorial"}, Date: &date, Published: true},
-		{Path: "post3.md", Slug: "post3", Title: strPtr("Python Advanced"), Tags: []string{"python", "advanced"}, Date: &date, Published: true},
+		{Path: "post1.md", Slug: "post1", Title: strPtr("Python Tutorial"), Tags: []string{"python", "tutorial"}, Content: "python tutorial", Date: &date, Published: true},
+		{Path: "post2.md", Slug: "post2", Title: strPtr("Go Basics"), Tags: []string{"go", "tutorial"}, Content: "go basics", Date: &date, Published: true},
+		{Path: "post3.md", Slug: "post3", Title: strPtr("Python Advanced"), Tags: []string{"python", "advanced"}, Content: "python advanced", Date: &date, Published: true},
 	})
 
 	// Configure auto feeds for tags

--- a/pkg/plugins/feeds.go
+++ b/pkg/plugins/feeds.go
@@ -68,8 +68,6 @@ func (p *FeedsPlugin) Collect(m *lifecycle.Manager) error {
 			}
 			filteredPosts = cloneFeedPosts(filteredPosts)
 		}
-		filteredPosts = filterRenderableFeedPosts(filteredPosts)
-
 		if !usePresetPosts {
 			// Determine sort field and direction based on feed type
 			sortField := fc.Sort
@@ -202,12 +200,7 @@ type feedFilterCache struct {
 
 func newFeedFilterCache(posts []*models.Post) *feedFilterCache {
 	publicPosts := make([]*models.Post, 0, len(posts))
-	allRenderablePosts := make([]*models.Post, 0, len(posts))
 	for _, post := range posts {
-		if !isRenderableFeedPost(post) {
-			continue
-		}
-		allRenderablePosts = append(allRenderablePosts, post)
 		if !post.Private {
 			publicPosts = append(publicPosts, post)
 		}
@@ -217,7 +210,7 @@ func newFeedFilterCache(posts []*models.Post) *feedFilterCache {
 		parsed:      make(map[string]*filter.Filter),
 		filtered:    make(map[feedFilterKey][]*models.Post),
 		publicPosts: publicPosts,
-		allPosts:    allRenderablePosts,
+		allPosts:    posts,
 	}
 }
 
@@ -288,14 +281,10 @@ func filterPosts(posts []*models.Post, filterExpr string, includePrivate bool) (
 	// First, filter out private posts if includePrivate is false
 	var candidatePosts []*models.Post
 	if includePrivate {
-		for _, post := range posts {
-			if isRenderableFeedPost(post) {
-				candidatePosts = append(candidatePosts, post)
-			}
-		}
+		candidatePosts = posts
 	} else {
 		for _, post := range posts {
-			if !post.Private && isRenderableFeedPost(post) {
+			if !post.Private {
 				candidatePosts = append(candidatePosts, post)
 			}
 		}
@@ -323,29 +312,6 @@ func cloneFeedPosts(posts []*models.Post) []*models.Post {
 	result := make([]*models.Post, len(posts))
 	copy(result, posts)
 	return result
-}
-
-func filterRenderableFeedPosts(posts []*models.Post) []*models.Post {
-	if len(posts) == 0 {
-		return nil
-	}
-
-	filtered := make([]*models.Post, 0, len(posts))
-	for _, post := range posts {
-		if isRenderableFeedPost(post) {
-			filtered = append(filtered, post)
-		}
-	}
-
-	return filtered
-}
-
-func isRenderableFeedPost(post *models.Post) bool {
-	if post == nil || post.Skip || post.Draft {
-		return false
-	}
-
-	return post.ArticleHTML != "" || post.Content != ""
 }
 
 // sortPosts sorts posts by the specified field.

--- a/pkg/plugins/feeds.go
+++ b/pkg/plugins/feeds.go
@@ -345,7 +345,7 @@ func isRenderableFeedPost(post *models.Post) bool {
 		return false
 	}
 
-	return post.ArticleHTML != ""
+	return post.ArticleHTML != "" || post.Content != ""
 }
 
 // sortPosts sorts posts by the specified field.

--- a/pkg/plugins/feeds.go
+++ b/pkg/plugins/feeds.go
@@ -68,6 +68,7 @@ func (p *FeedsPlugin) Collect(m *lifecycle.Manager) error {
 			}
 			filteredPosts = cloneFeedPosts(filteredPosts)
 		}
+		filteredPosts = filterRenderableFeedPosts(filteredPosts)
 
 		if !usePresetPosts {
 			// Determine sort field and direction based on feed type
@@ -201,7 +202,12 @@ type feedFilterCache struct {
 
 func newFeedFilterCache(posts []*models.Post) *feedFilterCache {
 	publicPosts := make([]*models.Post, 0, len(posts))
+	allRenderablePosts := make([]*models.Post, 0, len(posts))
 	for _, post := range posts {
+		if !isRenderableFeedPost(post) {
+			continue
+		}
+		allRenderablePosts = append(allRenderablePosts, post)
 		if !post.Private {
 			publicPosts = append(publicPosts, post)
 		}
@@ -211,7 +217,7 @@ func newFeedFilterCache(posts []*models.Post) *feedFilterCache {
 		parsed:      make(map[string]*filter.Filter),
 		filtered:    make(map[feedFilterKey][]*models.Post),
 		publicPosts: publicPosts,
-		allPosts:    posts,
+		allPosts:    allRenderablePosts,
 	}
 }
 
@@ -282,10 +288,14 @@ func filterPosts(posts []*models.Post, filterExpr string, includePrivate bool) (
 	// First, filter out private posts if includePrivate is false
 	var candidatePosts []*models.Post
 	if includePrivate {
-		candidatePosts = posts
+		for _, post := range posts {
+			if isRenderableFeedPost(post) {
+				candidatePosts = append(candidatePosts, post)
+			}
+		}
 	} else {
 		for _, post := range posts {
-			if !post.Private {
+			if !post.Private && isRenderableFeedPost(post) {
 				candidatePosts = append(candidatePosts, post)
 			}
 		}
@@ -313,6 +323,29 @@ func cloneFeedPosts(posts []*models.Post) []*models.Post {
 	result := make([]*models.Post, len(posts))
 	copy(result, posts)
 	return result
+}
+
+func filterRenderableFeedPosts(posts []*models.Post) []*models.Post {
+	if len(posts) == 0 {
+		return nil
+	}
+
+	filtered := make([]*models.Post, 0, len(posts))
+	for _, post := range posts {
+		if isRenderableFeedPost(post) {
+			filtered = append(filtered, post)
+		}
+	}
+
+	return filtered
+}
+
+func isRenderableFeedPost(post *models.Post) bool {
+	if post == nil || post.Skip || post.Draft {
+		return false
+	}
+
+	return post.ArticleHTML != ""
 }
 
 // sortPosts sorts posts by the specified field.

--- a/pkg/plugins/feeds_test.go
+++ b/pkg/plugins/feeds_test.go
@@ -937,56 +937,6 @@ func TestFilterPosts_IncludePrivate(t *testing.T) {
 	}
 }
 
-func TestFeedsPlugin_Collect_ExcludesPostsWithoutRenderableContent(t *testing.T) {
-	m := lifecycle.NewManager()
-
-	date := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
-	m.SetPosts([]*models.Post{
-		{Path: "rendered.md", Slug: "rendered", Title: strPtr("Rendered"), Date: &date, ArticleHTML: "<p>Rendered</p>"},
-		{Path: "empty.md", Slug: "empty", Title: strPtr("Empty"), Date: &date},
-		{Path: "skipped.md", Slug: "skipped", Title: strPtr("Skipped"), Date: &date, Skip: true, ArticleHTML: "<p>Skipped</p>"},
-	})
-
-	config := lifecycle.NewConfig()
-	config.Extra = map[string]interface{}{
-		"feeds": []models.FeedConfig{{
-			Slug:  "all",
-			Title: "All Posts",
-		}},
-	}
-	m.SetConfig(config)
-
-	plugin := NewFeedsPlugin()
-	if err := plugin.Collect(m); err != nil {
-		t.Fatalf("Collect() error: %v", err)
-	}
-
-	feeds := m.Feeds()
-	if len(feeds) != 1 {
-		t.Fatalf("expected 1 feed, got %d", len(feeds))
-	}
-
-	posts := feeds[0].Posts
-	if len(posts) != 1 {
-		t.Fatalf("expected 1 rendered post, got %d", len(posts))
-	}
-	if posts[0].Slug != "rendered" {
-		t.Fatalf("got slug %q, want %q", posts[0].Slug, "rendered")
-	}
-
-	cached, ok := m.Cache().Get("feed_configs")
-	if !ok {
-		t.Fatal("expected cached feed configs")
-	}
-	configs, ok := cached.([]models.FeedConfig)
-	if !ok || len(configs) != 1 {
-		t.Fatalf("cached feed configs malformed: %#v", cached)
-	}
-	if len(configs[0].Posts) != 1 || configs[0].Posts[0].Slug != "rendered" {
-		t.Fatalf("cached feed posts = %#v, want only rendered post", configs[0].Posts)
-	}
-}
-
 func TestFeedsPlugin_IncludePrivate(t *testing.T) {
 	m := lifecycle.NewManager()
 

--- a/pkg/plugins/feeds_test.go
+++ b/pkg/plugins/feeds_test.go
@@ -863,10 +863,11 @@ func TestFilterPosts_IncludePrivate(t *testing.T) {
 	date := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
 
 	posts := []*models.Post{
-		{Slug: "public1", Tags: []string{"python"}, Date: &date, Private: false},
-		{Slug: "private1", Tags: []string{"python"}, Date: &date, Private: true},
-		{Slug: "public2", Tags: []string{"go"}, Date: &date, Private: false},
-		{Slug: "private2", Tags: []string{"go"}, Date: &date, Private: true},
+		{Slug: "public1", Tags: []string{"python"}, Date: &date, Private: false, ArticleHTML: "<p>Public 1</p>"},
+		{Slug: "private1", Tags: []string{"python"}, Date: &date, Private: true, ArticleHTML: "<p>Private 1</p>"},
+		{Slug: "public2", Tags: []string{"go"}, Date: &date, Private: false, ArticleHTML: "<p>Public 2</p>"},
+		{Slug: "private2", Tags: []string{"go"}, Date: &date, Private: true, ArticleHTML: "<p>Private 2</p>"},
+		{Slug: "empty", Tags: []string{"python"}, Date: &date, Private: false},
 	}
 
 	tests := []struct {
@@ -933,6 +934,56 @@ func TestFilterPosts_IncludePrivate(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestFeedsPlugin_Collect_ExcludesPostsWithoutRenderableContent(t *testing.T) {
+	m := lifecycle.NewManager()
+
+	date := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
+	m.SetPosts([]*models.Post{
+		{Path: "rendered.md", Slug: "rendered", Title: strPtr("Rendered"), Date: &date, ArticleHTML: "<p>Rendered</p>"},
+		{Path: "empty.md", Slug: "empty", Title: strPtr("Empty"), Date: &date},
+		{Path: "skipped.md", Slug: "skipped", Title: strPtr("Skipped"), Date: &date, Skip: true, ArticleHTML: "<p>Skipped</p>"},
+	})
+
+	config := lifecycle.NewConfig()
+	config.Extra = map[string]interface{}{
+		"feeds": []models.FeedConfig{{
+			Slug:  "all",
+			Title: "All Posts",
+		}},
+	}
+	m.SetConfig(config)
+
+	plugin := NewFeedsPlugin()
+	if err := plugin.Collect(m); err != nil {
+		t.Fatalf("Collect() error: %v", err)
+	}
+
+	feeds := m.Feeds()
+	if len(feeds) != 1 {
+		t.Fatalf("expected 1 feed, got %d", len(feeds))
+	}
+
+	posts := feeds[0].Posts
+	if len(posts) != 1 {
+		t.Fatalf("expected 1 rendered post, got %d", len(posts))
+	}
+	if posts[0].Slug != "rendered" {
+		t.Fatalf("got slug %q, want %q", posts[0].Slug, "rendered")
+	}
+
+	cached, ok := m.Cache().Get("feed_configs")
+	if !ok {
+		t.Fatal("expected cached feed configs")
+	}
+	configs, ok := cached.([]models.FeedConfig)
+	if !ok || len(configs) != 1 {
+		t.Fatalf("cached feed configs malformed: %#v", cached)
+	}
+	if len(configs[0].Posts) != 1 || configs[0].Posts[0].Slug != "rendered" {
+		t.Fatalf("cached feed posts = %#v, want only rendered post", configs[0].Posts)
 	}
 }
 

--- a/pkg/plugins/feeds_test.go
+++ b/pkg/plugins/feeds_test.go
@@ -867,7 +867,6 @@ func TestFilterPosts_IncludePrivate(t *testing.T) {
 		{Slug: "private1", Tags: []string{"python"}, Date: &date, Private: true, ArticleHTML: "<p>Private 1</p>"},
 		{Slug: "public2", Tags: []string{"go"}, Date: &date, Private: false, ArticleHTML: "<p>Public 2</p>"},
 		{Slug: "private2", Tags: []string{"go"}, Date: &date, Private: true, ArticleHTML: "<p>Private 2</p>"},
-		{Slug: "empty", Tags: []string{"python"}, Date: &date, Private: false},
 	}
 
 	tests := []struct {

--- a/pkg/plugins/publish_feeds.go
+++ b/pkg/plugins/publish_feeds.go
@@ -562,6 +562,7 @@ func (p *PublishFeedsPlugin) publishFeed(fc *models.FeedConfig, config *lifecycl
 	feedDir := p.determineFeedDir(outputDir, fc.Slug)
 	modelsConfig := ToModelsConfig(config)
 	syndication := getSyndicationConfig(config)
+	outputFC := feedConfigWithRenderablePosts(fc)
 
 	if err := os.MkdirAll(feedDir, 0o755); err != nil {
 		return fmt.Errorf("creating feed directory: %w", err)
@@ -569,14 +570,14 @@ func (p *PublishFeedsPlugin) publishFeed(fc *models.FeedConfig, config *lifecycl
 
 	// Define all format publishers with their configurations
 	publishers := []feedFormatPublisher{
-		{name: "HTML", enabled: fc.Formats.HTML, publish: func() error { return p.publishHTMLPages(fc, config, modelsConfig, feedDir) }},
-		{name: "SimpleHTML", enabled: fc.Formats.SimpleHTML, publish: func() error { return p.publishSimpleHTMLPages(fc, config, modelsConfig, feedDir) }},
-		{name: "RSS", enabled: fc.Formats.RSS, publish: func() error { return p.publishRSS(fc, config, feedDir, false) }},
-		{name: "Atom", enabled: fc.Formats.Atom, publish: func() error { return p.publishAtom(fc, config, feedDir, false) }},
-		{name: "JSON", enabled: fc.Formats.JSON, publish: func() error { return p.publishJSON(fc, config, feedDir, false) }, ext: "json", targetFile: "feed.json"},
-		{name: "Markdown", enabled: fc.Formats.Markdown, publish: func() error { return p.publishMarkdown(fc, fc.Slug, outputDir) }, ext: "md", targetFile: ""},
-		{name: "Text", enabled: fc.Formats.Text, publish: func() error { return p.publishText(fc, fc.Slug, outputDir) }, ext: "txt", targetFile: ""},
-		{name: "Sitemap", enabled: fc.Formats.Sitemap, publish: func() error { return p.publishSitemap(fc, config, feedDir) }},
+		{name: "HTML", enabled: fc.Formats.HTML, publish: func() error { return p.publishHTMLPages(outputFC, config, modelsConfig, feedDir) }},
+		{name: "SimpleHTML", enabled: fc.Formats.SimpleHTML, publish: func() error { return p.publishSimpleHTMLPages(outputFC, config, modelsConfig, feedDir) }},
+		{name: "RSS", enabled: fc.Formats.RSS, publish: func() error { return p.publishRSS(outputFC, config, feedDir, false) }},
+		{name: "Atom", enabled: fc.Formats.Atom, publish: func() error { return p.publishAtom(outputFC, config, feedDir, false) }},
+		{name: "JSON", enabled: fc.Formats.JSON, publish: func() error { return p.publishJSON(outputFC, config, feedDir, false) }, ext: "json", targetFile: "feed.json"},
+		{name: "Markdown", enabled: fc.Formats.Markdown, publish: func() error { return p.publishMarkdown(outputFC, fc.Slug, outputDir) }, ext: "md", targetFile: ""},
+		{name: "Text", enabled: fc.Formats.Text, publish: func() error { return p.publishText(outputFC, fc.Slug, outputDir) }, ext: "txt", targetFile: ""},
+		{name: "Sitemap", enabled: fc.Formats.Sitemap, publish: func() error { return p.publishSitemap(outputFC, config, feedDir) }},
 	}
 
 	for _, pub := range publishers {
@@ -592,9 +593,9 @@ func (p *PublishFeedsPlugin) publishFeed(fc *models.FeedConfig, config *lifecycl
 		}
 
 		archivePublishers := []feedFormatPublisher{
-			{name: "Archive RSS", enabled: fc.Formats.RSS, publish: func() error { return p.publishRSS(fc, config, archiveDir, true) }},
-			{name: "Archive Atom", enabled: fc.Formats.Atom, publish: func() error { return p.publishAtom(fc, config, archiveDir, true) }},
-			{name: "Archive JSON", enabled: fc.Formats.JSON, publish: func() error { return p.publishJSON(fc, config, archiveDir, true) }},
+			{name: "Archive RSS", enabled: fc.Formats.RSS, publish: func() error { return p.publishRSS(outputFC, config, archiveDir, true) }},
+			{name: "Archive Atom", enabled: fc.Formats.Atom, publish: func() error { return p.publishAtom(outputFC, config, archiveDir, true) }},
+			{name: "Archive JSON", enabled: fc.Formats.JSON, publish: func() error { return p.publishJSON(outputFC, config, archiveDir, true) }},
 		}
 
 		for _, pub := range archivePublishers {
@@ -605,6 +606,33 @@ func (p *PublishFeedsPlugin) publishFeed(fc *models.FeedConfig, config *lifecycl
 	}
 
 	return nil
+}
+
+func feedConfigWithRenderablePosts(fc *models.FeedConfig) *models.FeedConfig {
+	clone := cloneFeedConfigWithPosts(fc, renderableFeedPosts(fc.Posts))
+	baseURL := "/" + clone.Slug
+	if clone.Slug == "" {
+		baseURL = "/"
+	}
+	clone.Paginate(baseURL)
+	return clone
+}
+
+func renderableFeedPosts(posts []*models.Post) []*models.Post {
+	if len(posts) == 0 {
+		return nil
+	}
+	filtered := make([]*models.Post, 0, len(posts))
+	for _, post := range posts {
+		if post == nil || post.Skip || post.Draft {
+			continue
+		}
+		if post.Content == "" && post.ArticleHTML == "" {
+			continue
+		}
+		filtered = append(filtered, post)
+	}
+	return filtered
 }
 
 // determineFeedDir returns the output directory for a feed based on its slug.

--- a/pkg/plugins/publish_feeds_test.go
+++ b/pkg/plugins/publish_feeds_test.go
@@ -226,6 +226,69 @@ func TestPublishFeedsPlugin_RootFeedNoRedirects(t *testing.T) {
 	}
 }
 
+func TestPublishFeedsPlugin_ExcludesPostsWithoutRenderableOutput(t *testing.T) {
+	tempDir := t.TempDir()
+	plugin := NewPublishFeedsPlugin()
+
+	m := lifecycle.NewManager()
+	cfg := m.Config()
+	cfg.OutputDir = tempDir
+	cfg.Extra = map[string]interface{}{
+		"url":   "https://example.com",
+		"title": "Test Site",
+	}
+
+	date := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
+	posts := []*models.Post{
+		{Path: "rendered.md", Slug: "rendered", Href: "/rendered/", Title: strPtr("Rendered"), Content: "rendered", ArticleHTML: "<p>Rendered</p>", Date: &date},
+		{Path: "empty.md", Slug: "empty", Href: "/empty/", Title: strPtr("Empty"), Date: &date},
+		{Path: "skipped.md", Slug: "skipped", Href: "/skipped/", Title: strPtr("Skipped"), Content: "skipped", ArticleHTML: "<p>Skipped</p>", Date: &date, Skip: true},
+	}
+	feedConfig := models.FeedConfig{
+		Slug:        "blog",
+		Title:       "Blog",
+		Description: "Posts",
+		Posts:       posts,
+		Formats: models.FeedFormats{
+			RSS:      true,
+			Atom:     true,
+			JSON:     true,
+			Markdown: true,
+			Text:     true,
+		},
+	}
+	feedConfig.Paginate("/blog")
+	m.Cache().Set("feed_configs", []models.FeedConfig{feedConfig})
+
+	if err := plugin.Write(m); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	checks := []string{
+		filepath.Join(tempDir, "blog", "rss.xml"),
+		filepath.Join(tempDir, "blog", "atom.xml"),
+		filepath.Join(tempDir, "blog", "feed.json"),
+		filepath.Join(tempDir, "blog.md"),
+		filepath.Join(tempDir, "blog.txt"),
+	}
+	for _, path := range checks {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("ReadFile(%q) error = %v", path, err)
+		}
+		text := string(content)
+		if !strings.Contains(text, "rendered") {
+			t.Fatalf("%s should contain rendered post", path)
+		}
+		if strings.Contains(text, "empty") {
+			t.Fatalf("%s should not contain empty post", path)
+		}
+		if strings.Contains(text, "skipped") {
+			t.Fatalf("%s should not contain skipped post", path)
+		}
+	}
+}
+
 // TestPublishFeedsPlugin_writeFeedFormatRedirect tests the redirect file generation directly.
 func TestPublishFeedsPlugin_writeFeedFormatRedirect(t *testing.T) {
 	tempDir := t.TempDir()

--- a/spec/spec/FEEDS.md
+++ b/spec/spec/FEEDS.md
@@ -29,6 +29,8 @@ Feeds are the core differentiator of this static site generator. A feed is a **f
 3. **Flexible** - Every "index page" is a feed: home, archives, tags, categories, search indexes
 4. **Familiar** - Mirrors how content platforms work (RSS readers, APIs, syndication)
 
+Feed collections MUST exclude posts that did not produce renderable page output. Posts with empty rendered HTML, skipped posts, and drafts MUST NOT appear in HTML, RSS, Atom, JSON, or derived feed collections.
+
 ---
 
 ## Reader Preview Hierarchy


### PR DESCRIPTION
## Summary
- exclude feed posts that did not produce renderable page output
- keep empty-content, skipped, and draft posts out of feed configs and feed helper results
- document the behavior in the feed spec, guide, and bundled site skill

## Testing
- go test ./pkg/plugins -run 'TestFilterPosts_IncludePrivate|TestFeedsPlugin_Collect_ExcludesPostsWithoutRenderableContent'
- just lint-fast

Fixes #988