### PR TITLE
fix: harden default theme accessibility defaults

### DIFF
--- a/pkg/palettes/builtin_integration_test.go
+++ b/pkg/palettes/builtin_integration_test.go
@@ -4,10 +4,10 @@ import (
 	"testing"
 )
 
-func resolveFirst(palette *Palette, names ...string) (string, string) {
+func resolveFirst(palette *Palette, names ...string) (name string, hex string) {
 	for _, name := range names {
-		if hex := palette.Resolve(name); hex != "" {
-			return name, hex
+		if resolved := palette.Resolve(name); resolved != "" {
+			return name, resolved
 		}
 	}
 	return "", ""
@@ -303,7 +303,6 @@ func TestPaletteContrastForDefaultThemeInteractiveComponents(t *testing.T) {
 	}
 
 	for _, name := range names {
-		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/palettes/builtin_integration_test.go
+++ b/pkg/palettes/builtin_integration_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func resolveFirst(palette *Palette, names ...string) (name string, hex string) {
+func resolveFirst(palette *Palette, names ...string) (name, hex string) {
 	for _, name := range names {
 		if resolved := palette.Resolve(name); resolved != "" {
 			return name, resolved

--- a/pkg/palettes/builtin_integration_test.go
+++ b/pkg/palettes/builtin_integration_test.go
@@ -4,6 +4,15 @@ import (
 	"testing"
 )
 
+func resolveFirst(palette *Palette, names ...string) (string, string) {
+	for _, name := range names {
+		if hex := palette.Resolve(name); hex != "" {
+			return name, hex
+		}
+	}
+	return "", ""
+}
+
 // TestBuiltInPalettesWCAGContrast validates that all built-in palettes
 // pass WCAG AA contrast requirements. This is an integration test that
 // ensures our shipped palettes meet accessibility standards.
@@ -233,6 +242,96 @@ func TestPaletteContrastForDefaultThemeReadability(t *testing.T) {
 				if ratio < check.minRatio {
 					t.Errorf("Palette %s: %s contrast ratio %.2f < %.1f required for %s",
 						name, check.fg, ratio, check.minRatio, check.desc)
+				}
+			}
+		})
+	}
+}
+
+// TestPaletteContrastForDefaultThemeInteractiveComponents validates the explicit
+// color combinations used by compact default-theme controls that have regressed
+// in Lighthouse before. These checks are intentionally named after the UI they
+// protect so future failures map back to concrete theme elements.
+func TestPaletteContrastForDefaultThemeInteractiveComponents(t *testing.T) {
+	t.Parallel()
+
+	names := BuiltinNames()
+	if len(names) == 0 {
+		t.Skip("No built-in palettes found")
+	}
+
+	componentChecks := []struct {
+		name      string
+		fgOptions []string
+		bg        string
+		minRatio  float64
+		level     string
+		desc      string
+	}{
+		{
+			name:      "post copy label",
+			fgOptions: []string{"text-primary"},
+			bg:        "bg-primary",
+			minRatio:  4.5,
+			level:     "AA",
+			desc:      "post copy summary text",
+		},
+		{
+			name:      "admonition title",
+			fgOptions: []string{"text-primary"},
+			bg:        "bg-surface",
+			minRatio:  4.5,
+			level:     "AA",
+			desc:      "admonition title text on default surfaces",
+		},
+		{
+			name:      "feed nav button label",
+			fgOptions: []string{"text-primary"},
+			bg:        "bg-primary",
+			minRatio:  4.5,
+			level:     "AA",
+			desc:      "feed navigation button glyphs",
+		},
+		{
+			name:      "card domain link",
+			fgOptions: []string{"text-primary"},
+			bg:        "bg-surface",
+			minRatio:  4.5,
+			level:     "AA",
+			desc:      "compact card domain links",
+		},
+	}
+
+	for _, name := range names {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			palette, err := LoadBuiltin(name)
+			if err != nil {
+				t.Fatalf("Failed to load palette %s: %v", name, err)
+			}
+
+			for _, check := range componentChecks {
+				fgName, fgHex := resolveFirst(palette, check.fgOptions...)
+				bgHex := palette.Resolve(check.bg)
+
+				if fgName == "" || bgHex == "" {
+					t.Errorf("Palette %s: missing color mapping for %s (%v on %s)",
+						name, check.name, check.fgOptions, check.bg)
+					continue
+				}
+
+				ratio, err := ContrastRatioFromHex(fgHex, bgHex)
+				if err != nil {
+					t.Errorf("Palette %s: invalid resolved colors for %s: %q on %q (%v)",
+						name, check.name, fgHex, bgHex, err)
+					continue
+				}
+
+				if ratio < check.minRatio {
+					t.Errorf("Palette %s: %s (%s on %s) contrast ratio %.2f < %.1f required for %s",
+						name, check.name, fgName, check.bg, ratio, check.minRatio, check.level)
 				}
 			}
 		})

--- a/pkg/palettes/builtin_integration_test.go
+++ b/pkg/palettes/builtin_integration_test.go
@@ -287,7 +287,7 @@ func TestPaletteContrastForDefaultThemeInteractiveComponents(t *testing.T) {
 		{
 			name:      "feed nav button label",
 			fgOptions: []string{"text-primary"},
-			bg:        "bg-primary",
+			bg:        "bg-surface",
 			minRatio:  4.5,
 			level:     "AA",
 			desc:      "feed navigation button glyphs",

--- a/pkg/themes/accessibility_test.go
+++ b/pkg/themes/accessibility_test.go
@@ -229,7 +229,7 @@ func TestCSSTouchTargets(t *testing.T) {
 	t.Run("card and feed nav targets are at least 24px tall", func(t *testing.T) {
 		cardSnippets := map[string]string{
 			"card titles":  ".card-link .card-title {\n  font-size: var(--text-base);\n  font-weight: 600;\n  margin-bottom: 0;\n  min-height: 24px;",
-			"card domains": ".card-link .card-domain {\n  display: block;\n  font-size: var(--text-xs);\n  color: var(--color-text-muted);\n  margin-top: var(--space-1);\n  text-decoration: none;\n  text-transform: lowercase;\n  min-height: 24px;",
+			"card domains": ".card-link .card-domain {\n  display: inline-flex;\n  align-items: center;\n  font-size: var(--text-xs);\n  color: var(--color-text);\n  margin-top: var(--space-1);\n  max-width: 100%;\n  min-width: 2rem;\n  min-height: 2rem;",
 		}
 
 		for label, snippet := range cardSnippets {
@@ -240,7 +240,7 @@ func TestCSSTouchTargets(t *testing.T) {
 
 		feedRules := map[string]*regexp.Regexp{
 			"feed nav title":   regexp.MustCompile(`(?s)\.feed-nav-title a\s*\{[^}]*min-height:\s*24px`),
-			"feed nav buttons": regexp.MustCompile(`(?s)\.feed-nav-cycle-btn\s*\{[^}]*width:\s*1\.5rem[^}]*height:\s*1\.5rem`),
+			"feed nav buttons": regexp.MustCompile(`(?s)\.feed-nav-cycle-btn\s*\{[^}]*width:\s*2rem[^}]*height:\s*2rem[^}]*min-width:\s*2rem[^}]*min-height:\s*2rem`),
 			"feed nav formats": regexp.MustCompile(`(?s)\.feed-nav-format-link\s*\{[^}]*min-height:\s*24px`),
 		}
 
@@ -248,6 +248,11 @@ func TestCSSTouchTargets(t *testing.T) {
 			if !rule.MatchString(allCSS) {
 				t.Errorf("%s should have a 24px touch target", label)
 			}
+		}
+
+		hasAvatarRule := regexp.MustCompile(`(?s)\.card-link \.card-(?:link-content|excerpt) a\.has-avatar\s*,\s*\.card-link \.card-excerpt a\.has-avatar\s*\{[^}]*display:\s*inline-flex[^}]*align-items:\s*center[^}]*min-width:\s*2rem[^}]*min-height:\s*2rem`)
+		if !hasAvatarRule.MatchString(cards) {
+			t.Error("avatar-enhanced links inside cards should have a 24px touch target")
 		}
 	})
 

--- a/pkg/themes/default/static/css/admonitions.css
+++ b/pkg/themes/default/static/css/admonitions.css
@@ -18,7 +18,7 @@
   gap: var(--space-2);
   font-weight: 600;
   margin-bottom: var(--space-2);
-  color: var(--admonition-color, var(--color-primary));
+  color: var(--color-text);
 }
 
 .admonition-title::before {

--- a/pkg/themes/default/static/css/admonitions.css
+++ b/pkg/themes/default/static/css/admonitions.css
@@ -19,6 +19,7 @@
   font-weight: 600;
   margin-bottom: var(--space-2);
   color: var(--color-text);
+  color: color-mix(in srgb, var(--admonition-color, var(--color-primary)) 45%, var(--color-text) 55%);
 }
 
 .admonition-title::before {

--- a/pkg/themes/default/static/css/cards.css
+++ b/pkg/themes/default/static/css/cards.css
@@ -99,15 +99,19 @@
   margin: 0 0 var(--space-2);
   font-size: var(--text-xl);
   line-height: var(--leading-tight);
+  color: var(--color-text);
 }
 
 .card .card-title a {
-  color: var(--color-text);
+  color: inherit;
   text-decoration: none;
 }
 
-.card .card-title a:hover {
-  color: var(--color-primary);
+.card .card-title:hover,
+.card .card-title a:hover,
+.card .card-title a:focus-visible {
+  color: inherit;
+  text-decoration: underline;
 }
 
 .card .card-description,
@@ -548,13 +552,17 @@
 }
 
 .card-link .card-domain {
-  display: block;
+  display: inline-flex;
+  align-items: center;
   font-size: var(--text-xs);
-  color: var(--color-text-muted);
+  color: var(--color-text);
   margin-top: var(--space-1);
+  max-width: 100%;
+  min-width: 2rem;
+  min-height: 2rem;
+  padding-right: 0.35rem;
   text-decoration: none;
   text-transform: lowercase;
-  min-height: 24px;
 
   /* Truncate long URLs */
   white-space: nowrap;
@@ -563,8 +571,16 @@
 }
 
 .card-link .card-domain:hover {
-  color: var(--color-primary);
+  color: inherit;
   text-decoration: underline;
+}
+
+.card-link .card-link-content a.has-avatar,
+.card-link .card-excerpt a.has-avatar {
+  display: inline-flex;
+  align-items: center;
+  min-width: 2rem;
+  min-height: 2rem;
 }
 
 .card-link .card-title {

--- a/pkg/themes/default/static/css/components.css
+++ b/pkg/themes/default/static/css/components.css
@@ -527,13 +527,15 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 1.5rem;
-  height: 1.5rem;
+  width: 2rem;
+  height: 2rem;
+  min-width: 2rem;
+  min-height: 2rem;
   padding: 0;
   border: 1px solid color-mix(in srgb, var(--color-text) 12%, transparent);
   border-radius: 4px;
   background: transparent;
-  color: var(--color-text-muted);
+  color: var(--color-text);
   font-size: var(--text-sm);
   line-height: 1;
   cursor: pointer;
@@ -1611,11 +1613,12 @@
   display: inline-flex;
   align-items: center;
   gap: 0.45rem;
+  min-height: 2rem;
   padding: 0.45rem 0.8rem;
   border: 1px solid var(--color-border);
   border-radius: 999px;
-  background: color-mix(in srgb, var(--color-surface) 88%, white);
-  color: var(--color-text-muted);
+  background: var(--color-background);
+  color: var(--color-text);
   font-size: 0.85rem;
   line-height: 1;
   transition: border-color 0.2s ease, color 0.2s ease, background-color 0.2s ease;
@@ -1640,9 +1643,9 @@
 .post-copy__details[open] .post-copy__summary,
 .post-copy__summary:hover,
 .post-copy__summary:focus-visible {
-  color: var(--color-primary);
-  border-color: var(--color-primary);
-  background: color-mix(in srgb, var(--color-primary) 10%, var(--color-surface));
+  color: var(--color-text);
+  border-color: var(--color-link-hover, var(--color-primary));
+  background: color-mix(in srgb, var(--color-background) 88%, var(--color-link-hover, var(--color-primary)) 12%);
 }
 
 .post-copy__details[open] .post-copy__summary::after {

--- a/pkg/themes/default/static/css/variables.css
+++ b/pkg/themes/default/static/css/variables.css
@@ -7,6 +7,8 @@
   --color-primary: #3b82f6;
   --color-primary-light: #60a5fa;
   --color-primary-dark: #2563eb;
+  --color-link: #1d4ed8;
+  --color-link-hover: #1e40af;
 
   /* Semantic colors */
   --color-text: #1f2937;
@@ -108,6 +110,8 @@
     --color-background: #111827;
     --color-surface: #1f2937;
     --color-border: #374151;
+    --color-link: #93c5fd;
+    --color-link-hover: #bfdbfe;
 
     /* Darker article shadow for dark mode */
     --article-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.3), 0 2px 4px -1px rgba(0, 0, 0, 0.2);

--- a/spec/spec/THEMES.md
+++ b/spec/spec/THEMES.md
@@ -12,7 +12,7 @@ Themes control the visual appearance of the generated site. The system supports:
 3. **Theme packages** - Installable, shareable, complete visual identities
 4. **Local overrides** - Any theme file can be overridden by placing it in your project
 5. **Readable by default** - Typography, contrast, and spacing optimized for reading
-6. **Accessible first** - WCAG 2.1 AA compliant colors and focus states
+6. **Accessible first** - WCAG 2.1 AA compliant colors, focus states, and compact touch targets
 
 ---
 
@@ -1640,6 +1640,8 @@ Template usage:
 
 Built-in themes MUST include styles for all admonition types.
 
+Built-in themes MUST keep interactive text and compact controls readable by default. This includes using link and accent treatments that pass WCAG AA contrast against the active surface and giving compact interactive elements at least a 24px effective touch target when they appear in dense UI such as cards, sidebars, or feed navigation.
+
 ### Admonition CSS
 
 ```css
@@ -1658,7 +1660,8 @@ Built-in themes MUST include styles for all admonition types.
   gap: var(--space-2);
   font-weight: 600;
   margin-bottom: var(--space-2);
-  color: var(--admonition-color, var(--color-primary));
+  color: var(--color-text);
+  color: color-mix(in srgb, var(--admonition-color, var(--color-primary)) 45%, var(--color-text) 55%);
 }
 
 .admonition-title::before {


### PR DESCRIPTION
## Summary
- tighten default theme contrast and touch targets for the compact controls that failed Lighthouse on `/ping-54/`
- add cross-palette regression coverage for the default theme combinations behind those failures
- document the built-in theme requirement for readable compact controls and 24px touch targets

## Testing
- `just fmt`
- `go test ./pkg/palettes/...`
- `go test ./pkg/themes/...`