### PR TITLE
feat: add source encryption command for private posts

### DIFF
--- a/cmd/markata-go/cmd/encryption.go
+++ b/cmd/markata-go/cmd/encryption.go
@@ -2,24 +2,29 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/WaylonWalker/markata-go/pkg/config"
 	"github.com/WaylonWalker/markata-go/pkg/encryption"
+	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
+	"github.com/WaylonWalker/markata-go/pkg/models"
+	"github.com/WaylonWalker/markata-go/pkg/plugins"
 	"github.com/spf13/cobra"
 )
 
 var (
 	encryptionPasswordLength int
 	encryptionCheckKey       string
+	encryptionDryRun         bool
 )
 
 var encryptionCmd = &cobra.Command{
 	Use:   "encryption",
 	Short: "Utilities for encryption keys and passwords",
-	Long: `Encryption utilities help you manage passwords for private posts.
-
-Currently the only helper is a password generator that creates a policy-compliant password.
+	Long: `Encryption utilities help you manage passwords and source-encrypted private posts.
 `,
 }
 
@@ -47,10 +52,24 @@ Use --key to check one specific key name.
 	RunE: runCheckPasswordCommand,
 }
 
+var encryptPostsCmd = &cobra.Command{
+	Use:   "encrypt-posts",
+	Short: "Encrypt all private Markdown source bodies",
+	Long: `Encrypt all private Markdown source bodies matched by the active content glob configuration.
+
+Posts are encrypted in place by default. Draft, skipped, public, and already
+source-encrypted posts are reported but not rewritten. Use --dry-run to preview
+changes without modifying files.
+`,
+	Args: cobra.NoArgs,
+	RunE: runEncryptPostsCommand,
+}
+
 func init() {
-	encryptionCmd.AddCommand(generatePasswordCmd, checkPasswordCmd)
+	encryptionCmd.AddCommand(generatePasswordCmd, checkPasswordCmd, encryptPostsCmd)
 	generatePasswordCmd.Flags().IntVar(&encryptionPasswordLength, "length", encryption.DefaultMinPasswordLength, "password length (must be at least the configured minimum)")
 	checkPasswordCmd.Flags().StringVar(&encryptionCheckKey, "key", "", "specific key name to check (default: all required keys)")
+	encryptPostsCmd.Flags().BoolVar(&encryptionDryRun, "dry-run", false, "report files that would be encrypted without modifying them")
 	rootCmd.AddCommand(encryptionCmd)
 }
 
@@ -103,6 +122,251 @@ func runCheckPasswordCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	return nil
+}
+
+func runEncryptPostsCommand(cmd *cobra.Command, _ []string) error {
+	cfg, err := config.Load(cfgFile)
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+	if !cfg.Encryption.Enabled {
+		return fmt.Errorf("encryption is disabled in config")
+	}
+
+	results, minDuration, minLength, err := evaluateEncryptionKeyPolicy(cfg, "")
+	if err != nil {
+		return err
+	}
+	if err := failOnEncryptionKeyPolicyFailures(results, minDuration, minLength); err != nil {
+		return err
+	}
+
+	files, err := encryptionContentFiles(cfg)
+	if err != nil {
+		return err
+	}
+
+	stats := encryptPostsStats{}
+	candidates := make([]encryptPostResult, 0)
+	for _, file := range files {
+		result, err := encryptPostSourceFile(file, cfg, true)
+		if err != nil {
+			return err
+		}
+		stats.add(result)
+		if result.Action == encryptPostActionEncrypted {
+			candidates = append(candidates, result)
+			if encryptionDryRun {
+				fmt.Fprintf(cmd.OutOrStdout(), "WOULD ENCRYPT %s key=%s\n", result.Path, result.KeyName)
+			}
+		}
+	}
+
+	if !encryptionDryRun {
+		for _, candidate := range candidates {
+			result, err := encryptPostSourceFile(candidate.Path, cfg, false)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "ENCRYPTED %s key=%s\n", result.Path, result.KeyName)
+		}
+	}
+
+	action := "Encrypted"
+	if encryptionDryRun {
+		action = "Would encrypt"
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "%s %d private post(s); skipped %d already encrypted, %d public, %d draft/skip.\n",
+		action, stats.Encrypted, stats.AlreadyEncrypted, stats.Public, stats.DraftOrSkip)
+
+	return nil
+}
+
+func failOnEncryptionKeyPolicyFailures(results []encryptionKeyPolicyResult, minDuration time.Duration, minLength int) error {
+	for _, result := range results {
+		if result.Err != nil {
+			return fmt.Errorf("encryption key %q failed policy (%s, min_length=%d, min_estimated_crack_time=%s): %w",
+				result.KeyName, result.EnvName, minLength, formatCrackDurationHuman(minDuration), result.Err)
+		}
+	}
+	return nil
+}
+
+func encryptionContentFiles(cfg *models.Config) ([]string, error) {
+	lifecycleConfig := lifecycle.NewConfig()
+	lifecycleConfig.ContentDir = "."
+	lifecycleConfig.GlobPatterns = append([]string{}, cfg.GlobConfig.Patterns...)
+	lifecycleConfig.Extra["use_gitignore"] = cfg.GlobConfig.UseGitignore
+
+	manager := lifecycle.NewManager()
+	manager.SetConfig(lifecycleConfig)
+
+	globPlugin := plugins.NewGlobPlugin()
+	if err := globPlugin.Configure(manager); err != nil {
+		return nil, fmt.Errorf("configure content glob: %w", err)
+	}
+	if err := globPlugin.Glob(manager); err != nil {
+		return nil, fmt.Errorf("scan content files: %w", err)
+	}
+
+	baseDir, err := filepath.Abs(lifecycleConfig.ContentDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve content dir: %w", err)
+	}
+
+	files := manager.Files()
+	paths := make([]string, 0, len(files))
+	for _, file := range files {
+		if filepath.IsAbs(file) {
+			paths = append(paths, file)
+			continue
+		}
+		paths = append(paths, filepath.Join(baseDir, file))
+	}
+	return paths, nil
+}
+
+type encryptPostAction string
+
+const (
+	encryptPostActionEncrypted        encryptPostAction = "encrypted"
+	encryptPostActionAlreadyEncrypted encryptPostAction = "already-encrypted"
+	encryptPostActionPublic           encryptPostAction = "public"
+	encryptPostActionDraftOrSkip      encryptPostAction = "draft-or-skip"
+)
+
+type encryptPostResult struct {
+	Path    string
+	KeyName string
+	Action  encryptPostAction
+}
+
+type encryptPostsStats struct {
+	Encrypted        int
+	AlreadyEncrypted int
+	Public           int
+	DraftOrSkip      int
+}
+
+func (s *encryptPostsStats) add(result encryptPostResult) {
+	switch result.Action {
+	case encryptPostActionEncrypted:
+		s.Encrypted++
+	case encryptPostActionAlreadyEncrypted:
+		s.AlreadyEncrypted++
+	case encryptPostActionPublic:
+		s.Public++
+	case encryptPostActionDraftOrSkip:
+		s.DraftOrSkip++
+	}
+}
+
+func encryptPostSourceFile(path string, cfg *models.Config, dryRun bool) (encryptPostResult, error) {
+	contentBytes, err := os.ReadFile(path)
+	if err != nil {
+		return encryptPostResult{}, fmt.Errorf("read %s: %w", path, err)
+	}
+	content := string(contentBytes)
+
+	_, body, rawFrontmatter, err := plugins.ParseFrontmatterWithRaw(content)
+	if err != nil {
+		return encryptPostResult{}, fmt.Errorf("parse frontmatter %s: %w", path, err)
+	}
+	if encryption.IsSourceEncrypted(body) {
+		return encryptPostResult{Path: path, Action: encryptPostActionAlreadyEncrypted}, nil
+	}
+
+	post, err := plugins.ParsePostFromContentWithConfig(path, content, cfg)
+	if err != nil {
+		return encryptPostResult{}, fmt.Errorf("parse %s: %w", path, err)
+	}
+	applyEncryptPostsPrivateTags(post, cfg)
+	if post.Draft || post.Skip {
+		return encryptPostResult{Path: path, Action: encryptPostActionDraftOrSkip}, nil
+	}
+	if !post.Private {
+		return encryptPostResult{Path: path, Action: encryptPostActionPublic}, nil
+	}
+
+	keyName := strings.TrimSpace(post.SecretKey)
+	if keyName == "" {
+		keyName = strings.TrimSpace(cfg.Encryption.DefaultKey)
+	}
+	if keyName == "" {
+		return encryptPostResult{}, fmt.Errorf("private post %s has no encryption key; set secret_key or encryption.default_key", path)
+	}
+	password := os.Getenv(plugins.EncryptionEnvPrefix + strings.ToUpper(keyName))
+	if password == "" {
+		return encryptPostResult{}, fmt.Errorf("private post %s requires %s%s", path, plugins.EncryptionEnvPrefix, strings.ToUpper(keyName))
+	}
+	if err := validateEncryptPostsPassword(password, cfg); err != nil {
+		return encryptPostResult{}, fmt.Errorf("private post %s key %q failed policy: %w", path, keyName, err)
+	}
+
+	encryptedBody, err := encryption.EncryptSourceMarkdown(body, keyName, password)
+	if err != nil {
+		return encryptPostResult{}, fmt.Errorf("encrypt source body for %s: %w", path, err)
+	}
+	if dryRun {
+		return encryptPostResult{Path: path, KeyName: keyName, Action: encryptPostActionEncrypted}, nil
+	}
+
+	nextContent := encryptedSourceDocument(rawFrontmatter, encryptedBody)
+	mode := os.FileMode(0o600)
+	if stat, err := os.Stat(path); err == nil {
+		mode = stat.Mode().Perm()
+	}
+	if err := os.WriteFile(path, []byte(nextContent), mode); err != nil {
+		return encryptPostResult{}, fmt.Errorf("write encrypted source %s: %w", path, err)
+	}
+	return encryptPostResult{Path: path, KeyName: keyName, Action: encryptPostActionEncrypted}, nil
+}
+
+func validateEncryptPostsPassword(password string, cfg *models.Config) error {
+	minLength := cfg.Encryption.MinPasswordLength
+	if minLength == 0 {
+		minLength = encryption.DefaultMinPasswordLength
+	}
+	minDurationValue := cfg.Encryption.MinEstimatedCrackTime
+	if minDurationValue == "" {
+		minDurationValue = encryption.DefaultMinEstimatedCrackTime
+	}
+	minDuration, err := encryption.ParseEstimatedCrackDuration(minDurationValue)
+	if err != nil {
+		return fmt.Errorf("invalid encryption.min_estimated_crack_time: %w", err)
+	}
+	return encryption.ValidatePassword(password, minLength, minDuration)
+}
+
+func applyEncryptPostsPrivateTags(post *models.Post, cfg *models.Config) {
+	if post == nil || cfg == nil || post.Skip || post.Draft {
+		return
+	}
+	for _, tag := range post.Tags {
+		if keyName, ok := cfg.Encryption.PrivateTags[strings.ToLower(tag)]; ok {
+			post.Private = true
+			if post.SecretKey == "" {
+				post.SecretKey = keyName // pragma: allowlist secret
+			}
+			return
+		}
+	}
+	if post.Template == "" {
+		return
+	}
+	if keyName, ok := cfg.Encryption.PrivateTags[strings.ToLower(post.Template)]; ok {
+		post.Private = true
+		if post.SecretKey == "" {
+			post.SecretKey = keyName // pragma: allowlist secret
+		}
+	}
+}
+
+func encryptedSourceDocument(rawFrontmatter, encryptedBody string) string {
+	if rawFrontmatter == "" {
+		return encryptedBody
+	}
+	return "---\n" + rawFrontmatter + "\n---\n" + encryptedBody
 }
 
 func formatCrackDurationHuman(d time.Duration) string {

--- a/cmd/markata-go/cmd/encryption_test.go
+++ b/cmd/markata-go/cmd/encryption_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/WaylonWalker/markata-go/pkg/encryption"
+	"github.com/WaylonWalker/markata-go/pkg/models"
+	"github.com/WaylonWalker/markata-go/pkg/plugins"
 )
 
 func TestGeneratePasswordCommand_DefaultLength(t *testing.T) {
@@ -101,6 +103,138 @@ func TestCheckPasswordCommand_Fail(t *testing.T) {
 	}
 }
 
+func TestEncryptPostSourceFile_PrivatePost(t *testing.T) {
+	cfg := testEncryptPostsConfig()
+	t.Setenv("MARKATA_GO_ENCRYPTION_KEY_DEFAULT", "h7Qm!2Vx9#Lp4@Td")
+	path := writeMarkdownFile(t, `---
+title: Secret
+private: true
+---
+# Secret
+body
+`)
+
+	result, err := encryptPostSourceFile(path, cfg, false)
+	if err != nil {
+		t.Fatalf("encryptPostSourceFile() error = %v", err)
+	}
+	if result.Action != encryptPostActionEncrypted {
+		t.Fatalf("action = %q, want %q", result.Action, encryptPostActionEncrypted)
+	}
+
+	content := readFileString(t, path)
+	_, body, err := plugins.ExtractFrontmatter(content)
+	if err != nil {
+		t.Fatalf("ExtractFrontmatter() error = %v", err)
+	}
+	if !encryption.IsSourceEncrypted(body) {
+		t.Fatalf("expected source-encrypted body, got %q", body)
+	}
+	decrypted, keyName, err := encryption.DecryptSourceMarkdown(body, "h7Qm!2Vx9#Lp4@Td")
+	if err != nil {
+		t.Fatalf("DecryptSourceMarkdown() error = %v", err)
+	}
+	if keyName != "default" {
+		t.Fatalf("keyName = %q, want default", keyName)
+	}
+	if decrypted != "# Secret\nbody\n" {
+		t.Fatalf("decrypted body = %q", decrypted)
+	}
+}
+
+func TestEncryptPostSourceFile_DryRunDoesNotWrite(t *testing.T) {
+	cfg := testEncryptPostsConfig()
+	t.Setenv("MARKATA_GO_ENCRYPTION_KEY_DEFAULT", "h7Qm!2Vx9#Lp4@Td")
+	original := `---
+title: Secret
+private: true
+---
+secret body
+`
+	path := writeMarkdownFile(t, original)
+
+	result, err := encryptPostSourceFile(path, cfg, true)
+	if err != nil {
+		t.Fatalf("encryptPostSourceFile() error = %v", err)
+	}
+	if result.Action != encryptPostActionEncrypted {
+		t.Fatalf("action = %q, want %q", result.Action, encryptPostActionEncrypted)
+	}
+	if got := readFileString(t, path); got != original {
+		t.Fatalf("dry run modified file: got %q", got)
+	}
+}
+
+func TestEncryptPostSourceFile_PrivateTagUsesTagKey(t *testing.T) {
+	cfg := testEncryptPostsConfig()
+	cfg.Encryption.PrivateTags = map[string]string{"diary": "personal"}
+	t.Setenv("MARKATA_GO_ENCRYPTION_KEY_PERSONAL", "h7Qm!2Vx9#Lp4@Td")
+	path := writeMarkdownFile(t, `---
+title: Diary
+tags:
+  - diary
+---
+tagged secret
+`)
+
+	result, err := encryptPostSourceFile(path, cfg, false)
+	if err != nil {
+		t.Fatalf("encryptPostSourceFile() error = %v", err)
+	}
+	if result.KeyName != "personal" {
+		t.Fatalf("key = %q, want personal", result.KeyName)
+	}
+
+	_, body, err := plugins.ExtractFrontmatter(readFileString(t, path))
+	if err != nil {
+		t.Fatalf("ExtractFrontmatter() error = %v", err)
+	}
+	_, keyName, err := encryption.DecryptSourceMarkdown(body, "h7Qm!2Vx9#Lp4@Td")
+	if err != nil {
+		t.Fatalf("DecryptSourceMarkdown() error = %v", err)
+	}
+	if keyName != "personal" {
+		t.Fatalf("encrypted marker key = %q, want personal", keyName)
+	}
+}
+
+func TestEncryptPostSourceFile_AlreadyEncryptedSkipsWithoutKey(t *testing.T) {
+	cfg := testEncryptPostsConfig()
+	encryptedBody, err := encryption.EncryptSourceMarkdown("secret body\n", "default", "h7Qm!2Vx9#Lp4@Td")
+	if err != nil {
+		t.Fatalf("EncryptSourceMarkdown() error = %v", err)
+	}
+	path := writeMarkdownFile(t, "---\ntitle: Secret\nprivate: true\n---\n"+encryptedBody)
+
+	result, err := encryptPostSourceFile(path, cfg, false)
+	if err != nil {
+		t.Fatalf("encryptPostSourceFile() error = %v", err)
+	}
+	if result.Action != encryptPostActionAlreadyEncrypted {
+		t.Fatalf("action = %q, want %q", result.Action, encryptPostActionAlreadyEncrypted)
+	}
+}
+
+func TestEncryptPostSourceFile_WeakExplicitKeyFails(t *testing.T) {
+	cfg := testEncryptPostsConfig()
+	t.Setenv("MARKATA_GO_ENCRYPTION_KEY_PERSONAL", "weak")
+	path := writeMarkdownFile(t, `---
+title: Secret
+private: true
+secret_key: personal
+---
+secret body
+`)
+
+	_, err := encryptPostSourceFile(path, cfg, true)
+	if err == nil {
+		t.Fatal("expected weak key error")
+	}
+	if !strings.Contains(err.Error(), "failed policy") {
+		t.Fatalf("expected policy error, got %v", err)
+	}
+}
+
 func writeEncryptionConfigFile(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -119,6 +253,40 @@ min_estimated_crack_time = "10y"
 		t.Fatalf("write config: %v", err)
 	}
 	return path
+}
+
+func testEncryptPostsConfig() *models.Config {
+	return &models.Config{
+		GlobConfig: models.GlobConfig{
+			Patterns:     []string{"**/*.md"},
+			UseGitignore: true,
+		},
+		Encryption: models.EncryptionConfig{
+			Enabled:               true,
+			DefaultKey:            "default",
+			EnforceStrength:       true,
+			MinPasswordLength:     14,
+			MinEstimatedCrackTime: "10y",
+		},
+	}
+}
+
+func writeMarkdownFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "post.md")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write markdown: %v", err)
+	}
+	return path
+}
+
+func readFileString(t *testing.T, path string) string {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(content)
 }
 
 func TestFormatCrackDurationHuman(t *testing.T) {

--- a/docs/guides/encryption.md
+++ b/docs/guides/encryption.md
@@ -144,11 +144,36 @@ markata-go encryption generate-password
 markata-go encryption generate-password --length 20
 markata-go encryption check
 markata-go encryption check --key default
+markata-go encryption encrypt-posts --dry-run
+markata-go encryption encrypt-posts
 ```
 
 The command prints only the password to stdout, making it easy to pipe into your `.env` file or a password manager. The optional `--length` flag requests a longer password (it must be at least the configured `min_password_length`). The generated password already meets the default crack-time and length thresholds.
 
 `encryption check` validates configured keys against your active policy and exits non-zero when a key is missing or weak. By default it checks every key referenced by `default_key` and `private_tags`.
+
+### Source-Encrypt Private Posts
+
+Use `encrypt-posts` to rewrite private Markdown files so the body is encrypted at rest in your source repository:
+
+```
+markata-go encryption encrypt-posts --dry-run
+markata-go encryption encrypt-posts
+```
+
+The command scans files matched by your active `glob.patterns`, then encrypts posts marked `private: true` or matched by `encryption.private_tags`. It skips draft, skipped, public, and already source-encrypted posts. `--dry-run` reports what would be encrypted without modifying files.
+
+Missing or weak keys fail before any files are written. The encrypted source keeps frontmatter readable and replaces only the Markdown body with a marker and ciphertext:
+
+```markdown
+---
+title: My Secret Post
+private: true
+---
+
+<!-- markata-encrypted-source:v1 key=default -->
+BASE64_AES_GCM_CIPHERTEXT
+```
 
 ## Lint Rule
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1901,6 +1901,30 @@ markata-go encryption check [--key <name>]
 By default this command checks all keys referenced by `encryption.default_key` and `encryption.private_tags`.
 It fails with a non-zero exit code if any key is missing from environment variables or too weak for the configured policy.
 
+##### encrypt-posts
+
+Encrypt all private Markdown source bodies matched by the active content glob configuration.
+
+```
+markata-go encryption encrypt-posts [--dry-run]
+```
+
+| Flag | Short | Description | Default |
+|------|-------|-------------|---------|
+| `--dry-run` | | Report files that would be encrypted without modifying them | `false` |
+
+The command rewrites matching private posts in place by default. It skips draft, skipped, public, and already source-encrypted posts. Missing or weak keys fail before any files are written.
+
+#### Examples
+
+```
+# Preview source encryption changes
+markata-go encryption encrypt-posts --dry-run
+
+# Encrypt private post source bodies in place
+markata-go encryption encrypt-posts
+```
+
 ---
 
 ## See Also

--- a/pkg/agentskill/bundle/markata-go-site/topics/cli-usage.md
+++ b/pkg/agentskill/bundle/markata-go-site/topics/cli-usage.md
@@ -59,6 +59,13 @@ Bare `markata-go config` behaves like `markata-go config show`.
 - `markata-go lint --fix` (auto-fix fixable issues)
 - `markata-go lint --dry-run` (show files without linting)
 
+### Encryption
+
+- `markata-go encryption generate-password` (generate a policy-compliant password)
+- `markata-go encryption check` (verify configured encryption keys)
+- `markata-go encryption encrypt-posts --dry-run` (preview source encryption for private posts)
+- `markata-go encryption encrypt-posts` (encrypt private Markdown bodies in place)
+
 ### Theme And Palette
 
 - `markata-go palette list`
@@ -137,6 +144,7 @@ markata-go build -o dist
 markata-go new "My Post" --no-input
 markata-go build -v
 markata-go lint --fix
+markata-go encryption encrypt-posts --dry-run
 ```
 
 ## What To Use When
@@ -147,6 +155,7 @@ markata-go lint --fix
 - inspect resolved configuration: `markata-go config show`
 - create new content: `markata-go new`
 - lint content before committing: `markata-go lint`
+- source-encrypt private Markdown before committing: `markata-go encryption encrypt-posts --dry-run`, then `markata-go encryption encrypt-posts`
 - validate config before deploy: `markata-go config validate`
 - validate palette contrast: `markata-go palette check <name>`
 - interactive local editing: `markata-go serve --fast`
@@ -165,6 +174,7 @@ markata-go lint --fix
 - use `--no-input` for automation or when the agent must avoid prompts
 - use `-v` when debugging plugin order, missing outputs, or config resolution issues
 - use `--dry-run` on build or lint to preview behavior without side effects
+- use `encryption encrypt-posts --dry-run` before rewriting private source files; make sure required `MARKATA_GO_ENCRYPTION_KEY_*` environment variables are set first
 
 ## Guidance
 


### PR DESCRIPTION
## Summary

- add `markata-go encryption encrypt-posts` with `--dry-run` for private Markdown source encryption
- validate configured and per-post keys before rewriting files
- document the workflow in encryption docs, CLI reference, and bundled site skill CLI guidance

Fixes follow-up to #1110

## Validation
- go test ./cmd/markata-go/cmd -run 'Test(GeneratePassword|CheckPassword|EncryptPost|FormatCrack)' -count=1
- go test ./...
- go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run --timeout=5m