### PR TITLE
fix(theme): use palette-native syntax colors

### DIFF
--- a/docs/guides/markdown.md
+++ b/docs/guides/markdown.md
@@ -927,26 +927,26 @@ line_numbers = false     # Line numbers (if supported)
 
 #### Automatic Theme from Palette
 
-By default, the syntax highlighting theme is **automatically derived** from your site's color palette. This ensures code blocks match your site's overall look:
+By default, syntax highlighting is **driven by your site's palette code colors**. This ensures code blocks match your site's overall look even when there is no exact Chroma theme match:
 
 ```toml
 [markata-go.theme]
-palette = "catppuccin-mocha"  # Code blocks will use catppuccin-mocha highlighting
+palette = "catppuccin-mocha"
 ```
 
-| Site Palette | Code Theme |
-|-------------|------------|
-| catppuccin-mocha | catppuccin-mocha |
-| catppuccin-latte | catppuccin-latte |
-| rose-pine | rose-pine |
-| gruvbox-dark | gruvbox |
-| gruvbox-light | gruvbox-light |
-| tokyo-night | tokyonight-night |
-| dracula | dracula |
-| solarized-dark | solarized-dark |
-| nord-dark | nord |
+The palette's `code-*` component roles control the generated CSS variables used by Chroma token classes:
 
-For palettes without an exact match, defaults are used based on light/dark variant.
+- `code-bg`
+- `code-text`
+- `code-comment`
+- `code-keyword`
+- `code-string`
+- `code-number`
+- `code-function`
+- `code-type`
+- `code-operator`
+
+If you want a specific Chroma theme instead of palette-native colors, set `markdown.highlight.theme` explicitly.
 
 #### Explicit Override
 

--- a/docs/guides/themes.md
+++ b/docs/guides/themes.md
@@ -164,6 +164,14 @@ These CSS custom properties can be overridden:
 | `--color-link-hover` | Link hover color | Depends on palette |
 | `--color-border` | Border color | Depends on palette |
 | `--color-code-bg` | Code block background | Depends on palette |
+| `--color-code-text` | Code block text | Depends on palette |
+| `--color-code-comment` | Code comments | Depends on palette |
+| `--color-code-keyword` | Code keywords | Depends on palette |
+| `--color-code-string` | Code strings | Depends on palette |
+| `--color-code-number` | Code numbers | Depends on palette |
+| `--color-code-function` | Code functions | Depends on palette |
+| `--color-code-type` | Code types and tags | Depends on palette |
+| `--color-code-operator` | Code operators | Depends on palette |
 | `--content-width` | Max content width | `720px` |
 | `--font-family` | Body font | System fonts |
 | `--font-family-mono` | Code font | Monospace fonts |

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -3114,7 +3114,7 @@ Variables are automatically available in your CSS:
 
 **Name:** `chroma_css`  
 **Stage:** Configure + Write  
-**Purpose:** Generates CSS for syntax highlighting from Chroma themes. Creates `css/chroma.css` with syntax highlighting styles that work with `render_markdown`'s CSS-class-based highlighting.
+**Purpose:** Generates `css/chroma.css` for syntax-highlighted code blocks. By default it styles Chroma token classes from the active palette's `code-*` colors; with `markdown.highlight.theme` it uses an explicit Chroma theme override.
 
 **Configuration (TOML):**
 ```toml
@@ -3123,15 +3123,15 @@ Variables are automatically available in your CSS:
 theme = "github-dark"  # Chroma theme name
 ```
 
-Or auto-derived from palette:
+Or use palette-native syntax colors:
 ```toml
 [theme]
-palette = "catppuccin-mocha"  # Automatically selects matching Chroma theme
+palette = "catppuccin-mocha"  # Uses the palette's code-* component colors
 ```
 
 **Behavior:**
-1. During Configure: Reads theme from `markdown.highlight.theme` or derives from palette
-2. Falls back to variant-appropriate default (dark palettes -> github-dark, light palettes -> github)
+1. During Configure: Reads `markdown.highlight.theme` if explicitly set
+2. Without an explicit theme, emits palette-native CSS using `--color-code-*` variables
 3. During Write: Generates `{output_dir}/css/chroma.css` with syntax highlighting styles
 
 **Available Chroma Themes:**
@@ -3167,20 +3167,17 @@ Include the generated CSS in your base template:
 <link rel="stylesheet" href="/css/chroma.css">
 ```
 
-**Palette to Chroma Theme Mapping:**
+**Palette-native roles used by default:**
 
-| Palette | Chroma Theme |
-|---------|--------------|
-| `catppuccin-mocha` | `catppuccin-mocha` |
-| `catppuccin-latte` | `catppuccin-latte` |
-| `dracula` | `dracula` |
-| `nord` | `nord` |
-| `gruvbox-dark` | `gruvbox` |
-| `gruvbox-light` | `gruvbox-light` |
-| `solarized-dark` | `solarized-dark` |
-| `solarized-light` | `solarized-light` |
-| `rose-pine` | `rose-pine` |
-| `tokyo-night` | `tokyo-night` |
+- `code-bg`
+- `code-text`
+- `code-comment`
+- `code-keyword`
+- `code-string`
+- `code-number`
+- `code-function`
+- `code-type`
+- `code-operator`
 
 **Related plugins:**
 - [[#render_markdown|render_markdown]] - Uses CSS classes for syntax highlighting

--- a/pkg/agentskill/bundle/markata-go-site/reference/palette-reference.md
+++ b/pkg/agentskill/bundle/markata-go-site/reference/palette-reference.md
@@ -100,6 +100,11 @@ Most useful semantic names:
 - `code-text`
 - `code-comment`
 - `code-keyword`
+- `code-string`
+- `code-number`
+- `code-function`
+- `code-type`
+- `code-operator`
 - `button-primary-bg`
 - `button-primary-text`
 - `button-secondary-bg`
@@ -128,5 +133,12 @@ The palette CSS plugin maps palette roles into site CSS variables such as:
 - `link-visited` -> `--color-link-visited`
 - `code-bg` -> `--color-code-bg`
 - `code-text` -> `--color-code-text`
+- `code-comment` -> `--color-code-comment`
+- `code-keyword` -> `--color-code-keyword`
+- `code-string` -> `--color-code-string`
+- `code-number` -> `--color-code-number`
+- `code-function` -> `--color-code-function`
+- `code-type` -> `--color-code-type`
+- `code-operator` -> `--color-code-operator`
 
 So if the task is “change the whole color system”, editing the palette is usually better than patching many CSS selectors.

--- a/pkg/plugins/chroma_css.go
+++ b/pkg/plugins/chroma_css.go
@@ -27,6 +27,7 @@ type ChromaCSSPlugin struct {
 	chromaTheme string
 	chromaCSS   string // Pre-generated CSS content (computed in Configure)
 	chromaHash  string // Content hash for cache busting
+	explicit    bool
 }
 
 // NewChromaCSSPlugin creates a new ChromaCSSPlugin.
@@ -48,44 +49,25 @@ func (p *ChromaCSSPlugin) Configure(m *lifecycle.Manager) error {
 	config := m.Config()
 	extra := config.Extra
 
-	configuredTheme := ""
-
-	// Try to get explicit highlight config from markdown.highlight.theme
-	if markdown, ok := extra["markdown"].(map[string]interface{}); ok {
-		if highlight, ok := markdown["highlight"].(map[string]interface{}); ok {
-			if theme, ok := highlight["theme"].(string); ok && theme != "" {
-				configuredTheme = theme
-			}
-		}
-	}
-
-	// Derive from palette if not explicitly set
-	if configuredTheme == "" {
-		paletteName := p.getPaletteName(extra)
-		if paletteName != "" {
-			chromaTheme := palettes.ChromaTheme(paletteName)
-			if chromaTheme != "" {
-				configuredTheme = chromaTheme
-			} else {
-				// Fallback based on variant
-				variant := p.getPaletteVariant(paletteName)
-				configuredTheme = palettes.ChromaThemeForVariant(variant)
-			}
-		}
-	}
-
-	// Use configured theme if found, otherwise keep default
+	configuredTheme, explicitTheme := p.getExplicitHighlightTheme(extra)
+	p.explicit = explicitTheme
 	if configuredTheme != "" {
 		p.chromaTheme = configuredTheme
 	}
 
-	// Pre-generate the CSS content so we can hash it for cache busting
-	style := styles.Get(p.chromaTheme)
-	if style == nil {
-		style = styles.Fallback
+	var (
+		css string
+		err error
+	)
+	if p.explicit {
+		style := styles.Get(p.chromaTheme)
+		if style == nil {
+			style = styles.Fallback
+		}
+		css, err = p.generateThemeCSS(style)
+	} else {
+		css = p.generatePaletteCSS()
 	}
-
-	css, err := p.generateCSS(style)
 	if err != nil {
 		return fmt.Errorf("generating chroma CSS: %w", err)
 	}
@@ -117,14 +99,18 @@ func (p *ChromaCSSPlugin) Write(m *lifecycle.Manager) error {
 	css := p.chromaCSS
 	if css == "" {
 		// Fallback: generate now if Configure didn't run (shouldn't happen)
-		style := styles.Get(p.chromaTheme)
-		if style == nil {
-			style = styles.Fallback
-		}
-		var err error
-		css, err = p.generateCSS(style)
-		if err != nil {
-			return fmt.Errorf("generating chroma CSS: %w", err)
+		if p.explicit {
+			style := styles.Get(p.chromaTheme)
+			if style == nil {
+				style = styles.Fallback
+			}
+			var err error
+			css, err = p.generateThemeCSS(style)
+			if err != nil {
+				return fmt.Errorf("generating chroma CSS: %w", err)
+			}
+		} else {
+			css = p.generatePaletteCSS()
 		}
 	}
 
@@ -154,8 +140,8 @@ func (p *ChromaCSSPlugin) Write(m *lifecycle.Manager) error {
 	return nil
 }
 
-// generateCSS creates CSS from a Chroma style.
-func (p *ChromaCSSPlugin) generateCSS(style *chroma.Style) (string, error) {
+// generateThemeCSS creates CSS from an explicit Chroma style override.
+func (p *ChromaCSSPlugin) generateThemeCSS(style *chroma.Style) (string, error) {
 	formatter := chromahtml.New(chromahtml.WithClasses(true), chromahtml.WithAllClasses(true))
 
 	var sb strings.Builder
@@ -171,32 +157,46 @@ func (p *ChromaCSSPlugin) generateCSS(style *chroma.Style) (string, error) {
 	return sb.String(), nil
 }
 
-// getPaletteName extracts the palette name from config.Extra.
-func (p *ChromaCSSPlugin) getPaletteName(extra map[string]interface{}) string {
-	if extra == nil {
-		return ""
-	}
-
-	if theme, ok := extra["theme"].(map[string]interface{}); ok {
-		if palette, ok := theme["palette"].(string); ok && palette != "" {
-			return palette
-		}
-	}
-
-	return ""
+// generatePaletteCSS styles Chroma token classes from the active palette's code colors.
+func (p *ChromaCSSPlugin) generatePaletteCSS() string {
+	var sb strings.Builder
+	sb.WriteString("/* Syntax highlighting - generated from palette code colors */\n\n")
+	sb.WriteString(`.chroma { color: var(--color-code-text, var(--color-text, currentColor)); background-color: var(--color-code-bg, var(--color-surface, transparent)); }
+.chroma .err { color: var(--color-error, #dc2626); background-color: color-mix(in srgb, var(--color-error, #dc2626) 14%, transparent); }
+.chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
+.chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; }
+.chroma .hl { background-color: color-mix(in srgb, var(--color-code-text, currentColor) 10%, var(--color-code-bg, transparent)); }
+.chroma .ln, .chroma .lnt { color: color-mix(in srgb, var(--color-code-text, currentColor) 45%, transparent); }
+.chroma .c, .chroma .ch, .chroma .cm, .chroma .c1, .chroma .cs, .chroma .cpf { color: var(--color-code-comment, var(--color-text-muted, #6b7280)); font-style: italic; }
+.chroma .k, .chroma .kc, .chroma .kd, .chroma .kn, .chroma .kp, .chroma .kr, .chroma .kt { color: var(--color-code-keyword, var(--color-primary, #7c3aed)); font-weight: 600; }
+.chroma .s, .chroma .sa, .chroma .sb, .chroma .sc, .chroma .dl, .chroma .sd, .chroma .s2, .chroma .se, .chroma .sh, .chroma .si, .chroma .sx, .chroma .sr, .chroma .s1, .chroma .ss { color: var(--color-code-string, var(--color-success, #059669)); }
+.chroma .m, .chroma .mb, .chroma .mf, .chroma .mh, .chroma .mi, .chroma .il, .chroma .mo, .chroma .bin, .chroma .oct, .chroma .hex { color: var(--color-code-number, var(--color-code-keyword, #7c3aed)); }
+.chroma .nf, .chroma .fm { color: var(--color-code-function, var(--color-link, #2563eb)); }
+.chroma .nc, .chroma .nn, .chroma .no, .chroma .nt, .chroma .nd, .chroma .ne, .chroma .nl { color: var(--color-code-type, var(--color-code-function, #2563eb)); }
+.chroma .o, .chroma .ow { color: var(--color-code-operator, var(--color-code-keyword, #7c3aed)); }
+.chroma .na, .chroma .py, .chroma .bp { color: var(--color-code-function, var(--color-link, #2563eb)); }
+.chroma .n, .chroma .nb, .chroma .nv, .chroma .vc, .chroma .vg, .chroma .vi, .chroma .vm { color: var(--color-code-text, var(--color-text, currentColor)); }
+.chroma .gi { color: var(--color-success, #059669); background-color: color-mix(in srgb, var(--color-success, #059669) 14%, transparent); }
+.chroma .gd { color: var(--color-error, #dc2626); background-color: color-mix(in srgb, var(--color-error, #dc2626) 14%, transparent); }
+`)
+	return sb.String()
 }
 
-// getPaletteVariant determines the variant (light/dark) of a palette by name.
-func (p *ChromaCSSPlugin) getPaletteVariant(paletteName string) palettes.Variant {
-	lightPatterns := []string{
-		"-light", "-latte", "-dawn", "-day", "-lotus",
+// getExplicitHighlightTheme returns the configured Chroma theme override, if any.
+func (p *ChromaCSSPlugin) getExplicitHighlightTheme(extra map[string]interface{}) (string, bool) {
+	if extra == nil {
+		return "", false
 	}
-	for _, pattern := range lightPatterns {
-		if strings.Contains(paletteName, pattern) {
-			return palettes.VariantLight
+
+	if markdown, ok := extra["markdown"].(map[string]interface{}); ok {
+		if highlight, ok := markdown["highlight"].(map[string]interface{}); ok {
+			if theme, ok := highlight["theme"].(string); ok && theme != "" {
+				return theme, true
+			}
 		}
 	}
-	return palettes.VariantDark
+
+	return "", false
 }
 
 // Priority returns the plugin priority for the write stage.

--- a/pkg/plugins/chroma_css_test.go
+++ b/pkg/plugins/chroma_css_test.go
@@ -18,14 +18,16 @@ func TestChromaCSSPlugin_Name(t *testing.T) {
 
 func TestChromaCSSPlugin_Configure(t *testing.T) {
 	tests := []struct {
-		name      string
-		extra     map[string]interface{}
-		wantTheme string
+		name         string
+		extra        map[string]interface{}
+		wantTheme    string
+		wantExplicit bool
 	}{
 		{
-			name:      "default theme",
-			extra:     map[string]interface{}{},
-			wantTheme: "github-dark",
+			name:         "default theme",
+			extra:        map[string]interface{}{},
+			wantTheme:    "github-dark",
+			wantExplicit: false,
 		},
 		{
 			name: "explicit theme",
@@ -36,16 +38,18 @@ func TestChromaCSSPlugin_Configure(t *testing.T) {
 					},
 				},
 			},
-			wantTheme: "monokai",
+			wantTheme:    "monokai",
+			wantExplicit: true,
 		},
 		{
-			name: "theme from palette",
+			name: "palette uses palette-native CSS",
 			extra: map[string]interface{}{
 				"theme": map[string]interface{}{
 					"palette": "catppuccin-mocha",
 				},
 			},
-			wantTheme: "catppuccin-mocha", // From palette mapping
+			wantTheme:    "github-dark",
+			wantExplicit: false,
 		},
 	}
 
@@ -62,6 +66,9 @@ func TestChromaCSSPlugin_Configure(t *testing.T) {
 
 			if p.chromaTheme != tt.wantTheme {
 				t.Errorf("chromaTheme = %q, want %q", p.chromaTheme, tt.wantTheme)
+			}
+			if p.explicit != tt.wantExplicit {
+				t.Errorf("explicit = %v, want %v", p.explicit, tt.wantExplicit)
 			}
 		})
 	}
@@ -102,6 +109,9 @@ func TestChromaCSSPlugin_Write(t *testing.T) {
 	}
 	if !strings.Contains(css, ".chroma") {
 		t.Error("expected .chroma class in CSS")
+	}
+	if !strings.Contains(css, "--color-code-keyword") {
+		t.Error("expected palette-native code color variables in CSS")
 	}
 	// Check for typical chroma classes
 	if !strings.Contains(css, ".kd") { // keyword declaration

--- a/pkg/plugins/palette_css.go
+++ b/pkg/plugins/palette_css.go
@@ -670,6 +670,20 @@ func (p *PaletteCSSPlugin) writePaletteVariablesIndented(buf *bytes.Buffer, pale
 		if codeText := palette.Resolve("code-text"); codeText != "" {
 			fmt.Fprintf(buf, "%s--color-code-text: %s;\n", indent, codeText)
 		}
+		for _, role := range []string{
+			"comment",
+			"keyword",
+			"string",
+			"number",
+			"function",
+			"type",
+			"operator",
+		} {
+			componentName := "code-" + role
+			if value := palette.Resolve(componentName); value != "" {
+				fmt.Fprintf(buf, "%s--color-%s: %s;\n", indent, componentName, value)
+			}
+		}
 	}
 
 	// Add admonition colors if available

--- a/pkg/plugins/palette_css_test.go
+++ b/pkg/plugins/palette_css_test.go
@@ -111,6 +111,9 @@ func TestPaletteCSSPlugin_Write_GeneratesCSS(t *testing.T) {
 	if !strings.Contains(css, "--color-primary") {
 		t.Error("expected --color-primary in CSS")
 	}
+	if !strings.Contains(css, "--color-code-keyword") {
+		t.Error("expected syntax highlighting code variables in CSS")
+	}
 }
 
 func TestPaletteCSSPlugin_Write_DefaultsToDarkWithoutSystemPreference(t *testing.T) {

--- a/spec/spec/THEMES.md
+++ b/spec/spec/THEMES.md
@@ -2072,47 +2072,29 @@ pre[data-language]::after {
 
 ### Syntax Highlighting Themes
 
-Implementations SHOULD support multiple syntax highlighting themes. The syntax highlighting theme can be:
+Implementations SHOULD support multiple syntax highlighting themes. Syntax highlighting can be:
 
 1. **Explicitly configured** via `markdown.highlight.theme`
-2. **Automatically derived** from the site's color palette (`theme.palette`)
-3. **Defaulted** based on palette variant (light/dark)
+2. **Automatically styled** from the site's palette component colors (`theme.palette`)
+3. **Defaulted** to a stable internal Chroma theme when no explicit override is set
 
-#### Palette-to-Theme Mapping
+#### Palette-native Styling
 
-When no explicit theme is set, the syntax highlighting theme is derived from the site palette:
+When no explicit theme is set, syntax highlighting CSS MUST be generated from the active palette's code component roles instead of relying on nearest-match Chroma themes. The generated CSS SHOULD use these palette-driven variables when available:
 
-| Site Palette | Chroma Theme | Notes |
-|-------------|--------------|-------|
-| `catppuccin-latte` | `catppuccin-latte` | Exact match |
-| `catppuccin-frappe` | `catppuccin-frappe` | Exact match |
-| `catppuccin-macchiato` | `catppuccin-macchiato` | Exact match |
-| `catppuccin-mocha` | `catppuccin-mocha` | Exact match |
-| `nord-light` | `nord` | Both variants use same theme |
-| `nord-dark` | `nord` | Both variants use same theme |
-| `gruvbox-light` | `gruvbox-light` | Light variant |
-| `gruvbox-dark` | `gruvbox` | Dark variant |
-| `tokyo-night` | `tokyonight-night` | Main variant |
-| `tokyo-night-storm` | `tokyonight-storm` | Storm variant |
-| `tokyo-night-day` | `tokyonight-day` | Light variant |
-| `rose-pine` | `rose-pine` | Exact match |
-| `rose-pine-moon` | `rose-pine-moon` | Exact match |
-| `rose-pine-dawn` | `rose-pine-dawn` | Exact match |
-| `everforest-light` | `evergarden` | Similar aesthetic |
-| `everforest-dark` | `evergarden` | Similar aesthetic |
-| `dracula` | `dracula` | Exact match |
-| `solarized-light` | `solarized-light` | Exact match |
-| `solarized-dark` | `solarized-dark` | Exact match |
-| `kanagawa-wave` | `vim` | Japanese aesthetic |
-| `kanagawa-dragon` | `vim` | Japanese aesthetic |
-| `kanagawa-lotus` | `modus-operandi` | Light variant |
-| `default-light` | `github` | Clean, neutral |
-| `default-dark` | `github-dark` | Clean, neutral |
-| `matte-black` | `monokai` | High contrast |
+- `code-bg`
+- `code-text`
+- `code-comment`
+- `code-keyword`
+- `code-string`
+- `code-number`
+- `code-function`
+- `code-type`
+- `code-operator`
 
-For unknown palettes, the default is determined by the palette's variant:
-- Light palettes: `github`
-- Dark palettes: `github-dark`
+If a palette omits some of these roles, implementations SHOULD fall back to sensible site variables such as `--color-text`, `--color-text-muted`, `--color-link`, `--color-primary`, `--color-success`, and `--color-error`.
+
+Explicit `markdown.highlight.theme` overrides MAY still use any supported Chroma theme.
 
 #### Available Themes
 


### PR DESCRIPTION
## Summary
- Generate syntax highlighting from palette-native `code-*` roles by default.
- Keep explicit `markdown.highlight.theme` overrides working.
- Update docs, spec, and the bundled site skill reference.

## Issue
- Fixes #1050

## Validation
- `just lint-fast`
- `go test ./pkg/plugins/...`
- `go test ./pkg/palettes/...`