### PR TITLE
Cache prerendered Mermaid SVGs

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -1027,6 +1027,10 @@ max_concurrent = 4
 # no_sandbox = true         # Required inside Docker or other containers
 ```
 
+Pre-rendered Mermaid SVGs are cached automatically. Hot builds reuse cached SVGs
+when the diagram source and rendering inputs match, avoiding repeated Chromium or
+`mmdc` rendering for unchanged diagrams.
+
 #### Chromium in Containers (Docker, Distrobox, Podman)
 
 Chromium's sandbox requires kernel capabilities that most containers restrict.

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -3657,6 +3657,7 @@ no_sandbox = false                                          # Required in contai
 5. When `use_css_variables` is true, reads site CSS custom properties and passes them to `mermaid.initialize()` so diagrams match the site palette automatically
 6. When `lightbox` is true, attaches click handlers to each rendered SVG. Clicking opens a programmatic GLightbox overlay with svg-pan-zoom for interactive pan and zoom. svg-pan-zoom (~29KB) is lazy-loaded from vendor assets by default.
 7. In chromium mode, the MermaidJS library is cached at `~/.cache/markata-go/mermaid/` to avoid re-downloading on each build
+8. In cli/chromium modes, rendered SVGs are cached in the build cache and reused when the diagram source and rendering inputs are unchanged
 
 **Markdown usage:**
 ````markdown

--- a/pkg/agentskill/bundle/markata-go-site/topics/faster-builds.md
+++ b/pkg/agentskill/bundle/markata-go-site/topics/faster-builds.md
@@ -50,6 +50,9 @@ So `--fast` is good for content, template, and most styling iteration, but it is
 - If output is network-bound, inspect plugins that fetch remote content.
 - If output is disk-bound, inspect globbing, cache load/save, feed publishing, and static output.
 - Prefer targeted fixes over broad cache-busting changes.
+- For sites that use `[markata-go.mermaid] mode = "chromium"` or `"cli"`, unchanged
+  diagrams should reuse cached SVG output on warm builds; if Mermaid remains a hotspot,
+  compare the diagram source and rendering inputs before recommending client mode.
 
 ## Slim Config Overrides With `-m fast.toml`
 

--- a/pkg/buildcache/cache.go
+++ b/pkg/buildcache/cache.go
@@ -130,6 +130,8 @@ type Cache struct {
 	postDataMemory sync.Map
 	// encryptedHTMLMemory maps EncryptedHTMLPath -> HTML string
 	encryptedHTMLMemory sync.Map
+	// mermaidSVGMemory maps MermaidSVGPath -> rendered SVG string
+	mermaidSVGMemory sync.Map
 }
 
 // PostCache stores cached metadata for a single post.
@@ -1189,6 +1191,9 @@ const HTMLCacheDir = "html-cache"
 // EncryptedHTMLCacheDir is the subdirectory for cached encrypted HTML files.
 const EncryptedHTMLCacheDir = "encrypted-html-cache"
 
+// MermaidSVGCacheDir is the subdirectory for cached prerendered Mermaid SVGs.
+const MermaidSVGCacheDir = "mermaid-svg-cache"
+
 // GetCachedArticleHTML returns the cached rendered HTML for a post if available.
 // Returns empty string if not cached or cache is stale.
 func (c *Cache) GetCachedArticleHTML(sourcePath, contentHash string) string {
@@ -1242,6 +1247,43 @@ func (c *Cache) CacheArticleHTML(sourcePath, contentHash, articleHTML string) er
 	c.dirty = true
 
 	return nil
+}
+
+// GetCachedMermaidSVG returns cached prerendered Mermaid SVG output if the hash matches.
+func (c *Cache) GetCachedMermaidSVG(sourcePath, renderHash string) string {
+	if sourcePath == "" || renderHash == "" {
+		return ""
+	}
+	cacheDir := filepath.Dir(c.path)
+	hashPrefix := renderHash
+	if len(hashPrefix) > 16 {
+		hashPrefix = hashPrefix[:16]
+	}
+	svgPath := filepath.Join(cacheDir, MermaidSVGCacheDir, hashPrefix+".html")
+
+	if val, ok := c.mermaidSVGMemory.Load(svgPath); ok {
+		if svg, ok := val.(string); ok {
+			return svg
+		}
+	}
+
+	data, err := os.ReadFile(svgPath)
+	if err != nil {
+		return ""
+	}
+
+	svg := string(data)
+	c.mermaidSVGMemory.Store(svgPath, svg)
+	return svg
+}
+
+// CacheMermaidSVG stores prerendered Mermaid SVG output keyed by render hash.
+func (c *Cache) CacheMermaidSVG(sourcePath, renderHash, svg string) error {
+	if sourcePath == "" || renderHash == "" {
+		return nil
+	}
+	_, err := c.cacheHTMLFile(MermaidSVGCacheDir, renderHash, svg, &c.mermaidSVGMemory)
+	return err
 }
 
 // ContentHash computes a hash of just the markdown content.

--- a/pkg/buildcache/cache.go
+++ b/pkg/buildcache/cache.go
@@ -1315,6 +1315,11 @@ func (c *Cache) CleanupMermaidSVG() (int, error) {
 	return removed, nil
 }
 
+// ResetMermaidSVGUsage clears per-build Mermaid SVG usage tracking.
+func (c *Cache) ResetMermaidSVGUsage() {
+	c.mermaidSVGUsed = sync.Map{}
+}
+
 func (c *Cache) mermaidSVGPath(renderHash string) string {
 	cacheDir := filepath.Dir(c.path)
 	hashPrefix := renderHash

--- a/pkg/buildcache/cache.go
+++ b/pkg/buildcache/cache.go
@@ -132,6 +132,8 @@ type Cache struct {
 	encryptedHTMLMemory sync.Map
 	// mermaidSVGMemory maps MermaidSVGPath -> rendered SVG string
 	mermaidSVGMemory sync.Map
+	// mermaidSVGUsed tracks Mermaid SVG cache file paths referenced in the current build.
+	mermaidSVGUsed sync.Map
 }
 
 // PostCache stores cached metadata for a single post.
@@ -1254,12 +1256,8 @@ func (c *Cache) GetCachedMermaidSVG(sourcePath, renderHash string) string {
 	if sourcePath == "" || renderHash == "" {
 		return ""
 	}
-	cacheDir := filepath.Dir(c.path)
-	hashPrefix := renderHash
-	if len(hashPrefix) > 16 {
-		hashPrefix = hashPrefix[:16]
-	}
-	svgPath := filepath.Join(cacheDir, MermaidSVGCacheDir, hashPrefix+".html")
+	svgPath := c.mermaidSVGPath(renderHash)
+	c.markMermaidSVGUsed(svgPath)
 
 	if val, ok := c.mermaidSVGMemory.Load(svgPath); ok {
 		if svg, ok := val.(string); ok {
@@ -1282,8 +1280,55 @@ func (c *Cache) CacheMermaidSVG(sourcePath, renderHash, svg string) error {
 	if sourcePath == "" || renderHash == "" {
 		return nil
 	}
+	c.markMermaidSVGUsed(c.mermaidSVGPath(renderHash))
 	_, err := c.cacheHTMLFile(MermaidSVGCacheDir, renderHash, svg, &c.mermaidSVGMemory)
 	return err
+}
+
+// CleanupMermaidSVG removes cached Mermaid SVG files not used in the current build.
+func (c *Cache) CleanupMermaidSVG() (int, error) {
+	cacheDir := filepath.Join(filepath.Dir(c.path), MermaidSVGCacheDir)
+	entries, err := os.ReadDir(cacheDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("reading mermaid svg cache dir: %w", err)
+	}
+
+	removed := 0
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		path := filepath.Join(cacheDir, entry.Name())
+		if _, ok := c.mermaidSVGUsed.Load(path); ok {
+			continue
+		}
+		if err := os.Remove(path); err != nil {
+			return removed, fmt.Errorf("removing stale mermaid svg cache %s: %w", path, err)
+		}
+		c.mermaidSVGMemory.Delete(path)
+		removed++
+	}
+
+	return removed, nil
+}
+
+func (c *Cache) mermaidSVGPath(renderHash string) string {
+	cacheDir := filepath.Dir(c.path)
+	hashPrefix := renderHash
+	if len(hashPrefix) > 16 {
+		hashPrefix = hashPrefix[:16]
+	}
+	return filepath.Join(cacheDir, MermaidSVGCacheDir, hashPrefix+".html")
+}
+
+func (c *Cache) markMermaidSVGUsed(path string) {
+	if path == "" {
+		return
+	}
+	c.mermaidSVGUsed.Store(path, struct{}{})
 }
 
 // ContentHash computes a hash of just the markdown content.

--- a/pkg/buildcache/cache_test.go
+++ b/pkg/buildcache/cache_test.go
@@ -391,3 +391,42 @@ func TestCache_CleanupMermaidSVG_RemovesUnusedFiles(t *testing.T) {
 		t.Fatalf("GetCachedMermaidSVG keep after cleanup = %q, want keep svg", got)
 	}
 }
+
+func TestCache_CleanupMermaidSVG_AfterUsageResetRemovesPreviouslyUsedFiles(t *testing.T) {
+	dir := t.TempDir()
+	cache := New(filepath.Join(dir, ".markata"))
+
+	if err := cache.CacheMermaidSVG("pages/keep.md", "keep-hash", "<svg>keep</svg>"); err != nil {
+		t.Fatalf("CacheMermaidSVG keep failed: %v", err)
+	}
+	if err := cache.CacheMermaidSVG("pages/drop.md", "drop-hash", "<svg>drop</svg>"); err != nil {
+		t.Fatalf("CacheMermaidSVG drop failed: %v", err)
+	}
+
+	if got := cache.GetCachedMermaidSVG("pages/keep.md", "keep-hash"); got != "<svg>keep</svg>" {
+		t.Fatalf("GetCachedMermaidSVG keep = %q, want keep svg", got)
+	}
+	if got := cache.GetCachedMermaidSVG("pages/drop.md", "drop-hash"); got != "<svg>drop</svg>" {
+		t.Fatalf("GetCachedMermaidSVG drop = %q, want drop svg", got)
+	}
+
+	cache.ResetMermaidSVGUsage()
+	if got := cache.GetCachedMermaidSVG("pages/keep.md", "keep-hash"); got != "<svg>keep</svg>" {
+		t.Fatalf("GetCachedMermaidSVG keep after reset = %q, want keep svg", got)
+	}
+
+	removed, err := cache.CleanupMermaidSVG()
+	if err != nil {
+		t.Fatalf("CleanupMermaidSVG failed: %v", err)
+	}
+	if removed != 1 {
+		t.Fatalf("CleanupMermaidSVG removed %d files, want 1", removed)
+	}
+
+	if got := cache.GetCachedMermaidSVG("pages/drop.md", "drop-hash"); got != "" {
+		t.Fatalf("GetCachedMermaidSVG drop after cleanup = %q, want empty", got)
+	}
+	if got := cache.GetCachedMermaidSVG("pages/keep.md", "keep-hash"); got != "<svg>keep</svg>" {
+		t.Fatalf("GetCachedMermaidSVG keep after cleanup = %q, want keep svg", got)
+	}
+}

--- a/pkg/buildcache/cache_test.go
+++ b/pkg/buildcache/cache_test.go
@@ -359,3 +359,35 @@ func TestCache_FeedMembershipHash_SaveLoad(t *testing.T) {
 		t.Errorf("GetFeedMembershipHash after load = %q, want %q", hash, "membership-hash-123")
 	}
 }
+
+func TestCache_CleanupMermaidSVG_RemovesUnusedFiles(t *testing.T) {
+	dir := t.TempDir()
+	cache := New(filepath.Join(dir, ".markata"))
+
+	if err := cache.CacheMermaidSVG("pages/keep.md", "keep-hash", "<svg>keep</svg>"); err != nil {
+		t.Fatalf("CacheMermaidSVG keep failed: %v", err)
+	}
+	if err := cache.CacheMermaidSVG("pages/drop.md", "drop-hash", "<svg>drop</svg>"); err != nil {
+		t.Fatalf("CacheMermaidSVG drop failed: %v", err)
+	}
+
+	cache = New(filepath.Join(dir, ".markata"))
+	if got := cache.GetCachedMermaidSVG("pages/keep.md", "keep-hash"); got != "<svg>keep</svg>" {
+		t.Fatalf("GetCachedMermaidSVG keep = %q, want keep svg", got)
+	}
+
+	removed, err := cache.CleanupMermaidSVG()
+	if err != nil {
+		t.Fatalf("CleanupMermaidSVG failed: %v", err)
+	}
+	if removed != 1 {
+		t.Fatalf("CleanupMermaidSVG removed %d files, want 1", removed)
+	}
+
+	if got := cache.GetCachedMermaidSVG("pages/drop.md", "drop-hash"); got != "" {
+		t.Fatalf("GetCachedMermaidSVG drop = %q, want empty", got)
+	}
+	if got := cache.GetCachedMermaidSVG("pages/keep.md", "keep-hash"); got != "<svg>keep</svg>" {
+		t.Fatalf("GetCachedMermaidSVG keep after cleanup = %q, want keep svg", got)
+	}
+}

--- a/pkg/plugins/build_cache.go
+++ b/pkg/plugins/build_cache.go
@@ -243,6 +243,13 @@ func (p *BuildCachePlugin) cleanupCache(m *lifecycle.Manager) error {
 	if removed > 0 {
 		buildCacheLog.Phase("cleanup").Printf("Removed %d stale cache entries", removed)
 	}
+	removedMermaid, err := p.cache.CleanupMermaidSVG()
+	if err != nil {
+		return err
+	}
+	if removedMermaid > 0 {
+		buildCacheLog.Phase("cleanup").Printf("Removed %d stale Mermaid SVG cache entries", removedMermaid)
+	}
 
 	// Save cache
 	return p.saveCache(m)

--- a/pkg/plugins/mermaid.go
+++ b/pkg/plugins/mermaid.go
@@ -27,6 +27,7 @@ type MermaidPlugin struct {
 	paletteColors *mermaidPaletteColors // resolved at configure time, nil if no palette
 	assetURLs     map[string]string
 	cache         *buildcache.Cache
+	renderKey     string
 }
 
 // NewMermaidPlugin creates a new MermaidPlugin with default settings.
@@ -194,6 +195,7 @@ func (p *MermaidPlugin) Render(m *lifecycle.Manager) (err error) {
 		return nil
 	}
 	p.cache = GetBuildCache(m)
+	p.renderKey = p.rendererCacheKey()
 
 	if p.config.Mode != mermaidModeClient {
 		renderer, createErr := newMermaidRenderer(p.config, p.paletteColors)
@@ -278,6 +280,8 @@ func (p *MermaidPlugin) diagramRenderHash(diagramCode string) string {
 
 	var builder strings.Builder
 	builder.WriteString("mermaid-svg-v1\n")
+	builder.WriteString("renderer:")
+	builder.WriteString(p.renderKey)
 	builder.WriteString("mode:")
 	builder.WriteString(p.config.Mode)
 	builder.WriteString("\ntheme:")
@@ -321,6 +325,29 @@ func (p *MermaidPlugin) diagramRenderHash(diagramCode string) string {
 	builder.WriteString("\ndiagram:\n")
 	builder.WriteString(diagramCode)
 	return buildcache.ContentHash(builder.String())
+}
+
+func (p *MermaidPlugin) rendererCacheKey() string {
+	if p.config.Mode == mermaidModeClient {
+		return ""
+	}
+
+	switch p.config.Mode {
+	case mermaidModeCLI:
+		info := checkCLIDependency(p.config.CLIConfig.MMDCPath)
+		if !info.IsInstalled {
+			return "cli:unavailable"
+		}
+		return "cli:" + info.BinaryPath + ":" + info.InstalledVersion
+	case mermaidModeChromium:
+		info := checkChromiumDependency(p.config.ChromiumConfig.BrowserPath)
+		if !info.IsInstalled {
+			return "chromium:unavailable"
+		}
+		return "chromium:" + info.BinaryPath + ":" + info.InstalledVersion + ":mermaidjs-v" + mermaidJSVersion
+	default:
+		return p.config.Mode
+	}
 }
 
 // mermaidCodeBlockRegex matches <pre><code class="language-mermaid"> blocks.

--- a/pkg/plugins/mermaid.go
+++ b/pkg/plugins/mermaid.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"html"
 	"log"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -306,6 +307,7 @@ func (p *MermaidPlugin) diagramRenderHash(diagramCode string) string {
 		builder.WriteString(p.config.CLIConfig.MMDCPath)
 		builder.WriteString("\ncli.extra_args:")
 		builder.WriteString(p.config.CLIConfig.ExtraArgs)
+		writeMermaidCLIFileInputHashes(&builder, p.config.CLIConfig.ExtraArgs)
 	}
 	if p.config.ChromiumConfig != nil {
 		builder.WriteString("\nchromium.browser_path:")
@@ -328,6 +330,60 @@ func (p *MermaidPlugin) diagramRenderHash(diagramCode string) string {
 	builder.WriteString("\ndiagram:\n")
 	builder.WriteString(diagramCode)
 	return buildcache.ContentHash(builder.String())
+}
+
+var mermaidCLIFileArgFlags = map[string]struct{}{
+	"--configFile":          {},
+	"--cssFile":             {},
+	"--puppeteerConfigFile": {},
+	"-c":                    {},
+	"-C":                    {},
+	"-p":                    {},
+}
+
+func writeMermaidCLIFileInputHashes(builder *strings.Builder, extraArgs string) {
+	if extraArgs == "" {
+		return
+	}
+
+	args := strings.Fields(extraArgs)
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if _, ok := mermaidCLIFileArgFlags[arg]; ok {
+			if i+1 < len(args) {
+				writeMermaidCLIFileInputHash(builder, args[i+1])
+				i++
+			}
+			continue
+		}
+
+		for flag := range mermaidCLIFileArgFlags {
+			prefix := flag + "="
+			if strings.HasPrefix(arg, prefix) {
+				writeMermaidCLIFileInputHash(builder, strings.TrimPrefix(arg, prefix))
+				break
+			}
+		}
+	}
+}
+
+func writeMermaidCLIFileInputHash(builder *strings.Builder, path string) {
+	if path == "" {
+		return
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		absPath = filepath.Clean(path)
+	}
+
+	builder.WriteString("\ncli.file_arg:")
+	builder.WriteString(absPath)
+	builder.WriteString(":")
+	if hash, err := buildcache.HashFile(absPath); err == nil && hash != "" {
+		builder.WriteString(hash)
+		return
+	}
+	builder.WriteString("unreadable")
 }
 
 func (p *MermaidPlugin) rendererCacheKey() string {

--- a/pkg/plugins/mermaid.go
+++ b/pkg/plugins/mermaid.go
@@ -2,11 +2,13 @@
 package plugins
 
 import (
+	"fmt"
 	"html"
 	"log"
 	"regexp"
 	"strings"
 
+	"github.com/WaylonWalker/markata-go/pkg/buildcache"
 	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
 	"github.com/WaylonWalker/markata-go/pkg/models"
 )
@@ -24,6 +26,7 @@ type MermaidPlugin struct {
 	renderer      mermaidRenderer
 	paletteColors *mermaidPaletteColors // resolved at configure time, nil if no palette
 	assetURLs     map[string]string
+	cache         *buildcache.Cache
 }
 
 // NewMermaidPlugin creates a new MermaidPlugin with default settings.
@@ -190,6 +193,7 @@ func (p *MermaidPlugin) Render(m *lifecycle.Manager) (err error) {
 	if !p.config.Enabled {
 		return nil
 	}
+	p.cache = GetBuildCache(m)
 
 	if p.config.Mode != mermaidModeClient {
 		renderer, createErr := newMermaidRenderer(p.config, p.paletteColors)
@@ -245,6 +249,78 @@ func (p *MermaidPlugin) Render(m *lifecycle.Manager) (err error) {
 	}
 
 	return nil
+}
+
+func (p *MermaidPlugin) renderDiagram(post *models.Post, diagramCode string) (string, error) {
+	renderHash := p.diagramRenderHash(diagramCode)
+	if p.cache != nil && renderHash != "" {
+		if cachedSVG := p.cache.GetCachedMermaidSVG(post.Path, renderHash); cachedSVG != "" {
+			return cachedSVG, nil
+		}
+	}
+
+	svgOutput, err := p.renderer.render(diagramCode)
+	if err != nil {
+		return "", err
+	}
+
+	if p.cache != nil && renderHash != "" {
+		//nolint:errcheck // caching is best-effort; rendering already succeeded.
+		p.cache.CacheMermaidSVG(post.Path, renderHash, svgOutput)
+	}
+	return svgOutput, nil
+}
+
+func (p *MermaidPlugin) diagramRenderHash(diagramCode string) string {
+	if p.config.Mode == mermaidModeClient {
+		return ""
+	}
+
+	var builder strings.Builder
+	builder.WriteString("mermaid-svg-v1\n")
+	builder.WriteString("mode:")
+	builder.WriteString(p.config.Mode)
+	builder.WriteString("\ntheme:")
+	builder.WriteString(p.config.Theme)
+	builder.WriteString("\nuse_css_variables:")
+	if p.config.UseCSSVariables {
+		builder.WriteString("true")
+	} else {
+		builder.WriteString("false")
+	}
+	builder.WriteString("\nlightbox:")
+	if p.config.Lightbox {
+		builder.WriteString("true")
+	} else {
+		builder.WriteString("false")
+	}
+	if p.config.CLIConfig != nil {
+		builder.WriteString("\ncli.mmdc_path:")
+		builder.WriteString(p.config.CLIConfig.MMDCPath)
+		builder.WriteString("\ncli.extra_args:")
+		builder.WriteString(p.config.CLIConfig.ExtraArgs)
+	}
+	if p.config.ChromiumConfig != nil {
+		builder.WriteString("\nchromium.browser_path:")
+		builder.WriteString(p.config.ChromiumConfig.BrowserPath)
+		builder.WriteString("\nchromium.timeout:")
+		builder.WriteString(fmt.Sprint(p.config.ChromiumConfig.Timeout))
+		builder.WriteString("\nchromium.max_concurrent:")
+		builder.WriteString(fmt.Sprint(p.config.ChromiumConfig.MaxConcurrent))
+		builder.WriteString("\nchromium.no_sandbox:")
+		if p.config.ChromiumConfig.NoSandbox {
+			builder.WriteString("true")
+		} else {
+			builder.WriteString("false")
+		}
+	}
+	if p.paletteColors != nil {
+		builder.WriteString("\npalette:")
+		builder.WriteString(p.paletteColors.themeVariablesJSON())
+	}
+	builder.WriteString("\ndiagram:\n")
+	builder.WriteString(diagramCode)
+	return buildcache.ContentHash(builder.String())
 }
 
 // mermaidCodeBlockRegex matches <pre><code class="language-mermaid"> blocks.
@@ -306,7 +382,7 @@ func (p *MermaidPlugin) processPost(post *models.Post) error {
 			}
 
 			// For pre-rendering modes (cli/chromium): render to SVG
-			svgOutput, err := renderer.render(diagramCode)
+			svgOutput, err := p.renderDiagram(post, diagramCode)
 			if err != nil {
 				log.Printf("[mermaid] render error for %s: %v", post.Path, err)
 				renderErr = models.NewMermaidRenderError(post.Path, p.config.Mode, "failed to render diagram", err)

--- a/pkg/plugins/mermaid.go
+++ b/pkg/plugins/mermaid.go
@@ -195,6 +195,9 @@ func (p *MermaidPlugin) Render(m *lifecycle.Manager) (err error) {
 		return nil
 	}
 	p.cache = GetBuildCache(m)
+	if p.cache != nil {
+		p.cache.ResetMermaidSVGUsage()
+	}
 	p.renderKey = p.rendererCacheKey()
 
 	if p.config.Mode != mermaidModeClient {

--- a/pkg/plugins/mermaid_check.go
+++ b/pkg/plugins/mermaid_check.go
@@ -7,6 +7,14 @@ import (
 	"strings"
 )
 
+func commandVersion(path string) string {
+	out, err := exec.Command(path, "--version").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
 // MermaidDependencyInfo provides information about a dependency and installation instructions
 type MermaidDependencyInfo struct {
 	Mode                string
@@ -31,6 +39,7 @@ func checkCLIDependency(mmdc string) *MermaidDependencyInfo {
 		if _, err := os.Stat(mmdc); err == nil {
 			info.IsInstalled = true
 			info.BinaryPath = mmdc
+			info.InstalledVersion = commandVersion(mmdc)
 			return info
 		}
 		// Provided path doesn't exist
@@ -44,10 +53,7 @@ Check the path and try again, or omit 'mmdc_path' to auto-detect.`, mmdc)
 	if path, err := exec.LookPath("mmdc"); err == nil {
 		info.IsInstalled = true
 		info.BinaryPath = path
-		// Try to get version
-		if out, err := exec.Command(path, "--version").Output(); err == nil {
-			info.InstalledVersion = strings.TrimSpace(string(out))
-		}
+		info.InstalledVersion = commandVersion(path)
 		return info
 	}
 
@@ -86,6 +92,7 @@ func checkChromiumDependency(browserPath string) *MermaidDependencyInfo {
 		if verifyBrowser(browserPath) {
 			info.IsInstalled = true
 			info.BinaryPath = browserPath
+			info.InstalledVersion = commandVersion(browserPath)
 			return info
 		}
 		// Provided path doesn't work
@@ -116,6 +123,7 @@ Check the path and try again, or omit 'browser_path' to auto-detect.`, browserPa
 		if verifyBrowser(path) {
 			info.IsInstalled = true
 			info.BinaryPath = path
+			info.InstalledVersion = commandVersion(path)
 			return info
 		}
 	}

--- a/pkg/plugins/mermaid_test.go
+++ b/pkg/plugins/mermaid_test.go
@@ -2,6 +2,8 @@ package plugins
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -794,6 +796,64 @@ func TestMermaidPlugin_RenderDiagram_CacheKeyIncludesRendererFingerprint(t *test
 	}
 	if renderer.calls != 1 {
 		t.Fatalf("renderer calls = %d, want 1", renderer.calls)
+	}
+}
+
+func TestMermaidPlugin_DiagramRenderHashIncludesCLIConfigFileContents(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "mermaid.json")
+	if err := os.WriteFile(configPath, []byte(`{"theme":"default"}`), 0o600); err != nil {
+		t.Fatalf("write config file: %v", err)
+	}
+
+	p := NewMermaidPlugin()
+	p.SetConfig(models.MermaidConfig{
+		Enabled: true,
+		Mode:    mermaidModeCLI,
+		Theme:   "default",
+		CLIConfig: &models.CLIRendererConfig{
+			ExtraArgs: "--configFile " + configPath,
+		},
+	})
+	p.renderKey = "cli:/usr/bin/mmdc:1.0.0"
+
+	first := p.diagramRenderHash("graph TD\nA-->B")
+	if err := os.WriteFile(configPath, []byte(`{"theme":"dark"}`), 0o600); err != nil {
+		t.Fatalf("rewrite config file: %v", err)
+	}
+	second := p.diagramRenderHash("graph TD\nA-->B")
+
+	if first == second {
+		t.Fatal("diagram render hash did not change after CLI config file contents changed")
+	}
+}
+
+func TestMermaidPlugin_DiagramRenderHashIncludesCLIEqualsFileArg(t *testing.T) {
+	dir := t.TempDir()
+	cssPath := filepath.Join(dir, "mermaid.css")
+	if err := os.WriteFile(cssPath, []byte("svg { color: black; }"), 0o600); err != nil {
+		t.Fatalf("write css file: %v", err)
+	}
+
+	p := NewMermaidPlugin()
+	p.SetConfig(models.MermaidConfig{
+		Enabled: true,
+		Mode:    mermaidModeCLI,
+		Theme:   "default",
+		CLIConfig: &models.CLIRendererConfig{
+			ExtraArgs: "--cssFile=" + cssPath,
+		},
+	})
+	p.renderKey = "cli:/usr/bin/mmdc:1.0.0"
+
+	first := p.diagramRenderHash("graph TD\nA-->B")
+	if err := os.WriteFile(cssPath, []byte("svg { color: white; }"), 0o600); err != nil {
+		t.Fatalf("rewrite css file: %v", err)
+	}
+	second := p.diagramRenderHash("graph TD\nA-->B")
+
+	if first == second {
+		t.Fatal("diagram render hash did not change after CLI css file contents changed")
 	}
 }
 

--- a/pkg/plugins/mermaid_test.go
+++ b/pkg/plugins/mermaid_test.go
@@ -728,6 +728,7 @@ func TestMermaidPlugin_RenderDiagram_CacheKeyIncludesTheme(t *testing.T) {
 
 	p := NewMermaidPlugin()
 	p.SetConfig(models.MermaidConfig{Enabled: true, Mode: mermaidModeChromium, Theme: "default"})
+	p.renderKey = "chromium:/usr/bin/chromium:Chromium 1:mermaidjs-v10"
 	p.renderer = &countingMermaidRenderer{svg: "<svg>default</svg>"}
 	p.cache = cache
 
@@ -738,6 +739,7 @@ func TestMermaidPlugin_RenderDiagram_CacheKeyIncludesTheme(t *testing.T) {
 
 	renderer := &countingMermaidRenderer{svg: "<svg>dark</svg>"}
 	p.SetConfig(models.MermaidConfig{Enabled: true, Mode: mermaidModeChromium, Theme: "dark"})
+	p.renderKey = "chromium:/usr/bin/chromium:Chromium 1:mermaidjs-v10"
 	p.renderer = renderer
 	p.cache = cache
 
@@ -756,11 +758,42 @@ func TestMermaidPlugin_RenderDiagram_CacheKeyIncludesTheme(t *testing.T) {
 func TestMermaidPlugin_RenderDiagram_PropagatesRenderErrors(t *testing.T) {
 	p := NewMermaidPlugin()
 	p.SetConfig(models.MermaidConfig{Enabled: true, Mode: mermaidModeChromium})
+	p.renderKey = "chromium:/usr/bin/chromium:Chromium 1:mermaidjs-v10"
 	p.renderer = &countingMermaidRenderer{err: errors.New("render failed")}
 
 	_, err := p.renderDiagram(&models.Post{Path: "pages/diagram.md"}, "graph TD\nA-->B")
 	if err == nil {
 		t.Fatal("expected render error")
+	}
+}
+
+func TestMermaidPlugin_RenderDiagram_CacheKeyIncludesRendererFingerprint(t *testing.T) {
+	cache := buildcache.New(t.TempDir())
+
+	p := NewMermaidPlugin()
+	p.SetConfig(models.MermaidConfig{Enabled: true, Mode: mermaidModeChromium, Theme: "default"})
+	p.renderKey = "chromium:/usr/bin/chromium:Chromium 1:mermaidjs-v10"
+	p.renderer = &countingMermaidRenderer{svg: "<svg>old</svg>"}
+	p.cache = cache
+
+	post := &models.Post{Path: "pages/diagram.md"}
+	if _, err := p.renderDiagram(post, "graph TD\nA-->B"); err != nil {
+		t.Fatalf("render old: %v", err)
+	}
+
+	renderer := &countingMermaidRenderer{svg: "<svg>new</svg>"}
+	p.renderKey = "chromium:/usr/bin/chromium:Chromium 2:mermaidjs-v10"
+	p.renderer = renderer
+
+	got, err := p.renderDiagram(post, "graph TD\nA-->B")
+	if err != nil {
+		t.Fatalf("render new: %v", err)
+	}
+	if got != "<svg>new</svg>" {
+		t.Fatalf("got %q, want new SVG", got)
+	}
+	if renderer.calls != 1 {
+		t.Fatalf("renderer calls = %d, want 1", renderer.calls)
 	}
 }
 

--- a/pkg/plugins/mermaid_test.go
+++ b/pkg/plugins/mermaid_test.go
@@ -1,12 +1,30 @@
 package plugins
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
+	"github.com/WaylonWalker/markata-go/pkg/buildcache"
 	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
 	"github.com/WaylonWalker/markata-go/pkg/models"
 )
+
+type countingMermaidRenderer struct {
+	calls int
+	svg   string
+	err   error
+}
+
+func (r *countingMermaidRenderer) render(_ string) (string, error) {
+	r.calls++
+	if r.err != nil {
+		return "", r.err
+	}
+	return r.svg, nil
+}
+
+func (r *countingMermaidRenderer) close() error { return nil }
 
 func TestMermaidPlugin_Name(t *testing.T) {
 	p := NewMermaidPlugin()
@@ -665,6 +683,85 @@ func TestMermaidPlugin_Interfaces(_ *testing.T) {
 	var _ lifecycle.ConfigurePlugin = p
 	var _ lifecycle.RenderPlugin = p
 	var _ lifecycle.PriorityPlugin = p
+}
+
+func TestMermaidPlugin_RenderDiagram_UsesCache(t *testing.T) {
+	cache := buildcache.New(t.TempDir())
+
+	renderer := &countingMermaidRenderer{svg: "<svg>cached</svg>"}
+	p := NewMermaidPlugin()
+	p.SetConfig(models.MermaidConfig{
+		Enabled:         true,
+		Mode:            mermaidModeChromium,
+		Theme:           "default",
+		UseCSSVariables: true,
+		Lightbox:        true,
+		ChromiumConfig: &models.ChromiumRendererConfig{
+			Timeout:       30,
+			MaxConcurrent: 4,
+			NoSandbox:     true,
+		},
+	})
+	p.renderer = renderer
+	p.cache = cache
+
+	post := &models.Post{Path: "pages/diagram.md"}
+	first, err := p.renderDiagram(post, "graph TD\nA-->B")
+	if err != nil {
+		t.Fatalf("first renderDiagram: %v", err)
+	}
+	second, err := p.renderDiagram(post, "graph TD\nA-->B")
+	if err != nil {
+		t.Fatalf("second renderDiagram: %v", err)
+	}
+
+	if first != "<svg>cached</svg>" || second != "<svg>cached</svg>" {
+		t.Fatalf("unexpected SVG outputs: %q %q", first, second)
+	}
+	if renderer.calls != 1 {
+		t.Fatalf("renderer calls = %d, want 1", renderer.calls)
+	}
+}
+
+func TestMermaidPlugin_RenderDiagram_CacheKeyIncludesTheme(t *testing.T) {
+	cache := buildcache.New(t.TempDir())
+
+	p := NewMermaidPlugin()
+	p.SetConfig(models.MermaidConfig{Enabled: true, Mode: mermaidModeChromium, Theme: "default"})
+	p.renderer = &countingMermaidRenderer{svg: "<svg>default</svg>"}
+	p.cache = cache
+
+	post := &models.Post{Path: "pages/diagram.md"}
+	if _, err := p.renderDiagram(post, "graph TD\nA-->B"); err != nil {
+		t.Fatalf("render default: %v", err)
+	}
+
+	renderer := &countingMermaidRenderer{svg: "<svg>dark</svg>"}
+	p.SetConfig(models.MermaidConfig{Enabled: true, Mode: mermaidModeChromium, Theme: "dark"})
+	p.renderer = renderer
+	p.cache = cache
+
+	got, err := p.renderDiagram(post, "graph TD\nA-->B")
+	if err != nil {
+		t.Fatalf("render dark: %v", err)
+	}
+	if got != "<svg>dark</svg>" {
+		t.Fatalf("got %q, want dark SVG", got)
+	}
+	if renderer.calls != 1 {
+		t.Fatalf("renderer calls = %d, want 1", renderer.calls)
+	}
+}
+
+func TestMermaidPlugin_RenderDiagram_PropagatesRenderErrors(t *testing.T) {
+	p := NewMermaidPlugin()
+	p.SetConfig(models.MermaidConfig{Enabled: true, Mode: mermaidModeChromium})
+	p.renderer = &countingMermaidRenderer{err: errors.New("render failed")}
+
+	_, err := p.renderDiagram(&models.Post{Path: "pages/diagram.md"}, "graph TD\nA-->B")
+	if err == nil {
+		t.Fatal("expected render error")
+	}
 }
 
 // TestMermaidPlugin_CLIMode_Fallback tests that CLI mode falls back to client rendering

--- a/spec/spec/MERMAID_PRERENDER.md
+++ b/spec/spec/MERMAID_PRERENDER.md
@@ -171,6 +171,13 @@ and cached at `~/.cache/markata-go/mermaid/mermaid-v{version}.min.js` following
 XDG conventions. Subsequent builds load from cache, eliminating the network
 download. The cache persists across projects and `--clean` / `--clean-all`.
 
+**Rendered SVG caching:** In `cli` and `chromium` modes, each rendered SVG is
+cached in the build cache and keyed by the diagram source plus rendering inputs:
+mode, theme, CSS-variable usage, lightbox setting, renderer configuration, and
+resolved palette theme variables. Hot builds reuse matching SVGs without
+invoking the external renderer. The cache MUST invalidate when any keyed input
+changes, and cache failures MUST NOT fail the build after rendering succeeds.
+
 **Setup:**
 
 ```bash
@@ -198,9 +205,10 @@ choco install chromium
 1. Start single Chrome instance (reused across all diagrams)
 2. Find `<pre><code class="language-mermaid">` blocks
 3. For each diagram (up to `max_concurrent` in parallel):
-   - Render via Chrome DevTools Protocol
-   - Extract SVG output
-   - Embed in HTML
+   - Reuse cached SVG output when the diagram and rendering inputs match
+   - Otherwise render via Chrome DevTools Protocol
+   - Extract SVG output and store it in the build cache
+   - Embed the SVG in HTML
 4. Close Chrome connection
 
 **Output:**


### PR DESCRIPTION
## Summary
- Cache prerendered Mermaid SVG output for `cli` and `chromium` modes using diagram source plus renderer/theme inputs.
- Reuse cached SVGs on hot builds so unchanged diagrams do not invoke Chromium or `mmdc`.
- Update the Mermaid spec, user docs, plugin reference, and bundled site-agent performance guidance.

## Benchmark
On `~/work/notes` with existing Chromium Mermaid config:
- Before: hot rebuild around 9.75s Markata / 10.41s wall, with Mermaid around 3.03s.
- After cache warm-up: hot rebuild around 1.36s Markata / 1.61s wall, with Mermaid no longer in hotspots.

## Validation
- `go test ./pkg/buildcache ./pkg/plugins`
- `go test ./...`
- `just lint-new`

Refs #1078