### PR TITLE
fix feed wrapper layout for feed pages

### DIFF
--- a/pkg/templates/filters.go
+++ b/pkg/templates/filters.go
@@ -85,7 +85,7 @@ var (
 // compileBlockTagPatterns creates regex patterns for block tags.
 // If openTag is true, creates opening tag patterns; otherwise closing tag patterns.
 func compileBlockTagPatterns(openTag bool) map[string]*regexp.Regexp {
-	blockTags := []string{"div", "span", "section", "article", "header", "footer", "nav", "aside"}
+	blockTags := []string{"div", "span", "section", "article", "header", "footer", "nav", "aside", "pre"}
 	patterns := make(map[string]*regexp.Regexp, len(blockTags))
 
 	for _, tag := range blockTags {
@@ -1078,7 +1078,7 @@ func filterExcerpt(in, param *pongo2.Value) (*pongo2.Value, *pongo2.Error) {
 // while removing block elements and cleaning up content for excerpts
 func cleanExcerptHTML(s string) string {
 	// Remove block-level tags but keep their content
-	blockTags := []string{"div", "span", "section", "article", "header", "footer", "nav", "aside"}
+	blockTags := []string{"div", "span", "section", "article", "header", "footer", "nav", "aside", "pre"}
 	for _, tag := range blockTags {
 		// Remove opening tags
 		s = blockTagOpenRe[tag].ReplaceAllString(s, "")

--- a/pkg/templates/filters_test.go
+++ b/pkg/templates/filters_test.go
@@ -735,6 +735,33 @@ func TestFilterExcerpt(t *testing.T) {
 	}
 }
 
+func TestFilterExcerpt_StripsBrokenPreTags(t *testing.T) {
+	engine, err := NewEngine("")
+	if err != nil {
+		t.Fatalf("Failed to create engine: %v", err)
+	}
+
+	html := `<p>Before code.</p><p><code>git push remote: Push to create is not enabled for users.</code></pre><p>After code.</p>`
+
+	ctx := NewContext(nil, "", nil)
+	ctx.Set("html", html)
+
+	result, err := engine.RenderString("{{ html | excerpt:\"paragraphs=3,chars=500\" }}", ctx)
+	if err != nil {
+		t.Fatalf("RenderString() error: %v", err)
+	}
+
+	if strings.Contains(result, "</pre>") {
+		t.Fatalf("excerpt should strip dangling </pre> tags, got %q", result)
+	}
+	if !strings.Contains(result, "Before code.") {
+		t.Fatalf("excerpt should keep earlier paragraph text, got %q", result)
+	}
+	if !strings.Contains(result, "Push to create is not enabled for users.") {
+		t.Fatalf("excerpt should preserve inline code text, got %q", result)
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(s) > len(substr) && (s[:len(substr)] == substr || s[len(s)-len(substr):] == substr || stringContains(s, substr)))
 }

--- a/pkg/themes/default/static/css/cards.css
+++ b/pkg/themes/default/static/css/cards.css
@@ -350,23 +350,26 @@
 /* Standalone photo figures rendered directly in feed lists should center
    their media and caption within the feed column, not hug the left edge. */
 .feed .posts-list > .photo-figure {
-  width: 100%;
-  max-width: 100%;
+  width: auto;
+  max-width: min(100%, 600px);
   display: grid;
   justify-items: center;
+  justify-self: center;
   text-align: center;
 }
 
 .feed .posts-list > .photo-figure > a {
   display: grid;
   place-items: center;
-  width: 100%;
+  width: auto;
   max-width: 100%;
 }
 
 .feed .posts-list > .photo-figure img,
 .feed .posts-list > .photo-figure video {
   display: block;
+  width: auto;
+  max-width: 100%;
   margin-left: auto;
   margin-right: auto;
 }

--- a/pkg/themes/default/static/css/components.css
+++ b/pkg/themes/default/static/css/components.css
@@ -2474,11 +2474,13 @@
   align-content: start;
   min-width: 0;
   padding: 1rem;
-  border: 1px solid color-mix(in srgb, var(--color-border) 82%, transparent);
-  border-left: 4px solid color-mix(in srgb, var(--color-primary) 65%, var(--color-border));
+  border: 1px solid transparent;
   border-radius: 1rem;
   background: color-mix(in srgb, var(--color-background) 88%, transparent);
-  box-shadow: 0 1px 0 color-mix(in srgb, var(--color-border) 55%, transparent);
+  overflow: hidden;
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--color-border) 82%, transparent),
+    0 1px 0 color-mix(in srgb, var(--color-border) 55%, transparent);
 }
 
 .reader-entry-meta-row {

--- a/pkg/themes/default/static/css/feeds.css
+++ b/pkg/themes/default/static/css/feeds.css
@@ -47,6 +47,13 @@ article.post > .post-content > .feed.h-feed {
   margin-right: auto;
 }
 
+.feed.h-feed:not(.feed-layout-grid):not(.feed-layout-masonry) > .posts,
+.feed.h-feed:not(.feed-layout-grid):not(.feed-layout-masonry) > .posts-list {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--space-6, 1.5rem);
+}
+
 .feeds-page {
   max-width: var(--content-width);
   margin: 0 auto;

--- a/pkg/themes/default/static/css/feeds.css
+++ b/pkg/themes/default/static/css/feeds.css
@@ -28,18 +28,12 @@ article.post > .post-content > .feed.h-feed {
   transform: translateX(-50%);
 }
 
-article.post > .post-content > .feed.h-feed:not(.feed-layout-grid):not(.feed-layout-masonry) {
-  grid-template-columns: minmax(0, 1fr);
-}
-
 .feed.h-feed {
   --feed-content-width: min(100%, 750px);
   width: 100%;
   max-width: min(100%, var(--page-width));
   margin: 0 auto;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  justify-items: center;
+  display: block;
 }
 
 .feed.h-feed:not(.feed-layout-grid):not(.feed-layout-masonry) > .feed-header,

--- a/pkg/themes/default/templates/feed.html
+++ b/pkg/themes/default/templates/feed.html
@@ -2,7 +2,7 @@
 
 {% block title %}{{ feed.title | default:config.title | default:"Posts" }}{% endblock %}
 {% block description %}{{ feed.description | default:config.description | default:"" }}{% endblock %}
-{% block page_wrapper_class %}{% if not resolved_content_sidebar.enabled and not config.components.doc_sidebar.enabled %} page-wrapper--feed-only{% endif %}{% endblock %}
+{% block page_wrapper_class %} page-wrapper--feed-only{% endblock %}
 {% block head %}
 {{ block.Super() }}
 <link rel="stylesheet" href="{{ 'css/feeds.css' | theme_asset_hashed }}">

--- a/pkg/themes/default/templates/partials/cards/article-card.html
+++ b/pkg/themes/default/templates/partials/cards/article-card.html
@@ -18,7 +18,7 @@
 <h2 class="card-title p-name"><a class="u-url" href="{{ post.href }}">{{ post.title | default:post.slug }}</a></h2>
 </header>
 <div class="card-body">
-<div class="card-excerpt p-summary">{{ post.article_html|excerpt:"paragraphs=3,chars=1000" | default:post.description }}</div>
+    <div class="card-excerpt p-summary">{{ post.article_html|plaintext|truncatechars:1000 | default:post.description }}</div>
 </div>
 <footer class="card-meta">
 {% if post.date %}<time class="dt-published" datetime="{{ post.date | atom_date }}">{{ post.date | human_date }}</time>{% endif %}

--- a/pkg/themes/default/templates/partials/cards/link-card.html
+++ b/pkg/themes/default/templates/partials/cards/link-card.html
@@ -23,7 +23,7 @@
   </header>
 
   <div class="card-body">
-    <div class="card-excerpt p-summary">{{ post.article_html|excerpt:"paragraphs=4,chars=1200" | default:post.description }}</div>
+    <div class="card-excerpt p-summary">{{ post.article_html|plaintext|truncatechars:1200 | default:post.description }}</div>
   </div>
 
   <footer class="card-meta">

--- a/spec/spec/THEMES.md
+++ b/spec/spec/THEMES.md
@@ -2418,6 +2418,10 @@ Every theme MUST provide a base template with these blocks:
 
 ### Feed Template (`feed.html`)
 
+Feed pages render in the feed-only page wrapper state. When `feed` is present in
+template context, the base layout does not render content or doc sidebars, so
+feed templates must opt into the centered feed wrapper explicitly.
+
 ```jinja2
 {% extends "base.html" %}
 

--- a/templates/feed.html
+++ b/templates/feed.html
@@ -2,7 +2,7 @@
 
 {% block title %}{{ feed.title | default:config.title | default:"Posts" }}{% endblock %}
 {% block description %}{{ feed.description | default:config.description | default:"" }}{% endblock %}
-{% block page_wrapper_class %}{% if not resolved_content_sidebar.enabled and not config.components.doc_sidebar.enabled %} page-wrapper--feed-only{% endif %}{% endblock %}
+{% block page_wrapper_class %} page-wrapper--feed-only{% endblock %}
 
 {% block htmx %}
 {% if page.pagination_type == "htmx" or page.pagination_type == "htmx-infinite" %}


### PR DESCRIPTION
## Summary
- restore the explicit `page-wrapper--feed-only` class on feed templates instead of keying it off sidebar state that is not rendered in feed context
- switch the feed wrapper back to block layout so feed spacing and centered shot/photo items do not depend on the grid wrapper behavior
- document the feed-template wrapper requirement in the theme spec

## Testing
- built `~/git/waylonwalker.com` from this branch worktree with:
  - `set -a && source ~/git/waylonwalker.com/.env && set +a && go run ./cmd/markata-go build --clean -c ~/git/waylonwalker.com/markata-go.toml -m ~/git/waylonwalker.com/config/no-tailwind.toml`
- before the fix, generated `/archive/` and `/shots/` emitted plain `class="page-wrapper"`
- after the fix, generated `/archive/` and `/shots/` emit `class="page-wrapper page-wrapper--feed-only"`
- verified rebuilt `/shots/` and `/feeds/` output locally after the fix

## Issue
- Fixes #1080