### PR TITLE
fix: feed sparkline hitboxes render valid SVG x values

### DIFF
--- a/pkg/plugins/feeds_listing.go
+++ b/pkg/plugins/feeds_listing.go
@@ -64,6 +64,7 @@ type sparklineWindow struct {
 type SparklinePoint struct {
 	X     float64
 	Y     float64
+	HitX  float64
 	Month string
 	Value int
 }
@@ -451,6 +452,7 @@ func buildFeedSparklineData(posts []*models.Post, window sparklineWindow) []Spar
 		points = append(points, SparklinePoint{
 			X:     x,
 			Y:     y,
+			HitX:  x - 2.6,
 			Month: months[i].Format("Jan 2006"),
 			Value: count,
 		})

--- a/pkg/plugins/feeds_listing_test.go
+++ b/pkg/plugins/feeds_listing_test.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"math"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -157,8 +158,8 @@ func TestMonthlyPostBuckets_UsesSharedWindow(t *testing.T) {
 	}
 	title := "Post"
 	posts := []*models.Post{
-		{Title: &title, Published: true, Date: testDate(2024, 1, 15)},
-		{Title: &title, Published: true, Date: testDate(2024, 4, 2)},
+		{Title: &title, Published: true, Date: testDate(1, 15)},
+		{Title: &title, Published: true, Date: testDate(4, 2)},
 	}
 	buckets, _ := monthlyPostBuckets(posts, window)
 	if len(buckets) != 4 {
@@ -169,7 +170,29 @@ func TestMonthlyPostBuckets_UsesSharedWindow(t *testing.T) {
 	}
 }
 
-func testDate(year int, month time.Month, day int) *time.Time {
-	t := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+func TestBuildFeedSparklineData_ComputesHitboxOffsets(t *testing.T) {
+	window := sparklineWindow{
+		Start: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+		End:   time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC),
+	}
+	title := "Post"
+	posts := []*models.Post{
+		{Title: &title, Published: true, Date: testDate(1, 15)},
+		{Title: &title, Published: true, Date: testDate(3, 15)},
+	}
+	data := buildFeedSparklineData(posts, window)
+	if len(data) != 3 {
+		t.Fatalf("expected 3 sparkline points, got %d", len(data))
+	}
+	wantHitX := []float64{-2.6, 45.4, 93.4}
+	for i, point := range data {
+		if math.Abs(point.HitX-wantHitX[i]) > 0.000001 {
+			t.Fatalf("point %d hitbox x = %v, want %v", i, point.HitX, wantHitX[i])
+		}
+	}
+}
+
+func testDate(month time.Month, day int) *time.Time {
+	t := time.Date(2024, month, day, 0, 0, 0, 0, time.UTC)
 	return &t
 }

--- a/pkg/themes/default/templates/feed.html
+++ b/pkg/themes/default/templates/feed.html
@@ -42,7 +42,7 @@
           <g class="feed-header-sparkline-point" data-label="{{ point.Month }} | {{ point.Value }} posts">
             <line class="feed-header-sparkline-guide" x1="{{ point.X }}" y1="0" x2="{{ point.X }}" y2="28"></line>
             <circle class="feed-header-sparkline-dot" cx="{{ point.X }}" cy="{{ point.Y }}" r="2.2"></circle>
-            <rect class="feed-header-sparkline-hit" x="{{ point.X|add:"-2.6" }}" y="0" width="5.2" height="28"></rect>
+            <rect class="feed-header-sparkline-hit" x="{{ point.HitX }}" y="0" width="5.2" height="28"></rect>
           </g>
           {% endfor %}
         </svg>

--- a/pkg/themes/default/templates/feeds.html
+++ b/pkg/themes/default/templates/feeds.html
@@ -134,7 +134,7 @@
                     <g class="feed-sparkline-point" data-label="{{ point.Month }} | {{ point.Value }} posts">
                       <line class="feed-sparkline-guide" x1="{{ point.X }}" y1="0" x2="{{ point.X }}" y2="28"></line>
                       <circle class="feed-sparkline-dot" cx="{{ point.X }}" cy="{{ point.Y }}" r="2.2"></circle>
-                      <rect class="feed-sparkline-hit" x="{{ point.X|add:"-2.6" }}" y="0" width="5.2" height="28"></rect>
+                      <rect class="feed-sparkline-hit" x="{{ point.HitX }}" y="0" width="5.2" height="28"></rect>
                     </g>
                     {% endfor %}
                   </svg>


### PR DESCRIPTION
## Summary
- precompute feed sparkline hitbox x coordinates before rendering templates
- avoid invalid SVG attributes like `x=\"78.367347-2.6\"` on `/feeds/`
- add regression coverage for the generated feeds listing output

Fixes #1060