### PR TITLE
fix(accessibility): add accessible names to generated media anchors

### DIFF
--- a/pkg/plugins/feed_helpers.go
+++ b/pkg/plugins/feed_helpers.go
@@ -613,7 +613,7 @@ func renderPhotoFigure(post map[string]interface{}) string {
 	image = templates.WithSize(image, 1200, 675)
 	builder := &strings.Builder{}
 	builder.WriteString("<figure class=\"photo-figure h-entry\">")
-	fmt.Fprintf(builder, "<a href=\"%s\"><img src=\"%s\" alt=\"%s\" loading=\"lazy\" width=\"1200\" height=\"675\"></a>", html.EscapeString(href), html.EscapeString(image), html.EscapeString(caption))
+	fmt.Fprintf(builder, "<a href=\"%s\" aria-label=\"%s\"><img src=\"%s\" alt=\"%s\" loading=\"lazy\" width=\"1200\" height=\"675\"></a>", html.EscapeString(href), html.EscapeString(caption), html.EscapeString(image), html.EscapeString(caption))
 	fmt.Fprintf(builder, "<figcaption class=\"p-summary\">%s</figcaption>", html.EscapeString(caption))
 	builder.WriteString("</figure>")
 	return builder.String()

--- a/pkg/plugins/feed_helpers_test.go
+++ b/pkg/plugins/feed_helpers_test.go
@@ -102,11 +102,26 @@ func TestFeedHelpers_RenderFeedPhotoCard(t *testing.T) {
 	if !strings.Contains(output, "photo-figure") {
 		t.Fatalf("expected photo figure class, got: %s", output)
 	}
+	if !strings.Contains(output, `aria-label="Wicket in his lab"`) {
+		t.Fatalf("expected accessible name on media anchor, got: %s", output)
+	}
 	if !strings.Contains(output, "<figure") || !strings.Contains(output, "<figcaption") {
 		t.Fatalf("expected figure markup for photo card, got: %s", output)
 	}
 	if !strings.Contains(output, description) {
 		t.Fatalf("expected photo description in figcaption, got: %s", output)
+	}
+}
+
+func TestFeedHelpers_RenderPhotoFigureAddsAccessibleName(t *testing.T) {
+	output := renderPhotoFigure(map[string]interface{}{
+		"href":        "/lab/",
+		"image":       "/lab.webp",
+		"description": "Wicket in his lab",
+	})
+
+	if !strings.Contains(output, `aria-label="Wicket in his lab"`) {
+		t.Fatalf("expected aria-label on fallback media anchor, got: %s", output)
 	}
 }
 

--- a/pkg/plugins/image_zoom.go
+++ b/pkg/plugins/image_zoom.go
@@ -3,6 +3,7 @@ package plugins
 
 import (
 	"fmt"
+	"html"
 	"regexp"
 	"strings"
 
@@ -229,30 +230,30 @@ func (p *ImageZoomPlugin) processPost(post *models.Post) error {
 
 	// Process all img tags using index-based replacement so we can inspect
 	// the surrounding HTML for each match (e.g. detect parent <a> tags).
-	html := post.ArticleHTML
-	matches := imageZoomImgTagRegex.FindAllStringSubmatchIndex(html, -1)
+	articleHTML := post.ArticleHTML
+	matches := imageZoomImgTagRegex.FindAllStringSubmatchIndex(articleHTML, -1)
 	if len(matches) == 0 {
 		return nil
 	}
 
 	var buf strings.Builder
-	buf.Grow(len(html) + len(matches)*100) // pre-allocate
+	buf.Grow(len(articleHTML) + len(matches)*100) // pre-allocate
 	lastEnd := 0
 
 	for _, loc := range matches {
 		// loc[0..1] = full match, loc[2..3] = capture group 1 (attrs)
 		matchStart, matchEnd := loc[0], loc[1]
 		attrStart, attrEnd := loc[2], loc[3]
-		attrs := html[attrStart:attrEnd]
+		attrs := articleHTML[attrStart:attrEnd]
 
 		// Write everything before this match
-		buf.WriteString(html[lastEnd:matchStart])
+		buf.WriteString(articleHTML[lastEnd:matchStart])
 		lastEnd = matchEnd
 
 		// Check if already has glightbox attribute
 		if strings.Contains(attrs, "data-glightbox") {
 			foundZoomable = true
-			buf.WriteString(html[matchStart:matchEnd])
+			buf.WriteString(articleHTML[matchStart:matchEnd])
 			continue
 		}
 
@@ -263,7 +264,7 @@ func (p *ImageZoomPlugin) processPost(post *models.Post) error {
 		shouldZoom := hasZoomableMarker || postZoomEnabled
 
 		if !shouldZoom {
-			buf.WriteString(html[matchStart:matchEnd])
+			buf.WriteString(articleHTML[matchStart:matchEnd])
 			continue
 		}
 
@@ -285,6 +286,10 @@ func (p *ImageZoomPlugin) processPost(post *models.Post) error {
 		}
 		if len(altMatch) > 1 {
 			alt = strings.TrimSpace(altMatch[1])
+		}
+		anchorLabel := alt
+		if anchorLabel == "" {
+			anchorLabel = "Open image"
 		}
 
 		// Build the glightbox data attribute
@@ -309,7 +314,7 @@ func (p *ImageZoomPlugin) processPost(post *models.Post) error {
 		// the HTML before the match: find the last <a or </a> and see
 		// which one is closer. If the last anchor-related tag is an
 		// opening <a (not </a>), the image is inside an anchor.
-		insideAnchor := isInsideAnchor(html, matchStart)
+		insideAnchor := isInsideAnchor(articleHTML, matchStart)
 
 		if insideAnchor {
 			// Image is already inside an anchor — just add glightbox
@@ -322,14 +327,16 @@ func (p *ImageZoomPlugin) processPost(post *models.Post) error {
 			// Wrap image in anchor for lightbox functionality
 			buf.WriteString(`<a href="`)
 			buf.WriteString(src)
-			buf.WriteString(`" class="glightbox-link"><img `)
+			buf.WriteString(`" class="glightbox-link" aria-label="`)
+			buf.WriteString(html.EscapeString(anchorLabel))
+			buf.WriteString(`"><img `)
 			buf.WriteString(cleanedAttrs)
 			buf.WriteString(`></a>`)
 		}
 	}
 
 	// Write remaining HTML after the last match
-	buf.WriteString(html[lastEnd:])
+	buf.WriteString(articleHTML[lastEnd:])
 	result := buf.String()
 
 	// Store whether this post needs the glightbox library

--- a/pkg/plugins/image_zoom_test.go
+++ b/pkg/plugins/image_zoom_test.go
@@ -77,8 +77,11 @@ func TestImageZoomPlugin_ProcessPostWithDataZoomable(t *testing.T) {
 	}
 
 	// Check that the image was wrapped in an anchor
-	if !containsSubstring(post.ArticleHTML, `<a href="test.jpg" class="glightbox-link">`) {
+	if !containsSubstring(post.ArticleHTML, `<a href="test.jpg" class="glightbox-link" aria-label="Test image">`) {
 		t.Errorf("ArticleHTML should contain glightbox anchor, got: %s", post.ArticleHTML)
+	}
+	if !containsSubstring(post.ArticleHTML, `aria-label="Test image"`) {
+		t.Errorf("ArticleHTML should contain accessible name on glightbox anchor, got: %s", post.ArticleHTML)
 	}
 
 	// Check that data-glightbox attribute was added
@@ -115,7 +118,7 @@ func TestImageZoomPlugin_ProcessPostWithZoomableClass(t *testing.T) {
 	}
 
 	// Check that the image was processed
-	if !containsSubstring(post.ArticleHTML, `<a href="photo.png" class="glightbox-link">`) {
+	if !containsSubstring(post.ArticleHTML, `<a href="photo.png" class="glightbox-link" aria-label="Photo">`) {
 		t.Errorf("ArticleHTML should contain glightbox anchor, got: %s", post.ArticleHTML)
 	}
 
@@ -144,7 +147,7 @@ func TestImageZoomPlugin_ProcessPostAutoAllImages(t *testing.T) {
 	}
 
 	// All images should be zoomable when AutoAllImages is true
-	if !containsSubstring(post.ArticleHTML, `<a href="test.jpg" class="glightbox-link">`) {
+	if !containsSubstring(post.ArticleHTML, `<a href="test.jpg" class="glightbox-link" aria-label="Regular image">`) {
 		t.Errorf("ArticleHTML should contain glightbox anchor with AutoAllImages, got: %s", post.ArticleHTML)
 	}
 }
@@ -171,7 +174,7 @@ func TestImageZoomPlugin_ProcessPostFrontmatterOverride(t *testing.T) {
 	}
 
 	// Image should be zoomable due to frontmatter override
-	if !containsSubstring(post.ArticleHTML, `<a href="test.jpg" class="glightbox-link">`) {
+	if !containsSubstring(post.ArticleHTML, `<a href="test.jpg" class="glightbox-link" aria-label="Regular image">`) {
 		t.Errorf("ArticleHTML should contain glightbox anchor with frontmatter override, got: %s", post.ArticleHTML)
 	}
 }
@@ -249,10 +252,10 @@ func TestImageZoomPlugin_MultipleImages(t *testing.T) {
 	}
 
 	// First and third images should be zoomable
-	if !containsSubstring(post.ArticleHTML, `<a href="a.jpg" class="glightbox-link">`) {
+	if !containsSubstring(post.ArticleHTML, `<a href="a.jpg" class="glightbox-link" aria-label="Image A">`) {
 		t.Errorf("First image should be zoomable")
 	}
-	if !containsSubstring(post.ArticleHTML, `<a href="c.jpg" class="glightbox-link">`) {
+	if !containsSubstring(post.ArticleHTML, `<a href="c.jpg" class="glightbox-link" aria-label="Image C">`) {
 		t.Errorf("Third image should be zoomable")
 	}
 

--- a/pkg/themes/default/templates/partials/cards/photo-card.html
+++ b/pkg/themes/default/templates/partials/cards/photo-card.html
@@ -3,7 +3,7 @@
 {# blocks creates blank-line + 4-space patterns that goldmark treats as code blocks #}
 {# when this template is used inside render_feed() (output injected into markdown). #}
 {% with post.image|media_url:post.video as media_src %}{% if media_src %}{% with media_src|with_size:"600" as sized_media %}<figure class="photo-figure h-entry">
-<a href="{{ post.href }}" class="u-url">
+<a href="{{ post.href }}" class="u-url" aria-label="{{ post.description | default:post.title | default:'Photo' }}">
 {% if media_src|is_video %}{% set poster_candidate = post | poster_url:media_src %}<video class="u-video" autoplay muted loop playsinline{% if poster_candidate %} poster="{{ poster_candidate | with_size:"600" }}"{% endif %}>
 <source src="{{ sized_media }}"{% with media_src|video_mime as mime %}{% if mime %} type="{{ mime }}"{% endif %}{% endwith %}>
 </video>

--- a/templates/partials/cards/photo-card.html
+++ b/templates/partials/cards/photo-card.html
@@ -3,7 +3,7 @@
 {# blocks creates blank-line + 4-space patterns that goldmark treats as code blocks #}
 {# when this template is used inside render_feed() (output injected into markdown). #}
 {% with post.image|media_url:post.video as media_src %}{% if media_src %}{% with media_src|with_size:"600" as sized_media %}<figure class="photo-figure h-entry">
-<a href="{{ post.href }}" class="u-url">
+<a href="{{ post.href }}" class="u-url" aria-label="{{ post.description | default:post.title | default:'Photo' }}">
 {% if media_src|is_video %}{% set poster_candidate = post | poster_url:media_src %}<video class="u-video" autoplay muted loop playsinline{% if poster_candidate %} poster="{{ poster_candidate | with_size:"600" }}"{% endif %}>
 <source src="{{ sized_media }}"{% with media_src|video_mime as mime %}{% if mime %} type="{{ mime }}"{% endif %}{% endwith %}>
 </video>


### PR DESCRIPTION
## Summary
- add accessible names to generated media anchors in feed helper output and photo cards
- preserve lightbox and image-zoom behavior while making generated links discernible to assistive tech
- add regression coverage for feed helpers and image zoom output

Fixes #1058