### PR TITLE
standardize shared theme typography scale usage

### DIFF
--- a/pkg/themes/default/static/css/components.css
+++ b/pkg/themes/default/static/css/components.css
@@ -342,7 +342,8 @@
 }
 
 .toc-item--level-3 {
-  font-size: var(--text-base);
+  /* Keep an intermediate size so nested TOC entries remain visually subordinate. */
+  font-size: 0.9375rem;
 }
 
 .toc-item--level-4 {

--- a/pkg/themes/default/static/css/components.css
+++ b/pkg/themes/default/static/css/components.css
@@ -342,7 +342,7 @@
 }
 
 .toc-item--level-3 {
-  font-size: 0.9375rem;
+  font-size: var(--text-base);
 }
 
 .toc-item--level-4 {
@@ -449,7 +449,7 @@
 
 .feed-nav-title {
   font-family: var(--font-mono);
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.1em;
@@ -469,7 +469,7 @@
 
 .feed-nav-counter {
   font-family: var(--font-mono);
-  font-size: 0.65rem;
+  font-size: var(--text-xs);
   font-weight: 600;
   color: var(--color-info, var(--color-text-muted));
   background: color-mix(in srgb, var(--color-info, var(--color-primary)) 12%, transparent);
@@ -516,7 +516,7 @@
   min-width: 0;
   max-width: 100%;
   font-family: var(--font-mono);
-  font-size: 0.8rem;
+  font-size: var(--text-sm);
   font-weight: 600;
   line-height: 1.2;
   padding: 0.55rem 0.75rem;
@@ -533,7 +533,7 @@
   border-radius: 4px;
   background: transparent;
   color: var(--color-text-muted);
-  font-size: 0.8rem;
+  font-size: var(--text-sm);
   line-height: 1;
   cursor: pointer;
   transition: color 0.15s, background-color 0.15s, border-color 0.15s;
@@ -620,7 +620,7 @@
   text-decoration: none;
   display: block;
   padding: 0.3rem 0.5rem;
-  font-size: 0.8125rem;
+  font-size: var(--text-sm);
   line-height: 1.35;
   transition: color 0.15s, background-color 0.15s, border-color 0.15s, transform 0.15s;
   border-left: 3px solid transparent;
@@ -675,14 +675,14 @@
 
 .feed-nav-hotkey {
   font-family: var(--font-mono);
-  font-size: 0.7rem;
+  font-size: var(--text-xs);
   color: var(--color-text-muted);
   white-space: nowrap;
 }
 
 .feed-nav-hotkey kbd {
   font-family: var(--font-mono);
-  font-size: 0.65rem;
+  font-size: var(--text-xs);
   font-weight: 600;
   padding: 0.125rem 0.35rem;
   color: var(--color-text-muted);
@@ -718,7 +718,7 @@
 }
 
 .content-sidebar-inner {
-  font-size: 0.875rem;
+  font-size: var(--text-sm);
 }
 
 /* Slash pages grid (rendered by render_slashes() in content sidebar) */

--- a/pkg/themes/default/static/css/main.css
+++ b/pkg/themes/default/static/css/main.css
@@ -942,7 +942,7 @@ body:has(.background-decoration) article.post {
   height: 16px;
   border-radius: 50%;
   border: 1px solid var(--color-border);
-  font-size: 10px;
+  font-size: var(--text-xs);
   font-style: italic;
   font-family: Georgia, serif;
   color: var(--color-text-muted);
@@ -1456,8 +1456,8 @@ a.wikilink.wikilink-missing:focus-visible {
 }
 
 .tooltip-title { font-weight: 600; margin-bottom: 4px; }
-.tooltip-desc { font-size: 0.9em; color: var(--color-text-muted); }
-.tooltip-date { font-size: 0.8em; color: var(--color-text-muted); margin-top: 8px; }
+.tooltip-desc { font-size: var(--text-sm); color: var(--color-text-muted); }
+.tooltip-date { font-size: var(--text-xs); color: var(--color-text-muted); margin-top: 8px; }
 
 @keyframes tooltipFadeIn {
   from { opacity: 0; transform: translateY(-4px); }

--- a/pkg/themes/readability_test.go
+++ b/pkg/themes/readability_test.go
@@ -133,10 +133,14 @@ func TestCSSFontSizeScale(t *testing.T) {
 
 	t.Run("font size variables are defined", func(t *testing.T) {
 		requiredSizes := []string{
+			"--text-xs",
 			"--text-base",
 			"--text-sm",
 			"--text-lg",
 			"--text-xl",
+			"--text-2xl",
+			"--text-3xl",
+			"--text-4xl",
 		}
 		for _, size := range requiredSizes {
 			if !strings.Contains(vars, size+":") {
@@ -173,6 +177,41 @@ func TestCSSFontSizeScale(t *testing.T) {
 			}
 		}
 	})
+}
+
+// TestCSSTypographyScaleUsage checks that obvious one-off text sizes map back to the shared scale.
+func TestCSSTypographyScaleUsage(t *testing.T) {
+	mainCSS, err := ReadStatic("css/main.css")
+	if err != nil {
+		t.Fatalf("Failed to read main.css: %v", err)
+	}
+	main := string(mainCSS)
+
+	componentsCSS, err := ReadStatic("css/components.css")
+	if err != nil {
+		t.Fatalf("Failed to read components.css: %v", err)
+	}
+	components := string(componentsCSS)
+
+	checks := []struct {
+		name     string
+		haystack string
+		rule     *regexp.Regexp
+	}{
+		{"feed nav title", components, regexp.MustCompile(`(?s)\.feed-nav-title\s*\{[^}]*font-size:\s*var\(--text-xs\);`)},
+		{"feed nav counter", components, regexp.MustCompile(`(?s)\.feed-nav-counter\s*\{[^}]*font-size:\s*var\(--text-xs\);`)},
+		{"feed nav picker", components, regexp.MustCompile(`(?s)\.feed-nav-picker-input\s*\{[^}]*font-size:\s*var\(--text-sm\);`)},
+		{"feed nav hotkey", components, regexp.MustCompile(`(?s)\.feed-nav-hotkey\s*\{[^}]*font-size:\s*var\(--text-xs\);`)},
+		{"content sidebar inner", components, regexp.MustCompile(`(?s)\.content-sidebar-inner\s*\{[^}]*font-size:\s*var\(--text-sm\);`)},
+		{"tooltip desc", main, regexp.MustCompile(`(?s)\.tooltip-desc\s*\{[^}]*font-size:\s*var\(--text-sm\);`)},
+		{"tooltip date", main, regexp.MustCompile(`(?s)\.tooltip-date\s*\{[^}]*font-size:\s*var\(--text-xs\);`)},
+	}
+
+	for _, tt := range checks {
+		if !tt.rule.MatchString(tt.haystack) {
+			t.Errorf("missing scale token for %s", tt.name)
+		}
+	}
 }
 
 // TestCSSColorContrast validates that CSS defines colors with consideration for contrast.

--- a/pkg/themes/readability_test.go
+++ b/pkg/themes/readability_test.go
@@ -198,6 +198,7 @@ func TestCSSTypographyScaleUsage(t *testing.T) {
 		haystack string
 		rule     *regexp.Regexp
 	}{
+		{"toc level 3", components, regexp.MustCompile(`(?s)\.toc-item--level-3\s*\{[^}]*font-size:\s*0\.9375rem;`)},
 		{"feed nav title", components, regexp.MustCompile(`(?s)\.feed-nav-title\s*\{[^}]*font-size:\s*var\(--text-xs\);`)},
 		{"feed nav counter", components, regexp.MustCompile(`(?s)\.feed-nav-counter\s*\{[^}]*font-size:\s*var\(--text-xs\);`)},
 		{"feed nav picker", components, regexp.MustCompile(`(?s)\.feed-nav-picker-input\s*\{[^}]*font-size:\s*var\(--text-sm\);`)},


### PR DESCRIPTION
## Summary
- replace a small set of obvious one-off font sizes in shared theme CSS with existing type-scale tokens
- cover the shared typography scale and the cleaned-up selectors with regression tests
- keep the scope focused on first-party shared CSS rather than a broad theme redesign

## Issues
- Refs #1074

## Testing
- `go test ./pkg/themes/...`

## Notes
This is a first pass on #1074 focused on the most obvious shared selectors in `components.css` and `main.css`.