### PR TITLE
feat(resource_hints): preconnect high-value media origins

### DIFF
--- a/docs/guides/resource-hints.md
+++ b/docs/guides/resource-hints.md
@@ -108,6 +108,7 @@ crossorigin = "anonymous"
 **When to use**:
 - Critical resources (fonts, critical CSS/JS)
 - Domains you know will be used immediately
+- High-value media origins like YouTube or Vimeo embeds
 - Limit to 3-5 per page for best results
 
 ### Preload

--- a/docs/reference/resource-hints-implementation.md
+++ b/docs/reference/resource-hints-implementation.md
@@ -152,7 +152,7 @@ func (p *ResourceHintsPlugin) Write(m *lifecycle.Manager) error {
 ### Typical Blog Post
 
 **Before**: 400+ hints (same site-wide list)  
-**After**: 2-8 hints (YouTube, GitHub, images actually on post)
+**After**: 2-8 hints (YouTube/Vimeo media embeds, GitHub, images actually on post)
 
 ### Blogroll Page
 

--- a/pkg/resourcehints/detector.go
+++ b/pkg/resourcehints/detector.go
@@ -106,15 +106,15 @@ var knownDomains = map[string]KnownDomainHint{
 		CrossOrigin: "",
 	},
 	"www.youtube.com": {
-		HintTypes:   []HintType{HintTypeDNSPrefetch},
+		HintTypes:   []HintType{HintTypePreconnect},
 		CrossOrigin: "",
 	},
 	"www.youtube-nocookie.com": {
-		HintTypes:   []HintType{HintTypeDNSPrefetch},
+		HintTypes:   []HintType{HintTypePreconnect},
 		CrossOrigin: "",
 	},
 	"player.vimeo.com": {
-		HintTypes:   []HintType{HintTypeDNSPrefetch},
+		HintTypes:   []HintType{HintTypePreconnect},
 		CrossOrigin: "",
 	},
 	"codepen.io": {

--- a/pkg/resourcehints/doc.go
+++ b/pkg/resourcehints/doc.go
@@ -31,6 +31,7 @@
 // The package includes built-in knowledge of common CDNs and services:
 //
 //   - Google Fonts (fonts.googleapis.com, fonts.gstatic.com)
+//   - Media embeds (www.youtube.com, www.youtube-nocookie.com, player.vimeo.com)
 //   - CDNs (cdn.jsdelivr.net, unpkg.com, cdnjs.cloudflare.com)
 //   - Analytics (www.google-analytics.com, www.googletagmanager.com)
 //

--- a/pkg/resourcehints/resourcehints_test.go
+++ b/pkg/resourcehints/resourcehints_test.go
@@ -134,6 +134,18 @@ func TestDetector_SuggestHints(t *testing.T) {
 			expectedTypes: []HintType{HintTypeDNSPrefetch},
 			expectedCross: "",
 		},
+		{
+			name:          "YouTube privacy-enhanced embed",
+			domain:        "www.youtube-nocookie.com",
+			expectedTypes: []HintType{HintTypePreconnect},
+			expectedCross: "",
+		},
+		{
+			name:          "Vimeo player",
+			domain:        "player.vimeo.com",
+			expectedTypes: []HintType{HintTypePreconnect},
+			expectedCross: "",
+		},
 	}
 
 	detector := NewDetector()


### PR DESCRIPTION
## Summary
- classify common render-critical media CDNs for `preconnect`
- add coverage for the updated resource hint detection behavior
- document the targeted preconnect strategy for media-heavy pages

Fixes #1063