### PR TITLE
fix(copy): hide unavailable post format routes

### DIFF
--- a/pkg/plugins/post_copy.go
+++ b/pkg/plugins/post_copy.go
@@ -32,15 +32,34 @@ func (p postCopyPayloads) JSON() string {
 func buildPostCopyPayloads(post *models.Post, config *lifecycle.Config, baseURL string) postCopyPayloads {
 	postURL := buildAbsolutePostURL(baseURL, post)
 	title := resolvePostTitle(post, "")
+	postFormats := models.NewPostFormatsConfig()
+	if config != nil {
+		postFormats = resolvePostFormats(post, config)
+	}
+
+	markdownURL := ""
+	textURL := ""
+	ansiCurl := ""
+	if post != nil && !post.Private {
+		if postFormats.Markdown {
+			markdownURL = buildAbsolutePostFormatURL(baseURL, post, ".md")
+		}
+		if postFormats.Text {
+			textURL = buildAbsolutePostFormatURL(baseURL, post, ".txt")
+		}
+		if postFormats.ANSI {
+			ansiCurl = buildPostCurlCommand(baseURL, post, ".ansi")
+		}
+	}
 
 	return postCopyPayloads{
 		Title:       title,
 		URL:         postURL,
 		Markdown:    buildPostCopyMarkdown(post, postURL),
 		Text:        buildPostCopyText(post, config, postURL),
-		MarkdownURL: buildAbsolutePostFormatURL(baseURL, post, ".md"),
-		TextURL:     buildAbsolutePostFormatURL(baseURL, post, ".txt"),
-		ANSICurl:    buildPostCurlCommand(baseURL, post, ".ansi"),
+		MarkdownURL: markdownURL,
+		TextURL:     textURL,
+		ANSICurl:    ansiCurl,
 	}
 }
 

--- a/pkg/plugins/post_copy_test.go
+++ b/pkg/plugins/post_copy_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
 	"github.com/WaylonWalker/markata-go/pkg/models"
 )
 
@@ -27,7 +28,7 @@ func TestBuildPostCopyPayloads(t *testing.T) {
 	if payloads.TextURL != "https://example.com/hello-world.txt" {
 		t.Fatalf("unexpected text url payload: %q", payloads.TextURL)
 	}
-	if payloads.ANSICurl != "curl https://example.com/hello-world.ansi" {
+	if payloads.ANSICurl != "" {
 		t.Fatalf("unexpected ansi curl payload: %q", payloads.ANSICurl)
 	}
 	if !strings.Contains(payloads.Markdown, "# Hello World") {
@@ -47,6 +48,70 @@ func TestBuildPostCopyPayloads(t *testing.T) {
 	}
 	if !strings.Contains(payloads.Text, "```python") {
 		t.Fatalf("expected text payload to use fenced code blocks, got %q", payloads.Text)
+	}
+}
+
+func TestBuildPostCopyPayloads_HidesDisabledFormatRoutes(t *testing.T) {
+	htmlEnabled := true
+	post := &models.Post{
+		Slug:        "hello-world",
+		Href:        "/hello-world/",
+		Title:       stringPtr("Hello World"),
+		Content:     "hello",
+		ArticleHTML: "<p>hello</p>",
+	}
+	config := &lifecycle.Config{
+		Extra: map[string]interface{}{
+			"post_formats": models.PostFormatsConfig{
+				HTML:     &htmlEnabled,
+				Markdown: false,
+				Text:     false,
+				ANSI:     false,
+			},
+		},
+	}
+
+	payloads := buildPostCopyPayloads(post, config, "https://example.com")
+	if payloads.MarkdownURL != "" {
+		t.Fatalf("expected markdown route to be hidden, got %q", payloads.MarkdownURL)
+	}
+	if payloads.TextURL != "" {
+		t.Fatalf("expected text route to be hidden, got %q", payloads.TextURL)
+	}
+	if payloads.ANSICurl != "" {
+		t.Fatalf("expected ansi route to be hidden, got %q", payloads.ANSICurl)
+	}
+}
+
+func TestBuildPostCopyPayloads_ShowsOnlyEnabledRoutes(t *testing.T) {
+	htmlEnabled := true
+	post := &models.Post{
+		Slug:        "hello-world",
+		Href:        "/hello-world/",
+		Title:       stringPtr("Hello World"),
+		Content:     "hello",
+		ArticleHTML: "<p>hello</p>",
+	}
+	config := &lifecycle.Config{
+		Extra: map[string]interface{}{
+			"post_formats": models.PostFormatsConfig{
+				HTML:     &htmlEnabled,
+				Markdown: true,
+				Text:     false,
+				ANSI:     true,
+			},
+		},
+	}
+
+	payloads := buildPostCopyPayloads(post, config, "https://example.com")
+	if payloads.MarkdownURL != "https://example.com/hello-world.md" {
+		t.Fatalf("unexpected markdown route: %q", payloads.MarkdownURL)
+	}
+	if payloads.TextURL != "" {
+		t.Fatalf("expected text route to be hidden, got %q", payloads.TextURL)
+	}
+	if payloads.ANSICurl != "curl https://example.com/hello-world.ansi" {
+		t.Fatalf("unexpected ansi route: %q", payloads.ANSICurl)
 	}
 }
 

--- a/pkg/plugins/templates_test.go
+++ b/pkg/plugins/templates_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
 	"github.com/WaylonWalker/markata-go/pkg/models"
+	"github.com/WaylonWalker/markata-go/pkg/templates"
 )
 
 func TestTemplatesPlugin_GetFeedSidebarPosts_PrefersPrimaryFeed(t *testing.T) {
@@ -509,6 +510,7 @@ func TestTemplatesPlugin_Render_UsesResolvedPostFormatsInTemplateContext(t *test
 	m := lifecycle.NewManager()
 	config := m.Config()
 	config.Extra["templates_dir"] = tmpDir
+	config.Extra["url"] = "https://example.com"
 	htmlEnabled := true
 	config.Extra["post_formats"] = models.PostFormatsConfig{
 		HTML:     &htmlEnabled,
@@ -546,6 +548,78 @@ func TestTemplatesPlugin_Render_UsesResolvedPostFormatsInTemplateContext(t *test
 
 	if !strings.Contains(post.HTML, "md-off ansi-on") {
 		t.Fatalf("expected template context to use resolved per-post post_formats, got %q", post.HTML)
+	}
+}
+
+func TestTemplatesPlugin_Render_PostCopyShowsOnlyAvailableRoutes(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "templates-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	componentDir := filepath.Join(tmpDir, "components")
+	if err := os.MkdirAll(componentDir, 0o755); err != nil {
+		t.Fatalf("Failed to create component dir: %v", err)
+	}
+	componentSource, err := os.ReadFile(filepath.Join("..", "..", "templates", "components", "post_copy.html"))
+	if err != nil {
+		t.Fatalf("Failed to read post_copy component: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(componentDir, "post_copy.html"), componentSource, 0o600); err != nil {
+		t.Fatalf("Failed to write post_copy component: %v", err)
+	}
+
+	templateContent := `{% include "components/post_copy.html" %}`
+	templatePath := filepath.Join(tmpDir, "post.html")
+	if err := os.WriteFile(templatePath, []byte(templateContent), 0o600); err != nil {
+		t.Fatalf("Failed to write template: %v", err)
+	}
+
+	engine, err := templates.NewEngine(tmpDir)
+	if err != nil {
+		t.Fatalf("NewEngine() error = %v", err)
+	}
+
+	config := &lifecycle.Config{Extra: map[string]interface{}{}}
+	htmlEnabled := true
+	config.Extra["post_formats"] = models.PostFormatsConfig{
+		HTML:     &htmlEnabled,
+		Markdown: true,
+		Text:     false,
+		ANSI:     false,
+	}
+
+	title := "Test Post"
+	post := &models.Post{
+		Title:       &title,
+		Slug:        "test-post",
+		Href:        "/test-post/",
+		Template:    "post.html",
+		Content:     "hello",
+		ArticleHTML: "<p>Hello World</p>",
+	}
+	payloads := buildPostCopyPayloads(post, config, "https://example.com")
+	ctx := templates.NewContext(post, post.ArticleHTML, models.NewConfig())
+	ctx.Set("post_copy_payloads", payloads)
+	ctx.Set("post_copy_payloads_json", payloads.JSON())
+
+	rendered, err := engine.Render("post.html", ctx)
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+
+	if !strings.Contains(rendered, `data-copy-kind="url"`) {
+		t.Fatal("expected URL copy route in rendered post copy menu")
+	}
+	if !strings.Contains(rendered, `data-copy-kind="markdown-url"`) {
+		t.Fatal("expected markdown route in rendered post copy menu")
+	}
+	if strings.Contains(rendered, `data-copy-kind="text-url"`) {
+		t.Fatal("did not expect text route in rendered post copy menu")
+	}
+	if strings.Contains(rendered, `data-copy-kind="ansi-curl"`) {
+		t.Fatal("did not expect ansi route in rendered post copy menu")
 	}
 }
 

--- a/pkg/themes/default/templates/components/post_copy.html
+++ b/pkg/themes/default/templates/components/post_copy.html
@@ -7,9 +7,15 @@
             <button type="button" class="post-copy__option" data-copy-kind="rich" role="menuitem">Rich</button>
             <button type="button" class="post-copy__option" data-copy-kind="markdown" role="menuitem">Markdown</button>
             <button type="button" class="post-copy__option" data-copy-kind="text" role="menuitem">Text</button>
+            {% if post_copy_payloads.MarkdownURL %}
             <button type="button" class="post-copy__option" data-copy-kind="markdown-url" role="menuitem">View Markdown</button>
+            {% endif %}
+            {% if post_copy_payloads.TextURL %}
             <button type="button" class="post-copy__option" data-copy-kind="text-url" role="menuitem">View Text</button>
+            {% endif %}
+            {% if post_copy_payloads.ANSICurl %}
             <button type="button" class="post-copy__option" data-copy-kind="ansi-curl" role="menuitem">curl .ansi</button>
+            {% endif %}
         </div>
     </details>
     <span class="post-copy__status" aria-live="polite"></span>

--- a/templates/components/post_copy.html
+++ b/templates/components/post_copy.html
@@ -7,9 +7,15 @@
             <button type="button" class="post-copy__option" data-copy-kind="rich" role="menuitem">Rich</button>
             <button type="button" class="post-copy__option" data-copy-kind="markdown" role="menuitem">Markdown</button>
             <button type="button" class="post-copy__option" data-copy-kind="text" role="menuitem">Text</button>
+            {% if post_copy_payloads.MarkdownURL %}
             <button type="button" class="post-copy__option" data-copy-kind="markdown-url" role="menuitem">View Markdown</button>
+            {% endif %}
+            {% if post_copy_payloads.TextURL %}
             <button type="button" class="post-copy__option" data-copy-kind="text-url" role="menuitem">View Text</button>
+            {% endif %}
+            {% if post_copy_payloads.ANSICurl %}
             <button type="button" class="post-copy__option" data-copy-kind="ansi-curl" role="menuitem">curl .ansi</button>
+            {% endif %}
         </div>
     </details>
     <span class="post-copy__status" aria-live="polite"></span>


### PR DESCRIPTION
## Summary
- stop the `Copy this post` menu from advertising `View Markdown`, `View Text`, and `curl .ansi` when those post-format routes are not enabled for the current post
- derive post copy route payloads from resolved post format config so the UI stays in sync with generated outputs
- add regression tests for payload generation and rendered copy menu route visibility

## Why
On a local notes site build, the copy menu exposed format routes that were not actually generated, which sent users to broken localhost routes from the menu.

## Testing
- go test ./pkg/plugins -run 'TestBuildPostCopyPayloads|TestTemplatesPlugin_Render_PostCopyShowsOnlyAvailableRoutes|TestPublishHTMLPlugin_FormatExtRedirectsWithHTMLEnabled|TestPublishHTMLPlugin_PostFormatsDefaultEnabled'