### PR TITLE
fix: restore default theme contrast tokens

### DIFF
--- a/pkg/palettes/builtin_integration_test.go
+++ b/pkg/palettes/builtin_integration_test.go
@@ -13,7 +13,7 @@ func resolveFirst(palette *Palette, names ...string) (name, hex string) {
 	return "", ""
 }
 
-func requireContrast(t *testing.T, paletteName string, fgName string, fgHex string, bgName string, bgHex string, minRatio float64, desc string) {
+func requireContrast(t *testing.T, paletteName, fgName, fgHex, bgName, bgHex string, minRatio float64, desc string) {
 	t.Helper()
 
 	ratio, err := ContrastRatioFromHex(fgHex, bgHex)

--- a/pkg/palettes/builtin_integration_test.go
+++ b/pkg/palettes/builtin_integration_test.go
@@ -13,6 +13,19 @@ func resolveFirst(palette *Palette, names ...string) (name, hex string) {
 	return "", ""
 }
 
+func requireContrast(t *testing.T, paletteName string, fgName string, fgHex string, bgName string, bgHex string, minRatio float64, desc string) {
+	t.Helper()
+
+	ratio, err := ContrastRatioFromHex(fgHex, bgHex)
+	if err != nil {
+		t.Fatalf("Palette %s: invalid resolved colors for %s: %q on %q (%v)", paletteName, desc, fgHex, bgHex, err)
+	}
+
+	if ratio < minRatio {
+		t.Errorf("Palette %s: %s (%s on %s) contrast ratio %.2f < %.1f required", paletteName, desc, fgName, bgName, ratio, minRatio)
+	}
+}
+
 // TestBuiltInPalettesWCAGContrast validates that all built-in palettes
 // pass WCAG AA contrast requirements. This is an integration test that
 // ensures our shipped palettes meet accessibility standards.
@@ -263,7 +276,7 @@ func TestPaletteContrastForDefaultThemeInteractiveComponents(t *testing.T) {
 	componentChecks := []struct {
 		name      string
 		fgOptions []string
-		bg        string
+		bgOptions []string
 		minRatio  float64
 		level     string
 		desc      string
@@ -271,7 +284,7 @@ func TestPaletteContrastForDefaultThemeInteractiveComponents(t *testing.T) {
 		{
 			name:      "post copy label",
 			fgOptions: []string{"text-primary"},
-			bg:        "bg-primary",
+			bgOptions: []string{"bg-primary"},
 			minRatio:  4.5,
 			level:     "AA",
 			desc:      "post copy summary text",
@@ -279,15 +292,23 @@ func TestPaletteContrastForDefaultThemeInteractiveComponents(t *testing.T) {
 		{
 			name:      "admonition title",
 			fgOptions: []string{"text-primary"},
-			bg:        "bg-surface",
+			bgOptions: []string{"admonition-note-bg", "bg-surface"},
 			minRatio:  4.5,
 			level:     "AA",
-			desc:      "admonition title text on default surfaces",
+			desc:      "admonition title text on note backgrounds",
+		},
+		{
+			name:      "warning admonition title",
+			fgOptions: []string{"text-primary"},
+			bgOptions: []string{"admonition-warning-bg", "admonition-warn-bg", "bg-surface"},
+			minRatio:  4.5,
+			level:     "AA",
+			desc:      "admonition title text on warning backgrounds",
 		},
 		{
 			name:      "feed nav button label",
 			fgOptions: []string{"text-primary"},
-			bg:        "bg-surface",
+			bgOptions: []string{"bg-surface"},
 			minRatio:  4.5,
 			level:     "AA",
 			desc:      "feed navigation button glyphs",
@@ -295,10 +316,26 @@ func TestPaletteContrastForDefaultThemeInteractiveComponents(t *testing.T) {
 		{
 			name:      "card domain link",
 			fgOptions: []string{"text-primary"},
-			bg:        "bg-surface",
+			bgOptions: []string{"bg-surface"},
 			minRatio:  4.5,
 			level:     "AA",
 			desc:      "compact card domain links",
+		},
+		{
+			name:      "homepage updated label",
+			fgOptions: []string{"text-secondary"},
+			bgOptions: []string{"bg-surface"},
+			minRatio:  4.5,
+			level:     "AA",
+			desc:      "small home card metadata labels",
+		},
+		{
+			name:      "webmention count label",
+			fgOptions: []string{"text-secondary"},
+			bgOptions: []string{"bg-surface"},
+			minRatio:  4.5,
+			level:     "AA",
+			desc:      "compact webmention count labels on cards",
 		},
 	}
 
@@ -313,25 +350,15 @@ func TestPaletteContrastForDefaultThemeInteractiveComponents(t *testing.T) {
 
 			for _, check := range componentChecks {
 				fgName, fgHex := resolveFirst(palette, check.fgOptions...)
-				bgHex := palette.Resolve(check.bg)
+				bgName, bgHex := resolveFirst(palette, check.bgOptions...)
 
-				if fgName == "" || bgHex == "" {
-					t.Errorf("Palette %s: missing color mapping for %s (%v on %s)",
-						name, check.name, check.fgOptions, check.bg)
+				if fgName == "" || bgName == "" {
+					t.Errorf("Palette %s: missing color mapping for %s (%v on %v)",
+						name, check.name, check.fgOptions, check.bgOptions)
 					continue
 				}
 
-				ratio, err := ContrastRatioFromHex(fgHex, bgHex)
-				if err != nil {
-					t.Errorf("Palette %s: invalid resolved colors for %s: %q on %q (%v)",
-						name, check.name, fgHex, bgHex, err)
-					continue
-				}
-
-				if ratio < check.minRatio {
-					t.Errorf("Palette %s: %s (%s on %s) contrast ratio %.2f < %.1f required for %s",
-						name, check.name, fgName, check.bg, ratio, check.minRatio, check.level)
-				}
+				requireContrast(t, name, fgName, fgHex, bgName, bgHex, check.minRatio, check.desc)
 			}
 		})
 	}

--- a/pkg/themes/accessibility_test.go
+++ b/pkg/themes/accessibility_test.go
@@ -158,6 +158,55 @@ func TestCSSFocusIndicators(t *testing.T) {
 	})
 }
 
+func TestDefaultThemeContrastSensitiveSelectorsUseAccessibleTokens(t *testing.T) {
+	t.Parallel()
+
+	homeCSS, err := ReadStatic("css/home.css")
+	if err != nil {
+		t.Fatalf("Failed to read home.css: %v", err)
+	}
+
+	webmentionsCSS, err := ReadStatic("css/webmentions.css")
+	if err != nil {
+		t.Fatalf("Failed to read webmentions.css: %v", err)
+	}
+
+	admonitionsCSS, err := ReadStatic("css/admonitions.css")
+	if err != nil {
+		t.Fatalf("Failed to read admonitions.css: %v", err)
+	}
+
+	home := normalizeNewlines(string(homeCSS))
+	webmentions := normalizeNewlines(string(webmentionsCSS))
+	admonitions := normalizeNewlines(string(admonitionsCSS))
+
+	if !strings.Contains(home, ".home-card .home-updated {\n  font-size: var(--text-sm);\n  color: var(--color-text-secondary);") {
+		t.Error("home updated labels should use --color-text-secondary without additional opacity reduction")
+	}
+	if strings.Contains(home, ".home-card .home-updated {\n  font-size: var(--text-sm);\n  color: var(--color-text-muted);\n  opacity:") {
+		t.Error("home updated labels should not reduce opacity on already-muted text")
+	}
+
+	if !strings.Contains(webmentions, ".wm-count {\n  display: inline-flex;\n  align-items: center;\n  gap: 0.25em;\n  white-space: nowrap;\n  color: var(--color-text-secondary);") {
+		t.Error("webmention count labels should inherit an accessible surface-safe text token")
+	}
+	for _, selector := range []string{".wm-likes", ".wm-reposts", ".wm-replies"} {
+		if !strings.Contains(webmentions, selector+" {\n  color: var(--color-text-secondary);") {
+			t.Errorf("%s should use the readable secondary text token on card surfaces", selector)
+		}
+	}
+
+	if !strings.Contains(admonitions, ".admonition-title {\n  display: flex;\n  align-items: center;\n  gap: var(--space-2);\n  font-weight: 600;\n  margin-bottom: var(--space-2);\n  color: var(--color-text);") {
+		t.Error("admonition titles should use the primary text token")
+	}
+	if strings.Contains(admonitions, "color-mix(in srgb") {
+		t.Error("admonition title text should not rely on mixed accent colors for readability")
+	}
+	if !strings.Contains(admonitions, ".admonition-title::before {\n  content: var(--admonition-icon, \"\");\n  font-size: 1.25em;\n  color: var(--admonition-color, var(--color-primary));") {
+		t.Error("admonition icons should carry the accent color when title text stays on readable text tokens")
+	}
+}
+
 // TestCSSTouchTargets validates that interactive elements meet minimum touch target sizes.
 // This is recommended by WCAG 2.5.5 Target Size (Level AAA) and mobile best practices.
 func TestCSSTouchTargets(t *testing.T) {

--- a/pkg/themes/default/static/css/admonitions.css
+++ b/pkg/themes/default/static/css/admonitions.css
@@ -19,12 +19,12 @@
   font-weight: 600;
   margin-bottom: var(--space-2);
   color: var(--color-text);
-  color: color-mix(in srgb, var(--admonition-color, var(--color-primary)) 45%, var(--color-text) 55%);
 }
 
 .admonition-title::before {
   content: var(--admonition-icon, "");
   font-size: 1.25em;
+  color: var(--admonition-color, var(--color-primary));
 }
 
 .admonition > *:last-child {

--- a/pkg/themes/default/static/css/home.css
+++ b/pkg/themes/default/static/css/home.css
@@ -172,8 +172,7 @@
 
 .home-card .home-updated {
   font-size: var(--text-sm);
-  color: var(--color-text-muted);
-  opacity: 0.7;
+  color: var(--color-text-secondary);
   margin-top: var(--space-4);
 }
 

--- a/pkg/themes/default/static/css/webmentions.css
+++ b/pkg/themes/default/static/css/webmentions.css
@@ -347,18 +347,19 @@
   align-items: center;
   gap: 0.25em;
   white-space: nowrap;
+  color: var(--color-text-secondary);
 }
 
 .wm-likes {
-  color: var(--color-error);
+  color: var(--color-text-secondary);
 }
 
 .wm-reposts {
-  color: var(--color-success);
+  color: var(--color-text-secondary);
 }
 
 .wm-replies {
-  color: var(--color-primary);
+  color: var(--color-text-secondary);
 }
 
 /* ==========================================================================

--- a/spec/spec/THEMES.md
+++ b/spec/spec/THEMES.md
@@ -14,6 +14,11 @@ Themes control the visual appearance of the generated site. The system supports:
 5. **Readable by default** - Typography, contrast, and spacing optimized for reading
 6. **Accessible first** - WCAG 2.1 AA compliant colors, focus states, and compact touch targets
 
+### Contrast Guarantees
+
+- Default theme text in compact UI surfaces such as home metadata, card metadata, and admonition titles MUST use text tokens that maintain WCAG 2.1 AA contrast at their rendered size.
+- Built-in palette regression tests MUST validate the default theme's concrete foreground/background combinations, not only abstract palette token pairs, so regressions in selector usage are caught across every shipped palette.
+
 ---
 
 ## Customization Philosophy


### PR DESCRIPTION
## Summary
- switch the failing compact UI selectors back to readable text tokens for home metadata, webmention counts, and admonition titles
- keep admonition accents on the icon while the title text stays on the primary text token
- add selector-level and built-in palette regression tests so these contrast checks run across every shipped palette

## Testing
- go test ./pkg/palettes ./pkg/themes

Refs #765