### PR TITLE
fix(blogroll): reapply config overrides over cached feeds

### DIFF
--- a/docs/guides/blogroll.md
+++ b/docs/guides/blogroll.md
@@ -559,7 +559,8 @@ cache_duration = "24h"          # How long to cache feeds
 2. On subsequent builds, cached feeds are used until `cache_duration` expires
 3. Expiration is based on the cached feed's recorded fetch time, not file mtimes
 4. If a refresh fails, the stale cached feed is reused instead of failing open
-5. Delete `cache/blogroll/` to force a fresh fetch
+5. Explicit config overrides like `title`, `description`, `site_url`, `image_url`, `handle`, aliases, category, and tags are reapplied even when cached feed data is reused
+6. Delete `cache/blogroll/` to force a fresh fetch
 
 ### Cache Duration Examples
 

--- a/pkg/agentskill/bundle/markata-go-site/topics/configuration.md
+++ b/pkg/agentskill/bundle/markata-go-site/topics/configuration.md
@@ -8,6 +8,8 @@ For standalone sites, prefer `markata-go.toml` unless the repo is already using 
 
 When a site has many feeds or environment-specific settings, keep `markata-go.toml` as the entrypoint and split the rest with `[markata-go].include`.
 
+For blogroll work, remember that explicit feed config overrides such as `site_url`, `image_url`, `title`, `handle`, aliases, category, and tags should take effect even when cached feed data is reused. Do not assume a stale cache must be deleted before config fixes apply.
+
 ## Config Discovery
 
 When `--config` is not passed, markata-go looks for config in this order:

--- a/pkg/plugins/blogroll.go
+++ b/pkg/plugins/blogroll.go
@@ -865,11 +865,21 @@ func initFeedFromConfig(config models.ExternalFeedConfig) *models.ExternalFeed {
 
 // mergeCachedFeed merges config values into a cached feed.
 func mergeCachedFeed(cached *models.ExternalFeed, config models.ExternalFeedConfig) *models.ExternalFeed {
+	cached.Config = config
 	if config.Title != "" {
 		cached.Title = config.Title
 	}
+	if config.Description != "" {
+		cached.Description = config.Description
+	}
 	if config.Category != "" {
 		cached.Category = config.Category
+	}
+	if config.SiteURL != "" {
+		cached.SiteURL = config.SiteURL
+	}
+	if config.ImageURL != "" {
+		cached.ImageURL = config.ImageURL
 	}
 	cached.Tags = config.Tags
 	return cached

--- a/pkg/plugins/blogroll_test.go
+++ b/pkg/plugins/blogroll_test.go
@@ -144,3 +144,56 @@ func TestBlogrollPlugin_LoadFromCache_UsesLastFetchedTimestamp(t *testing.T) {
 		t.Fatalf("cached.Title = %q, want Example", cached.Title)
 	}
 }
+
+func TestMergeCachedFeed_AppliesConfigOverrides(t *testing.T) {
+	cached := &models.ExternalFeed{
+		Config: models.ExternalFeedConfig{
+			URL:      "https://example.com/feed.xml",
+			Handle:   "old-handle",
+			Aliases:  []string{"old"},
+			SiteURL:  "http://example.com",
+			ImageURL: "http://example.com/old.png",
+		},
+		Title:       "Cached Title",
+		Description: "Cached description",
+		SiteURL:     "http://example.com",
+		ImageURL:    "http://example.com/old.png",
+		Category:    "Old",
+		Tags:        []string{"cached"},
+	}
+	config := models.ExternalFeedConfig{
+		URL:         "https://example.com/feed.xml",
+		Title:       "Config Title",
+		Description: "Config description",
+		Category:    "Config",
+		Tags:        []string{"fresh"},
+		SiteURL:     "https://example.com",
+		ImageURL:    "https://example.com/new.png",
+		Handle:      "new-handle",
+		Aliases:     []string{"new"},
+	}
+
+	merged := mergeCachedFeed(cached, config)
+
+	if merged.Config.Handle != "new-handle" {
+		t.Fatalf("merged.Config.Handle = %q, want %q", merged.Config.Handle, "new-handle")
+	}
+	if merged.Title != "Config Title" {
+		t.Fatalf("merged.Title = %q, want %q", merged.Title, "Config Title")
+	}
+	if merged.Description != "Config description" {
+		t.Fatalf("merged.Description = %q, want %q", merged.Description, "Config description")
+	}
+	if merged.Category != "Config" {
+		t.Fatalf("merged.Category = %q, want %q", merged.Category, "Config")
+	}
+	if merged.SiteURL != "https://example.com" {
+		t.Fatalf("merged.SiteURL = %q, want %q", merged.SiteURL, "https://example.com")
+	}
+	if merged.ImageURL != "https://example.com/new.png" {
+		t.Fatalf("merged.ImageURL = %q, want %q", merged.ImageURL, "https://example.com/new.png")
+	}
+	if len(merged.Tags) != 1 || merged.Tags[0] != "fresh" {
+		t.Fatalf("merged.Tags = %#v, want %#v", merged.Tags, []string{"fresh"})
+	}
+}

--- a/spec/spec/MENTIONS.md
+++ b/spec/spec/MENTIONS.md
@@ -113,6 +113,8 @@ aliases = ["ex", "exblog"]          # Additional handles
 
 The `site_url` becomes the link target for `@example`, `@ex`, and `@exblog`.
 
+When cached blogroll feed data exists, explicit config overrides such as `title`, `description`, `site_url`, `image_url`, `handle`, aliases, category, and tags MUST be reapplied before mentions resolve handles or avatar metadata. Config changes MUST take effect on the next build without requiring cache deletion.
+
 ### From Authors
 
 Authors defined in the site configuration (`[markata-go.authors.authors.*]`) are automatically registered as mentionable contacts. Each author is registered using their config key (ID) as the handle. The author's URL (if set) is used as the link target; if no URL is set, the author is not registered.


### PR DESCRIPTION
## Summary
- reapply explicit blogroll feed config overrides when cached feed data is reused
- keep cached feed metadata aligned with updated config for mentions and reader rendering
- document that config fixes should take effect without deleting the blogroll cache

## Testing
- go test ./pkg/plugins -run 'TestMergeCachedFeed_AppliesConfigOverrides|TestBlogrollPlugin_LoadFromCache_UsesLastFetchedTimestamp'
- just lint-fast

Fixes #1032