### PR TITLE
perf: improve LCP and TBT on media-heavy post pages

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -723,6 +723,8 @@ Configure backlinks/outlinks UI on post pages. You can render a graph, a list, o
 | `inlinks_limit` | int | `8` | Max inlinks shown in list mode. |
 | `outlinks_limit` | int | `8` | Max outlinks shown in list mode. |
 
+The graph loader is only emitted on pages that render the graph preview, so pages that stay in list-only mode avoid the graph JavaScript entirely.
+
 ```toml
 [markata-go.components.post_connections]
 enabled = true

--- a/docs/guides/garden.md
+++ b/docs/guides/garden.md
@@ -122,6 +122,8 @@ In your post template, include:
 
 The preview automatically hides when the post is not present in `graph.json` or has no connections.
 
+When the preview is not rendered, its JavaScript is not loaded either, which keeps ordinary article pages lighter.
+
 When view transitions are enabled, the preview also re-initializes after client-side page swaps, so navigating between posts does not require a hard refresh to render the graph.
 
 ## Filtering

--- a/pkg/plugins/templates_test.go
+++ b/pkg/plugins/templates_test.go
@@ -496,7 +496,7 @@ func TestTemplatesPlugin_Render_PostGraphScriptOnlyWhenGraphRenders(t *testing.T
 		name            string
 		inlinks         int
 		outlinks        int
-		wantGraphScript  bool
+		wantGraphScript bool
 	}{
 		{name: "no graph for sparse post", inlinks: 1, outlinks: 1, wantGraphScript: false},
 		{name: "graph for connected post", inlinks: 2, outlinks: 1, wantGraphScript: true},

--- a/pkg/plugins/templates_test.go
+++ b/pkg/plugins/templates_test.go
@@ -491,6 +491,56 @@ func TestTemplatesPlugin_Render_NoTemplate(t *testing.T) {
 	}
 }
 
+func TestTemplatesPlugin_Render_PostGraphScriptOnlyWhenGraphRenders(t *testing.T) {
+	tests := []struct {
+		name            string
+		inlinks         int
+		outlinks        int
+		wantGraphScript  bool
+	}{
+		{name: "no graph for sparse post", inlinks: 1, outlinks: 1, wantGraphScript: false},
+		{name: "graph for connected post", inlinks: 2, outlinks: 1, wantGraphScript: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewTemplatesPlugin()
+			m := lifecycle.NewManager()
+
+			config := m.Config()
+			config.Extra["templates_dir"] = "/nonexistent"
+
+			if err := p.Configure(m); err != nil {
+				t.Fatalf("Configure() error = %v", err)
+			}
+
+			title := "Test Post"
+			post := &models.Post{
+				Title:       &title,
+				Href:        "/test-post/",
+				Template:    "post.html",
+				ArticleHTML: "<p>Hello World</p>",
+			}
+			for i := 0; i < tt.inlinks; i++ {
+				post.Inlinks = append(post.Inlinks, &models.Link{SourceURL: "https://example.com/source/"})
+			}
+			for i := 0; i < tt.outlinks; i++ {
+				post.Outlinks = append(post.Outlinks, &models.Link{TargetURL: "https://example.com/target/"})
+			}
+			m.AddPost(post)
+
+			if err := p.Render(m); err != nil {
+				t.Fatalf("Render() error = %v", err)
+			}
+
+			hasGraphScript := strings.Contains(post.HTML, "post-graph.js")
+			if hasGraphScript != tt.wantGraphScript {
+				t.Fatalf("post-graph.js present = %v, want %v; HTML=%q", hasGraphScript, tt.wantGraphScript, post.HTML)
+			}
+		})
+	}
+}
+
 func TestTemplatesPlugin_Render_UsesResolvedPostFormatsInTemplateContext(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "templates-test")
 	if err != nil {

--- a/pkg/themes/default/templates/base.html
+++ b/pkg/themes/default/templates/base.html
@@ -693,12 +693,11 @@
    <script src="{{ 'js/palette-switcher.js' | theme_asset_hashed }}" defer></script>
    {% endif %}
 
-   {% if config.components.post_connections.enabled and config.components.post_connections.display_graph %}
-   <script>
-     window.MARKATA_GO_D3_URL = '{% if config.Extra.asset_urls.d3 %}{{ config.Extra.asset_urls.d3 }}{% else %}https://d3js.org/d3.v7.min.js{% endif %}';
-   </script>
-   <script src="{{ 'js/post-graph.js' | theme_asset_hashed }}" defer></script>
-   {% endif %}
+    {% if config.components.post_connections.enabled and config.components.post_connections.display_graph %}
+    <script>
+      window.MARKATA_GO_D3_URL = '{% if config.Extra.asset_urls.d3 %}{{ config.Extra.asset_urls.d3 }}{% else %}https://d3js.org/d3.v7.min.js{% endif %}';
+    </script>
+    {% endif %}
 
   <!-- View Transitions API - Global Navigation Interceptor -->
   {% if config.view_transitions.enabled | default:true %}

--- a/pkg/themes/default/templates/components/post_graph.html
+++ b/pkg/themes/default/templates/components/post_graph.html
@@ -90,6 +90,7 @@
     <div class="post-graph__tooltip" aria-live="polite"></div>
   </div>
 </section>
+<script src="{{ 'js/post-graph.js' | theme_asset_hashed }}" defer></script>
 {% endif %}
 
 {% if show_list %}

--- a/spec/spec/GARDEN.md
+++ b/spec/spec/GARDEN.md
@@ -151,6 +151,8 @@ The preview filters down to the current post plus its directly connected tags an
 
 Implementations MUST initialize the post graph on first page load and re-initialize it after `view-transition-complete` so graph previews continue working during SPA-style page swaps.
 
+The post graph script SHOULD only be emitted on pages that actually render the preview, so posts without a visible graph do not pay the JavaScript cost.
+
 The post connections component is configured via `[markata-go.components.post_connections]` and supports two modes:
 
 - `display = ["graph"]` for canvas-only graph rendering

--- a/templates/base.html
+++ b/templates/base.html
@@ -649,12 +649,11 @@
    <script src="{{ 'js/palette-switcher.js' | theme_asset_hashed }}" defer></script>
    {% endif %}
 
-   {% if config.components.post_connections.enabled and config.components.post_connections.display_graph %}
-   <script>
-     window.MARKATA_GO_D3_URL = '{% if config.Extra.asset_urls.d3 %}{{ config.Extra.asset_urls.d3 }}{% else %}https://d3js.org/d3.v7.min.js{% endif %}';
-   </script>
-   <script src="{{ 'js/post-graph.js' | theme_asset_hashed }}" defer></script>
-   {% endif %}
+    {% if config.components.post_connections.enabled and config.components.post_connections.display_graph %}
+    <script>
+      window.MARKATA_GO_D3_URL = '{% if config.Extra.asset_urls.d3 %}{{ config.Extra.asset_urls.d3 }}{% else %}https://d3js.org/d3.v7.min.js{% endif %}';
+    </script>
+    {% endif %}
 
   <!-- View Transitions API - Global Navigation Interceptor -->
   {% if config.view_transitions.enabled | default:true %}

--- a/templates/components/post_graph.html
+++ b/templates/components/post_graph.html
@@ -90,6 +90,7 @@
     <div class="post-graph__tooltip" aria-live="polite"></div>
   </div>
 </section>
+<script src="{{ 'js/post-graph.js' | theme_asset_hashed }}" defer></script>
 {% endif %}
 
 {% if show_list %}


### PR DESCRIPTION
## Summary
- defer garden graph scripts unless the page actually renders the graph component
- keep the base template from loading graph-specific assets site-wide
- document the page-specific loading behavior for garden graph output

Fixes #1065