### PR TITLE
fix(templates): unify visible HTML date rendering

### DIFF
--- a/docs/guides/templates.md
+++ b/docs/guides/templates.md
@@ -238,10 +238,13 @@ The built-in `slides_reveal` filter converts rendered HTML into reveal.js slide 
 
 | Filter | Example | Output |
 |--------|---------|--------|
+| `human_date` | `{{ date\|human_date }}` | `Jan 15, 2024` |
 | `date_format` | `{{ date\|date_format:"2006-01-02" }}` | `2024-01-15` |
 | `date_format` | `{{ date\|date_format:"January 2, 2006" }}` | `January 15, 2024` |
 | `rss_date` | `{{ date\|rss_date }}` | RFC 1123Z format for RSS |
 | `atom_date` | `{{ date\|atom_date }}` | RFC 3339 format for Atom |
+
+Use `human_date` for visible HTML dates so cards, post bylines, archive views, and reader metadata stay consistent while `datetime` attributes remain machine-readable.
 
 **Note:** Go uses reference time formatting. Common formats:
 
@@ -411,7 +414,7 @@ Partials are reusable template fragments. Use `{% include %}` to embed them:
     <footer>
         {% if post.Date %}
         <time datetime="{{ post.Date|atom_date }}">
-            {{ post.Date|date_format:"Jan 2, 2006" }}
+            {{ post.Date|human_date }}
         </time>
         {% endif %}
         {% if post.Extra.reading_time %}
@@ -457,7 +460,7 @@ Post templates render individual content pages. They receive the `post` and `bod
         <h1>{{ post.Title }}</h1>
         {% if post.Date %}
         <time datetime="{{ post.Date|atom_date }}">
-            {{ post.Date|date_format:"January 2, 2006" }}
+            {{ post.Date|human_date }}
         </time>
         {% endif %}
 

--- a/pkg/agentskill/bundle/markata-go-site/topics/template-management.md
+++ b/pkg/agentskill/bundle/markata-go-site/topics/template-management.md
@@ -125,12 +125,15 @@ Useful feed/page fields:
 
 - `date`
 - `date_format`
+- `human_date`
 - `rss_date`
 - `atom_date`
 - `slugify`
 - `truncate`
 - `truncatewords`
 - `default_if_none`
+
+Use `human_date` for visible HTML dates in cards, post bylines, archive views, and reader metadata. Keep `<time datetime="...">` values machine-readable with `atom_date` or RFC 3339 strings.
 - `length`
 - `first`
 - `last`

--- a/pkg/plugins/blogroll.go
+++ b/pkg/plugins/blogroll.go
@@ -1696,7 +1696,7 @@ func (p *BlogrollPlugin) readerEntryMap(entry *models.ExternalEntry, feed *model
 	if date := entryDate(entry); date != nil {
 		result["published"] = date
 		result["published_datetime"] = date.Format(time.RFC3339)
-		result["published_label"] = date.Format("Jan 2")
+		result["published_label"] = templates.FormatHumanDate(*date)
 		result["date_key"] = date.Format("2006-01-02")
 		result["date_iso"] = date.Format(time.RFC3339)
 	}

--- a/pkg/plugins/blogroll_reader_test.go
+++ b/pkg/plugins/blogroll_reader_test.go
@@ -68,7 +68,7 @@ func TestBlogrollPlugin_ReaderDayGroups(t *testing.T) {
 		t.Fatalf("source_icon_url = %q, want favicon URL for example.com", iconURL)
 	}
 
-	if got, want := groupEntries[0]["published_label"], "Apr 17"; got != want {
+	if got, want := groupEntries[0]["published_label"], "Apr 17, 2026"; got != want {
 		t.Fatalf("published_label = %v, want %v", got, want)
 	}
 

--- a/pkg/plugins/embeds.go
+++ b/pkg/plugins/embeds.go
@@ -704,7 +704,7 @@ func (p *EmbedsPlugin) buildInternalEmbedCard(post *models.Post, displayText str
 
 	if post.Date != nil {
 		sb.WriteString(`      <div class="embed-card-meta">`)
-		sb.WriteString(post.Date.Format("Jan 2, 2006"))
+		sb.WriteString(templates.FormatHumanDate(*post.Date))
 		sb.WriteString(`</div>`)
 		sb.WriteString("\n")
 	}

--- a/pkg/plugins/publish_feeds.go
+++ b/pkg/plugins/publish_feeds.go
@@ -952,7 +952,7 @@ func (p *PublishFeedsPlugin) generateFeedPageHTMLFallback(fc *models.FeedConfig,
                 <a href="{{.Href}}">
                     <h2>{{if .Title}}{{.Title}}{{else}}{{.Slug}}{{end}}</h2>
                 </a>
-                {{if .Date}}<time datetime="{{.Date.Format "2006-01-02"}}">{{.Date.Format "January 2, 2006"}}</time>{{end}}
+				{{if .Date}}<time datetime="{{.Date.Format "2006-01-02"}}">{{humanDate .Date}}</time>{{end}}
                 {{if .Description}}<p>{{.Description}}</p>{{end}}
             </article>
         {{end}}
@@ -969,7 +969,7 @@ func (p *PublishFeedsPlugin) generateFeedPageHTMLFallback(fc *models.FeedConfig,
 </body>
 </html>`
 
-	tmpl, err := template.New("feed").Parse(tmplStr)
+	tmpl, err := template.New("feed").Funcs(template.FuncMap{"humanDate": templates.FormatHumanDate}).Parse(tmplStr)
 	if err != nil {
 		return "", fmt.Errorf("parsing template: %w", err)
 	}

--- a/pkg/plugins/publish_html.go
+++ b/pkg/plugins/publish_html.go
@@ -740,7 +740,7 @@ func (p *PublishHTMLPlugin) renderOGWithBuiltinTemplate(post *models.Post, confi
 
 	dateStr := ""
 	if post.Date != nil {
-		dateStr = post.Date.Format("January 2, 2006")
+		dateStr = templates.FormatHumanDate(*post.Date)
 	}
 
 	imageURL := getPostExtraString(post, "image", "cover_image", "og_image")
@@ -998,7 +998,7 @@ func (p *PublishHTMLPlugin) wrapInTemplate(post *models.Post, config *lifecycle.
 	dateStr := ""
 	dateISO := ""
 	if post.Date != nil {
-		dateStr = post.Date.Format("January 2, 2006")
+		dateStr = templates.FormatHumanDate(*post.Date)
 		dateISO = post.Date.Format("2006-01-02")
 	}
 

--- a/pkg/templates/engine_test.go
+++ b/pkg/templates/engine_test.go
@@ -220,6 +220,11 @@ func TestEngine_RenderString_DateFilters(t *testing.T) {
 			template: "{{ post.date | date_format:\"2006-01-02\" }}",
 			want:     "2024-01-15",
 		},
+		{
+			name:     "human date format",
+			template: "{{ post.date | human_date }}",
+			want:     "Jan 15, 2024",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/templates/filters.go
+++ b/pkg/templates/filters.go
@@ -22,6 +22,9 @@ import (
 
 var registerOnce sync.Once
 
+// HumanDateFormat is the canonical visible HTML date format.
+const HumanDateFormat = "Jan 2, 2006"
+
 // assetHashRegistry stores asset path -> hash mappings for cache busting.
 // This is set by SetAssetHashes() before rendering templates.
 var assetHashRegistry map[string]string
@@ -107,6 +110,7 @@ func registerFilters() {
 		pongo2.RegisterFilter("rss_date", filterRSSDate)
 		pongo2.RegisterFilter("atom_date", filterAtomDate)
 		pongo2.RegisterFilter("date_format", filterDateFormat)
+		pongo2.RegisterFilter("human_date", filterHumanDate)
 		// Override the built-in date filter to handle *time.Time and string parsing
 		pongo2.ReplaceFilter("date", filterDate)
 
@@ -231,6 +235,20 @@ func filterDateFormat(in, param *pongo2.Value) (*pongo2.Value, *pongo2.Error) {
 	}
 
 	return pongo2.AsValue(t.Format(format)), nil
+}
+
+// FormatHumanDate formats a time value for visible HTML text.
+func FormatHumanDate(t time.Time) string {
+	return t.Format(HumanDateFormat)
+}
+
+func filterHumanDate(in, _ *pongo2.Value) (*pongo2.Value, *pongo2.Error) {
+	t, err := toTime(in)
+	if err != nil {
+		return pongo2.AsValue(""), nil
+	}
+
+	return pongo2.AsValue(FormatHumanDate(t)), nil
 }
 
 // filterSlugify converts a string to a URL-safe slug.

--- a/pkg/templates/filters_test.go
+++ b/pkg/templates/filters_test.go
@@ -1,6 +1,7 @@
 package templates
 
 import (
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -89,6 +90,79 @@ func TestFilterDateFormat(t *testing.T) {
 				t.Errorf("got %q, want %q", result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestFilterHumanDate(t *testing.T) {
+	engine, err := NewEngine("")
+	if err != nil {
+		t.Fatalf("Failed to create engine: %v", err)
+	}
+
+	date := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+	post := &models.Post{Date: &date}
+	ctx := NewContext(post, "", nil)
+
+	result, err := engine.RenderString("{{ post.date | human_date }}", ctx)
+	if err != nil {
+		t.Fatalf("RenderString() error: %v", err)
+	}
+
+	if result != "Jan 15, 2024" {
+		t.Fatalf("human_date: got %q, want %q", result, "Jan 15, 2024")
+	}
+}
+
+func TestTemplateTrees_UseHumanDateForVisibleHTMLDates(t *testing.T) {
+	files := []string{
+		"../../templates/components/post_byline.html",
+		"../../templates/partials/card.html",
+		"../../templates/partials/embed-card.html",
+		"../../templates/partials/feed_preview.html",
+		"../../templates/partials/cards/article-card.html",
+		"../../templates/partials/cards/default-card.html",
+		"../../templates/partials/cards/guide-card.html",
+		"../../templates/partials/cards/inline-card.html",
+		"../../templates/partials/cards/link-card.html",
+		"../../templates/partials/cards/note-card.html",
+		"../../templates/partials/cards/quote-card.html",
+		"../../templates/partials/cards/simple-card.html",
+		"../../templates/partials/cards/video-card.html",
+		"../../pkg/themes/default/templates/card.html",
+		"../../pkg/themes/default/templates/components/post_byline.html",
+		"../../pkg/themes/default/templates/og-card.html",
+		"../../pkg/themes/default/templates/partials/cards/article-card.html",
+		"../../pkg/themes/default/templates/partials/cards/default-card.html",
+		"../../pkg/themes/default/templates/partials/cards/guide-card.html",
+		"../../pkg/themes/default/templates/partials/cards/inline-card.html",
+		"../../pkg/themes/default/templates/partials/cards/link-card.html",
+		"../../pkg/themes/default/templates/partials/cards/note-card.html",
+		"../../pkg/themes/default/templates/partials/cards/quote-card.html",
+		"../../pkg/themes/default/templates/partials/cards/simple-card.html",
+		"../../pkg/themes/default/templates/partials/cards/video-card.html",
+	}
+	legacyPatterns := []string{
+		`| date:"Jan 2, 2006"`,
+		`| date:"January 2, 2006"`,
+		`| date:"2006-01-02"`,
+		`| date_format:"Jan 2, 2006"`,
+		`| date_format:"January 2, 2006"`,
+	}
+
+	for _, file := range files {
+		content, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("ReadFile(%q) error: %v", file, err)
+		}
+		text := string(content)
+		if !strings.Contains(text, "| human_date") {
+			t.Fatalf("template %q does not use human_date", file)
+		}
+		for _, pattern := range legacyPatterns {
+			if strings.Contains(text, pattern) {
+				t.Fatalf("template %q still contains legacy date pattern %q", file, pattern)
+			}
+		}
 	}
 }
 

--- a/pkg/themes/default/templates/card.html
+++ b/pkg/themes/default/templates/card.html
@@ -4,7 +4,7 @@
   <p class="card-description">{{ post.description }}</p>
   {% endif %}
   <div class="card-meta">
-    {% if post.date %}<time datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>{% endif %}
+    {% if post.date %}<time datetime="{{ post.date | atom_date }}">{{ post.date | human_date }}</time>{% endif %}
     {% if post.reading_time %}<span>{{ post.reading_time }} min</span>{% endif %}
   </div>
 </article>

--- a/pkg/themes/default/templates/components/post_byline.html
+++ b/pkg/themes/default/templates/components/post_byline.html
@@ -33,7 +33,7 @@
     {% if post.date or post.reading_time %}
     <div class="post-meta post-byline__meta">
         {% if post.date %}
-        <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+        <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | human_date }}</time>
         {% endif %}
         {% if post.reading_time %}
         <span class="post-meta__reading-time">{{ post.reading_time }} min read</span>
@@ -59,7 +59,7 @@
     {% if post.date or post.reading_time %}
     <div class="post-meta post-byline__meta">
         {% if post.date %}
-        <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+        <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | human_date }}</time>
         {% endif %}
         {% if post.reading_time %}
         <span class="post-meta__reading-time">{{ post.reading_time }} min read</span>
@@ -72,7 +72,7 @@
 {# No author info, just date/reading time #}
 <div class="post-meta post-meta--header">
     {% if post.date %}
-    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | human_date }}</time>
     {% endif %}
     {% if post.reading_time %}
     <span class="post-meta__reading-time">{{ post.reading_time }} min read</span>

--- a/pkg/themes/default/templates/og-card.html
+++ b/pkg/themes/default/templates/og-card.html
@@ -228,7 +228,7 @@
             </div>
         </div>
         {% if post.date %}
-        <span class="og-date">{{ post.date | date:"January 2, 2006" }}</span>
+        <span class="og-date">{{ post.date | human_date }}</span>
         {% endif %}
     </footer>
 </body>

--- a/pkg/themes/default/templates/partials/cards/article-card.html
+++ b/pkg/themes/default/templates/partials/cards/article-card.html
@@ -21,7 +21,7 @@
 <div class="card-excerpt p-summary">{{ post.article_html|excerpt:"paragraphs=3,chars=1000" | default:post.description }}</div>
 </div>
 <footer class="card-meta">
-{% if post.date %}<time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>{% endif %}
+{% if post.date %}<time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | human_date }}</time>{% endif %}
 {% if post.reading_time %}<span class="reading-time">{{ post.reading_time }} min read</span>{% endif %}
 {% include "partials/webmention-counts.html" %}
 {% if post.tags %}<div class="card-tags">{% for tag in post.tags %}<a href="/tags/{{ tag | slugify }}/" class="tag p-category">{{ tag }}</a>{% endfor %}</div>{% endif %}

--- a/pkg/themes/default/templates/partials/cards/default-card.html
+++ b/pkg/themes/default/templates/partials/cards/default-card.html
@@ -13,7 +13,7 @@
 
   <footer class="card-meta">
     {% if post.date %}
-    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | human_date }}</time>
     {% endif %}
     {% if post.reading_time %}<span class="reading-time">{{ post.reading_time }} min</span>{% endif %}
     {% include "partials/webmention-counts.html" %}

--- a/pkg/themes/default/templates/partials/cards/guide-card.html
+++ b/pkg/themes/default/templates/partials/cards/guide-card.html
@@ -16,7 +16,7 @@
 
   <footer class="card-meta">
     {% if post.date %}
-    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | human_date }}</time>
     {% endif %}
     {% if post.reading_time %}<span class="reading-time">{{ post.reading_time }} min</span>{% endif %}
   </footer>

--- a/pkg/themes/default/templates/partials/cards/inline-card.html
+++ b/pkg/themes/default/templates/partials/cards/inline-card.html
@@ -9,7 +9,7 @@
 
   <footer class="card-meta">
     {% if post.date %}
-    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | human_date }}</time>
     {% endif %}
     <a href="{{ post.href }}" class="card-permalink">Permalink</a>
   </footer>

--- a/pkg/themes/default/templates/partials/cards/link-card.html
+++ b/pkg/themes/default/templates/partials/cards/link-card.html
@@ -28,7 +28,7 @@
 
   <footer class="card-meta">
     {% if post.date %}
-    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | human_date }}</time>
     {% endif %}
     {% if post.tags %}
     <div class="card-tags">

--- a/pkg/themes/default/templates/partials/cards/note-card.html
+++ b/pkg/themes/default/templates/partials/cards/note-card.html
@@ -21,7 +21,7 @@
 
   <footer class="card-meta">
     {% if post.date %}
-    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | human_date }}</time>
     {% endif %}
     {% include "partials/webmention-counts.html" %}
     <a href="{{ post.href }}" class="card-link">View</a>

--- a/pkg/themes/default/templates/partials/cards/quote-card.html
+++ b/pkg/themes/default/templates/partials/cards/quote-card.html
@@ -29,7 +29,7 @@
     {% endif %}
 
     {% if post.date %}
-    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | human_date }}</time>
     {% endif %}
   </footer>
 </article>

--- a/pkg/themes/default/templates/partials/cards/simple-card.html
+++ b/pkg/themes/default/templates/partials/cards/simple-card.html
@@ -2,7 +2,7 @@
 <li class="simple-item h-entry">
   <a class="simple-item-title u-url p-name" href="{{ post.href }}">{{ post.title | default:post.slug }}</a>
   {% if post.date %}
-  <time class="simple-item-date dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"2006-01-02" }}</time>
+  <time class="simple-item-date dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | human_date }}</time>
   {% endif %}
   {% if post.reading_time %}
   <span class="simple-item-reading-time">{{ post.reading_time }} min</span>

--- a/pkg/themes/default/templates/partials/cards/video-card.html
+++ b/pkg/themes/default/templates/partials/cards/video-card.html
@@ -23,7 +23,7 @@
 {% if post.description %}<p class="card-description p-summary">{{ post.description | truncatechars:150 }}</p>
 {% endif %}</div>
 <footer class="card-meta">
-{% if post.date %}<time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+{% if post.date %}<time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | human_date }}</time>
 {% endif %}{% if post.duration %}<span class="duration">{{ post.duration }}</span>{% endif %}
 </footer>
 </article>

--- a/pkg/themes/default/templates/partials/webmentions.html
+++ b/pkg/themes/default/templates/partials/webmentions.html
@@ -102,7 +102,7 @@
           <div class="webmention-author-info">
             <a href="{{ mention.Author.URL|default:mention.URL }}" class="webmention-author-name" rel="nofollow noopener">{{ mention.Author.Name|default:"Anonymous" }}</a>
             {% if mention.Published %}
-            <time datetime="{{ mention.Published }}" class="webmention-date">{{ mention.Published }}</time>
+            <time datetime="{{ mention.Published }}" class="webmention-date">{{ mention.Published | human_date }}</time>
             {% endif %}
           </div>
         </div>
@@ -145,7 +145,7 @@
           <div class="webmention-author-info">
             <a href="{{ mention.Author.URL|default:mention.URL }}" class="webmention-author-name" rel="nofollow noopener">{{ mention.Author.Name|default:"Anonymous" }}</a>
             {% if mention.Published %}
-            <time datetime="{{ mention.Published }}" class="webmention-date">{{ mention.Published }}</time>
+            <time datetime="{{ mention.Published }}" class="webmention-date">{{ mention.Published | human_date }}</time>
             {% endif %}
           </div>
         </div>

--- a/spec/spec/TEMPLATES.md
+++ b/spec/spec/TEMPLATES.md
@@ -955,11 +955,13 @@ Default templates include Microformats2 classes for IndieWeb compatibility.
 
 Single post templates MUST include `h-entry` markup:
 
+Visible HTML dates SHOULD use the shared `human_date` filter so post pages, cards, archive views, and reader metadata render as `Apr 15, 2026` while `datetime` attributes remain machine-readable.
+
 ```html
 <article class="post h-entry">
   <a class="u-url" href="{{ config.url }}{{ post.href }}" hidden></a>
   <h1 class="p-name">{{ post.title }}</h1>
-  <time class="dt-published" datetime="{{ post.date | atom_date }}">...</time>
+  <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | human_date }}</time>
   <div class="post-content e-content">{{ body | safe }}</div>
   {% for tag in post.tags %}
   <a class="p-category" href="/tags/{{ tag | slugify }}/">{{ tag }}</a>

--- a/templates/components/post_byline.html
+++ b/templates/components/post_byline.html
@@ -33,7 +33,7 @@
     {% if post.date or post.reading_time %}
     <div class="post-meta post-byline__meta">
         {% if post.date %}
-        <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+        <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | human_date }}</time>
         {% endif %}
         {% if post.reading_time %}
         <span class="post-meta__reading-time">{{ post.reading_time }} min read</span>
@@ -59,7 +59,7 @@
     {% if post.date or post.reading_time %}
     <div class="post-meta post-byline__meta">
         {% if post.date %}
-        <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+        <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | human_date }}</time>
         {% endif %}
         {% if post.reading_time %}
         <span class="post-meta__reading-time">{{ post.reading_time }} min read</span>
@@ -72,7 +72,7 @@
 {# No author info, just date/reading time #}
 <div class="post-meta post-meta--header">
     {% if post.date %}
-    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | human_date }}</time>
     {% endif %}
     {% if post.reading_time %}
     <span class="post-meta__reading-time">{{ post.reading_time }} min read</span>

--- a/templates/partials/card.html
+++ b/templates/partials/card.html
@@ -1,7 +1,7 @@
 <article class="card">
     <h2><a href="{{ post.href }}">{{ post.title }}</a></h2>
     {% if post.date %}
-    <time datetime="{{ post.date | atom_date }}">{{ post.date | date:"Jan 2, 2006" }}</time>
+    <time datetime="{{ post.date | atom_date }}">{{ post.date | human_date }}</time>
     {% endif %}
     {% if post.description %}
     <p>{{ post.description | striptags | truncate:200 }}</p>

--- a/templates/partials/cards/article-card.html
+++ b/templates/partials/cards/article-card.html
@@ -15,7 +15,7 @@
 
   <footer class="card-meta">
     {% if post.date %}
-    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | human_date }}</time>
     {% endif %}
     {% if post.reading_time %}<span class="reading-time">{{ post.reading_time }} min read</span>{% endif %}
     {% include "partials/webmention-counts.html" %}

--- a/templates/partials/cards/default-card.html
+++ b/templates/partials/cards/default-card.html
@@ -9,7 +9,7 @@
 
   <footer class="card-meta">
     {% if post.date %}
-    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | human_date }}</time>
     {% endif %}
     {% if post.reading_time %}<span class="reading-time">{{ post.reading_time }} min</span>{% endif %}
     {% include "partials/webmention-counts.html" %}

--- a/templates/partials/cards/guide-card.html
+++ b/templates/partials/cards/guide-card.html
@@ -14,7 +14,7 @@
 
     <footer class="card-meta">
       {% if post.date %}
-      <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+      <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | human_date }}</time>
       {% endif %}
       {% if post.reading_time %}<span class="reading-time">{{ post.reading_time }} min</span>{% endif %}
     </footer>

--- a/templates/partials/cards/inline-card.html
+++ b/templates/partials/cards/inline-card.html
@@ -8,7 +8,7 @@
 
   <footer class="card-meta">
     {% if post.date %}
-    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | human_date }}</time>
     {% endif %}
     <a href="{{ post.href }}" class="card-permalink">Permalink</a>
   </footer>

--- a/templates/partials/cards/link-card.html
+++ b/templates/partials/cards/link-card.html
@@ -28,7 +28,7 @@
 
   <footer class="card-meta">
     {% if post.date %}
-    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | human_date }}</time>
     {% endif %}
     {% if post.tags %}
     <div class="card-tags">

--- a/templates/partials/cards/note-card.html
+++ b/templates/partials/cards/note-card.html
@@ -12,7 +12,7 @@
 
   <footer class="card-meta">
     {% if post.date %}
-    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | human_date }}</time>
     {% endif %}
     {% include "partials/webmention-counts.html" %}
     <a href="{{ post.href }}" class="card-link">View</a>

--- a/templates/partials/cards/quote-card.html
+++ b/templates/partials/cards/quote-card.html
@@ -25,7 +25,7 @@
     {% endif %}
 
     {% if post.date %}
-    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+    <time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | human_date }}</time>
     {% endif %}
   </footer>
 </article>

--- a/templates/partials/cards/simple-card.html
+++ b/templates/partials/cards/simple-card.html
@@ -2,7 +2,7 @@
 <li class="simple-item h-entry">
   <a class="simple-item-title u-url p-name" href="{{ post.href }}">{{ post.title | default:post.slug }}</a>
   {% if post.date %}
-  <time class="simple-item-date dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"2006-01-02" }}</time>
+  <time class="simple-item-date dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | human_date }}</time>
   {% endif %}
   {% if post.reading_time %}
   <span class="simple-item-reading-time">{{ post.reading_time }} min</span>

--- a/templates/partials/cards/video-card.html
+++ b/templates/partials/cards/video-card.html
@@ -25,7 +25,7 @@
 {% if post.description %}<p class="card-description p-summary">{{ post.description | truncatechars:150 }}</p>
 {% endif %}
 <footer class="card-meta">
-{% if post.date %}<time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | date:"January 2, 2006" }}</time>
+{% if post.date %}<time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | human_date }}</time>
 {% endif %}{% if post.duration %}<span class="duration">{{ post.duration }}</span>{% endif %}
 </footer>
 </div>

--- a/templates/partials/embed-card.html
+++ b/templates/partials/embed-card.html
@@ -31,7 +31,7 @@
       <div class="embed-card-description">{{ post.description|truncate:200 }}</div>
       {% endif %}
       {% if post.date %}
-      <div class="embed-card-meta">{{ post.date | date:"Jan 2, 2006" }}</div>
+      <div class="embed-card-meta">{{ post.date | human_date }}</div>
       {% endif %}
     </div>
   </a>

--- a/templates/partials/feed_preview.html
+++ b/templates/partials/feed_preview.html
@@ -5,7 +5,7 @@
         <li class="feed-preview__item">
             <a class="feed-preview__title" href="{{ post.href }}">{{ post.title }}</a>
             {% if post.date %}
-            <time datetime="{{ post.date | atom_date }}">{{ post.date | date:"Jan 2, 2006" }}</time>
+            <time datetime="{{ post.date | atom_date }}">{{ post.date | human_date }}</time>
             {% endif %}
             {% if post.description %}
             <p>{{ post.description | striptags | truncate:160 }}</p>

--- a/templates/partials/webmentions.html
+++ b/templates/partials/webmentions.html
@@ -102,7 +102,7 @@
           <div class="webmention-author-info">
             <a href="{{ mention.Author.URL|default:mention.URL }}" class="webmention-author-name" rel="nofollow noopener">{{ mention.Author.Name|default:"Anonymous" }}</a>
             {% if mention.Published %}
-            <time datetime="{{ mention.Published }}" class="webmention-date">{{ mention.Published }}</time>
+            <time datetime="{{ mention.Published }}" class="webmention-date">{{ mention.Published | human_date }}</time>
             {% endif %}
           </div>
         </div>
@@ -145,7 +145,7 @@
           <div class="webmention-author-info">
             <a href="{{ mention.Author.URL|default:mention.URL }}" class="webmention-author-name" rel="nofollow noopener">{{ mention.Author.Name|default:"Anonymous" }}</a>
             {% if mention.Published %}
-            <time datetime="{{ mention.Published }}" class="webmention-date">{{ mention.Published }}</time>
+            <time datetime="{{ mention.Published }}" class="webmention-date">{{ mention.Published | human_date }}</time>
             {% endif %}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add a shared `human_date` formatter for visible HTML dates
- update both active template trees, reader labels, and fallback HTML renderers to use the same format
- add regression coverage so visible HTML dates stay standardized across templates

## Testing
- go test ./pkg/templates -run 'TestFilterHumanDate|TestTemplateTrees_UseHumanDateForVisibleHTMLDates|TestPostMap_DateFilters'
- go test ./pkg/plugins -run 'TestBlogrollPlugin_ReaderDayGroups'
- just lint-fast

Fixes #1019