### PR TITLE
fix(search): remove invalid aria-expanded from bleve input

### DIFF
--- a/pkg/assets/registry_test.go
+++ b/pkg/assets/registry_test.go
@@ -1,6 +1,9 @@
 package assets
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -135,5 +138,17 @@ func TestAssetURLsAreValid(t *testing.T) {
 		if asset.Type == "" {
 			t.Errorf("asset %s has empty Type", asset.Name)
 		}
+	}
+}
+
+func TestBleveSearchScript_DoesNotSetAriaExpanded(t *testing.T) {
+	path := filepath.Join("..", "themes", "default", "static", "js", "bleve-search.js")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read bleve search script: %v", err)
+	}
+
+	if strings.Contains(string(content), "aria-expanded") {
+		t.Fatal("bleve search script should not set aria-expanded on the input")
 	}
 }

--- a/pkg/themes/default/static/js/bleve-search.js
+++ b/pkg/themes/default/static/js/bleve-search.js
@@ -40,7 +40,6 @@
 
   root.appendChild(wrapper);
 
-  input.setAttribute('aria-expanded', 'false');
   input.setAttribute('aria-controls', 'bleve-search-results');
   input.setAttribute('aria-activedescendant', '');
   results.id = 'bleve-search-results';
@@ -267,13 +266,11 @@
 
   function showResults() {
     results.hidden = false;
-    input.setAttribute('aria-expanded', 'true');
   }
 
   function hideResults() {
     activeIndex = -1;
     results.hidden = true;
-    input.setAttribute('aria-expanded', 'false');
     input.setAttribute('aria-activedescendant', '');
     var links = getResultLinks();
     for (var i = 0; i < links.length; i++) {


### PR DESCRIPTION
## Summary
- remove invalid `aria-expanded` usage from the Bleve search input
- keep the search results wiring focused on valid input and listbox semantics
- add regression coverage for the bundled search asset output

Fixes #1059