### PR TITLE
fix: render explicit images in default feed cards

### DIFF
--- a/pkg/themes/default/templates/partials/cards/default-card.html
+++ b/pkg/themes/default/templates/partials/cards/default-card.html
@@ -5,6 +5,14 @@
     <h2 class="card-title p-name"><a class="u-url" href="{{ post.href }}">{{ post.title | default:post.slug }}</a></h2>
   </header>
 
+  {% if post.image or post.cover or post.cover_image or post.og_image %}
+  {% with post.image|default:post.cover|default:post.cover_image|default:post.og_image as media %}
+  <a href="{{ post.href }}" class="card-media u-url">
+    <img src="{{ media|with_size:"1200,675" }}" alt="{{ post.title | default:post.description | default:'Post image' }}" class="card-thumbnail u-photo" width="1200" height="675" loading="lazy">
+  </a>
+  {% endwith %}
+  {% endif %}
+
   <div class="card-body">
     {% if post.description %}
     <p class="card-description p-summary">{{ post.description }}</p>

--- a/templates/partials/cards/default-card.html
+++ b/templates/partials/cards/default-card.html
@@ -3,6 +3,14 @@
 <article class="card card-default h-entry">
   <h2 class="card-title p-name"><a class="u-url" href="{{ post.href }}">{{ post.title | default:post.slug }}</a></h2>
 
+  {% if post.image or post.cover or post.cover_image or post.og_image %}
+  {% with post.image|default:post.cover|default:post.cover_image|default:post.og_image as media %}
+  <a href="{{ post.href }}" class="card-media u-url">
+    <img src="{{ media|with_size:"1200,675" }}" alt="{{ post.title | default:post.description | default:'Post image' }}" class="card-thumbnail u-photo" width="1200" height="675" loading="lazy">
+  </a>
+  {% endwith %}
+  {% endif %}
+
   {% if post.description %}
   <p class="card-description p-summary">{{ post.description }}</p>
   {% endif %}


### PR DESCRIPTION
## Summary
- render explicit frontmatter images in the built-in `default-card` templates
- keep cards without explicit media unchanged
- fixes #1044 so feed pages using `card-default` show note images without site-local overrides