### PR TITLE
perf: reduce large feed sidebar runtime work

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -662,6 +662,7 @@ Series/collection navigation sidebar for posts in the same feed.
 | `width` | string | `"250px"` | Sidebar width |
 | `title` | string | `""` | Custom title (defaults to feed title) |
 | `feeds` | array | `[]` | Feed slugs to show navigation for |
+| `max_posts` | integer | `0` | Limit rendered sidebar items; when set, keeps a window around the current post |
 
 ```toml
 [markata-go.components.feed_sidebar]
@@ -670,6 +671,7 @@ position = "left"
 width = "250px"
 title = "In this series"
 feeds = ["tutorials", "guides"]
+max_posts = 51
 ```
 
 **Responsive behavior:** Sidebars are hidden on mobile (< 768px) and shown inline on tablets (768px - 1024px).

--- a/pkg/agentskill/bundle/markata-go-site/reference/feed-patterns.md
+++ b/pkg/agentskill/bundle/markata-go-site/reference/feed-patterns.md
@@ -158,8 +158,22 @@ No additional config is needed. The sitemap plugin runs in the Write stage after
 - card rendering often happens in a partial
 - RSS and Atom can use separate XML templates
 
+## Feed Sidebar Windowing
+
+Large feeds can make post sidebars expensive and noisy. Use `max_posts` under `[markata-go.components.feed_sidebar]` to cap sidebar entries while keeping the current post visible.
+
+```toml
+[markata-go.components.feed_sidebar]
+enabled = true
+feeds = ["blog", "docs"]
+max_posts = 51
+```
+
+A value of `0` or an omitted value means no cap. When capped, markata-go renders a contiguous window around the current post when possible.
+
 ## Agent Guidance
 
 - if the task is “change an index page”, check whether that page is backed by a feed first
 - if the task is “show only X posts”, check `filter`, `limit`, `offset`, and `items_per_page`
+- if the task is “make post sidebars shorter” or “speed up huge series sidebars”, check `components.feed_sidebar.max_posts`
 - if the task is “change archive card layout”, change the feed template or card partial before changing content

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -138,6 +138,11 @@ type FeedSidebarConfig struct {
 
 	// Feeds is the list of feed slugs to show navigation for
 	Feeds []string `json:"feeds,omitempty" yaml:"feeds,omitempty" toml:"feeds,omitempty"`
+
+	// MaxPosts caps the number of sidebar posts shown. When positive, markata-go
+	// keeps a centered window around the current post instead of rendering the
+	// entire feed list.
+	MaxPosts int `json:"max_posts,omitempty" yaml:"max_posts,omitempty" toml:"max_posts,omitempty"`
 }
 
 // ContentSidebarConfig configures a content sidebar that renders a post

--- a/pkg/plugins/templates.go
+++ b/pkg/plugins/templates.go
@@ -650,8 +650,16 @@ func (p *TemplatesPlugin) renderPost(post *models.Post, config *lifecycle.Config
 //  1. Series – post has a "series" key in Extra
 //  2. Explicit frontmatter – post.PrevNextFeed or post.Extra["sidebar_feed"]
 //  3. Tag-based feeds – from config feed_sidebar.feeds
-//  4. Auto-discovery – find the best (smallest non-excluded) feed containing this post
+//  4. Auto-discovery – find the best (smallest non-excluded) feed containing this post,
+//     preferring primary feeds only as a tie-breaker for equally specific candidates.
 func (p *TemplatesPlugin) getFeedSidebarPosts(post *models.Post, config *lifecycle.Config, m *lifecycle.Manager) ([]*models.Post, *models.FeedConfig) {
+	maxPosts := 0
+	if config != nil {
+		if components, ok := config.Extra["components"].(models.ComponentsConfig); ok {
+			maxPosts = components.FeedSidebar.MaxPosts
+		}
+	}
+
 	// 1. Series
 	seriesPosts, seriesFeed := p.getSeriesSidebarPosts(post, config, m)
 	if seriesPosts != nil {
@@ -662,29 +670,60 @@ func (p *TemplatesPlugin) getFeedSidebarPosts(post *models.Post, config *lifecyc
 	if explicitSlug := p.getExplicitFeedSlug(post); explicitSlug != "" {
 		posts, fc := p.feedFromCachedConfigs(explicitSlug, post, m)
 		if posts != nil {
-			return posts, fc
+			return trimSidebarPosts(posts, post.Slug, maxPosts), fc
 		}
 	}
 
 	// 3. Tag-based feeds from feed_sidebar config
 	tagPosts, tagFeed := p.getTagFeedSidebarPosts(post, config, m)
 	if tagPosts != nil {
-		return tagPosts, tagFeed
+		return trimSidebarPosts(tagPosts, post.Slug, maxPosts), tagFeed
 	}
 
-	// 4. Prefer a primary feed from cached feed configs when available.
-	primaryPosts, primaryFeed := p.getPrimaryFeedSidebarPosts(post, m)
-	if primaryPosts != nil {
-		return primaryPosts, primaryFeed
-	}
-
-	// 5. Auto-discovery: find the best feed containing this post
+	// 4. Auto-discovery: find the best feed containing this post
 	autoPosts, autoFeed := p.autoDiscoverFeed(post, config, m)
 	if autoPosts != nil {
-		return autoPosts, autoFeed
+		return trimSidebarPosts(autoPosts, post.Slug, maxPosts), autoFeed
 	}
 
 	return nil, nil
+}
+
+func trimSidebarPosts(posts []*models.Post, currentSlug string, maxPosts int) []*models.Post {
+	if maxPosts <= 0 || len(posts) <= maxPosts {
+		return posts
+	}
+
+	currentIndex := -1
+	for i, p := range posts {
+		if p != nil && p.Slug == currentSlug {
+			currentIndex = i
+			break
+		}
+	}
+	if currentIndex == -1 {
+		trimmed := make([]*models.Post, maxPosts)
+		copy(trimmed, posts[:maxPosts])
+		return trimmed
+	}
+
+	half := maxPosts / 2
+	start := currentIndex - half
+	if start < 0 {
+		start = 0
+	}
+	end := start + maxPosts
+	if end > len(posts) {
+		end = len(posts)
+		start = end - maxPosts
+		if start < 0 {
+			start = 0
+		}
+	}
+
+	trimmed := make([]*models.Post, end-start)
+	copy(trimmed, posts[start:end])
+	return trimmed
 }
 
 func (p *TemplatesPlugin) getPrimaryFeedSidebarPosts(post *models.Post, m *lifecycle.Manager) ([]*models.Post, *models.FeedConfig) {
@@ -901,10 +940,12 @@ func (p *TemplatesPlugin) autoDiscoverFeed(post *models.Post, config *lifecycle.
 		return nil, nil
 	}
 
-	// Pick the smallest feed (most specific)
+	// Pick the smallest feed (most specific). If two candidates are equally
+	// specific, prefer the primary feed so configured navigation still wins
+	// when the scope is otherwise identical.
 	best := candidates[0]
 	for _, c := range candidates[1:] {
-		if c.count < best.count {
+		if c.count < best.count || (c.count == best.count && c.fc.Primary && !best.fc.Primary) {
 			best = c
 		}
 	}

--- a/pkg/plugins/templates.go
+++ b/pkg/plugins/templates.go
@@ -726,35 +726,6 @@ func trimSidebarPosts(posts []*models.Post, currentSlug string, maxPosts int) []
 	return trimmed
 }
 
-func (p *TemplatesPlugin) getPrimaryFeedSidebarPosts(post *models.Post, m *lifecycle.Manager) ([]*models.Post, *models.FeedConfig) {
-	if post == nil || post.Slug == "" {
-		return nil, nil
-	}
-
-	cached, ok := m.Cache().Get("feed_configs")
-	if !ok {
-		return nil, nil
-	}
-	configs, ok := cached.([]models.FeedConfig)
-	if !ok {
-		return nil, nil
-	}
-
-	for i := range configs {
-		fc := &configs[i]
-		if !fc.Primary || fc.IncludePrivate {
-			continue
-		}
-		for _, fp := range fc.Posts {
-			if fp.Slug == post.Slug {
-				return fc.Posts, fc
-			}
-		}
-	}
-
-	return nil, nil
-}
-
 // getExplicitFeedSlug returns a feed slug from post frontmatter, if any.
 // Checks post.Extra["sidebar_feed"] first, then post.PrevNextFeed.
 func (p *TemplatesPlugin) getExplicitFeedSlug(post *models.Post) string {
@@ -872,6 +843,21 @@ func (p *TemplatesPlugin) getTagFeedSidebarPosts(post *models.Post, config *life
 	return nil, nil
 }
 
+type autoFeedCandidate struct {
+	fc    *models.FeedConfig
+	count int
+}
+
+func selectBestAutoFeedCandidate(candidates []autoFeedCandidate) autoFeedCandidate {
+	best := candidates[0]
+	for _, c := range candidates[1:] {
+		if c.count < best.count || (c.count == best.count && c.fc.Primary && !best.fc.Primary) {
+			best = c
+		}
+	}
+	return best
+}
+
 // autoDiscoverFeed finds the best feed containing this post from cached feed_configs.
 // It prefers smaller/more specific feeds over large catch-all feeds.
 // Feeds with slugs like "archive", "all", "subscription-*" are deprioritized.
@@ -905,11 +891,7 @@ func (p *TemplatesPlugin) autoDiscoverFeed(post *models.Post, config *lifecycle.
 	// Prefixes to skip
 	skipPrefixes := []string{"subscription-", "tags/"}
 
-	type candidate struct {
-		fc    *models.FeedConfig
-		count int
-	}
-	var candidates []candidate
+	var candidates []autoFeedCandidate
 
 	for i := range configs {
 		fc := &configs[i]
@@ -930,7 +912,7 @@ func (p *TemplatesPlugin) autoDiscoverFeed(post *models.Post, config *lifecycle.
 		// Check if this post is in the feed
 		for _, fp := range fc.Posts {
 			if fp.Slug == post.Slug {
-				candidates = append(candidates, candidate{fc: fc, count: len(fc.Posts)})
+				candidates = append(candidates, autoFeedCandidate{fc: fc, count: len(fc.Posts)})
 				break
 			}
 		}
@@ -943,12 +925,7 @@ func (p *TemplatesPlugin) autoDiscoverFeed(post *models.Post, config *lifecycle.
 	// Pick the smallest feed (most specific). If two candidates are equally
 	// specific, prefer the primary feed so configured navigation still wins
 	// when the scope is otherwise identical.
-	best := candidates[0]
-	for _, c := range candidates[1:] {
-		if c.count < best.count || (c.count == best.count && c.fc.Primary && !best.fc.Primary) {
-			best = c
-		}
-	}
+	best := selectBestAutoFeedCandidate(candidates)
 
 	return best.fc.Posts, best.fc
 }

--- a/pkg/plugins/templates_test.go
+++ b/pkg/plugins/templates_test.go
@@ -48,6 +48,65 @@ func TestTemplatesPlugin_GetFeedSidebarPosts_PrefersPrimaryFeed(t *testing.T) {
 	}
 }
 
+func TestTemplatesPlugin_GetFeedSidebarPosts_PrefersSmallerFeedOverLargePrimary(t *testing.T) {
+	p := NewTemplatesPlugin()
+	m := lifecycle.NewManager()
+
+	enabled := true
+	m.Config().Extra["components"] = models.ComponentsConfig{
+		FeedSidebar: models.FeedSidebarConfig{Enabled: &enabled},
+	}
+
+	title := "Post"
+	post := &models.Post{Slug: "post", Title: &title, Href: "/post/"}
+	otherOne := &models.Post{Slug: "other-1", Href: "/other-1/"}
+	otherTwo := &models.Post{Slug: "other-2", Href: "/other-2/"}
+
+	primary := models.FeedConfig{
+		Slug:    "primary",
+		Title:   "Primary",
+		Primary: true,
+		Posts:   []*models.Post{post, otherOne, otherTwo},
+	}
+	secondary := models.FeedConfig{
+		Slug:  "secondary",
+		Title: "Secondary",
+		Posts: []*models.Post{post},
+	}
+	m.Cache().Set("feed_configs", []models.FeedConfig{primary, secondary})
+
+	posts, feed := p.getFeedSidebarPosts(post, m.Config(), m)
+	if feed == nil {
+		t.Fatal("expected a sidebar feed")
+	}
+	if feed.Slug != "secondary" {
+		t.Fatalf("expected smaller feed, got %q", feed.Slug)
+	}
+	if len(posts) != 1 || posts[0].Slug != post.Slug {
+		t.Fatalf("unexpected sidebar posts: %#v", posts)
+	}
+}
+
+func TestTrimSidebarPosts_CentersCurrentPostWithinWindow(t *testing.T) {
+	posts := make([]*models.Post, 0, 7)
+	for i := 0; i < 7; i++ {
+		slug := string(rune('a' + i))
+		posts = append(posts, &models.Post{Slug: slug})
+	}
+
+	trimmed := trimSidebarPosts(posts, "d", 3)
+	if len(trimmed) != 3 {
+		t.Fatalf("trimmed len = %d, want 3", len(trimmed))
+	}
+	got := []string{trimmed[0].Slug, trimmed[1].Slug, trimmed[2].Slug}
+	want := []string{"c", "d", "e"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("trimmed slugs = %#v, want %#v", got, want)
+		}
+	}
+}
+
 func TestTemplatesPlugin_BuildSidebarFeedsJSON_RotationIncludesOnlyPrimary(t *testing.T) {
 	p := NewTemplatesPlugin()
 	m := lifecycle.NewManager()
@@ -536,6 +595,14 @@ func TestTemplatesPlugin_Render_PostGraphScriptOnlyWhenGraphRenders(t *testing.T
 			hasGraphScript := strings.Contains(post.HTML, "post-graph.js")
 			if hasGraphScript != tt.wantGraphScript {
 				t.Fatalf("post-graph.js present = %v, want %v; HTML=%q", hasGraphScript, tt.wantGraphScript, post.HTML)
+			}
+
+			if tt.wantGraphScript {
+				if !strings.Contains(post.HTML, "IntersectionObserver") {
+					t.Fatalf("expected lazy graph loader in HTML, got %q", post.HTML)
+				}
+			} else if strings.Contains(post.HTML, "IntersectionObserver") {
+				t.Fatalf("unexpected lazy graph loader for sparse post, got %q", post.HTML)
 			}
 		})
 	}

--- a/pkg/themes/default/templates/base.html
+++ b/pkg/themes/default/templates/base.html
@@ -442,7 +442,6 @@
 
   <!-- Conditional CSS Runtime Loader (for view transitions) -->
   <script src="{{ 'js/conditional-css.js' | theme_asset_hashed }}" defer></script>
-  <script src="{{ 'js/feed-cycling.js' | theme_asset_hashed }}" defer></script>
 
   <!-- Conditional Script Loading: Only load when needed -->
   <script>
@@ -470,6 +469,48 @@
       }
     })();
 
+    function appendDeferredScript(src, onload) {
+      var existing = document.querySelector('script[src="' + src + '"]');
+      if (existing) {
+        if (onload) {
+          if (existing.dataset.loaded === 'true') {
+            onload();
+          } else {
+            existing.addEventListener('load', onload, { once: true });
+          }
+        }
+        return existing;
+      }
+
+      var script = document.createElement('script');
+      script.src = src;
+      script.defer = true;
+      script.addEventListener('load', function() {
+        script.dataset.loaded = 'true';
+        if (onload) {
+          onload();
+        }
+      }, { once: true });
+      document.body.appendChild(script);
+      return script;
+    }
+
+    function runWhenIdle(callback, timeout) {
+      if ('requestIdleCallback' in window) {
+        window.requestIdleCallback(callback, { timeout: timeout || 2000 });
+        return;
+      }
+      window.setTimeout(callback, timeout || 1200);
+    }
+
+    function runAfterLoad(callback) {
+      if (document.readyState === 'complete') {
+        callback();
+        return;
+      }
+      window.addEventListener('load', callback, { once: true });
+    }
+
     // Custom Navigation Shortcuts from config
     {% if config.shortcuts and config.shortcuts.navigation %}
     window.customShortcuts = {
@@ -481,63 +522,65 @@
 
     // Wikilink Hover Tooltips - only load if wikilinks with data-title exist
     if (document.querySelector('.wikilink[data-title]')) {
-      const script = document.createElement('script');
-      script.src = '{{ 'js/tooltips.js' | theme_asset_hashed }}';
-      script.defer = true;
-      document.body.appendChild(script);
+      runAfterLoad(function() {
+        runWhenIdle(function() {
+          appendDeferredScript('{{ 'js/tooltips.js' | theme_asset_hashed }}');
+        });
+      });
     }
 
     // Mention Cards - only load if mention links exist
     if (document.querySelector('a.mention')) {
-      const mentionScript = document.createElement('script');
-      mentionScript.src = '{{ 'js/mention-cards.js' | theme_asset_hashed }}';
-      mentionScript.defer = true;
-      document.body.appendChild(mentionScript);
+      runAfterLoad(function() {
+        runWhenIdle(function() {
+          appendDeferredScript('{{ 'js/mention-cards.js' | theme_asset_hashed }}');
+        });
+      });
     }
 
-    // Keyboard Shortcuts Registry - load the core registry first, then load dependent scripts
-    const shortcutsRegistryScript = document.createElement('script');
-    shortcutsRegistryScript.src = '{{ 'js/shortcuts-registry.js' | theme_asset_hashed }}';
-    // Use onload to ensure registry is fully loaded before dependent scripts
-    shortcutsRegistryScript.onload = function() {
-      // Keyboard Shortcuts - load search and core shortcuts
-      if (document.querySelector('#pagefind-search, #shortcuts-modal, [type="search"]')) {
-        const shortcutsScript = document.createElement('script');
-        shortcutsScript.src = '{{ 'js/search-shortcuts.js' | theme_asset_hashed }}';
-        document.body.appendChild(shortcutsScript);
-      }
+    function loadShortcutsRuntime() {
+      appendDeferredScript('{{ 'js/shortcuts-registry.js' | theme_asset_hashed }}', function() {
+        if (document.querySelector('#pagefind-search, #shortcuts-modal, [type="search"]')) {
+          appendDeferredScript('{{ 'js/search-shortcuts.js' | theme_asset_hashed }}');
+        }
 
-      // Scrolling Shortcuts - always available
-      const scrollingScript = document.createElement('script');
-      scrollingScript.src = '{{ 'js/scrolling-shortcuts.js' | theme_asset_hashed }}';
-      document.body.appendChild(scrollingScript);
+        appendDeferredScript('{{ 'js/scrolling-shortcuts.js' | theme_asset_hashed }}');
 
-      // Navigation Shortcuts - load if feed/sidebar/card pagination affordances exist
-      if (document.querySelector('.feed, .feed-sidebar, .card, [data-card], [data-action="prev"], [data-action="next"], .pagination-prev, .pagination-next')) {
-        const navigationScript = document.createElement('script');
-        navigationScript.src = '{{ 'js/navigation-shortcuts.js' | theme_asset_hashed }}';
-        document.body.appendChild(navigationScript);
-      }
+        if (document.querySelector('.feed, .feed-sidebar, .card, [data-card], [data-action="prev"], [data-action="next"], .pagination-prev, .pagination-next')) {
+          appendDeferredScript('{{ 'js/navigation-shortcuts.js' | theme_asset_hashed }}');
+        }
 
-      // History Shortcuts - always available (go back/forward)
-      const historyScript = document.createElement('script');
-      historyScript.src = '{{ 'js/history-shortcuts.js' | theme_asset_hashed }}';
-      document.body.appendChild(historyScript);
-    };
-    document.body.appendChild(shortcutsRegistryScript);
+        appendDeferredScript('{{ 'js/history-shortcuts.js' | theme_asset_hashed }}');
+      });
+    }
+
+    runAfterLoad(function() {
+      runWhenIdle(loadShortcutsRuntime, 2500);
+    });
 
     // Custom Shortcuts - load if custom shortcuts are defined in config
       {% if config.shortcuts and config.shortcuts.navigation %}
-      const customShortcutsScript = document.createElement('script');
-      customShortcutsScript.src = '{{ 'js/custom-shortcuts.js' | theme_asset_hashed }}';
-      document.body.appendChild(customShortcutsScript);
+      runAfterLoad(function() {
+        runWhenIdle(function() {
+          appendDeferredScript('{{ 'js/custom-shortcuts.js' | theme_asset_hashed }}');
+        });
+      });
       {% endif %}
     // Pagination (JS mode) - only load if JS pagination element exists
     if (document.querySelector('.pagination-js')) {
-      const paginationScript = document.createElement('script');
-      paginationScript.src = '{{ 'js/pagination.js' | theme_asset_hashed }}';
-      paginationScript.defer = true;
-      document.body.appendChild(paginationScript);
+      runAfterLoad(function() {
+        runWhenIdle(function() {
+          appendDeferredScript('{{ 'js/pagination.js' | theme_asset_hashed }}');
+        });
+      });
+    }
+
+    if (document.querySelector('#feed-sidebar-data')) {
+      runAfterLoad(function() {
+        runWhenIdle(function() {
+          appendDeferredScript('{{ 'js/feed-cycling.js' | theme_asset_hashed }}');
+        });
+      });
     }
 
     // GLightbox - load when page has zoomable images

--- a/pkg/themes/default/templates/components/post_graph.html
+++ b/pkg/themes/default/templates/components/post_graph.html
@@ -90,7 +90,54 @@
     <div class="post-graph__tooltip" aria-live="polite"></div>
   </div>
 </section>
-<script src="{{ 'js/post-graph.js' | theme_asset_hashed }}" defer></script>
+<script>
+(function() {
+  var graphSection = document.currentScript && document.currentScript.previousElementSibling;
+  if (!graphSection || !graphSection.classList || !graphSection.classList.contains('post-graph')) {
+    return;
+  }
+
+  var scriptSrc = '{{ 'js/post-graph.js' | theme_asset_hashed }}';
+  var loaded = false;
+
+  function loadGraphScript() {
+    if (loaded) {
+      return;
+    }
+    loaded = true;
+
+    if (document.querySelector('script[src="' + scriptSrc + '"]')) {
+      return;
+    }
+
+    var script = document.createElement('script');
+    script.src = scriptSrc;
+    script.defer = true;
+    document.body.appendChild(script);
+  }
+
+  if ('IntersectionObserver' in window) {
+    var observer = new IntersectionObserver(function(entries) {
+      for (var i = 0; i < entries.length; i++) {
+        if (entries[i].isIntersecting) {
+          observer.disconnect();
+          loadGraphScript();
+          return;
+        }
+      }
+    }, { rootMargin: '400px 0px' });
+    observer.observe(graphSection);
+    return;
+  }
+
+  if ('requestIdleCallback' in window) {
+    window.requestIdleCallback(loadGraphScript, { timeout: 2000 });
+    return;
+  }
+
+  window.setTimeout(loadGraphScript, 1200);
+})();
+</script>
 {% endif %}
 
 {% if show_list %}

--- a/spec/spec/GARDEN.md
+++ b/spec/spec/GARDEN.md
@@ -153,6 +153,8 @@ Implementations MUST initialize the post graph on first page load and re-initial
 
 The post graph script SHOULD only be emitted on pages that actually render the preview, so posts without a visible graph do not pay the JavaScript cost.
 
+When the default post graph component renders, implementations SHOULD defer loading the graph runtime until the component is near the viewport. Browsers with `IntersectionObserver` support SHOULD use viewport proximity; browsers without it SHOULD fall back to an idle or delayed load so the graph remains functional without blocking initial page rendering.
+
 The post connections component is configured via `[markata-go.components.post_connections]` and supports two modes:
 
 - `display = ["graph"]` for canvas-only graph rendering

--- a/spec/spec/LAYOUTS.md
+++ b/spec/spec/LAYOUTS.md
@@ -305,7 +305,26 @@ show_copyright = true
 copyright_text = "Copyright 2024 My Company"
 show_social_links = true
 show_nav_links = true
+
+# Feed sidebar component
+[markata-go.components.feed_sidebar]
+enabled = true
+position = "left"
+width = "250px"
+feeds = ["docs", "guides"]
+max_posts = 51
 ```
+
+The feed sidebar component renders navigation for posts that share a feed with the current post. Feed selection order is:
+
+1. series metadata
+2. explicit post frontmatter such as `prev_next_feed` or `sidebar_feed`
+3. configured `feed_sidebar.feeds`
+4. automatic discovery from feeds that contain the current post
+
+Automatic discovery MUST choose the smallest matching feed as the most specific navigation set. When two matching feeds have the same size, a primary feed wins the tie.
+
+`max_posts` limits the rendered sidebar items. A value of `0` or less means no limit. When `max_posts` is positive and the matching feed has more posts than the limit, implementations MUST render a contiguous window that includes the current post and SHOULD center that window around the current post when possible. If the current post cannot be found in the selected feed, implementations SHOULD render the first `max_posts` entries.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `components.feed_sidebar.max_posts` to cap long post sidebar navigation around the current post.
- Prefer the smallest matching feed for sidebar auto-discovery, using primary feeds only as a tie-breaker.
- Defer optional default-theme scripts, including feed cycling and post graph loading, until they are needed.

Fixes #1085

## Validation
- `go test ./pkg/plugins`
- `git diff --check`

## Notes
- `just lint-new` was attempted but is blocked locally by a Go toolchain mismatch: Go 1.26 stdlib files are being typechecked with Go 1.25, which causes unrelated dependency/typecheck failures.