### PR TITLE
fix: webawesome layer cascade, view-transition scripts, feed centering

### DIFF
--- a/docs/guides/view-transitions.md
+++ b/docs/guides/view-transitions.md
@@ -103,6 +103,12 @@ if (window.initTooltips) window.initTooltips();
 if (window.initScrollSpy) window.initScrollSpy();
 ```
 
+### 5. Head Asset Synchronization
+
+When navigating between pages with different head assets, the transition script syncs the new page's `<link rel="stylesheet">`, `<style>`, and `<script>` tags into the current document head. This ensures features that are only included on certain pages — such as Web Awesome custom elements, MathJax, or Mermaid — load correctly when transitioning into a page that needs them.
+
+Scripts are matched by `(type, src)` for external scripts and by `(type, textContent)` for inline scripts. Only NEW scripts are added; existing scripts are never re-executed (re-running a script that defines custom elements would throw). Cloned `<script>` nodes are inert in the browser, so the script is recreated via `document.createElement('script')` with attributes copied across before insertion.
+
 ## Browser Support
 
 - ✅ **Chrome/Edge 111+** - Full support

--- a/pkg/themes/default/static/css/feeds.css
+++ b/pkg/themes/default/static/css/feeds.css
@@ -9,6 +9,30 @@
   margin-right: auto;
 }
 
+/*
+ * When a post template (article.post) contains a rendered feed (e.g. a
+ * landing page using {{ render_feed(...) }}), the article's default
+ * --content-width (~65ch) is narrower than the feed card list's intrinsic
+ * 750px width. Without this override the cards overflow the article's
+ * centered column and appear visually offset to the right of the page.
+ * Widen the article column to fit the feed when one is present.
+ */
+article.post:has(> .post-content > .feed.h-feed),
+article.post:has(> .feed.h-feed) {
+  max-width: min(100%, calc(750px + (var(--space-4, 1rem) * 2)));
+}
+
+/*
+ * Inside article.post, constrain the feed grid to a single column that
+ * cannot exceed the container width. Without an explicit
+ * grid-template-columns the auto track can grow past the container due
+ * to intrinsic sizing of card children, causing the posts list to
+ * appear shifted right.
+ */
+article.post .feed.h-feed {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 .feed.h-feed {
   --feed-content-width: min(100%, 750px);
   width: 100%;

--- a/pkg/themes/default/static/js/view-transitions.js
+++ b/pkg/themes/default/static/js/view-transitions.js
@@ -628,6 +628,56 @@
     });
   }
 
+  function headScriptKey(node) {
+    if (!node || node.tagName !== 'SCRIPT') return '';
+    const src = node.getAttribute('src') || '';
+    if (src) {
+      return ['script', node.getAttribute('type') || '', src].join('::');
+    }
+    // Inline scripts in <head> are keyed by their text content. We do NOT
+    // re-execute matching inline scripts; we only add ones that don't already
+    // exist on the live document.
+    return ['script', node.getAttribute('type') || '', 'inline', node.textContent || ''].join('::');
+  }
+
+  /**
+   * Sync <script> tags from the new document's <head> into the live document.
+   *
+   * Without this, navigating from a page that does not load a particular head
+   * script (for example the Web Awesome module loader) into a page that does
+   * means the script never runs and custom elements (wa-*) never upgrade.
+   *
+   * We only ADD missing scripts; we do not remove or re-execute scripts that
+   * already exist, since module imports are idempotent and re-injecting a
+   * loader can re-register custom elements (which throws).
+   */
+  function syncHeadScripts(newDoc) {
+    if (!newDoc || !newDoc.head) return;
+
+    const head = document.head;
+    const existingKeys = new Set(
+      Array.from(head.querySelectorAll('script')).map(headScriptKey).filter(Boolean)
+    );
+
+    Array.from(newDoc.head.querySelectorAll('script')).forEach((node) => {
+      const key = headScriptKey(node);
+      if (!key || existingKeys.has(key)) return;
+
+      // Re-create the element so the browser actually executes it. Cloning a
+      // <script> node parsed by DOMParser does not run; we must construct a
+      // fresh element and copy over attributes/contents.
+      const fresh = document.createElement('script');
+      Array.from(node.attributes).forEach((attr) => {
+        fresh.setAttribute(attr.name, attr.value);
+      });
+      if (!node.hasAttribute('src')) {
+        fresh.textContent = node.textContent || '';
+      }
+      head.appendChild(fresh);
+      existingKeys.add(key);
+    });
+  }
+
   function replaceElementContents(selector, newDoc) {
     const currentElement = document.querySelector(selector);
     const nextElement = newDoc.querySelector(selector);
@@ -684,6 +734,7 @@
     syncDocumentElementAttributes(newDoc);
     syncBodyAttributes(newDoc);
     syncHeadStyles(newDoc);
+    syncHeadScripts(newDoc);
 
     // Update title
     document.title = newDoc.title;

--- a/pkg/themes/default/templates/base.html
+++ b/pkg/themes/default/templates/base.html
@@ -31,6 +31,14 @@
     })();
   </script>
 
+  <!--
+    Pre-declare Web Awesome's @layer wa-native FIRST so site CSS layers
+    (declared by main.css) take precedence. Without this, native.css's
+    global `a { color: var(--wa-color-text-link); }` rule wins the cascade
+    and turns every link on the page blue. Inert when webawesome is unused.
+  -->
+  <style>@layer wa-native, wa-utilities, wa-color-palette, wa-color-variant, wa-theme, wa-theme-dimension, wa-theme-overrides;</style>
+
   <!-- Core CSS (always loaded) -->
   <link rel="stylesheet" href="{{ 'css/variables.css' | theme_asset_hashed }}">
   {% if config.theme.palette or config.theme.palette_light or config.theme.palette_dark or config.theme.seed_color %}

--- a/spec/spec/WEBAWESOME.md
+++ b/spec/spec/WEBAWESOME.md
@@ -225,6 +225,18 @@ When `source = "cdn"`, the plugin loads the same files from the configured CDN b
 
 The autoloader uses a MutationObserver to discover `<wa-*>` tags in the document and lazy-imports the matching component module on demand. Pages without any `<wa-*>` tags do not load Web Awesome CSS or JavaScript.
 
+## CSS Cascade Layers
+
+Web Awesome's `native.css` declares `@layer wa-native, wa-utilities, wa-color-palette, wa-color-variant, wa-theme, wa-theme-dimension, wa-theme-overrides;` and styles native elements (including `a`) inside `@layer wa-native`. Because Web Awesome stylesheets are loaded after the site's own stylesheets, naive ordering causes Web Awesome's `wa-native` layer to register last and win the cascade for unscoped element selectors such as `a`, overriding the site's link color.
+
+To prevent this, the default `base.html` template MUST pre-declare the Web Awesome layer order in an inline `<style>` block placed in `<head>` before any `<link rel="stylesheet">`:
+
+```html
+<style>@layer wa-native, wa-utilities, wa-color-palette, wa-color-variant, wa-theme, wa-theme-dimension, wa-theme-overrides;</style>
+```
+
+Pre-declaring the layers pins `wa-native` as the FIRST registered layer, so any unlayered or later-registered site styles win as expected. This must remain in the head on EVERY page (not gated on `needs_webawesome`) because the site's own cascade depends on stable layer order.
+
 ## Theming
 
 The plugin adds Web Awesome theme classes to the `<html>` element when needed:

--- a/templates/base.html
+++ b/templates/base.html
@@ -31,6 +31,14 @@
     })();
   </script>
 
+  <!--
+    Pre-declare Web Awesome's @layer wa-native FIRST so site CSS layers
+    (declared by main.css) take precedence. Without this, native.css's
+    global `a { color: var(--wa-color-text-link); }` rule wins the cascade
+    and turns every link on the page blue. Inert when webawesome is unused.
+  -->
+  <style>@layer wa-native, wa-utilities, wa-color-palette, wa-color-variant, wa-theme, wa-theme-dimension, wa-theme-overrides;</style>
+
   <!-- Core CSS (always loaded) -->
   <link rel="stylesheet" href="{{ 'css/variables.css' | theme_asset_hashed }}">
   {% if config.theme.palette or config.theme.palette_light or config.theme.palette_dark or config.theme.seed_color %}


### PR DESCRIPTION
Fixes #1046
Refs #1042

## Summary

Three fixes bundled together because they all surfaced while testing webawesome on a real site:

1. **CSS layer cascade** — pre-declare `@layer wa-native, ...` in `<head>` so site styles win over webawesome's native element styles (links no longer turn blue).
2. **View-transition scripts** — sync new `<script>` tags from the destination page so webawesome (and other lazy-loaded head scripts) upgrade after a SPA-style navigation.
3. **Feed centering** — widen `article.post` and pin the feed grid when a homepage uses `{{ render_feed(...) }}` inside the default post template.

## Changes

| File | Change |
|------|--------|
| `pkg/themes/default/templates/base.html` | Inline `@layer` pre-declaration in head |
| `templates/base.html` | Same (parallel template tree) |
| `pkg/themes/default/static/js/view-transitions.js` | Add `syncHeadScripts()` after `syncHeadStyles()` in `updateDocument` |
| `pkg/themes/default/static/css/feeds.css` | `article.post:has(.feed.h-feed)` widening + grid-template-columns pin |
| `spec/spec/WEBAWESOME.md` | Document layer pre-declaration requirement |
| `docs/guides/view-transitions.md` | Document head asset sync behavior |

## Testing

- `go vet ./...`
- `go test ./pkg/plugins/ ./pkg/templates/ -count=1`
- Clean rebuild of a real site using webawesome; verified in browser via Playwright (`agent-browser`):
  - Link color is `rgb(255, 205, 17)` (site `--color-link`), not webawesome blue
  - Navigation from non-wa page -> wa page upgrades `wa-comparison` and other custom elements
  - Homepage feed cards centered (article center == viewport center)

## Skill

Bundled site skill not changed: these fixes restore expected behavior for site authors and do not introduce new patterns. Author-facing guidance in the skill still says "use existing template wiring rather than hand-rolling tags," which remains correct.