### PR TITLE
fix(feeds): restore feed-only wrapper layout

### DIFF
--- a/pkg/themes/default/static/css/feeds.css
+++ b/pkg/themes/default/static/css/feeds.css
@@ -28,18 +28,12 @@ article.post > .post-content > .feed.h-feed {
   transform: translateX(-50%);
 }
 
-article.post > .post-content > .feed.h-feed:not(.feed-layout-grid):not(.feed-layout-masonry) {
-  grid-template-columns: minmax(0, 1fr);
-}
-
 .feed.h-feed {
   --feed-content-width: min(100%, 750px);
   width: 100%;
   max-width: min(100%, var(--page-width));
   margin: 0 auto;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  justify-items: center;
+  display: block;
 }
 
 .feed.h-feed:not(.feed-layout-grid):not(.feed-layout-masonry) > .feed-header,

--- a/pkg/themes/default/templates/feed.html
+++ b/pkg/themes/default/templates/feed.html
@@ -2,7 +2,7 @@
 
 {% block title %}{{ feed.title | default:config.title | default:"Posts" }}{% endblock %}
 {% block description %}{{ feed.description | default:config.description | default:"" }}{% endblock %}
-{% block page_wrapper_class %}{% if not resolved_content_sidebar.enabled and not config.components.doc_sidebar.enabled %} page-wrapper--feed-only{% endif %}{% endblock %}
+{% block page_wrapper_class %} page-wrapper--feed-only{% endblock %}
 {% block head %}
 {{ block.Super() }}
 <link rel="stylesheet" href="{{ 'css/feeds.css' | theme_asset_hashed }}">

--- a/spec/spec/THEMES.md
+++ b/spec/spec/THEMES.md
@@ -2418,6 +2418,10 @@ Every theme MUST provide a base template with these blocks:
 
 ### Feed Template (`feed.html`)
 
+Feed pages render in the feed-only page wrapper state. When `feed` is present in
+template context, the base layout does not render content or doc sidebars, so
+feed templates must opt into the centered feed wrapper explicitly.
+
 ```jinja2
 {% extends "base.html" %}
 

--- a/templates/feed.html
+++ b/templates/feed.html
@@ -2,7 +2,7 @@
 
 {% block title %}{{ feed.title | default:config.title | default:"Posts" }}{% endblock %}
 {% block description %}{{ feed.description | default:config.description | default:"" }}{% endblock %}
-{% block page_wrapper_class %}{% if not resolved_content_sidebar.enabled and not config.components.doc_sidebar.enabled %} page-wrapper--feed-only{% endif %}{% endblock %}
+{% block page_wrapper_class %} page-wrapper--feed-only{% endblock %}
 
 {% block htmx %}
 {% if page.pagination_type == "htmx" or page.pagination_type == "htmx-infinite" %}


### PR DESCRIPTION
## Summary
- restore the explicit `page-wrapper--feed-only` class on feed pages instead of keying it off sidebar settings that are not rendered in feed context
- switch the feed wrapper back to block layout so feed spacing and centered shot/photo items do not depend on the newer grid wrapper behavior
- document the feed-template wrapper requirement in the theme spec

## Testing
- built `~/git/waylonwalker.com` from this worktree with:
  - `set -a && source ~/git/waylonwalker.com/.env && set +a && go run ./cmd/markata-go build --clean -c ~/git/waylonwalker.com/markata-go.toml -m ~/git/waylonwalker.com/config/no-tailwind.toml`
- verified generated output includes `page-wrapper--feed-only` on `/shots/` and `/archive/`
- captured local Chromium screenshots for `/shots/` and `/feeds/` from the rebuilt output

## Issue
- Fixes #1080

## Notes
- no bundled skill update was needed because this change only restores internal feed-page layout behavior in the default templates/CSS