### PR TITLE
fix: resolve HN reader and embed metadata

### DIFF
--- a/docs/guides/blogroll.md
+++ b/docs/guides/blogroll.md
@@ -325,6 +325,7 @@ The reader page shows the latest posts from all feeds in reverse chronological o
 - Two-column entry grid on desktop, single column on mobile
 - Each entry shows: source favicon, source name, date, title, description, optional image
 - Links to the original article
+- Hacker News discussion URLs are normalized to the outbound article URL when one is available, while the source feed label stays visible and the original discussion link remains available as "Found on HN"
 - Pagination navigation (when more than one page)
 
 **Deterministic ordering:**
@@ -424,6 +425,10 @@ Create `templates/reader.html`:
             {% endif %}
           </div>
 
+          {% if entry.original_url %}
+          <div class="reader-entry-found-on">Found on HN: <a href="{{ entry.original_url }}" target="_blank" rel="noopener noreferrer">discussion</a></div>
+          {% endif %}
+
           <h2 class="reader-entry-title">
             <a href="{{ entry.url }}" target="_blank" rel="noopener noreferrer">{{ entry.title }}<span class="visually-hidden">(opens in new tab)</span></a>
           </h2>
@@ -470,6 +475,7 @@ Create `templates/reader.html`:
 | `entry_count` | int | Total number of entries across all pages |
 | `page` | ReaderPage | Pagination information |
 | `pagination_type` | string | Pagination type ("manual", "htmx", "js") |
+| `original_url` | string | Original discussion link when a feed entry was normalized |
 
 ### ReaderPage Fields
 

--- a/docs/guides/embeds.md
+++ b/docs/guides/embeds.md
@@ -49,6 +49,8 @@ Here's a great resource:
 
 This resolves metadata via oEmbed (when available), then falls back to Open Graph, and displays a card with the title, description, and image.
 
+If the URL is a Hacker News discussion link, markata-go resolves the outbound article URL first so the card can use the real article metadata while still showing a "Found on HN" link to the original discussion.
+
 Supported options (space-separated):
 
 - `no_title`, `no_description`, `no_meta`

--- a/pkg/models/blogroll.go
+++ b/pkg/models/blogroll.go
@@ -226,6 +226,9 @@ type ExternalEntry struct {
 	// URL is the link to the full article
 	URL string `json:"url"`
 
+	// OriginalURL is the original link from the feed, if different from URL.
+	OriginalURL string `json:"original_url,omitempty"`
+
 	// Title is the entry title
 	Title string `json:"title"`
 

--- a/pkg/plugins/blogroll.go
+++ b/pkg/plugins/blogroll.go
@@ -387,18 +387,16 @@ func parseRSS2Feed(data []byte) (*blogrollParsedFeed, []*models.ExternalEntry, e
 
 		// Extract image from various sources (priority order)
 		imageURL := extractEntryImage(item)
-		resolvedURL, originalURL := resolveHackerNewsReference(item.Link)
-		if originalURL != "" {
-			if metadata, ok := fetchHackerNewsArticleMetadata(resolvedURL); ok && metadata != nil {
-				if metadata.Title != "" {
-					item.Title = metadata.Title
-				}
-				if metadata.Description != "" {
-					item.Description = metadata.Description
-				}
-				if metadata.Image != "" {
-					imageURL = metadata.Image
-				}
+		resolvedURL, originalURL, metadata := enrichHackerNewsFeedEntry(item.Link)
+		if metadata != nil {
+			if metadata.Title != "" {
+				item.Title = metadata.Title
+			}
+			if metadata.Description != "" {
+				item.Description = metadata.Description
+			}
+			if metadata.Image != "" {
+				imageURL = metadata.Image
 			}
 		}
 
@@ -499,18 +497,16 @@ func parseAtomFeed(data []byte) (*blogrollParsedFeed, []*models.ExternalEntry, e
 
 		// Extract first image from content
 		imageURL := extractAtomEntryImage(entry)
-		resolvedURL, originalURL := resolveHackerNewsReference(entryURL)
-		if originalURL != "" {
-			if metadata, ok := fetchHackerNewsArticleMetadata(resolvedURL); ok && metadata != nil {
-				if metadata.Title != "" {
-					entry.Title = metadata.Title
-				}
-				if metadata.Description != "" {
-					entry.Summary = metadata.Description
-				}
-				if metadata.Image != "" {
-					imageURL = metadata.Image
-				}
+		resolvedURL, originalURL, metadata := enrichHackerNewsFeedEntry(entryURL)
+		if metadata != nil {
+			if metadata.Title != "" {
+				entry.Title = metadata.Title
+			}
+			if metadata.Description != "" {
+				entry.Summary = metadata.Description
+			}
+			if metadata.Image != "" {
+				imageURL = metadata.Image
 			}
 		}
 

--- a/pkg/plugins/blogroll.go
+++ b/pkg/plugins/blogroll.go
@@ -33,8 +33,9 @@ const categoryUncategorized = "Uncategorized"
 
 // Default slug constants for blogroll pages.
 const (
-	defaultBlogrollSlug = "blogroll"
-	defaultReaderSlug   = "reader"
+	defaultBlogrollSlug  = "blogroll"
+	defaultReaderSlug    = "reader"
+	blogrollCacheVersion = "hn-meta-v2"
 )
 
 // Default directory constants.
@@ -386,12 +387,28 @@ func parseRSS2Feed(data []byte) (*blogrollParsedFeed, []*models.ExternalEntry, e
 
 		// Extract image from various sources (priority order)
 		imageURL := extractEntryImage(item)
+		resolvedURL, originalURL := resolveHackerNewsReference(item.Link)
+		if originalURL != "" {
+			if metadata, ok := fetchHackerNewsArticleMetadata(resolvedURL); ok && metadata != nil {
+				if metadata.Title != "" {
+					item.Title = metadata.Title
+				}
+				if metadata.Description != "" {
+					item.Description = metadata.Description
+				}
+				if metadata.Image != "" {
+					imageURL = metadata.Image
+				}
+			}
+		}
 
 		// Create entry
+		entryURL := normalizeExternalURL(resolvedURL)
 		entry := &models.ExternalEntry{
 			ID:          id,
 			Title:       item.Title,
-			URL:         normalizeExternalURL(item.Link),
+			URL:         entryURL,
+			OriginalURL: originalURL,
 			Published:   pubDatePtr,
 			Updated:     pubDatePtr,
 			Author:      author,
@@ -482,12 +499,27 @@ func parseAtomFeed(data []byte) (*blogrollParsedFeed, []*models.ExternalEntry, e
 
 		// Extract first image from content
 		imageURL := extractAtomEntryImage(entry)
+		resolvedURL, originalURL := resolveHackerNewsReference(entryURL)
+		if originalURL != "" {
+			if metadata, ok := fetchHackerNewsArticleMetadata(resolvedURL); ok && metadata != nil {
+				if metadata.Title != "" {
+					entry.Title = metadata.Title
+				}
+				if metadata.Description != "" {
+					entry.Summary = metadata.Description
+				}
+				if metadata.Image != "" {
+					imageURL = metadata.Image
+				}
+			}
+		}
 
 		// Create entry
 		extEntry := &models.ExternalEntry{
 			ID:          entry.ID,
 			Title:       entry.Title,
-			URL:         normalizeExternalURL(entryURL),
+			URL:         normalizeExternalURL(resolvedURL),
+			OriginalURL: originalURL,
 			Published:   pubDatePtr,
 			Updated:     updDatePtr,
 			Author:      entry.Author.Name,
@@ -1100,7 +1132,7 @@ func (p *BlogrollPlugin) saveToCache(feed *models.ExternalFeed, cacheDir string)
 
 // cacheKey generates a cache key from a URL.
 func (p *BlogrollPlugin) cacheKey(url string) string {
-	hash := sha256.Sum256([]byte(url))
+	hash := sha256.Sum256([]byte(blogrollCacheVersion + "|" + url))
 	return hex.EncodeToString(hash[:8])
 }
 
@@ -1686,6 +1718,7 @@ func (p *BlogrollPlugin) readerEntryMap(entry *models.ExternalEntry, feed *model
 		"feed_title":       sourceTitle,
 		"id":               entry.ID,
 		"url":              entry.URL,
+		"original_url":     entry.OriginalURL,
 		"title":            entry.Title,
 		"description":      entry.Description,
 		"content":          entry.Content,

--- a/pkg/plugins/blogroll_reader_test.go
+++ b/pkg/plugins/blogroll_reader_test.go
@@ -137,10 +137,9 @@ func TestReaderPreviewForEntry_Hierarchy(t *testing.T) {
 }
 
 func TestNormalizeHackerNewsURL_ResolvesArticleURL(t *testing.T) {
-	articleURL := "https://example.com/article"
 	articleServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
-		_, _ = w.Write([]byte(`<!DOCTYPE html>
+		if _, err := w.Write([]byte(`<!DOCTYPE html>
 <html>
 <head>
 	<title>Article Title</title>
@@ -149,10 +148,12 @@ func TestNormalizeHackerNewsURL_ResolvesArticleURL(t *testing.T) {
 	<meta property="og:image" content="https://example.com/article.jpg">
 </head>
 <body></body>
-</html>`))
+</html>`)); err != nil {
+			t.Errorf("write article html: %v", err)
+		}
 	}))
 	defer articleServer.Close()
-	articleURL = articleServer.URL
+	articleURL := articleServer.URL
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v0/item/123.json" {
 			t.Errorf("unexpected path: %s", r.URL.Path)
@@ -160,7 +161,9 @@ func TestNormalizeHackerNewsURL_ResolvesArticleURL(t *testing.T) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"url":"` + articleURL + `"}`))
+		if _, err := w.Write([]byte(`{"url":"` + articleURL + `"}`)); err != nil {
+			t.Errorf("write HN json: %v", err)
+		}
 	}))
 	defer server.Close()
 

--- a/pkg/plugins/blogroll_reader_test.go
+++ b/pkg/plugins/blogroll_reader_test.go
@@ -1,6 +1,8 @@
 package plugins
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -131,6 +133,83 @@ func TestReaderPreviewForEntry_Hierarchy(t *testing.T) {
 				t.Fatalf("readerPreviewForEntry() = (%q, %q), want (%q, %q)", gotURL, gotKind, tt.wantURL, tt.wantKind)
 			}
 		})
+	}
+}
+
+func TestNormalizeHackerNewsURL_ResolvesArticleURL(t *testing.T) {
+	articleURL := "https://example.com/article"
+	articleServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<!DOCTYPE html>
+<html>
+<head>
+	<title>Article Title</title>
+	<meta property="og:title" content="Article Title">
+	<meta property="og:description" content="Article Description">
+	<meta property="og:image" content="https://example.com/article.jpg">
+</head>
+<body></body>
+</html>`))
+	}))
+	defer articleServer.Close()
+	articleURL = articleServer.URL
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v0/item/123.json" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"url":"` + articleURL + `"}`))
+	}))
+	defer server.Close()
+
+	oldBaseURL := hackerNewsItemAPIBaseURL
+	oldClient := hackerNewsHTTPClient
+	hackerNewsItemAPIBaseURL = server.URL + "/v0/item/%s.json"
+	hackerNewsHTTPClient = server.Client()
+	defer func() {
+		hackerNewsItemAPIBaseURL = oldBaseURL
+		hackerNewsHTTPClient = oldClient
+	}()
+
+	rawURL := "https://news.ycombinator.com/item?id=123"
+	if got := normalizeHackerNewsURL(rawURL); got != articleURL {
+		t.Fatalf("normalizeHackerNewsURL() = %q, want %q", got, articleURL)
+	}
+
+	feedXML := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Hacker News</title>
+  <entry>
+    <id>123</id>
+    <title>Story title</title>
+    <published>2026-04-17T12:17:00Z</published>
+    <link rel="alternate" href="` + rawURL + `"/>
+  </entry>
+</feed>`)
+
+	_, entries, err := parseAtomFeed(feedXML)
+	if err != nil {
+		t.Fatalf("parseAtomFeed() error = %v", err)
+	}
+	if got, want := len(entries), 1; got != want {
+		t.Fatalf("len(entries) = %d, want %d", got, want)
+	}
+	if got, want := entries[0].URL, articleURL; got != want {
+		t.Fatalf("entry.URL = %q, want %q", got, want)
+	}
+	if got, want := entries[0].Title, "Article Title"; got != want {
+		t.Fatalf("entry.Title = %q, want %q", got, want)
+	}
+	if got, want := entries[0].Description, "Article Description"; got != want {
+		t.Fatalf("entry.Description = %q, want %q", got, want)
+	}
+	if got, want := entries[0].ImageURL, "https://example.com/article.jpg"; got != want {
+		t.Fatalf("entry.ImageURL = %q, want %q", got, want)
+	}
+	if got, want := entries[0].OriginalURL, rawURL; got != want {
+		t.Fatalf("entry.OriginalURL = %q, want %q", got, want)
 	}
 }
 

--- a/pkg/plugins/embeds.go
+++ b/pkg/plugins/embeds.go
@@ -799,13 +799,14 @@ func (p *EmbedsPlugin) processExternalEmbedsInText(text string, _ *models.Post) 
 		rawURL := strings.TrimSpace(groups[1])
 		options := parseEmbedOptions(groups[2])
 
-		parsedURL, err := url.Parse(rawURL)
+		resolvedURL, sourceURL := resolveHackerNewsReference(rawURL)
+		parsedURL, err := url.Parse(resolvedURL)
 		if err != nil || (parsedURL.Scheme != schemeHTTP && parsedURL.Scheme != schemeHTTPS) {
 			return match
 		}
 
 		metadata := p.fetchExternalMetadata(rawURL)
-		return p.buildExternalEmbedCard(rawURL, parsedURL, metadata, options)
+		return p.buildExternalEmbedCard(resolvedURL, parsedURL, metadata, options, sourceURL)
 	})
 
 	// Process ![embed](url|options) with options
@@ -818,13 +819,14 @@ func (p *EmbedsPlugin) processExternalEmbedsInText(text string, _ *models.Post) 
 		rawURL := strings.TrimSpace(groups[1])
 		options := parseEmbedOptions(groups[2])
 
-		parsedURL, err := url.Parse(rawURL)
+		resolvedURL, sourceURL := resolveHackerNewsReference(rawURL)
+		parsedURL, err := url.Parse(resolvedURL)
 		if err != nil || (parsedURL.Scheme != schemeHTTP && parsedURL.Scheme != schemeHTTPS) {
 			return match
 		}
 
 		metadata := p.fetchExternalMetadata(rawURL)
-		return p.buildExternalEmbedCard(rawURL, parsedURL, metadata, options)
+		return p.buildExternalEmbedCard(resolvedURL, parsedURL, metadata, options, sourceURL)
 	})
 
 	// Process ![embed](url) basic syntax
@@ -837,13 +839,14 @@ func (p *EmbedsPlugin) processExternalEmbedsInText(text string, _ *models.Post) 
 		rawURL := strings.TrimSpace(groups[1])
 
 		// Validate URL
-		parsedURL, err := url.Parse(rawURL)
+		resolvedURL, sourceURL := resolveHackerNewsReference(rawURL)
+		parsedURL, err := url.Parse(resolvedURL)
 		if err != nil || (parsedURL.Scheme != schemeHTTP && parsedURL.Scheme != schemeHTTPS) {
 			return match
 		}
 
 		metadata := p.fetchExternalMetadata(rawURL)
-		return p.buildExternalEmbedCard(rawURL, parsedURL, metadata, EmbedOptions{})
+		return p.buildExternalEmbedCard(resolvedURL, parsedURL, metadata, EmbedOptions{}, sourceURL)
 	})
 
 	return externalObsidianEmbedRegex.ReplaceAllStringFunc(processed, func(match string) string {
@@ -869,7 +872,8 @@ func (p *EmbedsPlugin) processExternalEmbedsInText(text string, _ *models.Post) 
 			options = parseEmbedOptions(groups[3])
 		}
 
-		parsedURL, err := url.Parse(rawURL)
+		resolvedURL, sourceURL := resolveHackerNewsReference(rawURL)
+		parsedURL, err := url.Parse(resolvedURL)
 		if err != nil || (parsedURL.Scheme != schemeHTTP && parsedURL.Scheme != schemeHTTPS) {
 			return match
 		}
@@ -877,7 +881,7 @@ func (p *EmbedsPlugin) processExternalEmbedsInText(text string, _ *models.Post) 
 		metadata := p.fetchExternalMetadata(rawURL)
 		metadata = p.applyExternalTitleOverride(metadata, override)
 
-		return p.buildExternalEmbedCard(rawURL, parsedURL, metadata, options)
+		return p.buildExternalEmbedCard(resolvedURL, parsedURL, metadata, options, sourceURL)
 	})
 }
 
@@ -997,6 +1001,7 @@ func (p *EmbedsPlugin) fetchOGMetadata(rawURL string) *OGMetadata {
 
 // fetchExternalMetadata resolves external metadata using the configured strategy.
 func (p *EmbedsPlugin) fetchExternalMetadata(rawURL string) *OGMetadata {
+	resolvedURL := normalizeHackerNewsURL(rawURL)
 	strategy := strings.ToLower(p.config.ResolutionStrategy)
 	if strategy == "" {
 		strategy = strategyOEmbedFirst
@@ -1009,18 +1014,18 @@ func (p *EmbedsPlugin) fetchExternalMetadata(rawURL string) *OGMetadata {
 	}
 
 	tryOEmbed := func() (*OGMetadata, bool) {
-		return p.resolveOEmbedMetadata(rawURL)
+		return p.resolveOEmbedMetadata(resolvedURL)
 	}
 
 	tryCached := func() *OGMetadata {
-		if cached := p.fetchCachedMetadata(rawURL, "oembed"); cached != nil {
+		if cached := p.fetchCachedMetadata(resolvedURL, "oembed"); cached != nil {
 			return cached
 		}
-		return p.fetchCachedMetadata(rawURL, "og")
+		return p.fetchCachedMetadata(resolvedURL, "og")
 	}
 
 	tryOG := func() *OGMetadata {
-		return p.fetchOGMetadata(rawURL)
+		return p.fetchOGMetadata(resolvedURL)
 	}
 
 	switch strategy {
@@ -1451,8 +1456,8 @@ func applyEmbedMode(opts *EmbedOptions, mode string) bool {
 // It respects the EmbedOptions to control what elements are displayed.
 //
 //nolint:gocyclo // multiple rendering modes require conditional branches
-func (p *EmbedsPlugin) buildExternalEmbedCard(rawURL string, parsedURL *url.URL, metadata *OGMetadata, opts EmbedOptions) string {
-	if giphyID := extractGiphyID(rawURL); giphyID != "" {
+func (p *EmbedsPlugin) buildExternalEmbedCard(displayURL string, parsedURL *url.URL, metadata *OGMetadata, opts EmbedOptions, sourceURL string) string {
+	if giphyID := extractGiphyID(displayURL); giphyID != "" {
 		if metadata == nil {
 			metadata = &OGMetadata{}
 		}
@@ -1466,7 +1471,7 @@ func (p *EmbedsPlugin) buildExternalEmbedCard(rawURL string, parsedURL *url.URL,
 			metadata.Title = "Giphy GIF"
 		}
 	}
-	if codepenUser, codepenID := extractCodePenID(rawURL); codepenID != "" {
+	if codepenUser, codepenID := extractCodePenID(displayURL); codepenID != "" {
 		if metadata == nil {
 			metadata = &OGMetadata{}
 		}
@@ -1482,7 +1487,7 @@ func (p *EmbedsPlugin) buildExternalEmbedCard(rawURL string, parsedURL *url.URL,
 	}
 	if metadata != nil {
 		normalizeOGMetadata(metadata)
-		videoID := extractYouTubeVideoID(rawURL)
+		videoID := extractYouTubeVideoID(displayURL)
 		if videoID == "" {
 			videoID = extractYouTubeVideoIDFromMetadata(metadata)
 		}
@@ -1556,7 +1561,7 @@ func (p *EmbedsPlugin) buildExternalEmbedCard(rawURL string, parsedURL *url.URL,
 	// Handle hover mode - shows image, swaps to embed on hover
 	if opts.Hover && metadata.HTML != "" {
 		sb.WriteString(`  <a href="`)
-		sb.WriteString(html.EscapeString(rawURL))
+		sb.WriteString(html.EscapeString(displayURL))
 		sb.WriteString(`" class="embed-card-link" target="_blank" rel="noopener noreferrer">`)
 		sb.WriteString("\n")
 		if p.config.ShowImage && metadata.Image != "" {
@@ -1608,7 +1613,7 @@ func (p *EmbedsPlugin) buildExternalEmbedCard(rawURL string, parsedURL *url.URL,
 		}
 
 		sb.WriteString(`  <a href="`)
-		sb.WriteString(html.EscapeString(rawURL))
+		sb.WriteString(html.EscapeString(displayURL))
 		sb.WriteString(`" class="embed-card-link-only" target="_blank" rel="noopener noreferrer">`)
 		sb.WriteString(html.EscapeString(linkTitle))
 		sb.WriteString(`</a>`)
@@ -1624,7 +1629,7 @@ func (p *EmbedsPlugin) buildExternalEmbedCard(rawURL string, parsedURL *url.URL,
 			label := buildExternalImageAlt(metadata, domain, !opts.NoTitle)
 			labelEscaped := html.EscapeString(label)
 			sb.WriteString(`  <a href="`)
-			sb.WriteString(html.EscapeString(rawURL))
+			sb.WriteString(html.EscapeString(displayURL))
 			sb.WriteString(`" target="_blank" rel="noopener noreferrer"`)
 			if label != "" {
 				sb.WriteString(` title="`)
@@ -1649,7 +1654,7 @@ func (p *EmbedsPlugin) buildExternalEmbedCard(rawURL string, parsedURL *url.URL,
 
 	// Standard card mode (default)
 	sb.WriteString(`  <a href="`)
-	sb.WriteString(html.EscapeString(rawURL))
+	sb.WriteString(html.EscapeString(displayURL))
 	sb.WriteString(`" class="embed-card-link" target="_blank" rel="noopener noreferrer">`)
 	sb.WriteString("\n")
 
@@ -1700,6 +1705,12 @@ func (p *EmbedsPlugin) buildExternalEmbedCard(rawURL string, parsedURL *url.URL,
 		}
 		sb.WriteString(html.EscapeString(domain))
 		sb.WriteString(`</div>`)
+		sb.WriteString("\n")
+	}
+	if sourceURL != "" && !opts.NoMeta {
+		sb.WriteString(`      <div class="embed-card-source">Found on HN: <a href="`)
+		sb.WriteString(html.EscapeString(sourceURL))
+		sb.WriteString(`" target="_blank" rel="noopener noreferrer">discussion</a></div>`)
 		sb.WriteString("\n")
 	}
 

--- a/pkg/plugins/embeds_test.go
+++ b/pkg/plugins/embeds_test.go
@@ -368,6 +368,77 @@ func TestEmbedsPlugin_ExternalEmbed(t *testing.T) {
 	}
 }
 
+func TestEmbedsPlugin_ExternalEmbed_HackerNewsDiscussionURL(t *testing.T) {
+	articleServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<!DOCTYPE html>
+<html>
+<head>
+	<title>Article Title</title>
+	<meta property="og:title" content="Article Title">
+	<meta property="og:description" content="Article Description">
+	<meta property="og:image" content="https://example.com/article.jpg">
+	<meta property="og:site_name" content="Article Site">
+</head>
+<body></body>
+</html>`))
+	}))
+	defer articleServer.Close()
+
+	hnServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v0/item/456.json" {
+			t.Errorf("unexpected HN API path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"url":"` + articleServer.URL + `"}`))
+	}))
+	defer hnServer.Close()
+
+	oldBaseURL := hackerNewsItemAPIBaseURL
+	oldClient := hackerNewsHTTPClient
+	hackerNewsItemAPIBaseURL = hnServer.URL + "/v0/item/%s.json"
+	hackerNewsHTTPClient = hnServer.Client()
+	defer func() {
+		hackerNewsItemAPIBaseURL = oldBaseURL
+		hackerNewsHTTPClient = oldClient
+	}()
+
+	p := NewEmbedsPlugin()
+	p.config.OEmbedEnabled = false
+	tmpDir := t.TempDir()
+	p.config.CacheDir = filepath.Join(tmpDir, "cache")
+
+	m := lifecycle.NewManager()
+	m.SetPosts([]*models.Post{{
+		Path:    "source.md",
+		Slug:    "source-post",
+		Content: "Here is an external embed: ![embed](https://news.ycombinator.com/item?id=456)",
+	}})
+
+	if err := p.Transform(m); err != nil {
+		t.Fatalf("Transform failed: %v", err)
+	}
+
+	result := m.Posts()[0]
+	if !containsString(result.Content, "Article Title") {
+		t.Fatalf("expected resolved article title in content, got: %s", result.Content)
+	}
+	if !containsString(result.Content, "Article Description") {
+		t.Fatalf("expected resolved article description in content, got: %s", result.Content)
+	}
+	if !containsString(result.Content, "Found on HN:") {
+		t.Fatalf("expected Found on HN link in content, got: %s", result.Content)
+	}
+	if !containsString(result.Content, `href="`+articleServer.URL+`"`) {
+		t.Fatalf("expected resolved article link to be the card target, got: %s", result.Content)
+	}
+	if !containsString(result.Content, `href="https://news.ycombinator.com/item?id=456"`) {
+		t.Fatalf("expected original HN discussion link to remain available, got: %s", result.Content)
+	}
+}
+
 func TestEmbedsPlugin_ExternalEmbed_ObsidianStyle(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/html")

--- a/pkg/plugins/embeds_test.go
+++ b/pkg/plugins/embeds_test.go
@@ -371,7 +371,7 @@ func TestEmbedsPlugin_ExternalEmbed(t *testing.T) {
 func TestEmbedsPlugin_ExternalEmbed_HackerNewsDiscussionURL(t *testing.T) {
 	articleServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
-		_, _ = w.Write([]byte(`<!DOCTYPE html>
+		if _, err := w.Write([]byte(`<!DOCTYPE html>
 <html>
 <head>
 	<title>Article Title</title>
@@ -381,7 +381,9 @@ func TestEmbedsPlugin_ExternalEmbed_HackerNewsDiscussionURL(t *testing.T) {
 	<meta property="og:site_name" content="Article Site">
 </head>
 <body></body>
-</html>`))
+</html>`)); err != nil {
+			t.Errorf("write article html: %v", err)
+		}
 	}))
 	defer articleServer.Close()
 
@@ -392,7 +394,9 @@ func TestEmbedsPlugin_ExternalEmbed_HackerNewsDiscussionURL(t *testing.T) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"url":"` + articleServer.URL + `"}`))
+		if _, err := w.Write([]byte(`{"url":"` + articleServer.URL + `"}`)); err != nil {
+			t.Errorf("write HN json: %v", err)
+		}
 	}))
 	defer hnServer.Close()
 

--- a/pkg/plugins/hackernews.go
+++ b/pkg/plugins/hackernews.go
@@ -1,0 +1,214 @@
+package plugins
+
+import (
+	"encoding/json"
+	"fmt"
+	"html"
+	"io"
+	"net/http"
+	neturl "net/url"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+)
+
+var hackerNewsItemAPIBaseURL = "https://hacker-news.firebaseio.com/v0/item/%s.json"
+
+var hackerNewsHTTPClient = &http.Client{Timeout: 10 * time.Second}
+
+var hackerNewsURLCache sync.Map
+
+var (
+	hackerNewsHTMLTitleRegex = regexp.MustCompile(`(?is)<title[^>]*>(.*?)</title>`)
+	hackerNewsOGTitleRegex   = regexp.MustCompile(`(?is)<meta[^>]+property=['"]og:title['"][^>]+content=['"]([^'"]+)['"]|<meta[^>]+content=['"]([^'"]+)['"][^>]+property=['"]og:title['"]`)
+	hackerNewsOGDescRegex    = regexp.MustCompile(`(?is)<meta[^>]+property=['"]og:description['"][^>]+content=['"]([^'"]+)['"]|<meta[^>]+content=['"]([^'"]+)['"][^>]+property=['"]og:description['"]`)
+	hackerNewsOGImageRegex   = regexp.MustCompile(`(?is)<meta[^>]+property=['"]og:image['"][^>]+content=['"]([^'"]+)['"]|<meta[^>]+content=['"]([^'"]+)['"][^>]+property=['"]og:image['"]`)
+	hackerNewsDescRegex      = regexp.MustCompile(`(?is)<meta[^>]+name=['"]description['"][^>]+content=['"]([^'"]+)['"]|<meta[^>]+content=['"]([^'"]+)['"][^>]+name=['"]description['"]`)
+)
+
+type hackerNewsItem struct {
+	URL string `json:"url"`
+}
+
+type hackerNewsMetadata struct {
+	Title       string
+	Description string
+	Image       string
+}
+
+// normalizeHackerNewsURL resolves Hacker News discussion URLs to their outbound article URLs.
+// If resolution fails or the item has no outbound URL, the original URL is returned.
+func normalizeHackerNewsURL(rawURL string) string {
+	if rawURL == "" {
+		return ""
+	}
+
+	if cached, ok := hackerNewsURLCache.Load(rawURL); ok {
+		if resolved, _ := cached.(string); resolved != "" {
+			return resolved
+		}
+		return rawURL
+	}
+
+	if !isHackerNewsDiscussionURL(rawURL) {
+		return rawURL
+	}
+
+	resolvedURL, ok := fetchHackerNewsArticleURL(rawURL)
+	if !ok {
+		return rawURL
+	}
+	if resolvedURL == "" {
+		hackerNewsURLCache.Store(rawURL, "")
+		return rawURL
+	}
+
+	hackerNewsURLCache.Store(rawURL, resolvedURL)
+	return resolvedURL
+}
+
+func resolveHackerNewsReference(rawURL string) (resolvedURL, originalURL string) {
+	if !isHackerNewsDiscussionURL(rawURL) {
+		return rawURL, ""
+	}
+
+	resolvedURL = normalizeHackerNewsURL(rawURL)
+	if resolvedURL == "" {
+		return rawURL, ""
+	}
+	if resolvedURL != rawURL {
+		return resolvedURL, rawURL
+	}
+	return rawURL, ""
+}
+
+func isHackerNewsDiscussionURL(rawURL string) bool {
+	parsed, err := neturl.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+
+	host := strings.ToLower(parsed.Hostname())
+	host = strings.TrimPrefix(host, "www.")
+	if host != "news.ycombinator.com" {
+		return false
+	}
+
+	if !strings.EqualFold(parsed.Path, "/item") {
+		return false
+	}
+
+	return strings.TrimSpace(parsed.Query().Get("id")) != ""
+}
+
+func fetchHackerNewsArticleURL(rawURL string) (string, bool) {
+	parsed, err := neturl.Parse(rawURL)
+	if err != nil {
+		return "", false
+	}
+
+	id := strings.TrimSpace(parsed.Query().Get("id"))
+	if id == "" {
+		return "", false
+	}
+
+	apiURL := fmt.Sprintf(hackerNewsItemAPIBaseURL, id)
+	req, err := http.NewRequest(http.MethodGet, apiURL, nil)
+	if err != nil {
+		return "", false
+	}
+
+	resp, err := hackerNewsHTTPClient.Do(req)
+	if err != nil {
+		return "", false
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", false
+	}
+
+	var item hackerNewsItem
+	if err := json.NewDecoder(resp.Body).Decode(&item); err != nil {
+		return "", false
+	}
+
+	return strings.TrimSpace(item.URL), true
+}
+
+func fetchHackerNewsArticleMetadata(articleURL string) (*hackerNewsMetadata, bool) {
+	if articleURL == "" {
+		return nil, false
+	}
+
+	req, err := http.NewRequest(http.MethodGet, articleURL, nil)
+	if err != nil {
+		return nil, false
+	}
+	req.Header.Set("User-Agent", "markata-go/1.0 (+https://github.com/WaylonWalker/markata-go)")
+
+	resp, err := hackerNewsHTTPClient.Do(req)
+	if err != nil {
+		return nil, false
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, false
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
+	if err != nil {
+		return nil, false
+	}
+
+	htmlContent := string(body)
+	metadata := &hackerNewsMetadata{
+		Title:       extractHackerNewsOGTitle(htmlContent),
+		Description: extractHackerNewsOGDescription(htmlContent),
+		Image:       extractHackerNewsOGImage(htmlContent),
+	}
+	if metadata.Title == "" {
+		metadata.Title = extractHackerNewsHTMLTitle(htmlContent)
+	}
+	if metadata.Description == "" {
+		metadata.Description = extractHackerNewsDescription(htmlContent)
+	}
+
+	return metadata, true
+}
+
+func extractHackerNewsOGTitle(htmlContent string) string {
+	return extractHackerNewsMetaMatch(htmlContent, hackerNewsOGTitleRegex)
+}
+
+func extractHackerNewsOGDescription(htmlContent string) string {
+	return extractHackerNewsMetaMatch(htmlContent, hackerNewsOGDescRegex)
+}
+
+func extractHackerNewsOGImage(htmlContent string) string {
+	return extractHackerNewsMetaMatch(htmlContent, hackerNewsOGImageRegex)
+}
+
+func extractHackerNewsDescription(htmlContent string) string {
+	return extractHackerNewsMetaMatch(htmlContent, hackerNewsDescRegex)
+}
+
+func extractHackerNewsMetaMatch(htmlContent string, pattern *regexp.Regexp) string {
+	if match := pattern.FindStringSubmatch(htmlContent); len(match) > 1 {
+		for _, candidate := range match[1:] {
+			if candidate != "" {
+				return html.UnescapeString(candidate)
+			}
+		}
+	}
+	return ""
+}
+
+func extractHackerNewsHTMLTitle(htmlContent string) string {
+	if match := hackerNewsHTMLTitleRegex.FindStringSubmatch(htmlContent); len(match) > 1 {
+		return strings.TrimSpace(html.UnescapeString(match[1]))
+	}
+	return ""
+}

--- a/pkg/plugins/hackernews.go
+++ b/pkg/plugins/hackernews.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"html"
@@ -45,7 +46,7 @@ func normalizeHackerNewsURL(rawURL string) string {
 	}
 
 	if cached, ok := hackerNewsURLCache.Load(rawURL); ok {
-		if resolved, _ := cached.(string); resolved != "" {
+		if resolved, ok := cached.(string); ok && resolved != "" {
 			return resolved
 		}
 		return rawURL
@@ -114,7 +115,7 @@ func fetchHackerNewsArticleURL(rawURL string) (string, bool) {
 	}
 
 	apiURL := fmt.Sprintf(hackerNewsItemAPIBaseURL, id)
-	req, err := http.NewRequest(http.MethodGet, apiURL, nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, apiURL, http.NoBody)
 	if err != nil {
 		return "", false
 	}
@@ -142,7 +143,7 @@ func fetchHackerNewsArticleMetadata(articleURL string) (*hackerNewsMetadata, boo
 		return nil, false
 	}
 
-	req, err := http.NewRequest(http.MethodGet, articleURL, nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, articleURL, http.NoBody)
 	if err != nil {
 		return nil, false
 	}
@@ -177,6 +178,16 @@ func fetchHackerNewsArticleMetadata(articleURL string) (*hackerNewsMetadata, boo
 	}
 
 	return metadata, true
+}
+
+func enrichHackerNewsFeedEntry(rawURL string) (resolvedURL, originalURL string, metadata *hackerNewsMetadata) {
+	resolvedURL, originalURL = resolveHackerNewsReference(rawURL)
+	if originalURL == "" {
+		return resolvedURL, originalURL, nil
+	}
+
+	metadata, _ = fetchHackerNewsArticleMetadata(resolvedURL)
+	return resolvedURL, originalURL, metadata
 }
 
 func extractHackerNewsOGTitle(htmlContent string) string {

--- a/pkg/themes/default/static/css/components.css
+++ b/pkg/themes/default/static/css/components.css
@@ -2001,6 +2001,17 @@
   gap: 0.5rem;
 }
 
+.embed-card-source {
+  margin-top: 0.35rem;
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+
+.embed-card-source a {
+  color: inherit;
+  font-weight: 600;
+}
+
 /* Internal embed card (no image) - compact layout */
 .embed-card:not(.embed-card-external) {
   border-left: 4px solid var(--color-primary);
@@ -2517,6 +2528,17 @@
   font-weight: 600;
   white-space: nowrap;
   text-align: right;
+}
+
+.reader-entry-found-on {
+  margin-top: 0.35rem;
+  color: var(--color-text-muted);
+  font-size: 0.8rem;
+}
+
+.reader-entry-found-on a {
+  color: inherit;
+  font-weight: 600;
 }
 
 .reader-entry-title {

--- a/pkg/themes/default/templates/reader.html
+++ b/pkg/themes/default/templates/reader.html
@@ -70,6 +70,10 @@
             {% endif %}
           </div>
 
+          {% if entry.original_url %}
+          <div class="reader-entry-found-on">Found on HN: <a href="{{ entry.original_url }}" target="_blank" rel="noopener noreferrer">discussion</a></div>
+          {% endif %}
+
           <h2 class="reader-entry-title">
             <a href="{{ entry.url }}" target="_blank" rel="noopener noreferrer">{{ entry.title }}<span class="visually-hidden">(opens in new tab)</span></a>
           </h2>

--- a/spec/spec/EMBEDS.md
+++ b/spec/spec/EMBEDS.md
@@ -121,17 +121,20 @@ A post cannot embed itself. Attempting to do so adds a warning comment:
 ### Behavior
 
 1. Validates the URL (must be http or https)
-2. Resolves metadata using the configured strategy:
-   - **oembed_first** (default): try oEmbed providers, fall back to OG
-   - **og_first**: try OG, fall back to oEmbed providers
-   - **oembed_only**: only use oEmbed (no OG fallback)
-3. Caches metadata (configurable TTL)
-4. Selects a mode (explicit option, provider override, oEmbed type default, or global default)
-5. Generates an embed card with:
-   - OG image (if available and enabled)
-   - OG title (or fallback)
-   - OG description (truncated)
-   - Site name and domain
+2. If the URL is a Hacker News discussion link, resolves the outbound article URL through the HN item API and uses that for metadata lookup and the main card target when available.
+3. Resolves metadata using the configured strategy:
+    - **oembed_first** (default): try oEmbed providers, fall back to OG
+    - **og_first**: try OG, fall back to oEmbed providers
+    - **oembed_only**: only use oEmbed (no OG fallback)
+4. Caches metadata (configurable TTL)
+5. Selects a mode (explicit option, provider override, oEmbed type default, or global default)
+6. Generates an embed card with:
+    - OG image (if available and enabled)
+    - OG title (or fallback)
+    - OG description (truncated)
+    - Site name and domain
+
+When HN normalization succeeds, the card should still show a secondary "Found on HN" link to the original discussion URL instead of hiding the source.
 
 ### Metadata Resolution
 

--- a/spec/spec/FEEDS.md
+++ b/spec/spec/FEEDS.md
@@ -423,6 +423,7 @@ The reader page aggregates the latest posts from all followed feeds into a curat
 - Entries are grouped by calendar day in reverse chronological order.
 - Each day group renders a large date rail and a two-column content grid on wide screens.
 - Each entry shows a source favicon up front, the source name, publish date, title, description, and optional image.
+- When a feed item points at a Hacker News discussion URL, the collector resolves the outbound article URL for the main card, preserves the original HN permalink, and keeps the feed source label visible.
 - The layout collapses to a single column on small screens.
 
 ### Template Context
@@ -436,6 +437,8 @@ The reader page aggregates the latest posts from all followed feeds into a curat
   - `count`
   - `entries`
 - each entry map includes `feed_url`, `feed_title`, `source_icon_url`, `published_datetime`, `published_label`, `url`, `title`, `description`, and `image_url`
+- when available, `url` points at the resolved article URL rather than the discussion page for Hacker News items
+- `original_url` preserves the original HN discussion link when a feed item was normalized
 
 ---
 

--- a/templates/reader.html
+++ b/templates/reader.html
@@ -71,6 +71,10 @@
             {% endif %}
           </div>
 
+          {% if entry.original_url %}
+          <div class="reader-entry-found-on">Found on HN: <a href="{{ entry.original_url }}" target="_blank" rel="noopener noreferrer">discussion</a></div>
+          {% endif %}
+
           <h2 class="reader-entry-title">
             <a href="{{ entry.url }}" target="_blank" rel="noopener noreferrer">{{ entry.title }}<span class="visually-hidden">(opens in new tab)</span></a>
           </h2>


### PR DESCRIPTION
## Summary
- Resolve Hacker News discussion links to the outbound article for reader cards and external embeds
- Preserve the original HN discussion URL as a visible "Found on HN" link
- Invalidate the blogroll cache so existing reader data refreshes with the new metadata

Fixes #1025