### PR TITLE
fix(media): preserve dimensions for generated inline media and lightbox output

### DIFF
--- a/docs/guides/markdown.md
+++ b/docs/guides/markdown.md
@@ -2120,7 +2120,7 @@ Use the `{data-zoomable}` attribute marker to make specific images zoomable:
 
 ```html
 <a href="/images/sunset.jpg" class="glightbox-link">
-  <img src="/images/sunset.jpg" alt="Beautiful sunset" class="glightbox" data-glightbox="description: Beautiful sunset">
+  <img src="/images/sunset.jpg" alt="Beautiful sunset" class="glightbox" width="1200" height="675" data-glightbox="description: Beautiful sunset">
 </a>
 
 <img src="/images/icon.png" alt="Regular image without zoom">

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -1390,10 +1390,11 @@ image_zoom: true
 2. Finds images with `{data-zoomable}` or `{.zoomable}` markers
 3. Removes the markers from alt text
 4. Wraps images in anchor tags with GLightbox classes
-5. Adds `data-glightbox` attribute for the lightbox
-6. Tracks which posts need the lightbox library
-7. In Write stage, stores configuration for templates to inject JS/CSS
-8. Prefers shared vendored GLightbox assets from `[markata-go.assets]` when available, otherwise falls back to the legacy `cdn` toggle
+5. Preserves explicit width/height when the source URL already carries media size hints
+6. Adds `data-glightbox` attribute for the lightbox
+7. Tracks which posts need the lightbox library
+8. In Write stage, stores configuration for templates to inject JS/CSS
+9. Prefers shared vendored GLightbox assets from `[markata-go.assets]` when available, otherwise falls back to the legacy `cdn` toggle
 
 **HTML output:**
 
@@ -1406,7 +1407,8 @@ Output:
 ```html
 <a href="/images/sunset.jpg" class="glightbox-link">
   <img src="/images/sunset.jpg" alt="Beautiful sunset"
-       class="glightbox" data-glightbox="description: Beautiful sunset">
+       class="glightbox" width="1200" height="675"
+       data-glightbox="description: Beautiful sunset">
 </a>
 ```
 

--- a/pkg/plugins/image_zoom.go
+++ b/pkg/plugins/image_zoom.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
 	"github.com/WaylonWalker/markata-go/pkg/models"
+	markatatemplates "github.com/WaylonWalker/markata-go/pkg/templates"
 )
 
 // ImageZoomPlugin adds optional image zoom/lightbox functionality using GLightbox.
@@ -208,6 +209,12 @@ var imgAltRegex = regexp.MustCompile(`alt="([^"]*)"`)
 // imgClassRegex matches the class attribute in an img tag for replacement.
 var imgClassRegex = regexp.MustCompile(`class="([^"]*)"`)
 
+// imgWidthRegex matches the width attribute in an img tag.
+var imgWidthRegex = regexp.MustCompile(`width="([^"]*)"`)
+
+// imgHeightRegex matches the height attribute in an img tag.
+var imgHeightRegex = regexp.MustCompile(`height="([^"]*)"`)
+
 // processPost processes a single post's HTML for images that should be zoomable.
 func (p *ImageZoomPlugin) processPost(post *models.Post) error {
 	// Skip posts marked as skip or with no HTML content
@@ -307,6 +314,8 @@ func (p *ImageZoomPlugin) processPost(post *models.Post) error {
 			cleanedAttrs = `class="glightbox" ` + cleanedAttrs
 		}
 
+		cleanedAttrs = appendImageDimensions(cleanedAttrs, src)
+
 		// Add the data-glightbox attribute
 		cleanedAttrs = cleanedAttrs + " " + glightboxAttr
 
@@ -349,6 +358,26 @@ func (p *ImageZoomPlugin) processPost(post *models.Post) error {
 
 	post.ArticleHTML = result
 	return nil
+}
+
+func appendImageDimensions(attrs, src string) string {
+	if src == "" {
+		return attrs
+	}
+
+	width, height, ok := markatatemplates.MediaDimensionsFromURL(src)
+	if !ok {
+		return attrs
+	}
+
+	if width > 0 && !imgWidthRegex.MatchString(attrs) {
+		attrs += fmt.Sprintf(` width="%d"`, width)
+	}
+	if height > 0 && !imgHeightRegex.MatchString(attrs) {
+		attrs += fmt.Sprintf(` height="%d"`, height)
+	}
+
+	return attrs
 }
 
 // Write injects GLightbox CSS and JS into posts that need it.

--- a/pkg/plugins/image_zoom_test.go
+++ b/pkg/plugins/image_zoom_test.go
@@ -266,6 +266,35 @@ func TestImageZoomPlugin_MultipleImages(t *testing.T) {
 	}
 }
 
+func TestImageZoomPlugin_ProcessPostPreservesDimensionsFromSizedMediaURL(t *testing.T) {
+	p := NewImageZoomPlugin()
+	p.SetConfig(models.ImageZoomConfig{
+		Enabled:       true,
+		Library:       "glightbox",
+		Selector:      ".glightbox",
+		AutoAllImages: true,
+	})
+
+	post := &models.Post{
+		ArticleHTML: `<p><img src="https://dropper.wayl.one/image.jpg?w=1200&h=675" alt="Sized image"></p>`,
+	}
+
+	err := p.processPost(post)
+	if err != nil {
+		t.Fatalf("processPost() error = %v", err)
+	}
+
+	if !containsSubstring(post.ArticleHTML, `width="1200"`) {
+		t.Fatalf("ArticleHTML should preserve width, got: %s", post.ArticleHTML)
+	}
+	if !containsSubstring(post.ArticleHTML, `height="675"`) {
+		t.Fatalf("ArticleHTML should preserve height, got: %s", post.ArticleHTML)
+	}
+	if !containsSubstring(post.ArticleHTML, `<a href="https://dropper.wayl.one/image.jpg?w=1200&h=675" class="glightbox-link" aria-label="Sized image">`) {
+		t.Fatalf("ArticleHTML should still wrap the image for lightbox, got: %s", post.ArticleHTML)
+	}
+}
+
 func TestImageZoomPlugin_Configure_PrefersVendoredAssets(t *testing.T) {
 	p := NewImageZoomPlugin()
 	m := lifecycle.NewManager()

--- a/pkg/templates/filters_test.go
+++ b/pkg/templates/filters_test.go
@@ -172,15 +172,15 @@ func TestTemplateTrees_PreserveSizedMediaDimensions(t *testing.T) {
 		expected []string
 	}{
 		{
-			file:    "../../pkg/themes/default/templates/partials/cards/article-card.html",
+			file:     "../../pkg/themes/default/templates/partials/cards/article-card.html",
 			expected: []string{`width="220"`, `height="160"`},
 		},
 		{
-			file:    "../../pkg/themes/default/templates/partials/cards/video-card.html",
+			file:     "../../pkg/themes/default/templates/partials/cards/video-card.html",
 			expected: []string{`width="1200"`, `height="675"`},
 		},
 		{
-			file:    "../../templates/partials/cards/video-card.html",
+			file:     "../../templates/partials/cards/video-card.html",
 			expected: []string{`width="1200"`, `height="675"`},
 		},
 	}

--- a/pkg/templates/filters_test.go
+++ b/pkg/templates/filters_test.go
@@ -166,6 +166,41 @@ func TestTemplateTrees_UseHumanDateForVisibleHTMLDates(t *testing.T) {
 	}
 }
 
+func TestTemplateTrees_PreserveSizedMediaDimensions(t *testing.T) {
+	tests := []struct {
+		file     string
+		expected []string
+	}{
+		{
+			file:    "../../pkg/themes/default/templates/partials/cards/article-card.html",
+			expected: []string{`width="220"`, `height="160"`},
+		},
+		{
+			file:    "../../pkg/themes/default/templates/partials/cards/video-card.html",
+			expected: []string{`width="1200"`, `height="675"`},
+		},
+		{
+			file:    "../../templates/partials/cards/video-card.html",
+			expected: []string{`width="1200"`, `height="675"`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.file, func(t *testing.T) {
+			content, err := os.ReadFile(tt.file)
+			if err != nil {
+				t.Fatalf("ReadFile(%q) error: %v", tt.file, err)
+			}
+			text := string(content)
+			for _, needle := range tt.expected {
+				if !strings.Contains(text, needle) {
+					t.Fatalf("template %q does not contain %s", tt.file, needle)
+				}
+			}
+		})
+	}
+}
+
 func TestFilterSlugify(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/pkg/templates/media.go
+++ b/pkg/templates/media.go
@@ -86,6 +86,24 @@ func WithSize(raw string, width, height int) string {
 	return u.String()
 }
 
+// MediaDimensionsFromURL extracts known width/height query parameters from a media URL.
+// It recognizes both w/h and width/height parameter names.
+func MediaDimensionsFromURL(raw string) (width, height int, ok bool) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return 0, 0, false
+	}
+
+	qs := u.Query()
+	if width = positiveIntFromString(firstNonEmpty(qs.Get("w"), qs.Get("width"))); width > 0 {
+		ok = true
+	}
+	if height = positiveIntFromString(firstNonEmpty(qs.Get("h"), qs.Get("height"))); height > 0 {
+		ok = true
+	}
+	return width, height, ok
+}
+
 // IsVideoURL reports whether a URL ends with a known video extension.
 func IsVideoURL(raw string) bool {
 	ext := extensionFromURL(raw)
@@ -176,6 +194,23 @@ func normalizeTrustedMediaURL(raw string) string {
 		return u.String()
 	}
 	return raw
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func positiveIntFromString(raw string) int {
+	v, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil || v <= 0 {
+		return 0
+	}
+	return v
 }
 
 func stringFromMap(data map[string]interface{}, key string) string {

--- a/pkg/templates/media_test.go
+++ b/pkg/templates/media_test.go
@@ -1,0 +1,27 @@
+package templates
+
+import "testing"
+
+func TestMediaDimensionsFromURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantWidth  int
+		wantHeight int
+		wantOK     bool
+	}{
+		{name: "w and h", input: "https://example.com/image.jpg?w=1200&h=675", wantWidth: 1200, wantHeight: 675, wantOK: true},
+		{name: "width and height", input: "https://example.com/image.jpg?width=800&height=600", wantWidth: 800, wantHeight: 600, wantOK: true},
+		{name: "width only", input: "https://example.com/image.jpg?w=900", wantWidth: 900, wantHeight: 0, wantOK: true},
+		{name: "unrelated query", input: "https://example.com/image.jpg?foo=bar", wantWidth: 0, wantHeight: 0, wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			width, height, ok := MediaDimensionsFromURL(tt.input)
+			if width != tt.wantWidth || height != tt.wantHeight || ok != tt.wantOK {
+				t.Fatalf("MediaDimensionsFromURL(%q) = (%d, %d, %v), want (%d, %d, %v)", tt.input, width, height, ok, tt.wantWidth, tt.wantHeight, tt.wantOK)
+			}
+		})
+	}
+}

--- a/pkg/themes/default/templates/partials/cards/article-card.html
+++ b/pkg/themes/default/templates/partials/cards/article-card.html
@@ -6,10 +6,10 @@
 <article class="card card-article h-entry{% if media_src %} has-cover{% endif %}">
 {% if media_src %}
 <a href="{{ post.href }}" class="card-cover u-url">
-{% if media_src|is_video %}{% set poster_candidate = post | poster_url:media_src %}<video class="card-cover-img u-video" autoplay muted loop playsinline{% if poster_candidate %} poster="{{ poster_candidate | with_size:"600" }}"{% endif %}>
+{% if media_src|is_video %}{% set poster_candidate = post | poster_url:media_src %}<video class="card-cover-img u-video" autoplay muted loop playsinline width="220" height="160"{% if poster_candidate %} poster="{{ poster_candidate | with_size:"600" }}"{% endif %}>
 <source src="{{ media_src|with_size:"600" }}"{% with media_src|video_mime as mime %}{% if mime %} type="{{ mime }}"{% endif %}{% endwith %}>
 </video>
-{% else %}<img src="{{ media_src|with_size:"600" }}" alt="{{ post.title | default:post.slug }}" class="card-cover-img u-photo" loading="lazy">
+{% else %}<img src="{{ media_src|with_size:"600" }}" alt="{{ post.title | default:post.slug }}" class="card-cover-img u-photo" width="220" height="160" loading="lazy">
 {% endif %}
 </a>
 {% endif %}

--- a/pkg/themes/default/templates/partials/cards/video-card.html
+++ b/pkg/themes/default/templates/partials/cards/video-card.html
@@ -4,7 +4,7 @@
 <article class="card card-video h-entry">
 <header class="card-header">
 {% with post.image|media_url:post.video as media_src %}{% if media_src %}{% with media_src|with_size:"1200,675" as sized_media %}<a href="{{ post.href }}" class="card-video-link u-url">
-{% if media_src|is_video %}{% set poster_candidate = post | poster_url:media_src %}<video class="card-thumbnail u-video" autoplay muted loop playsinline{% if poster_candidate %} poster="{{ poster_candidate | with_size:"1200,675" }}"{% endif %}>
+{% if media_src|is_video %}{% set poster_candidate = post | poster_url:media_src %}<video class="card-thumbnail u-video" autoplay muted loop playsinline width="1200" height="675"{% if poster_candidate %} poster="{{ poster_candidate | with_size:"1200,675" }}"{% endif %}>
 <source src="{{ sized_media }}"{% with media_src|video_mime as mime %}{% if mime %} type="{{ mime }}"{% endif %}{% endwith %}>
 </video>
 {% else %}<div class="card-video-container">

--- a/templates/partials/cards/video-card.html
+++ b/templates/partials/cards/video-card.html
@@ -4,7 +4,7 @@
 <article class="card card-video h-entry">
 <header class="card-header">
 {% with post.image|media_url:post.video as media_src %}{% if media_src %}{% with media_src|with_size:"1200,675" as sized_media %}<a href="{{ post.href }}" class="card-video-link u-url">
-{% if media_src|is_video %}{% set poster_candidate = post | poster_url:media_src %}<video class="card-thumbnail u-video" autoplay muted loop playsinline{% if poster_candidate %} poster="{{ poster_candidate | with_size:"1200,675" }}"{% endif %}>
+{% if media_src|is_video %}{% set poster_candidate = post | poster_url:media_src %}<video class="card-thumbnail u-video" autoplay muted loop playsinline width="1200" height="675"{% if poster_candidate %} poster="{{ poster_candidate | with_size:"1200,675" }}"{% endif %}>
 <source src="{{ sized_media }}"{% with media_src|video_mime as mime %}{% if mime %} type="{{ mime }}"{% endif %}{% endwith %}>
 </video>
 {% else %}<div class="card-video-container">


### PR DESCRIPTION
## Summary
- preserve intrinsic media dimensions in generated lightbox and card output when the source URL already provides them
- add regression coverage for the media helpers, lightbox output, and affected templates
- document the generated media dimension behavior in the user docs

Fixes #1064