### PR TITLE
fix/web awesome

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches:
       - main
+      - "markata/**"
+      - "perf/**"
+      - "dev/**"
     tags:
       - "v*"
   pull_request:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -530,6 +530,14 @@ go tool pprof -http=:8080 /tmp/cpu.prof
 go tool pprof -top /tmp/mem.prof
 ```
 
+### Benchmark Prerequisites For Real Sites
+
+- If the target site uses encrypted/private posts, benchmark commands must either:
+  - provide the required `MARKATA_GO_ENCRYPTION_KEY_*` environment variables, or
+  - explicitly disable encryption for both baseline and candidate runs with `MARKATA_GO_ENCRYPTION_ENABLED=false`
+- Do not assume the benchmark shell has access to a developer's local secrets or `.env` loader.
+- When encryption is disabled to unblock local measurements, call that out in the benchmark report so comparisons are interpreted correctly.
+
 The lifecycle timing instrumentation in `hooks.go` logs any plugin taking >50ms. This is a permanent feature -- use these logs to identify bottlenecks.
 
 ### Plugin Caching Pattern

--- a/benchmarks/waylonwalker_author_loop_2026-06-26.md
+++ b/benchmarks/waylonwalker_author_loop_2026-06-26.md
@@ -1,0 +1,30 @@
+# waylonwalker.com author loop benchmark (2026-06-26)
+
+Baseline commit: `d7a64eb` with no working-tree changes
+Candidate: current `markata/go-perf` working tree
+Site: `../waylonwalker.com`
+Command shape: `MARKATA_GO_BLOGROLL_ENABLED=false MARKATA_GO_ENCRYPTION_ENABLED=false markata-go build --fast -m fast.toml`
+
+## Method
+
+- Built a clean baseline binary from a detached worktree at `HEAD`.
+- Built a candidate binary from the current working tree.
+- For cold and warm timings, removed `output`, `cache`, `.markata`, `.markata-cache`, and `.markata.cache` before the first run.
+- For changed-post timings, primed the cache, appended a temporary HTML comment to `pages/blog/ai.md`, ran one build, and restored the file.
+
+## Results
+
+| Scenario | Baseline | Candidate | Delta |
+| --- | ---: | ---: | ---: |
+| Cold | 2.18s | 1.74s | -20.2% |
+| Warm 1 | 0.42s | 0.41s | -2.4% |
+| Warm 2 | 0.42s | 0.40s | -4.8% |
+| Changed post | 0.49s | 0.52s | +6.1% |
+
+## Notes
+
+- The biggest measured gain in this pass is lower cold-start overhead on the fast authoring config.
+- Unchanged warm builds stayed roughly flat while remaining very fast.
+- The changed-post delta is within noise for this small sample and should not be treated as a confirmed regression without repeated runs.
+- Dominant hotspots during these runs were still `cdn_assets`, `link_avatars`, `render_markdown`, `tailwind`, and feed/listing writes after content edits.
+- No live in-cluster timing was captured in this note.

--- a/cmd/markata-go/cmd/build.go
+++ b/cmd/markata-go/cmd/build.go
@@ -309,6 +309,7 @@ func printBuildBenchmarkSummary(summary buildstats.Summary) {
 
 	hotspots := topHotspots(summary.Hotspots, 5)
 	if len(hotspots) == 0 {
+		printNetworkRequestSummary(summary.Requests)
 		return
 	}
 
@@ -316,6 +317,8 @@ func printBuildBenchmarkSummary(summary buildstats.Summary) {
 	for _, hotspot := range hotspots {
 		outlnf("    %s %s", hotspotKey(hotspot.Stage, hotspot.Plugin), formatDuration(hotspot.Duration))
 	}
+
+	printNetworkRequestSummary(summary.Requests)
 }
 
 func printResourceLine(label string, duration, total time.Duration) {
@@ -363,6 +366,16 @@ func topHotspots(hotspots []buildstats.Hotspot, limit int) []buildstats.Hotspot 
 	return hotspots[:limit]
 }
 
+func topRequests(requests []buildstats.RequestTiming, limit int) []buildstats.RequestTiming {
+	if len(requests) == 0 || limit <= 0 {
+		return nil
+	}
+	if len(requests) < limit {
+		limit = len(requests)
+	}
+	return requests[:limit]
+}
+
 func formatDuration(duration time.Duration) string {
 	text := duration.Round(10 * time.Millisecond).String()
 	if text != "0s" && strings.HasSuffix(text, "0s") {
@@ -380,6 +393,36 @@ func percent(duration, total time.Duration) float64 {
 
 func hotspotKey(stage, plugin string) string {
 	return colorizeOutput(stage+"/"+plugin, stageThemeColor(stage))
+}
+
+func printNetworkRequestSummary(requests []buildstats.RequestTiming) {
+	requests = topRequests(requests, 10)
+	if len(requests) == 0 {
+		return
+	}
+
+	outlnf("  %s", buildLabel("Slowest requests:"))
+	for _, request := range requests {
+		outlnf("    %s %s %s", requestKey(request), formatDuration(request.Duration), requestStatus(request))
+	}
+}
+
+func requestKey(request buildstats.RequestTiming) string {
+	plugin := hotspotKey(request.Stage, request.Plugin)
+	if request.Plugin == "" {
+		plugin = colorizeOutput(request.Stage, stageThemeColor(request.Stage))
+	}
+	return plugin + " " + request.Method + " " + request.URL
+}
+
+func requestStatus(request buildstats.RequestTiming) string {
+	if request.Error != "" {
+		return "(" + request.Error + ")"
+	}
+	if request.Status > 0 {
+		return fmt.Sprintf("(HTTP %d)", request.Status)
+	}
+	return ""
 }
 
 func buildLabel(name string) string {

--- a/cmd/markata-go/cmd/builder_admin.go
+++ b/cmd/markata-go/cmd/builder_admin.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/WaylonWalker/markata-go/pkg/builderadmin"
+	"github.com/spf13/cobra"
+)
+
+var (
+	builderAdminHost                 string
+	builderAdminPort                 int
+	builderAdminSourceDir            string
+	builderAdminSiteDir              string
+	builderAdminCacheMount           string
+	builderAdminHistoryDir           string
+	builderAdminWatch                bool
+	builderAdminWatchDebounce        time.Duration
+	builderAdminFast                 bool
+	builderAdminMermaidMode          string
+	builderAdminReleasesKeep         int
+	builderAdminSuccessfulBuildsKeep int
+	builderAdminFailedBuildsKeep     int
+	builderAdminRefreshRunsKeep      int
+	builderAdminBuildTimeout         time.Duration
+	builderAdminRefreshTaskSpecs     []string
+)
+
+var builderAdminCmd = &cobra.Command{
+	Use:   "builder-admin",
+	Short: "Run the long-lived builder admin HTTP service",
+	Long: `Run the long-lived builder admin HTTP service.
+
+The service keeps a warm build worker running for hostPath and Kubernetes authoring loops.
+It exposes a queue-driven UI/API for builds, logs, releases, rollback, and scheduled refresh tasks.`,
+	RunE: runBuilderAdmin,
+}
+
+func init() {
+	rootCmd.AddCommand(builderAdminCmd)
+	builderAdminCmd.Flags().StringVar(&builderAdminHost, "host", "127.0.0.1", "host to bind to")
+	builderAdminCmd.Flags().IntVar(&builderAdminPort, "port", 8080, "port to listen on")
+	builderAdminCmd.Flags().StringVar(&builderAdminSourceDir, "source-dir", ".", "source directory to watch and build from")
+	builderAdminCmd.Flags().StringVar(&builderAdminSiteDir, "site-dir", "public", "site root that contains releases/ and current")
+	builderAdminCmd.Flags().StringVar(&builderAdminCacheMount, "cache-mount", "", "optional dedicated cache mount for .markata symlinks")
+	builderAdminCmd.Flags().StringVar(&builderAdminHistoryDir, "history-dir", "", "directory for persisted builder-admin state and logs")
+	builderAdminCmd.Flags().BoolVar(&builderAdminWatch, "watch", true, "enable recursive file watching")
+	builderAdminCmd.Flags().DurationVar(&builderAdminWatchDebounce, "watch-debounce", 2*time.Second, "debounce window for file-watch rebuilds")
+	builderAdminCmd.Flags().BoolVar(&builderAdminFast, "fast", false, "run queued builds with --fast")
+	builderAdminCmd.Flags().StringVar(&builderAdminMermaidMode, "mermaid-mode", "", "override [markata-go.mermaid].mode for queued builds")
+	builderAdminCmd.Flags().IntVar(&builderAdminReleasesKeep, "releases-keep", 10, "number of rendered releases to keep")
+	builderAdminCmd.Flags().IntVar(&builderAdminSuccessfulBuildsKeep, "successful-builds-keep", 50, "number of successful build records to keep")
+	builderAdminCmd.Flags().IntVar(&builderAdminFailedBuildsKeep, "failed-builds-keep", 100, "number of failed build records to keep")
+	builderAdminCmd.Flags().IntVar(&builderAdminRefreshRunsKeep, "refresh-runs-keep", 100, "number of refresh run records to keep")
+	builderAdminCmd.Flags().DurationVar(&builderAdminBuildTimeout, "build-timeout", 2*time.Hour, "maximum runtime for a queued build or refresh task")
+	builderAdminCmd.Flags().StringArrayVar(&builderAdminRefreshTaskSpecs, "refresh-task", nil, "repeatable task spec: name|every|enqueue|arg1|arg2...")
+}
+
+func runBuilderAdmin(_ *cobra.Command, _ []string) error {
+	refreshTasks, err := parseRefreshTasks(builderAdminRefreshTaskSpecs)
+	if err != nil {
+		return err
+	}
+	svc, err := builderadmin.New(builderadmin.Config{
+		Host:                 builderAdminHost,
+		Port:                 builderAdminPort,
+		SourceDir:            builderAdminSourceDir,
+		SiteDir:              builderAdminSiteDir,
+		ConfigPath:           cfgFile,
+		CacheMount:           builderAdminCacheMount,
+		HistoryDir:           builderAdminHistoryDir,
+		WatchEnabled:         builderAdminWatch,
+		WatchDebounce:        builderAdminWatchDebounce,
+		Fast:                 builderAdminFast,
+		MermaidMode:          builderAdminMermaidMode,
+		ReleasesKeep:         builderAdminReleasesKeep,
+		SuccessfulBuildsKeep: builderAdminSuccessfulBuildsKeep,
+		FailedBuildsKeep:     builderAdminFailedBuildsKeep,
+		RefreshRunsKeep:      builderAdminRefreshRunsKeep,
+		RefreshTasks:         refreshTasks,
+		BuildTimeout:         builderAdminBuildTimeout,
+	})
+	if err != nil {
+		return err
+	}
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+	return svc.Start(ctx)
+}
+
+func parseRefreshTasks(specs []string) ([]builderadmin.RefreshTaskConfig, error) {
+	tasks := make([]builderadmin.RefreshTaskConfig, 0, len(specs))
+	for _, spec := range specs {
+		parts := strings.Split(spec, "|")
+		if len(parts) < 4 {
+			return nil, fmt.Errorf("invalid --refresh-task %q: expected name|every|enqueue|arg1|arg2...", spec)
+		}
+		enqueue := strings.EqualFold(parts[2], "true") || parts[2] == "1" || strings.EqualFold(parts[2], "yes")
+		tasks = append(tasks, builderadmin.RefreshTaskConfig{
+			Name:                  parts[0],
+			Every:                 parts[1],
+			EnqueueBuildOnSuccess: enqueue,
+			Args:                  append([]string(nil), parts[3:]...),
+		})
+	}
+	return tasks, nil
+}

--- a/cmd/markata-go/cmd/core_test.go
+++ b/cmd/markata-go/cmd/core_test.go
@@ -73,6 +73,9 @@ func TestPrintBuildResult_IncludesBenchmarkSummary(t *testing.T) {
 				{Stage: "collect", Plugin: "blogroll", Duration: 3 * time.Second},
 				{Stage: "render", Plugin: "link_avatars", Duration: 2 * time.Second},
 			},
+			Requests: []buildstats.RequestTiming{
+				{Stage: "collect", Plugin: "blogroll", Method: "GET", URL: "https://example.com/feed.xml", Duration: 4 * time.Second, Status: 200},
+			},
 		},
 	})
 
@@ -90,6 +93,8 @@ func TestPrintBuildResult_IncludesBenchmarkSummary(t *testing.T) {
 		"Hotspots:",
 		"collect/blogroll",
 		"render/link_avatars",
+		"Slowest requests:",
+		"GET https://example.com/feed.xml",
 		"Duration: 9.87s",
 	} {
 		if !strings.Contains(output, want) {

--- a/docs/guides/blogroll.md
+++ b/docs/guides/blogroll.md
@@ -582,16 +582,18 @@ The blogroll plugin caches fetched feeds to avoid hitting external servers on ev
 [markata-go.blogroll]
 cache_dir = "cache/blogroll"    # Cache directory
 cache_duration = "24h"          # How long to cache feeds
+refresh_on_build = false         # Reuse cache during builds; refresh with `reader update`
 ```
 
 ### Cache Behavior
 
-1. On first build, all feeds are fetched and cached
-2. On subsequent builds, cached feeds are used until `cache_duration` expires
-3. Expiration is based on the cached feed's recorded fetch time, not file mtimes
-4. If a refresh fails, the stale cached feed is reused instead of failing open
-5. Explicit config overrides like `title`, `description`, `site_url`, `image_url`, `handle`, aliases, category, and tags are reapplied even when cached feed data is reused
-6. Delete `cache/blogroll/` to force a fresh fetch
+1. `markata-go reader update` is the explicit cache refresh command for blogroll and reader feeds
+2. When `refresh_on_build = false`, normal builds reuse cached feed data and do not make remote refresh requests
+3. When `refresh_on_build = true`, builds use cached feeds until `cache_duration` expires, then refresh as needed
+4. Expiration is based on the cached feed's recorded fetch time, not file mtimes
+5. If a refresh fails, the stale cached feed is reused instead of failing open
+6. Explicit config overrides like `title`, `description`, `site_url`, `image_url`, `handle`, aliases, category, and tags are reapplied even when cached feed data is reused
+7. Delete `cache/blogroll/` to force a fresh fetch
 
 ### Cache Duration Examples
 
@@ -834,6 +836,7 @@ max_entries = 50              # Override global max_entries_per_feed
 | `enabled` | bool | `false` | Enable blogroll plugin |
 | `cache_dir` | string | `"cache/blogroll"` | Cache directory |
 | `cache_duration` | string | `"24h"` | Cache TTL (Go duration) |
+| `refresh_on_build` | bool | `false` | Allow builds to refresh remote blogroll feeds |
 | `timeout` | int | `30` | HTTP timeout in seconds |
 | `concurrent_requests` | int | `5` | Max parallel fetches |
 | `max_entries_per_feed` | int | `50` | Global max entries per feed |
@@ -849,9 +852,32 @@ max_entries = 50              # Override global max_entries_per_feed
 
 ## Fast Builds During Development
 
-When working on large sites with many blogroll feeds, fetching external feeds on every build can significantly slow down development. You can use environment variables to temporarily disable the blogroll for faster builds:
+When working on large sites with many blogroll feeds, the best default is usually to keep blogroll pages enabled while separating refresh from normal builds.
 
-### Disable Blogroll via Environment Variable
+### Keep Blogroll Pages, Skip Refresh During Builds
+
+```toml
+[markata-go.blogroll]
+enabled = true
+refresh_on_build = false
+```
+
+Then refresh on demand:
+
+```bash
+markata-go reader update
+markata-go build
+```
+
+For one-off runs, you can also set:
+
+```bash
+MARKATA_GO_BLOGROLL_REFRESH_ON_BUILD=false markata-go build
+```
+
+If you want the smallest possible loop, you can still disable the plugin entirely:
+
+### Disable Blogroll Via Environment Variable
 
 ```bash
 # Build without fetching blogroll feeds

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -1433,6 +1433,7 @@ refresh attempts fail.
 | `enabled` | bool | `false` | Enable blogroll plugin |
 | `cache_dir` | string | `"cache/blogroll"` | Cache directory |
 | `cache_duration` | string | `"24h"` | Cache TTL (Go duration format) |
+| `refresh_on_build` | bool | `false` | Allow normal builds to refresh blogroll feeds over the network |
 | `timeout` | int | `30` | HTTP timeout in seconds |
 | `concurrent_requests` | int | `5` | Max parallel feed fetches |
 | `max_entries_per_feed` | int | `50` | Max entries per feed |
@@ -1443,6 +1444,7 @@ refresh attempts fail.
 enabled = true
 cache_dir = "cache/blogroll"
 cache_duration = "24h"
+refresh_on_build = false
 timeout = 30
 concurrent_requests = 5
 max_entries_per_feed = 50
@@ -1947,8 +1949,8 @@ Create a `fast-markata-go.toml` for quick development builds:
 glob_patterns = ["posts/draft-*.md"]
 
 [markata-go.blogroll]
-# Disable blogroll for faster builds
-enabled = false
+# Keep blogroll pages but refresh them separately
+refresh_on_build = false
 ```
 
 Use it with:

--- a/docs/guides/deployment/builder-admin.md
+++ b/docs/guides/deployment/builder-admin.md
@@ -1,0 +1,115 @@
+---
+title: "Builder Admin"
+description: "Run a long-lived builder admin service for fast Kubernetes authoring loops"
+date: 2026-06-27
+published: true
+tags:
+  - documentation
+  - deployment
+  - kubernetes
+  - performance
+---
+
+# Builder Admin
+
+The builder admin service keeps a warm markata-go build worker running inside your cluster.
+
+Instead of starting a new Kubernetes Job for every authoring build, it keeps one HTTP service alive with:
+
+- a serialized build queue
+- file watching that enqueues builds
+- build history and full raw logs
+- release history and current live release
+- rollback by promoting an older rendered release
+- scheduled refresh tasks for reader, blogroll, or other remote-content commands
+
+## What It Is Good For
+
+Use builder admin when:
+
+- your site content already lives on a mounted filesystem such as a hostPath
+- you care about fast authoring loops more than one-shot batch builds
+- you want an operator UI for builds and releases
+- you want remote-content refreshes to stay decoupled from normal content builds
+
+## Basic Helm Values
+
+```yaml
+builderAdmin:
+  enabled: true
+  port: 8080
+  watch:
+    enabled: true
+    debounce: 2s
+  releases:
+    keep: 10
+  history:
+    successfulBuilds: 50
+    failedBuilds: 100
+    refreshRuns: 100
+  refreshTasks:
+    - name: reader-update
+      every: 30m
+      enqueueBuildOnSuccess: true
+      args:
+        - markata-go
+        - --config
+        - /data/source/markata-go.toml
+        - reader
+        - update
+```
+
+## Accessing The UI
+
+The first version is designed to work well with `kubectl port-forward`.
+
+```bash
+kubectl port-forward svc/go-waylonwalker-com-notes-builder-admin 8080:8080 -n go-waylonwalker-com-notes
+```
+
+Then open:
+
+```text
+http://localhost:8080
+```
+
+## What You Can See
+
+The UI shows:
+
+- queued and running builds
+- recent successful and failed builds
+- the trigger source for each build
+- per-build duration and phase timings
+- full raw logs
+- parsed markata-go performance summary lines
+- current live release
+- old releases that can be promoted back to live
+- refresh task history
+
+## Build Triggers
+
+Builder admin can enqueue builds from:
+
+- the UI
+- HTTP API calls
+- debounced file-watch events
+- successful refresh task runs when configured to enqueue a build
+
+## Rollback
+
+Rollback in the first version promotes a previous rendered release by repointing the `current` symlink.
+
+This is fast and keeps the release model simple, but it does not restore the historical source tree.
+
+## Scheduled Refresh Tasks
+
+Refresh tasks are external commands that run on an interval.
+
+Examples:
+
+- `markata-go reader update`
+- `markata-go blogroll update --force`
+- a custom remote-asset fetch command
+
+Use them to keep reader/blogroll data or other remote caches fresh without slowing down every normal content build.

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -69,6 +69,7 @@ The default `markata-go build` summary now includes two fast feedback signals:
 
 - **Resource profile** - estimated wall-time spent on CPU work, network wait, disk read wait, disk write wait, and idle time
 - **Hotspots** - the slowest lifecycle plugin hooks from that build
+- **Slowest requests** - the longest outbound HTTP requests with plugin attribution
 
 Example:
 
@@ -84,15 +85,42 @@ Build completed successfully!
     collect/blogroll 31.77s
     cleanup/pagefind 26.32s
     write/publish_feeds 8.54s
+  Slowest requests:
+    collect/blogroll GET https://example.com/feed.xml 12.40s (HTTP 200)
+    transform/mentions GET https://slow.example.com/ 6.80s (context deadline exceeded)
 ```
 
 Use this summary to decide what tool to reach for next:
 
 - mostly `CPU` -> capture a CPU profile with `just perf-profile`
-- mostly `Network wait` -> inspect plugins that fetch remote content or external metadata
+- mostly `Network wait` -> inspect `Slowest requests` first, then the owning plugins that fetch remote content or external metadata
 - mostly `Disk read` -> inspect globbing, cache loads, index reads, and wide content scans
 - mostly `Disk write` -> inspect publishing, cache saves, index generation, and emitted static output
 - mostly `Idle` -> look for subprocess waits, scheduler gaps, or work that is happening outside the Go process
+
+### Concrete Flow For Real Site Builds
+
+Use this flow when you want to answer "what feature is slowing this build down?"
+
+1. Run a build that matches the feature set you care about.
+   - for the everyday dev loop, use `markata-go build --fast`
+   - for real feature attribution, run the full build without `--fast`
+2. Read the footer in this order:
+   - `Resource profile` tells you whether the build is mostly CPU, network, disk read, or disk write bound
+   - `Hotspots` tells you which plugin hooks are slow overall
+   - `Slowest requests` tells you which exact network calls dominated wall time
+3. If `Slowest requests` points to one plugin repeatedly, fix that plugin first.
+   - add or verify cache reuse
+   - reduce duplicate fetches
+   - batch requests or lower request count
+   - make timeouts and concurrency explicit
+4. Export structured data when you need a diffable artifact:
+
+```bash
+markata-go build --benchmark-json benchmark.json
+```
+
+5. If the build is still mostly CPU after network fixes, capture `--cpuprofile` and inspect the hottest functions with `go tool pprof`.
 
 ### JSON Benchmarks
 
@@ -109,6 +137,7 @@ The JSON output includes:
 - whole-build resource totals
 - per-stage timings and per-stage estimated resources
 - plugin timing entries used for hotspot ranking
+- request timing entries used for the slowest-request list
 - build counts and warnings
 
 ### Per-Stage Detail

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -96,6 +96,8 @@ Use this summary to decide what tool to reach for next:
 - mostly `Network wait` -> inspect `Slowest requests` first, then the owning plugins that fetch remote content or external metadata
 - mostly `Disk read` -> inspect globbing, cache loads, index reads, and wide content scans
 - mostly `Disk write` -> inspect publishing, cache saves, index generation, and emitted static output
+- if `configure/build_cache` is hot on warm builds, check whether the template or config tree actually changed; unchanged template trees now reuse a cheap fingerprint before falling back to a full content hash
+- if `/tags` or `/garden` hashing is hot, prefer cached per-post semantic hashes over re-deriving the same per-post summaries inside the listing hashers
 - mostly `Idle` -> look for subprocess waits, scheduler gaps, or work that is happening outside the Go process
 
 ### Concrete Flow For Real Site Builds

--- a/docs/guides/webawesome.md
+++ b/docs/guides/webawesome.md
@@ -168,7 +168,9 @@ Use carousels for screenshot galleries or visual changelogs.
 ```markdown
 ::: wa-carousel {navigation="true" pagination="true"}
 ![First screenshot](/images/one.webp)
+First screenshot caption
 ![Second screenshot](/images/two.webp)
+Second screenshot caption
 :::
 ```
 
@@ -186,7 +188,7 @@ Use animated images to give readers play and pause controls for GIF or animated 
 :::
 ```
 
-The longer `::: webawesome comparison` form remains supported as an alias, but `wa-*` is the recommended authoring style.
+The longer `::: webawesome comparison` form remains supported as an alias, but `wa-*` is the recommended authoring style. You can combine Web Awesome container classes with layout or utility classes; for example, a rendered container with `class="not-prose wa-carousel"` is still detected and converted.
 
 ```markdown
 ::: webawesome comparison {position=65}
@@ -221,7 +223,7 @@ If you prefer to load assets from a CDN instead of self-hosting, set `source = "
 [markata-go.webawesome]
 source = "cdn"
 version = "3.5.0"
-# cdn_base_url defaults to https://cdn.jsdelivr.net/npm/@awesome.me/webawesome@<version>/dist
+# cdn_base_url defaults to https://cdn.jsdelivr.net/npm/@awesome.me/webawesome@<version>/dist-cdn
 ```
 
 Self-hosting (the default) is recommended when your site must build without external CDN dependencies, when your privacy policy avoids third-party asset requests, or when you want stable, immutable component versions tied to your repo. You can prefetch the shared asset cache with `markata-go assets download`.
@@ -238,6 +240,6 @@ Raw Web Awesome HTML works too. Any page containing a `<wa-*>` element automatic
 
 ## Component Loading
 
-Pages that use any `wa-*` element automatically get the Web Awesome stylesheet and the Web Awesome autoloader. The autoloader watches the document for `<wa-*>` tags and lazy-imports the matching component modules on demand, so each page only downloads what it actually uses. Pages without `wa-*` elements do not load Web Awesome CSS or JavaScript.
+Pages that use any `wa-*` element automatically get the Web Awesome stylesheet and initialized Web Awesome autoloader. The built-in template imports `webawesome.loader.js`, sets the configured base path, and calls `startLoader()` so the autoloader watches the document for `<wa-*>` tags and lazy-imports the matching component modules on demand. Each page only downloads what it actually uses. Pages without `wa-*` elements do not load Web Awesome CSS or JavaScript.
 
-When `source = "vendor"`, the theme stylesheet and autoloader are served from your site under `output_dir` (for example `/assets/vendor/webawesome/styles/themes/default.css` and `/assets/vendor/webawesome/webawesome.loader.js`). The focused theme stylesheet avoids Web Awesome's global native-element styles so normal site typography and link styling stay unchanged. These files come from the npm tarball downloaded through the shared `[markata-go.assets]` cache/output pipeline. When `source = "cdn"`, they are served from `https://cdn.jsdelivr.net/npm/@awesome.me/webawesome@VERSION/dist/`.
+When `source = "vendor"`, the theme stylesheet and autoloader are served from your site under `output_dir` (for example `/assets/vendor/webawesome/styles/themes/default.css` and `/assets/vendor/webawesome/webawesome.loader.js`). The focused theme stylesheet avoids Web Awesome's global native-element styles so normal site typography and link styling stay unchanged. These files come from the npm tarball downloaded through the shared `[markata-go.assets]` cache/output pipeline. When `source = "cdn"`, they are served from the browser-ready `https://cdn.jsdelivr.net/npm/@awesome.me/webawesome@VERSION/dist-cdn/` subtree.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -294,12 +294,15 @@ Successful builds also print a compact benchmark summary with:
 
 - estimated wall-time spent on CPU work, network wait, disk read wait, disk write wait, and idle time
 - the slowest lifecycle hotspots so you can spot expensive plugins quickly
+- the slowest outbound HTTP requests so network-bound plugins stop hiding in aggregate wait time
 
 For deeper analysis:
 
 - `markata-go build --benchmark-json benchmark.json` writes machine-readable benchmark data to a file
 - `markata-go build --benchmark-json -` writes only the benchmark JSON to stdout
 - `markata-go build -v --benchmark-detailed` adds per-stage resource summaries to the build footer
+
+When requests are present, the footer prints the 10 slowest network waits with stage, plugin, method, sanitized URL, duration, and either HTTP status or the request error.
 
 The resource profile is approximate. It is intended for local hotspot hunting, not precise system profiling.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -264,6 +264,50 @@ markata-go build -c production.toml
 markata-go build --clean -v -o dist
 ```
 
+### builder-admin
+
+Run the long-lived builder admin HTTP service for Kubernetes and authoring workflows.
+
+#### Usage
+
+```bash
+markata-go builder-admin [flags]
+```
+
+#### Flags
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--host` | Host to bind to | `127.0.0.1` |
+| `--port` | Port to listen on | `8080` |
+| `--source-dir` | Mounted source directory to watch and build from | `.` |
+| `--site-dir` | Mounted site root that contains `releases/` and `current` | `public` |
+| `--watch` | Enable recursive file watching and queued rebuilds | `true` |
+| `--watch-debounce` | Debounce window for coalescing file changes | `2s` |
+| `--fast` | Use `markata-go build --fast` for queued builds | `false` |
+| `--mermaid-mode` | Override `[markata-go.mermaid].mode` for queued builds | `""` |
+| `--cache-mount` | Optional dedicated cache mount used for `.markata` and `.markata-cache` symlinks | `""` |
+| `--history-dir` | Directory for persisted admin state and logs | `<site-dir>/.builder-admin` |
+| `--releases-keep` | Number of rendered releases to keep on disk | `10` |
+| `--refresh-task` | Repeatable task spec in the form `name|every|enqueue|arg1|arg2...` | none |
+
+#### Examples
+
+```bash
+# Run locally against mounted source and site paths
+markata-go builder-admin \
+  --config /data/source/markata-go.toml \
+  --source-dir /data/source \
+  --site-dir /data/site \
+  --cache-mount /data/cache \
+  --fast \
+  --watch
+
+# Add a scheduled reader refresh that enqueues a build when complete
+markata-go builder-admin \
+  --refresh-task 'reader-update|30m|true|markata-go|--config|/data/source/markata-go.toml|reader|update'
+```
+
 #### Exit Codes
 
 | Code | Description |

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -4055,11 +4055,13 @@ When `source = "vendor"`, the plugin downloads Web Awesome through the shared `[
 
 **Markdown syntax:**
 ```markdown
-::: webawesome comparison {position=42 caption="Before and after"}
+::: wa-comparison {position=42 caption="Before and after"}
 ![Before](/images/before.webp)
 ![After](/images/after.webp)
 :::
 ```
+
+The longer `::: webawesome comparison` alias is also supported. Web Awesome classes can be combined with other container classes; detection treats `wa-*` or `webawesome <component>` as class tokens rather than requiring them to appear first.
 
 See the [[webawesome-components|Web Awesome Components]] guide for demos and self-hosting details.
 

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -14,9 +14,11 @@ This chart deploys a reusable markata-go notes workload that:
 - Set `MARKATA_GO_SOURCE_ARCHIVE_ENCRYPT=true` when publishing if you want the uploaded archive encrypted with `MARKATA_GO_ENCRYPTION_KEY_DEFAULT`.
 - The search pod runs `markata-go search-server --mode watch-content --host 0.0.0.0` so bleve stays in sync when the source PVC changes.
 - The search pod now waits for the source PVC to be populated before starting, which avoids booting against an empty archive mount and indexing `0 posts`.
+- Site and search probes now check every 5s instead of every 10s, which trims rollout and restart latency without making the health checks brittle.
 - Runtime pods use a dedicated ServiceAccount with `automountServiceAccountToken: false`, disable service links, and apply `RuntimeDefault` seccomp with stricter container security settings where they are low risk.
 - A NetworkPolicy now limits runtime pod egress to cluster DNS, so the site and search pods cannot freely call other cluster services by default.
 - The build CronJob uses a source PVC lock by default so overlapping manual jobs cannot update the shared source and site PVCs at the same time.
+- Default lock polling and search debounce values are intentionally short (`2s`) so the feedback loop feels tighter when a developer triggers back-to-back builds or restarts the search pod.
 - The build CronJob now overrides `[markata-go.mermaid].mode` to `client` by default, which avoids Chromium hangs seen in-cluster; set `build.mermaid.mode` back to `chromium` or `""` if you want to rely on the source repo config instead.
 - If your new namespace does not already have `aws-default`, enable `aws.sealedSecret` and provide sealed credentials in values.
 - By default the chart reuses a shared `markata-go-encryption` Secret name for `MARKATA_GO_ENCRYPTION_KEY_DEFAULT`; override `markataEncryption.secretName` only if your established secret uses a different name.
@@ -133,6 +135,15 @@ storage:
 ```
 
 This mode is node-local. The chart does not add any scheduling guard, so make sure the workloads land on a node where those paths exist.
+
+For search-heavy dev loops, you can also point the search PVC at a node-local storage class and give it a new claim suffix so it rebuilds on local disk instead of Longhorn:
+
+```yaml
+storage:
+  search:
+    storageClassName: hostpath
+    pvcNameSuffix: "-local"
+```
 
 The search deployment defaults to `Recreate` strategy because the bundled search index PVC is typically `ReadWriteOnce`, which prevents safe rolling updates across old and new pods.
 

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -157,6 +157,17 @@ build:
 
 That keeps XDG caches plus markata's `.markata` and `.markata-cache` incremental state outside the synced source tree while still letting the build recreate source-root symlinks on each run.
 
+You can also enable a best-effort build notification hook:
+
+```yaml
+build:
+  notify:
+    enabled: true
+    url: https://ntfy.example.com/topic
+```
+
+When enabled, the build CronJob posts a small result summary on success or failure. Notification failures do not fail the build.
+
 For large sites using hardlinked releases, the build job now seeds a stable work directory at `/data/site/.build-work` from `current` before running `markata-go build`. That gives incremental write stages a real on-disk baseline for unchanged files while still publishing via an atomic `current` symlink swap at the end.
 
 ```yaml

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -71,6 +71,7 @@ just push
 - `storage.source.mode` and `storage.site.mode` default to `pvc` and can be set to `hostPath` for node-local content.
 - Use `nodeSelector` when hostPath-backed content exists only on a specific node.
 - `build.cacheDir` defaults to `/data/site/.cache/xdg` so tool caches survive between builds on the site volume.
+- Enable `storage.cache` when you want a dedicated PVC for build caches. The build CronJob recreates `.markata` and `.markata-cache` in the source tree as symlinks into that cache volume, which keeps incremental state out of source sync paths.
 
 ## Offline builds
 
@@ -138,6 +139,23 @@ The search deployment defaults to `Recreate` strategy because the bundled search
 In `watch-content` mode the search server runs with `/data/search` as its working directory and uses `search.configPath` to load the site config from the mounted source tree. This keeps `.markata/cache` and the Bleve index on writable storage instead of trying to write cache files into the source hostPath.
 
 To preserve build-time tool caches between runs, keep `build.cacheDir` on persistent storage. The default points at the site volume so cached helper binaries and assets survive CronJob restarts instead of being lost with the pod `emptyDir`.
+
+For deployments that sync the source tree with `rsync --delete` or otherwise treat `/data/source` as disposable, prefer a dedicated cache volume:
+
+```yaml
+storage:
+  cache:
+    enabled: true
+    storageClassName: longhorn
+    size: 10Gi
+    accessModes:
+      - ReadWriteOnce
+
+build:
+  cacheDir: /data/cache/xdg
+```
+
+That keeps XDG caches plus markata's `.markata` and `.markata-cache` incremental state outside the synced source tree while still letting the build recreate source-root symlinks on each run.
 
 For large sites using hardlinked releases, the build job now seeds a stable work directory at `/data/site/.build-work` from `current` before running `markata-go build`. That gives incremental write stages a real on-disk baseline for unchanged files while still publishing via an atomic `current` symlink swap at the end.
 

--- a/helm-chart/templates/_helpers.tpl
+++ b/helm-chart/templates/_helpers.tpl
@@ -28,6 +28,10 @@ helm.sh/chart: "{{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }
 {{- printf "%s-notes-search%s-pvc" .Values.project_identifier (.Values.storage.search.pvcNameSuffix | default "") -}}
 {{- end -}}
 
+{{- define "markata-notes.cachePvcName" -}}
+{{- printf "%s-notes-cache%s-pvc" .Values.project_identifier (.Values.storage.cache.pvcNameSuffix | default "") -}}
+{{- end -}}
+
 {{- define "markata-notes.host" -}}
 {{- default (printf "%s.example.com" .Values.project_identifier) .Values.ingress.host -}}
 {{- end -}}

--- a/helm-chart/templates/build-cronjob.yaml
+++ b/helm-chart/templates/build-cronjob.yaml
@@ -138,6 +138,12 @@ spec:
                   }
                   trap cleanup_lock EXIT INT TERM
                   {{- end }}
+                  {{- if .Values.storage.cache.enabled }}
+                  mkdir -p {{ .Values.storage.cache.mountPath | quote }}/build {{ .Values.storage.cache.mountPath | quote }}/plugin {{ .Values.storage.cache.mountPath | quote }}/xdg
+                  rm -rf /data/source/.markata /data/source/.markata-cache
+                  ln -sfn {{ printf "%s/build" .Values.storage.cache.mountPath | quote }} /data/source/.markata
+                  ln -sfn {{ printf "%s/plugin" .Values.storage.cache.mountPath | quote }} /data/source/.markata-cache
+                  {{- end }}
                   build_work="/data/site/.build-work"
                   mkdir -p {{ .Values.build.cacheDir | quote }} /data/site/releases
                   rm -rf "${build_work}"
@@ -193,6 +199,10 @@ spec:
                   mountPath: /data/source
                 - name: site
                   mountPath: /data/site
+                {{- if .Values.storage.cache.enabled }}
+                - name: cache
+                  mountPath: {{ .Values.storage.cache.mountPath | quote }}
+                {{- end }}
           volumes:
             - name: source
               {{- if eq (.Values.storage.source.mode | default "pvc") "hostPath" }}
@@ -212,4 +222,15 @@ spec:
               persistentVolumeClaim:
                 claimName: "{{ include "markata-notes.sitePvcName" . }}"
               {{- end }}
+            {{- if .Values.storage.cache.enabled }}
+            - name: cache
+              {{- if eq (.Values.storage.cache.mode | default "pvc") "hostPath" }}
+              hostPath:
+                path: {{ .Values.storage.cache.hostPath.path | quote }}
+                type: {{ .Values.storage.cache.hostPath.type | quote }}
+              {{- else }}
+              persistentVolumeClaim:
+                claimName: "{{ include "markata-notes.cachePvcName" . }}"
+              {{- end }}
+            {{- end }}
 {{- end }}

--- a/helm-chart/templates/build-cronjob.yaml
+++ b/helm-chart/templates/build-cronjob.yaml
@@ -144,15 +144,7 @@ spec:
                     {{- if and .Values.build.notify.enabled .Values.build.notify.url }}
                     build_finished=$(date +%s)
                     elapsed_seconds=$((build_finished - build_started))
-                    message=$(cat <<EOF
-project={{ .Values.project_identifier }}
-status=${status}
-job=${HOSTNAME}
-elapsed_seconds=${elapsed_seconds}
-builder_image={{ .Values.build.builderImage.name }}:{{ .Values.build.builderImage.tag }}
-cache_dir={{ .Values.build.cacheDir }}
-EOF
-)
+                    message=$(printf 'project={{ .Values.project_identifier }}\nstatus=%s\njob=%s\nelapsed_seconds=%s\nbuilder_image={{ .Values.build.builderImage.name }}:{{ .Values.build.builderImage.tag }}\ncache_dir={{ .Values.build.cacheDir }}\n' "${status}" "${HOSTNAME}" "${elapsed_seconds}")
                     wget -qO- \
                       --timeout=10 \
                       --header="Title: {{ .Values.project_identifier }} notes build ${status}" \
@@ -184,15 +176,7 @@ EOF
                     {{- if and .Values.build.notify.enabled .Values.build.notify.url }}
                     build_finished=$(date +%s)
                     elapsed_seconds=$((build_finished - build_started))
-                    message=$(cat <<EOF
-project={{ .Values.project_identifier }}
-status=${status}
-job=${HOSTNAME}
-elapsed_seconds=${elapsed_seconds}
-builder_image={{ .Values.build.builderImage.name }}:{{ .Values.build.builderImage.tag }}
-cache_dir={{ .Values.build.cacheDir }}
-EOF
-)
+                    message=$(printf 'project={{ .Values.project_identifier }}\nstatus=%s\njob=%s\nelapsed_seconds=%s\nbuilder_image={{ .Values.build.builderImage.name }}:{{ .Values.build.builderImage.tag }}\ncache_dir={{ .Values.build.cacheDir }}\n' "${status}" "${HOSTNAME}" "${elapsed_seconds}")
                     wget -qO- \
                       --timeout=10 \
                       --header="Title: {{ .Values.project_identifier }} notes build ${status}" \

--- a/helm-chart/templates/build-cronjob.yaml
+++ b/helm-chart/templates/build-cronjob.yaml
@@ -133,10 +133,83 @@ spec:
                 - |
                   {{- if .Values.build.lock.enabled }}
                   lock_dir=/data/source/{{ .Values.build.lock.dirName }}
+                  notified=0
+                  build_started=$(date +%s)
+                  notify_result() {
+                    status="$1"
+                    if [ "${notified}" -ne 0 ]; then
+                      return 0
+                    fi
+                    notified=1
+                    {{- if and .Values.build.notify.enabled .Values.build.notify.url }}
+                    build_finished=$(date +%s)
+                    elapsed_seconds=$((build_finished - build_started))
+                    message=$(cat <<EOF
+project={{ .Values.project_identifier }}
+status=${status}
+job=${HOSTNAME}
+elapsed_seconds=${elapsed_seconds}
+builder_image={{ .Values.build.builderImage.name }}:{{ .Values.build.builderImage.tag }}
+cache_dir={{ .Values.build.cacheDir }}
+EOF
+)
+                    wget -qO- \
+                      --timeout=10 \
+                      --header="Title: {{ .Values.project_identifier }} notes build ${status}" \
+                      --post-data="${message}" \
+                      {{ .Values.build.notify.url | quote }} >/dev/null 2>&1 || true
+                    {{- end }}
+                  }
                   cleanup_lock() {
+                    rc=$?
+                    if [ "${rc}" -eq 0 ]; then
+                      notify_result success
+                    else
+                      notify_result failed
+                    fi
                     rm -rf "${lock_dir}"
+                    exit "${rc}"
                   }
                   trap cleanup_lock EXIT INT TERM
+                  {{- end }}
+                  {{- if not .Values.build.lock.enabled }}
+                  notified=0
+                  build_started=$(date +%s)
+                  notify_result() {
+                    status="$1"
+                    if [ "${notified}" -ne 0 ]; then
+                      return 0
+                    fi
+                    notified=1
+                    {{- if and .Values.build.notify.enabled .Values.build.notify.url }}
+                    build_finished=$(date +%s)
+                    elapsed_seconds=$((build_finished - build_started))
+                    message=$(cat <<EOF
+project={{ .Values.project_identifier }}
+status=${status}
+job=${HOSTNAME}
+elapsed_seconds=${elapsed_seconds}
+builder_image={{ .Values.build.builderImage.name }}:{{ .Values.build.builderImage.tag }}
+cache_dir={{ .Values.build.cacheDir }}
+EOF
+)
+                    wget -qO- \
+                      --timeout=10 \
+                      --header="Title: {{ .Values.project_identifier }} notes build ${status}" \
+                      --post-data="${message}" \
+                      {{ .Values.build.notify.url | quote }} >/dev/null 2>&1 || true
+                    {{- end }}
+                  }
+                  cleanup_job() {
+                    rc=$?
+                    if [ "${rc}" -eq 0 ]; then
+                      notify_result success
+                    else
+                      notify_result failed
+                    fi
+                    exit "${rc}"
+                  }
+                  trap cleanup_job EXIT INT TERM
                   {{- end }}
                   {{- if .Values.storage.cache.enabled }}
                   mkdir -p {{ .Values.storage.cache.mountPath | quote }}/build {{ .Values.storage.cache.mountPath | quote }}/plugin {{ .Values.storage.cache.mountPath | quote }}/xdg

--- a/helm-chart/templates/build-cronjob.yaml
+++ b/helm-chart/templates/build-cronjob.yaml
@@ -214,7 +214,7 @@ spec:
                   [markata-go.mermaid]
                   mode = {{ .Values.build.mermaid.mode | squote }}
                   EOF
-                  markata-go build -m /tmp/markata-go-build-override.toml --output "${build_work}"
+                  markata-go build {{- if .Values.build.fast }} --fast{{- end }} -m /tmp/markata-go-build-override.toml --output "${build_work}"
                   {{- else }}
                   markata-go build --output "${build_work}"
                   {{- end }}

--- a/helm-chart/templates/builder-admin.yaml
+++ b/helm-chart/templates/builder-admin.yaml
@@ -1,0 +1,205 @@
+{{- if .Values.builderAdmin.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ .Values.project_identifier }}-notes-builder-admin"
+  namespace: "{{ include "markata-notes.namespace" . }}"
+  labels:
+    service: "{{ .Values.project_identifier }}-notes-builder-admin"
+    {{- include "markata-notes.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: "{{ .Values.project_identifier }}-notes-builder-admin"
+  template:
+    metadata:
+      labels:
+        service: "{{ .Values.project_identifier }}-notes-builder-admin"
+        {{- include "markata-notes.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: "{{ include "markata-notes.serviceAccountName" . }}"
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      enableServiceLinks: false
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      {{- if and .Values.build.enabled (ne (.Values.storage.source.mode | default "pvc") "hostPath") .Values.search.waitForSource.enabled }}
+      initContainers:
+        - name: wait-for-source
+          image: "{{ .Values.build.builderImage.name }}:{{ .Values.build.builderImage.tag }}"
+          imagePullPolicy: {{ .Values.build.builderImage.pullPolicy }}
+          command:
+            - /bin/sh
+            - -ceu
+          args:
+            - |
+              deadline=$(($(date +%s) + {{ .Values.search.waitForSource.timeoutSeconds }}))
+              until [ -f /data/source/.markata-notes-source-ready ] || [ -f /data/source/markata-go.toml ] || [ -f /data/source/markata.toml ] || [ -d /data/source/pages ] || [ -d /data/source/content ]; do
+                if [ "$(date +%s)" -ge "$deadline" ]; then
+                  echo "timed out waiting for source content in /data/source" >&2
+                  ls -la /data/source >&2
+                  exit 1
+                fi
+                sleep {{ .Values.search.waitForSource.pollIntervalSeconds }}
+              done
+          resources:
+            {{- toYaml .Values.search.waitForSource.resources | nindent 12 }}
+          volumeMounts:
+            - name: source
+              mountPath: /data/source
+      {{- end }}
+      containers:
+        - name: "{{ .Values.project_identifier }}-notes-builder-admin"
+          image: "{{ .Values.build.builderImage.name }}:{{ .Values.build.builderImage.tag }}"
+          imagePullPolicy: {{ .Values.build.builderImage.pullPolicy }}
+          command:
+            - markata-go
+            - builder-admin
+          args:
+            - --host
+            - {{ .Values.builderAdmin.host | quote }}
+            - --port
+            - {{ .Values.builderAdmin.port | quote }}
+            - --source-dir
+            - /data/source
+            - --site-dir
+            - /data/site
+            - --history-dir
+            - {{ .Values.builderAdmin.historyDir | quote }}
+            - --watch={{ ternary "true" "false" .Values.builderAdmin.watch.enabled }}
+            - --watch-debounce
+            - {{ .Values.builderAdmin.watch.debounce | quote }}
+            - --releases-keep
+            - {{ .Values.builderAdmin.releases.keep | quote }}
+            - --successful-builds-keep
+            - {{ .Values.builderAdmin.history.successfulBuilds | quote }}
+            - --failed-builds-keep
+            - {{ .Values.builderAdmin.history.failedBuilds | quote }}
+            - --refresh-runs-keep
+            - {{ .Values.builderAdmin.history.refreshRuns | quote }}
+            - --build-timeout
+            - {{ printf "%ds" (int .Values.builderAdmin.buildTimeoutSeconds) | quote }}
+            {{- if .Values.builderAdmin.fast }}
+            - --fast
+            {{- end }}
+            {{- if .Values.builderAdmin.mermaidMode }}
+            - --mermaid-mode
+            - {{ .Values.builderAdmin.mermaidMode | quote }}
+            {{- end }}
+            {{- if .Values.storage.cache.enabled }}
+            - --cache-mount
+            - {{ .Values.storage.cache.mountPath | quote }}
+            {{- end }}
+            {{- if .Values.search.configPath }}
+            - --config
+            - {{ .Values.search.configPath | quote }}
+            {{- end }}
+            {{- range .Values.builderAdmin.refreshTasks }}
+            - --refresh-task
+            - {{ printf "%s|%s|%t|%s" .name .every .enqueueBuildOnSuccess (join "|" .args) | quote }}
+            {{- end }}
+          {{- if .Values.markataEncryption.secretName }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.markataEncryption.secretName | quote }}
+          {{- end }}
+          env:
+            - name: HTTP_PROXY
+              value: {{ .Values.build.proxy.http | quote }}
+            - name: HTTPS_PROXY
+              value: {{ .Values.build.proxy.https | quote }}
+            - name: MARKATA_GO_OFFLINE
+              value: {{ ternary "true" "false" .Values.offline.enabled | quote }}
+            - name: MARKATA_GO_BUNDLED_ASSETS_CACHE_DIR
+              value: {{ .Values.offline.bundledAssetsCacheDir | quote }}
+            - name: MARKATA_GO_BUNDLED_MERMAID_DIR
+              value: {{ .Values.offline.bundledMermaidDir | quote }}
+            - name: XDG_CACHE_HOME
+              value: {{ .Values.build.cacheDir | quote }}
+            {{- with .Values.build.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - containerPort: {{ .Values.builderAdmin.port }}
+              name: http
+          resources:
+            {{- toYaml .Values.builderAdmin.resources | nindent 12 }}
+          volumeMounts:
+            - name: source
+              mountPath: /data/source
+            - name: site
+              mountPath: /data/site
+            {{- if .Values.storage.cache.enabled }}
+            - name: cache
+              mountPath: {{ .Values.storage.cache.mountPath | quote }}
+            {{- end }}
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            timeoutSeconds: 1
+            failureThreshold: 30
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            timeoutSeconds: 1
+            periodSeconds: 5
+            failureThreshold: 12
+      volumes:
+        - name: source
+          {{- if eq (.Values.storage.source.mode | default "pvc") "hostPath" }}
+          hostPath:
+            path: {{ .Values.storage.source.hostPath.path | quote }}
+            type: {{ .Values.storage.source.hostPath.type | quote }}
+          {{- else }}
+          persistentVolumeClaim:
+            claimName: "{{ include "markata-notes.sourcePvcName" . }}"
+          {{- end }}
+        - name: site
+          {{- if eq (.Values.storage.site.mode | default "pvc") "hostPath" }}
+          hostPath:
+            path: {{ .Values.storage.site.hostPath.path | quote }}
+            type: {{ .Values.storage.site.hostPath.type | quote }}
+          {{- else }}
+          persistentVolumeClaim:
+            claimName: "{{ include "markata-notes.sitePvcName" . }}"
+          {{- end }}
+        {{- if .Values.storage.cache.enabled }}
+        - name: cache
+          {{- if eq (.Values.storage.cache.mode | default "pvc") "hostPath" }}
+          hostPath:
+            path: {{ .Values.storage.cache.hostPath.path | quote }}
+            type: {{ .Values.storage.cache.hostPath.type | quote }}
+          {{- else }}
+          persistentVolumeClaim:
+            claimName: "{{ include "markata-notes.cachePvcName" . }}"
+          {{- end }}
+        {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ .Values.project_identifier }}-notes-builder-admin"
+  namespace: "{{ include "markata-notes.namespace" . }}"
+  labels:
+    service: "{{ .Values.project_identifier }}-notes-builder-admin"
+    {{- include "markata-notes.labels" . | nindent 4 }}
+spec:
+  selector:
+    service: "{{ .Values.project_identifier }}-notes-builder-admin"
+  ports:
+    - name: http
+      protocol: TCP
+      port: {{ .Values.builderAdmin.port }}
+      targetPort: http
+{{- end }}

--- a/helm-chart/templates/builder-admin.yaml
+++ b/helm-chart/templates/builder-admin.yaml
@@ -9,6 +9,8 @@ metadata:
     {{- include "markata-notes.labels" . | nindent 4 }}
 spec:
   replicas: 1
+  strategy:
+    type: {{ .Values.builderAdmin.strategy.type | quote }}
   selector:
     matchLabels:
       service: "{{ .Values.project_identifier }}-notes-builder-admin"

--- a/helm-chart/templates/pvcs.yaml
+++ b/helm-chart/templates/pvcs.yaml
@@ -48,3 +48,20 @@ spec:
   resources:
     requests:
       storage: {{ .Values.storage.search.size | quote }}
+{{- if .Values.storage.cache.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "{{ include "markata-notes.cachePvcName" . }}"
+  namespace: "{{ include "markata-notes.namespace" . }}"
+  labels:
+    {{- include "markata-notes.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.storage.cache.accessModes | nindent 4 }}
+  storageClassName: {{ .Values.storage.cache.storageClassName | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.storage.cache.size | quote }}
+{{- end }}

--- a/helm-chart/templates/search.yaml
+++ b/helm-chart/templates/search.yaml
@@ -122,13 +122,13 @@ spec:
               port: http
             timeoutSeconds: 1
             failureThreshold: 30
-            periodSeconds: 10
+            periodSeconds: 5
           readinessProbe:
             httpGet:
               path: /health
               port: http
             timeoutSeconds: 1
-            periodSeconds: 10
+            periodSeconds: 5
             failureThreshold: 12
       volumes:
         {{- if ne .Values.search.mode "read-only-index" }}

--- a/helm-chart/templates/site.yaml
+++ b/helm-chart/templates/site.yaml
@@ -52,13 +52,13 @@ spec:
               port: 80
             timeoutSeconds: 1
             failureThreshold: 30
-            periodSeconds: 10
+            periodSeconds: 5
           readinessProbe:
             httpGet:
               path: /
               port: 80
             timeoutSeconds: 1
-            periodSeconds: 10
+            periodSeconds: 5
             failureThreshold: 12
       volumes:
         - name: site

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -41,6 +41,9 @@ build:
   failedJobsHistoryLimit: 6
   ttlSecondsAfterFinished: 259200
   activeDeadlineSeconds: 1800
+  notify:
+    enabled: false
+    url: ""
   mermaid:
     mode: client
   lock:

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -168,6 +168,18 @@ storage:
     accessModes:
       - ReadWriteOnce
     pvcNameSuffix: ""
+  cache:
+    enabled: false
+    mode: pvc
+    storageClassName: longhorn
+    size: 10Gi
+    accessModes:
+      - ReadWriteOnce
+    pvcNameSuffix: ""
+    mountPath: /data/cache
+    hostPath:
+      path: ""
+      type: DirectoryOrCreate
 
 ingress:
   enabled: true

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -41,6 +41,7 @@ build:
   failedJobsHistoryLimit: 6
   ttlSecondsAfterFinished: 259200
   activeDeadlineSeconds: 1800
+  fast: false
   notify:
     enabled: false
     url: ""

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -50,7 +50,7 @@ build:
   lock:
     enabled: true
     dirName: ".markata-notes-build-lock"
-    pollIntervalSeconds: 5
+    pollIntervalSeconds: 2
     staleAfterBufferSeconds: 600
   releases:
     keep: 3
@@ -104,11 +104,11 @@ search:
     pullPolicy: IfNotPresent
   mode: watch-content
   port: 3001
-  watchDebounce: 5s
+  watchDebounce: 2s
   waitForSource:
     enabled: true
     timeoutSeconds: 900
-    pollIntervalSeconds: 5
+    pollIntervalSeconds: 2
     resources:
       requests:
         cpu: 10m

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -76,6 +76,33 @@ build:
       memory: 2Gi
       ephemeral-storage: 4Gi
 
+builderAdmin:
+  enabled: false
+  host: 0.0.0.0
+  port: 8080
+  watch:
+    enabled: true
+    debounce: 2s
+  fast: false
+  mermaidMode: client
+  releases:
+    keep: 10
+  history:
+    successfulBuilds: 50
+    failedBuilds: 100
+    refreshRuns: 100
+  buildTimeoutSeconds: 7200
+  historyDir: /data/site/.builder-admin
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+      ephemeral-storage: 500Mi
+    limits:
+      memory: 1Gi
+      ephemeral-storage: 2Gi
+  refreshTasks: []
+
 site:
   replicaCount: 1
   image:

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -80,6 +80,8 @@ builderAdmin:
   enabled: false
   host: 0.0.0.0
   port: 8080
+  strategy:
+    type: Recreate
   watch:
     enabled: true
     debounce: 2s

--- a/pkg/agentskill/bundle/markata-go-site/reference/webawesome.md
+++ b/pkg/agentskill/bundle/markata-go-site/reference/webawesome.md
@@ -50,6 +50,7 @@ General rule:
 
 - `::: wa-<component>` is the preferred authoring form
 - `::: webawesome <component>` remains supported as an alias
+- Web Awesome classes can be combined with other container classes; `wa-*` or the `webawesome <component>` class pair may appear anywhere in the rendered `class` attribute.
 
 ## Raw HTML Support
 
@@ -62,6 +63,7 @@ Raw Web Awesome custom elements are also supported:
 Important rule:
 
 - any page containing rendered `<wa-*>` elements should trigger Web Awesome asset loading automatically
+- built-in template wiring imports `webawesome.loader.js`, sets the configured base path, and calls `startLoader()`; a passive module script alone does not initialize component discovery
 - markata-go loads the focused Web Awesome theme stylesheet, such as `/assets/vendor/webawesome/styles/themes/default.css`, rather than the global `styles/webawesome.css` bundle so Web Awesome native-element styles do not override the site's normal typography and link styling
 
 ## Component Reference
@@ -291,7 +293,9 @@ Rendered shape:
 ```markdown
 ::: wa-carousel {navigation="true" pagination="true"}
 ![First screenshot](/images/one.webp)
+First screenshot caption
 ![Second screenshot](/images/two.webp)
+Second screenshot caption
 :::
 ```
 
@@ -299,6 +303,7 @@ Rules:
 
 - the body should contain one or more images
 - each image becomes a `wa-carousel-item`
+- optional plain text or `<figcaption>` content immediately after an image becomes that slide's caption
 - common attrs include `navigation` and `pagination`
 
 ### Animated Image
@@ -377,6 +382,7 @@ CDN mode:
 
 - `source = "cdn"`
 - serves Web Awesome assets from `cdn_base_url`
+- the default `cdn_base_url` uses Web Awesome's browser-ready `dist-cdn` subtree; avoid the package `dist` subtree unless the site also provides the import map/bundling needed for bare module specifiers
 
 Important rules:
 

--- a/pkg/agentskill/bundle/markata-go-site/topics/build-deployment.md
+++ b/pkg/agentskill/bundle/markata-go-site/topics/build-deployment.md
@@ -101,6 +101,7 @@ steps:
 - if the runtime build environment is offline, make sure `.markata/assets-cache` or another configured asset cache is already populated before relying on self-hosted CDN assets.
 - for Helm or ArgoCD source-archive deployments, prefer environment-specific `MARKATA_GO_*` overrides such as `MARKATA_GO_URL` instead of editing the repo just to change hostnames
 - for Helm or ArgoCD feedback loops, inspect the chart's lock and debounce knobs (`build.lock.pollIntervalSeconds`, `search.waitForSource.pollIntervalSeconds`, `search.watchDebounce`) before chasing deeper build bugs; shorter values make manual rebuilds and search restarts feel noticeably snappier
+- for Kubernetes hostPath authoring deployments, prefer the long-lived `builder-admin` service over one-shot build Jobs when the goal is fast interactive rebuilds, release history, rollback, and scheduled remote refreshes
 - for Kubernetes hostPath deployments, confirm the mounted source path and served site root are the real node paths, and remember the served site root may contain release directories plus a `current` symlink rather than a flat output tree
 - Validate that feed URLs, social URLs, and asset URLs use the expected domain after build.
 

--- a/pkg/agentskill/bundle/markata-go-site/topics/build-deployment.md
+++ b/pkg/agentskill/bundle/markata-go-site/topics/build-deployment.md
@@ -100,6 +100,7 @@ steps:
 - If previews and production use different domains, inject `MARKATA_GO_URL` per environment instead of hardcoding one value.
 - if the runtime build environment is offline, make sure `.markata/assets-cache` or another configured asset cache is already populated before relying on self-hosted CDN assets.
 - for Helm or ArgoCD source-archive deployments, prefer environment-specific `MARKATA_GO_*` overrides such as `MARKATA_GO_URL` instead of editing the repo just to change hostnames
+- for Helm or ArgoCD feedback loops, inspect the chart's lock and debounce knobs (`build.lock.pollIntervalSeconds`, `search.waitForSource.pollIntervalSeconds`, `search.watchDebounce`) before chasing deeper build bugs; shorter values make manual rebuilds and search restarts feel noticeably snappier
 - for Kubernetes hostPath deployments, confirm the mounted source path and served site root are the real node paths, and remember the served site root may contain release directories plus a `current` symlink rather than a flat output tree
 - Validate that feed URLs, social URLs, and asset URLs use the expected domain after build.
 

--- a/pkg/agentskill/bundle/markata-go-site/topics/cli-usage.md
+++ b/pkg/agentskill/bundle/markata-go-site/topics/cli-usage.md
@@ -13,6 +13,7 @@ Use this topic for everyday site work and safe project inspection.
 - `markata-go build --dry-run` (run through Collect, show counts, skip Write)
 - `markata-go reader update` (refresh external feed cache for `/reader/` without building)
 - `markata-go reader update --concurrency 12` (override reader refresh parallelism for one run)
+- `MARKATA_GO_BLOGROLL_REFRESH_ON_BUILD=false markata-go build` (keep blogroll pages but skip remote refresh during the build)
 - `markata-go build --benchmark-json benchmark.json`
 - `markata-go build -v --benchmark-detailed`
 - `markata-go serve` (dev server with live reload)

--- a/pkg/agentskill/bundle/markata-go-site/topics/faster-builds.md
+++ b/pkg/agentskill/bundle/markata-go-site/topics/faster-builds.md
@@ -7,11 +7,13 @@ Use this topic when the task is build speed, local iteration speed, or profiling
 - use `markata-go build --fast` for faster development loops
 - use `markata-go serve --fast` for the normal live-edit loop
 - use `markata-go reader update` when you only need fresh `/reader/` feed data for the next build
+- prefer `[markata-go.blogroll] refresh_on_build = false` when you want to keep blogroll pages but move remote refresh work out of the normal build
 - use `markata-go reader update --concurrency <n>` when reader refresh latency is dominated by many remote feeds
 - use `-m fast.toml` or `--merge-config fast.toml` when you want a slimmer dev config without editing the main site config
 - compare warm builds, not just cold builds
 - use `markata-go build --benchmark-json benchmark.json` for structured timing
 - use `markata-go build -v --benchmark-detailed` when you need stage detail
+- read the `Slowest requests` footer section before assuming a slow plugin is CPU-bound
 
 ## What `--fast` Skips
 
@@ -99,9 +101,18 @@ Use merge configs for scope changes. Use `--fast` for expensive output-step skip
 3. if the build is slow, capture `--benchmark-json` or `--benchmark-detailed`
 4. compare warm builds before changing caching behavior
 
+## Concrete Profiling Flow
+
+1. run the build that matches the question you are asking
+2. read `Resource profile` to see whether the slowdown is mostly CPU, network, disk read, or disk write
+3. read `Hotspots` to find the slow plugin hook
+4. read `Slowest requests` to find the exact remote waits inside that plugin
+5. if the build is still CPU-heavy after network issues are understood, switch to `--cpuprofile`
+
 ## Common Culprits
 
 - remote metadata or embed fetching
+- blogroll and reader feed refreshes during normal builds when cache-only mode is not configured
 - pagefind, minification, and purge steps
 - feed-heavy sites with many aggregate pages
 - custom templates or plugins doing repeated expensive work

--- a/pkg/agentskill/bundle/markata-go-site/topics/faster-builds.md
+++ b/pkg/agentskill/bundle/markata-go-site/topics/faster-builds.md
@@ -54,6 +54,8 @@ So `--fast` is good for content, template, and most styling iteration, but it is
 - If output is network-bound, inspect plugins that fetch remote content.
 - If output is read-heavy, inspect globbing, cache loads, and broad content scans.
 - If output is write-heavy, inspect cache saves, feed publishing, Pagefind output, and static output.
+- If warm builds still spend time in `configure/build_cache`, check whether template or config files actually changed before assuming the cache is stale; the build cache now fingerprints the template tree before it does a full rehash.
+- If `/tags` or `/garden` writes are hot, prefer cached per-post semantic hashes so the listing hashes don't need to re-derive the same per-post summaries every build.
 - Prefer targeted fixes over broad cache-busting changes.
 - For sites that use `[markata-go.mermaid] mode = "chromium"` or `"cli"`, unchanged
   diagrams should reuse cached SVG output on warm builds; if Mermaid remains a hotspot,

--- a/pkg/agentskill/bundle/markata-go-site/topics/template-management.md
+++ b/pkg/agentskill/bundle/markata-go-site/topics/template-management.md
@@ -218,7 +218,7 @@ For sites using the `webawesome` hook, prefer authoring content with markdown co
 Useful guidance:
 
 - raw `<wa-*>` elements are also supported and trigger asset loading automatically
-- do not hardcode Web Awesome `<script>` or `<link>` tags if the site already relies on the built-in plugin wiring
+- do not hardcode Web Awesome `<script>` or `<link>` tags if the site already relies on the built-in plugin wiring; if you must customize the template wiring, import `webawesome.loader.js`, set the configured base path, and call `startLoader()`
 - if a template needs to guard extra markup or classes around Web Awesome usage, inspect existing checks first; per-page detection is usually driven by the presence of rendered `wa-*` elements in the page body
 - if vendor assets are enabled, the resolved URLs come from config-driven asset mappings rather than fixed `/assets/vendor/webawesome/` assumptions
 

--- a/pkg/buildcache/cache.go
+++ b/pkg/buildcache/cache.go
@@ -216,6 +216,13 @@ type PostCache struct {
 
 	// TailwindTokens stores the extracted Tailwind-relevant tokens for the post.
 	TailwindTokens string `json:"tailwind_tokens,omitempty"`
+
+	// MentionsHash is a hash of the Content input + mention resolution state.
+	// When either the raw content or resolved mention metadata changes, this hash changes.
+	MentionsHash string `json:"mentions_hash,omitempty"`
+
+	// MentionsContent is the cached Content output after mentions transform processing.
+	MentionsContent string `json:"mentions_content,omitempty"`
 }
 
 // FeedCache stores cached metadata for a single feed.
@@ -796,6 +803,43 @@ func (c *Cache) CacheGlossaryHTML(sourcePath, combinedHash, html string) {
 	c.dirty = true
 }
 
+// GetCachedMentionsContent returns cached mentions transform output if the hash matches.
+// Returns the cached content and true if valid, empty string and false otherwise.
+func (c *Cache) GetCachedMentionsContent(sourcePath, contentHash string) (string, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	cached, ok := c.Posts[sourcePath]
+	if !ok {
+		return "", false
+	}
+	if cached.MentionsHash == "" || cached.MentionsHash != contentHash {
+		return "", false
+	}
+	return cached.MentionsContent, true
+}
+
+// CacheMentionsContent stores the mentions transform output keyed by content hash.
+func (c *Cache) CacheMentionsContent(sourcePath, contentHash, content string) {
+	if sourcePath == "" || contentHash == "" {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if cached, ok := c.Posts[sourcePath]; ok {
+		cached.MentionsHash = contentHash
+		cached.MentionsContent = content
+	} else {
+		c.Posts[sourcePath] = &PostCache{
+			MentionsHash:    contentHash,
+			MentionsContent: content,
+		}
+	}
+	c.dirty = true
+}
+
 // GetCachedTailwindTokens returns cached Tailwind tokens if the HTML hash matches.
 func (c *Cache) GetCachedTailwindTokens(sourcePath, htmlHash string) (string, bool) {
 	c.mu.RLock()
@@ -806,6 +850,21 @@ func (c *Cache) GetCachedTailwindTokens(sourcePath, htmlHash string) (string, bo
 		return "", false
 	}
 	if cached.TailwindHTMLHash == "" || cached.TailwindHTMLHash != htmlHash {
+		return "", false
+	}
+	return cached.TailwindTokens, true
+}
+
+// GetStoredTailwindTokens returns cached Tailwind tokens without validating the
+// HTML hash. This is safe for unchanged posts whose final HTML is known to be
+// identical to the prior build even if the current build has not eagerly
+// restored the cached full-page HTML into memory.
+func (c *Cache) GetStoredTailwindTokens(sourcePath string) (string, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	cached, ok := c.Posts[sourcePath]
+	if !ok || cached.TailwindTokens == "" {
 		return "", false
 	}
 	return cached.TailwindTokens, true

--- a/pkg/buildcache/cache.go
+++ b/pkg/buildcache/cache.go
@@ -78,6 +78,9 @@ type Cache struct {
 	// GardenHash caches the garden view output state
 	GardenHash string `json:"garden_hash,omitempty"`
 
+	// FeedsListingHash caches the /feeds listing output state.
+	FeedsListingHash string `json:"feeds_listing_hash,omitempty"`
+
 	// TailwindManifestHash caches the generated Tailwind token manifest state.
 	TailwindManifestHash string `json:"tailwind_manifest_hash,omitempty"`
 
@@ -598,6 +601,24 @@ func (c *Cache) GetGardenHash() string {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.GardenHash
+}
+
+// SetFeedsListingHash stores the feeds listing hash in the cache.
+func (c *Cache) SetFeedsListingHash(hash string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.FeedsListingHash == hash {
+		return
+	}
+	c.FeedsListingHash = hash
+	c.dirty = true
+}
+
+// GetFeedsListingHash returns the cached feeds listing hash.
+func (c *Cache) GetFeedsListingHash() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.FeedsListingHash
 }
 
 // MarkSkipped records that a post was skipped (already up to date).
@@ -1123,8 +1144,9 @@ func ComputePostInputHash(content, frontmatter, template string) string {
 func (c *Cache) SetDependencies(sourcePath, sourceSlug string, targets []string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.Graph.SetDependencies(sourcePath, sourceSlug, targets)
-	c.dirty = true
+	if c.Graph.SetDependencies(sourcePath, sourceSlug, targets) {
+		c.dirty = true
+	}
 }
 
 // GetAffectedPosts returns all posts that need rebuilding when the given

--- a/pkg/buildcache/cache.go
+++ b/pkg/buildcache/cache.go
@@ -32,9 +32,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -62,6 +64,10 @@ type Cache struct {
 
 	// TemplatesHash is the combined hash of all template files
 	TemplatesHash string `json:"templates_hash"`
+
+	// TemplatesFingerprint is a cheap filesystem fingerprint used to skip
+	// recomputing TemplatesHash when the template tree is unchanged.
+	TemplatesFingerprint string `json:"templates_fingerprint,omitempty"`
 
 	// AssetsHash is the combined hash of all static assets (JS/CSS)
 	AssetsHash string `json:"assets_hash,omitempty"`
@@ -307,7 +313,7 @@ func (c *Cache) Save() error {
 		return fmt.Errorf("creating cache directory: %w", err)
 	}
 
-	data, err := json.MarshalIndent(c, "", "  ")
+	data, err := json.Marshal(c)
 	if err != nil {
 		return fmt.Errorf("marshaling cache: %w", err)
 	}
@@ -355,6 +361,35 @@ func (c *Cache) SetTemplatesHash(hash string) bool {
 	c.Feeds = make(map[string]*FeedCache)
 	c.TailwindManifestHash = ""
 	c.PagefindCorpusHash = ""
+	c.dirty = true
+	return true
+}
+
+// GetTemplatesHash returns the cached template content hash.
+func (c *Cache) GetTemplatesHash() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.TemplatesHash
+}
+
+// GetTemplatesFingerprint returns the cached template tree fingerprint.
+func (c *Cache) GetTemplatesFingerprint() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.TemplatesFingerprint
+}
+
+// SetTemplatesFingerprint updates the template tree fingerprint and marks the
+// cache dirty only when the fingerprint actually changes.
+func (c *Cache) SetTemplatesFingerprint(hash string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.TemplatesFingerprint == hash {
+		return false
+	}
+
+	c.TemplatesFingerprint = hash
 	c.dirty = true
 	return true
 }
@@ -1098,6 +1133,73 @@ func HashDirectory(dir string, extensions []string) (string, error) {
 			return "", err
 		}
 		h.Write(content)
+	}
+
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// HashDirectoryState computes a cheap fingerprint for a directory tree.
+// It includes each matching file's relative path, size, and modtime so callers
+// can skip a full content hash when the tree is unchanged.
+func HashDirectoryState(dir string, extensions []string) (string, error) {
+	extMap := make(map[string]bool)
+	for _, ext := range extensions {
+		extMap[ext] = true
+	}
+
+	type fileState struct {
+		path    string
+		size    int64
+		modTime int64
+	}
+
+	states := make([]fileState, 0, 64)
+	err := filepath.WalkDir(dir, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		ext := filepath.Ext(path)
+		if len(extMap) > 0 && !extMap[ext] {
+			return nil
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+
+		relPath, err := filepath.Rel(dir, path)
+		if err != nil {
+			relPath = path
+		}
+
+		states = append(states, fileState{
+			path:    relPath,
+			size:    info.Size(),
+			modTime: info.ModTime().UnixNano(),
+		})
+		return nil
+	})
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+
+	sort.Slice(states, func(i, j int) bool { return states[i].path < states[j].path })
+
+	h := sha256.New()
+	for _, state := range states {
+		h.Write([]byte(state.path))
+		h.Write([]byte{0})
+		h.Write([]byte(strconv.FormatInt(state.size, 10)))
+		h.Write([]byte{0})
+		h.Write([]byte(strconv.FormatInt(state.modTime, 10)))
+		h.Write([]byte{0})
 	}
 
 	return hex.EncodeToString(h.Sum(nil)), nil

--- a/pkg/buildcache/cache_test.go
+++ b/pkg/buildcache/cache_test.go
@@ -89,6 +89,18 @@ func TestCache_ShouldRebuildWithSlug_NoDependencyChange(t *testing.T) {
 	}
 }
 
+func TestCache_SetDependencies_UnchangedDoesNotMarkDirty(t *testing.T) {
+	cache := New("")
+	cache.SetDependencies("pages/post-a.md", "post-a", []string{"post-b"})
+	cache.dirty = false
+
+	cache.SetDependencies("pages/post-a.md", "post-a", []string{"post-b", "post-b"})
+
+	if cache.dirty {
+		t.Fatal("dirty = true, want false for unchanged dependencies")
+	}
+}
+
 func TestCache_GetChangedSlugs(t *testing.T) {
 	cache := New("")
 

--- a/pkg/buildcache/cache_test.go
+++ b/pkg/buildcache/cache_test.go
@@ -394,6 +394,58 @@ func TestCache_FeedMembershipHash_SaveLoad(t *testing.T) {
 	}
 }
 
+func TestCache_SetTemplatesFingerprint_UnchangedDoesNotMarkDirty(t *testing.T) {
+	cache := New("")
+	cache.TemplatesFingerprint = "fingerprint-123"
+	cache.dirty = false
+
+	if changed := cache.SetTemplatesFingerprint("fingerprint-123"); changed {
+		t.Fatal("SetTemplatesFingerprint returned true for unchanged fingerprint")
+	}
+	if cache.dirty {
+		t.Fatal("dirty = true, want false for unchanged fingerprint")
+	}
+}
+
+func TestHashDirectoryState_Deterministic(t *testing.T) {
+	dir := t.TempDir()
+	templatesDir := filepath.Join(dir, "templates")
+	if err := os.MkdirAll(templatesDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+
+	filePath := filepath.Join(templatesDir, "base.html")
+	if err := os.WriteFile(filePath, []byte("<html>one</html>"), 0o600); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	hash1, err := HashDirectoryState(templatesDir, []string{".html"})
+	if err != nil {
+		t.Fatalf("HashDirectoryState first call failed: %v", err)
+	}
+	hash2, err := HashDirectoryState(templatesDir, []string{".html"})
+	if err != nil {
+		t.Fatalf("HashDirectoryState second call failed: %v", err)
+	}
+	if hash1 == "" {
+		t.Fatal("HashDirectoryState returned empty hash for non-empty directory")
+	}
+	if hash1 != hash2 {
+		t.Fatalf("HashDirectoryState = %q then %q, want deterministic output", hash1, hash2)
+	}
+
+	if err := os.WriteFile(filePath, []byte("<html>two and more</html>"), 0o600); err != nil {
+		t.Fatalf("WriteFile update failed: %v", err)
+	}
+	hash3, err := HashDirectoryState(templatesDir, []string{".html"})
+	if err != nil {
+		t.Fatalf("HashDirectoryState updated call failed: %v", err)
+	}
+	if hash1 == hash3 {
+		t.Fatalf("HashDirectoryState = %q after file change, want different hash", hash3)
+	}
+}
+
 func TestCache_CleanupMermaidSVG_RemovesUnusedFiles(t *testing.T) {
 	dir := t.TempDir()
 	cache := New(filepath.Join(dir, ".markata"))

--- a/pkg/buildcache/graph.go
+++ b/pkg/buildcache/graph.go
@@ -52,12 +52,35 @@ func NewDependencyGraph() *DependencyGraph {
 // This replaces any existing dependencies for the source.
 // The sourceSlug is the slug of the source post (for reverse lookups).
 // The targets are slugs of linked posts.
-func (g *DependencyGraph) SetDependencies(sourcePath, sourceSlug string, targets []string) {
+// It returns true when the dependency graph changed.
+func (g *DependencyGraph) SetDependencies(sourcePath, sourceSlug string, targets []string) bool {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
+	var unique []string
+	if len(targets) > 0 {
+		seen := make(map[string]bool, len(targets))
+		unique = make([]string, 0, len(targets))
+		for _, t := range targets {
+			if !seen[t] {
+				seen[t] = true
+				unique = append(unique, t)
+			}
+		}
+		sort.Strings(unique)
+	}
+
+	oldTargets, hadTargets := g.Dependencies[sourcePath]
+	oldSlug := g.PathToSlug[sourcePath]
+	sameSlug := sourceSlug == "" || oldSlug == sourceSlug
+	if sameSlug && slicesEqual(oldTargets, unique) {
+		if len(unique) > 0 || !hadTargets {
+			return false
+		}
+	}
+
 	// Remove old dependencies from reverse index
-	if oldTargets, ok := g.Dependencies[sourcePath]; ok {
+	if hadTargets {
 		for _, target := range oldTargets {
 			g.removeDependent(target, sourcePath)
 		}
@@ -69,19 +92,9 @@ func (g *DependencyGraph) SetDependencies(sourcePath, sourceSlug string, targets
 	}
 
 	// Store new dependencies
-	if len(targets) == 0 {
+	if len(unique) == 0 {
 		delete(g.Dependencies, sourcePath)
 	} else {
-		// Deduplicate and sort for deterministic output
-		seen := make(map[string]bool, len(targets))
-		unique := make([]string, 0, len(targets))
-		for _, t := range targets {
-			if !seen[t] {
-				seen[t] = true
-				unique = append(unique, t)
-			}
-		}
-		sort.Strings(unique)
 		g.Dependencies[sourcePath] = unique
 
 		// Update reverse index
@@ -89,6 +102,20 @@ func (g *DependencyGraph) SetDependencies(sourcePath, sourceSlug string, targets
 			g.addDependent(target, sourcePath)
 		}
 	}
+
+	return true
+}
+
+func slicesEqual(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // GetDependencies returns the targets that a source post links to.

--- a/pkg/buildcache/graph_test.go
+++ b/pkg/buildcache/graph_test.go
@@ -113,6 +113,17 @@ func TestSetDependencies_Empty(t *testing.T) {
 	}
 }
 
+func TestSetDependencies_UnchangedReturnsFalse(t *testing.T) {
+	g := NewDependencyGraph()
+
+	if !g.SetDependencies("pages/post-a.md", "post-a", []string{"post-b", "post-c"}) {
+		t.Fatal("first SetDependencies() = false, want true")
+	}
+	if g.SetDependencies("pages/post-a.md", "post-a", []string{"post-c", "post-b", "post-b"}) {
+		t.Fatal("unchanged SetDependencies() = true, want false")
+	}
+}
+
 func TestGetAffectedPosts_Direct(t *testing.T) {
 	g := NewDependencyGraph()
 

--- a/pkg/builderadmin/service.go
+++ b/pkg/builderadmin/service.go
@@ -780,7 +780,11 @@ func (s *Service) runLoggedCommand(ctx context.Context, log io.Writer, cwd strin
 	cmdArgs := args[1:]
 	cmd := exec.CommandContext(ctx, cmdName, cmdArgs...)
 	if strings.HasPrefix(cmdName, "-") || cmdName == "build" || strings.HasSuffix(cmdName, "markata-go") || filepath.Base(cmdName) == filepath.Base(s.executable) {
-		cmd = exec.CommandContext(ctx, s.executable, args...)
+		if strings.HasSuffix(cmdName, "markata-go") || filepath.Base(cmdName) == filepath.Base(s.executable) {
+			cmd = exec.CommandContext(ctx, s.executable, cmdArgs...)
+		} else {
+			cmd = exec.CommandContext(ctx, s.executable, args...)
+		}
 	}
 	cmd.Stdout = log
 	cmd.Stderr = log

--- a/pkg/builderadmin/service.go
+++ b/pkg/builderadmin/service.go
@@ -707,7 +707,7 @@ func (s *Service) prepareBuild(log io.Writer) error {
 	current := filepath.Join(s.cfg.SiteDir, "current")
 	if _, err := os.Stat(current); err == nil {
 		_, _ = fmt.Fprintln(log, "seeding build work from current release")
-		return s.runLoggedCommand(context.Background(), log, "", nil, "cp", "-al", filepath.Join(current, "."), buildWork+string(os.PathSeparator))
+		return s.runLoggedCommand(context.Background(), log, "", nil, "cp", "-al", current+"/.", buildWork+string(os.PathSeparator))
 	}
 	return nil
 }
@@ -719,13 +719,12 @@ func (s *Service) buildCommandArgs(id, buildWork string) ([]string, func(), erro
 	}
 	cleanup := func() {}
 	if s.cfg.MermaidMode != "" {
-		overridePath := filepath.Join(s.overrideDir, id+".toml")
+		overridePath := filepath.Join(s.overrideDir, "builder-admin.toml")
 		contents := fmt.Sprintf("[markata-go.mermaid]\nmode = %q\n", s.cfg.MermaidMode)
 		if err := os.WriteFile(overridePath, []byte(contents), 0o644); err != nil {
 			return nil, cleanup, err
 		}
 		args = append(args, "-m", overridePath)
-		cleanup = func() { _ = os.Remove(overridePath) }
 	}
 	args = append(args, "build")
 	if s.cfg.Fast {

--- a/pkg/builderadmin/service.go
+++ b/pkg/builderadmin/service.go
@@ -1392,6 +1392,33 @@ const indexHTML = `<!doctype html>
     .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; }
     .wide { overflow-x: auto; }
     .muted { color: var(--muted); }
+    .tabs {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-bottom: 14px;
+    }
+    .tabs a {
+      display: inline-flex;
+      align-items: center;
+      border: 1px solid var(--line-soft);
+      border-radius: 999px;
+      padding: 9px 14px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-size: 0.72rem;
+      color: var(--muted);
+      background: rgba(255,255,255,0.03);
+    }
+    .tabs a.active {
+      color: var(--text);
+      background: var(--panel-strong);
+      border-color: var(--line);
+    }
+    .tab-panel { display: none; }
+    .tab-panel:target { display: block; }
+    .tab-panel.default-panel { display: block; }
+    .tab-shell .tab-panel:target ~ .default-panel { display: none; }
     @media (max-width: 1200px) {
       .hero, .section-grid, .grid { grid-template-columns: 1fr 1fr; }
     }
@@ -1497,72 +1524,76 @@ const indexHTML = `<!doctype html>
   </section>
   </div>
 
-  <section class="card wide">
-    <div class="panel-head"><h2>Builds</h2><span>trimmed summaries, full logs one click away</span></div>
-    <table>
-      <thead><tr><th>ID</th><th>Status</th><th>Trigger</th><th>Total</th><th>Build</th><th>Release</th><th>Logs</th><th>Summary</th></tr></thead>
-      <tbody>
-      {{ range .State.Builds }}
-      <tr>
-        <td><code>{{ .ID }}</code></td>
-        <td>{{ .Status }}</td>
-        <td>{{ .TriggerType }}</td>
-        <td>{{ msToSeconds .TotalMS }}</td>
-        <td>{{ msToSeconds .BuildMS }}</td>
-        <td>{{ if .ReleaseID }}<code>{{ .ReleaseID }}</code>{{ end }}</td>
-        <td>{{ if .LogPath }}<a href="/logs/{{ .LogPath }}">log</a>{{ end }}</td>
-        <td class="summary-cell">{{ if .PerfSummary }}<div class="summary-meta">{{ len .PerfSummary }} perf lines</div><div class="summary-list mono">{{ range summaryPreview .PerfSummary }}<div>{{ . }}</div>{{ end }}</div>{{ end }}</td>
-      </tr>
-      {{ else }}
-      <tr><td colspan="8">No builds yet.</td></tr>
-      {{ end }}
-      </tbody>
-    </table>
-  </section>
+  <section class="card wide tab-shell">
+    <div class="panel-head"><h2>Workspace</h2><span>switch between builds, refreshes, and releases</span></div>
+    <nav class="tabs">
+      <a href="#builds" class="active">Builds</a>
+      <a href="#refresh-runs">Refresh Runs</a>
+      <a href="#releases">Releases</a>
+    </nav>
 
-  <div class="section-grid">
-  <section class="card wide">
-    <div class="panel-head"><h2>Refresh Runs</h2><span>scheduled remote freshness</span></div>
-    <table>
-      <thead><tr><th>ID</th><th>Task</th><th>Status</th><th>Total</th><th>Logs</th><th>Build</th><th>Command</th></tr></thead>
-      <tbody>
-      {{ range .State.Refresh }}
-      <tr>
-        <td><code>{{ .ID }}</code></td>
-        <td>{{ .TaskName }}</td>
-        <td>{{ .Status }}</td>
-        <td>{{ msToSeconds .TotalMS }}</td>
-        <td>{{ if .LogPath }}<a href="/logs/{{ .LogPath }}">log</a>{{ end }}</td>
-        <td>{{ if .EnqueuedBuildID }}<code>{{ .EnqueuedBuildID }}</code>{{ end }}</td>
-        <td class="mono muted">{{ if .Command }}{{ index .Command 0 }} {{ end }}</td>
-      </tr>
-      {{ else }}
-      <tr><td colspan="7">No refresh runs yet.</td></tr>
-      {{ end }}
-      </tbody>
-    </table>
-  </section>
+    <section id="builds" class="tab-panel default-panel">
+      <table>
+        <thead><tr><th>ID</th><th>Status</th><th>Trigger</th><th>Total</th><th>Build</th><th>Release</th><th>Logs</th><th>Summary</th></tr></thead>
+        <tbody>
+        {{ range .State.Builds }}
+        <tr>
+          <td><code>{{ .ID }}</code></td>
+          <td>{{ .Status }}</td>
+          <td>{{ .TriggerType }}</td>
+          <td>{{ msToSeconds .TotalMS }}</td>
+          <td>{{ msToSeconds .BuildMS }}</td>
+          <td>{{ if .ReleaseID }}<code>{{ .ReleaseID }}</code>{{ end }}</td>
+          <td>{{ if .LogPath }}<a href="/logs/{{ .LogPath }}">log</a>{{ end }}</td>
+          <td class="summary-cell">{{ if .PerfSummary }}<div class="summary-meta">{{ len .PerfSummary }} perf lines</div><div class="summary-list mono">{{ range summaryPreview .PerfSummary }}<div>{{ . }}</div>{{ end }}</div>{{ end }}</td>
+        </tr>
+        {{ else }}
+        <tr><td colspan="8">No builds yet.</td></tr>
+        {{ end }}
+        </tbody>
+      </table>
+    </section>
 
-  <section class="card">
-    <div class="panel-head"><h2>Releases</h2><span>promote prior output</span></div>
-    <table>
-      <thead><tr><th>ID</th><th>Current</th><th>Created</th><th>Build</th><th>Action</th></tr></thead>
-      <tbody>
-      {{ range .Releases }}
-      <tr>
-        <td><code>{{ .ID }}</code></td>
-        <td>{{ if .Current }}live{{ end }}</td>
-        <td>{{ since .CreatedAt }}</td>
-        <td>{{ if .BuildID }}<code>{{ .BuildID }}</code>{{ end }}</td>
-        <td>{{ if not .Current }}<form method="post" action="/api/releases/{{ .ID }}/rollback"><button class="secondary" type="submit">Promote</button></form>{{ end }}</td>
-      </tr>
-      {{ else }}
-      <tr><td colspan="5">No releases found.</td></tr>
-      {{ end }}
-      </tbody>
-    </table>
+    <section id="refresh-runs" class="tab-panel">
+      <table>
+        <thead><tr><th>ID</th><th>Task</th><th>Status</th><th>Total</th><th>Logs</th><th>Build</th><th>Command</th></tr></thead>
+        <tbody>
+        {{ range .State.Refresh }}
+        <tr>
+          <td><code>{{ .ID }}</code></td>
+          <td>{{ .TaskName }}</td>
+          <td>{{ .Status }}</td>
+          <td>{{ msToSeconds .TotalMS }}</td>
+          <td>{{ if .LogPath }}<a href="/logs/{{ .LogPath }}">log</a>{{ end }}</td>
+          <td>{{ if .EnqueuedBuildID }}<code>{{ .EnqueuedBuildID }}</code>{{ end }}</td>
+          <td class="mono muted">{{ if .Command }}{{ index .Command 0 }} {{ end }}</td>
+        </tr>
+        {{ else }}
+        <tr><td colspan="7">No refresh runs yet.</td></tr>
+        {{ end }}
+        </tbody>
+      </table>
+    </section>
+
+    <section id="releases" class="tab-panel">
+      <table>
+        <thead><tr><th>ID</th><th>Current</th><th>Created</th><th>Build</th><th>Action</th></tr></thead>
+        <tbody>
+        {{ range .Releases }}
+        <tr>
+          <td><code>{{ .ID }}</code></td>
+          <td>{{ if .Current }}live{{ end }}</td>
+          <td>{{ since .CreatedAt }}</td>
+          <td>{{ if .BuildID }}<code>{{ .BuildID }}</code>{{ end }}</td>
+          <td>{{ if not .Current }}<form method="post" action="/api/releases/{{ .ID }}/rollback"><button class="secondary" type="submit">Promote</button></form>{{ end }}</td>
+        </tr>
+        {{ else }}
+        <tr><td colspan="5">No releases found.</td></tr>
+        {{ end }}
+        </tbody>
+      </table>
+    </section>
   </section>
-  </div>
 </main>
 </body>
 </html>`

--- a/pkg/builderadmin/service.go
+++ b/pkg/builderadmin/service.go
@@ -1044,6 +1044,13 @@ func (s *Service) loadState() error {
 	if err := json.Unmarshal(data, &s.state); err != nil {
 		return fmt.Errorf("decode state: %w", err)
 	}
+	// Queue and running state are in-memory worker concerns. If the pod restarted,
+	// the old worker is gone, so clear transient state instead of showing ghosts.
+	s.state.Queue = nil
+	s.state.Running = nil
+	s.stateMu.Lock()
+	s.saveStateLocked()
+	s.stateMu.Unlock()
 	return nil
 }
 

--- a/pkg/builderadmin/service.go
+++ b/pkg/builderadmin/service.go
@@ -1,0 +1,1325 @@
+package builderadmin
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"html/template"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+const (
+	defaultLogDirName   = "logs"
+	defaultStateName    = "state.json"
+	defaultOverrideName = "overrides"
+	defaultListenHost   = "127.0.0.1"
+	defaultListenPort   = 8080
+	defaultReleaseKeep  = 10
+)
+
+type Config struct {
+	Host                 string
+	Port                 int
+	SourceDir            string
+	SiteDir              string
+	ConfigPath           string
+	CacheMount           string
+	HistoryDir           string
+	WatchEnabled         bool
+	WatchDebounce        time.Duration
+	Fast                 bool
+	MermaidMode          string
+	ReleasesKeep         int
+	SuccessfulBuildsKeep int
+	FailedBuildsKeep     int
+	RefreshRunsKeep      int
+	RefreshTasks         []RefreshTaskConfig
+	BuildTimeout         time.Duration
+}
+
+type RefreshTaskConfig struct {
+	Name                  string   `json:"name"`
+	Every                 string   `json:"every"`
+	EnqueueBuildOnSuccess bool     `json:"enqueue_build_on_success"`
+	Args                  []string `json:"args"`
+
+	interval time.Duration
+}
+
+type State struct {
+	Queue   []QueuedOperation `json:"queue"`
+	Running *RunningOperation `json:"running,omitempty"`
+	Builds  []BuildRecord     `json:"builds"`
+	Refresh []RefreshRecord   `json:"refresh"`
+}
+
+type QueuedOperation struct {
+	ID          string    `json:"id"`
+	Kind        string    `json:"kind"`
+	Label       string    `json:"label"`
+	TriggerType string    `json:"trigger_type"`
+	Detail      string    `json:"detail,omitempty"`
+	Changed     []string  `json:"changed,omitempty"`
+	EnqueuedAt  time.Time `json:"enqueued_at"`
+	ReleaseID   string    `json:"release_id,omitempty"`
+	TaskName    string    `json:"task_name,omitempty"`
+}
+
+type RunningOperation struct {
+	ID          string    `json:"id"`
+	Kind        string    `json:"kind"`
+	Label       string    `json:"label"`
+	TriggerType string    `json:"trigger_type"`
+	Detail      string    `json:"detail,omitempty"`
+	StartedAt   time.Time `json:"started_at"`
+	Phase       string    `json:"phase"`
+}
+
+type BuildRecord struct {
+	ID              string    `json:"id"`
+	Kind            string    `json:"kind"`
+	Status          string    `json:"status"`
+	TriggerType     string    `json:"trigger_type"`
+	TriggerDetail   string    `json:"trigger_detail,omitempty"`
+	ChangedPaths    []string  `json:"changed_paths,omitempty"`
+	EnqueuedAt      time.Time `json:"enqueued_at"`
+	StartedAt       time.Time `json:"started_at"`
+	FinishedAt      time.Time `json:"finished_at"`
+	QueueWaitMS     int64     `json:"queue_wait_ms"`
+	PrepareMS       int64     `json:"prepare_ms"`
+	BuildMS         int64     `json:"build_ms"`
+	PromoteMS       int64     `json:"promote_ms"`
+	PruneMS         int64     `json:"prune_ms"`
+	TotalMS         int64     `json:"total_ms"`
+	ReleaseID       string    `json:"release_id,omitempty"`
+	ReleasePath     string    `json:"release_path,omitempty"`
+	BecameLive      bool      `json:"became_live"`
+	LogPath         string    `json:"log_path,omitempty"`
+	PerfSummary     []string  `json:"perf_summary,omitempty"`
+	Error           string    `json:"error,omitempty"`
+	RollbackRelease string    `json:"rollback_release,omitempty"`
+}
+
+type RefreshRecord struct {
+	ID                    string    `json:"id"`
+	TaskName              string    `json:"task_name"`
+	Status                string    `json:"status"`
+	TriggerType           string    `json:"trigger_type"`
+	TriggerDetail         string    `json:"trigger_detail,omitempty"`
+	EnqueuedAt            time.Time `json:"enqueued_at"`
+	StartedAt             time.Time `json:"started_at"`
+	FinishedAt            time.Time `json:"finished_at"`
+	QueueWaitMS           int64     `json:"queue_wait_ms"`
+	RunMS                 int64     `json:"run_ms"`
+	TotalMS               int64     `json:"total_ms"`
+	LogPath               string    `json:"log_path,omitempty"`
+	EnqueuedBuildID       string    `json:"enqueued_build_id,omitempty"`
+	EnqueueBuildOnSuccess bool      `json:"enqueue_build_on_success"`
+	Command               []string  `json:"command,omitempty"`
+	Error                 string    `json:"error,omitempty"`
+}
+
+type ReleaseView struct {
+	ID           string    `json:"id"`
+	Path         string    `json:"path"`
+	CreatedAt    time.Time `json:"created_at"`
+	Current      bool      `json:"current"`
+	BuildID      string    `json:"build_id,omitempty"`
+	RollbackOnly bool      `json:"rollback_only"`
+}
+
+type Service struct {
+	cfg          Config
+	executable   string
+	statePath    string
+	logDir       string
+	overrideDir  string
+	queueCh      chan queueRequest
+	watchMu      sync.Mutex
+	watchChanged map[string]struct{}
+	watchTimer   *time.Timer
+	stateMu      sync.Mutex
+	state        State
+	server       *http.Server
+}
+
+type queueRequest struct {
+	QueuedOperation
+	commandArgs []string
+}
+
+func New(cfg Config) (*Service, error) {
+	if cfg.Host == "" {
+		cfg.Host = defaultListenHost
+	}
+	if cfg.Port == 0 {
+		cfg.Port = defaultListenPort
+	}
+	if cfg.SourceDir == "" {
+		cfg.SourceDir = "."
+	}
+	if cfg.SiteDir == "" {
+		cfg.SiteDir = "public"
+	}
+	if cfg.HistoryDir == "" {
+		cfg.HistoryDir = filepath.Join(cfg.SiteDir, ".builder-admin")
+	}
+	if cfg.WatchDebounce <= 0 {
+		cfg.WatchDebounce = 2 * time.Second
+	}
+	if cfg.ReleasesKeep <= 0 {
+		cfg.ReleasesKeep = defaultReleaseKeep
+	}
+	if cfg.SuccessfulBuildsKeep <= 0 {
+		cfg.SuccessfulBuildsKeep = 50
+	}
+	if cfg.FailedBuildsKeep <= 0 {
+		cfg.FailedBuildsKeep = 100
+	}
+	if cfg.RefreshRunsKeep <= 0 {
+		cfg.RefreshRunsKeep = 100
+	}
+	if cfg.BuildTimeout <= 0 {
+		cfg.BuildTimeout = 2 * time.Hour
+	}
+	for i := range cfg.RefreshTasks {
+		if cfg.RefreshTasks[i].Name == "" {
+			return nil, fmt.Errorf("refresh task name is required")
+		}
+		if len(cfg.RefreshTasks[i].Args) == 0 {
+			return nil, fmt.Errorf("refresh task %q must define args", cfg.RefreshTasks[i].Name)
+		}
+		d, err := time.ParseDuration(cfg.RefreshTasks[i].Every)
+		if err != nil {
+			return nil, fmt.Errorf("refresh task %q invalid every duration: %w", cfg.RefreshTasks[i].Name, err)
+		}
+		cfg.RefreshTasks[i].interval = d
+	}
+	execPath, err := os.Executable()
+	if err != nil {
+		return nil, fmt.Errorf("resolve executable: %w", err)
+	}
+	s := &Service{
+		cfg:          cfg,
+		executable:   execPath,
+		statePath:    filepath.Join(cfg.HistoryDir, defaultStateName),
+		logDir:       filepath.Join(cfg.HistoryDir, defaultLogDirName),
+		overrideDir:  filepath.Join(cfg.HistoryDir, defaultOverrideName),
+		queueCh:      make(chan queueRequest, 128),
+		watchChanged: make(map[string]struct{}),
+	}
+	if err := os.MkdirAll(s.logDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create log dir: %w", err)
+	}
+	if err := os.MkdirAll(s.overrideDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create override dir: %w", err)
+	}
+	if err := s.loadState(); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func (s *Service) Start(ctx context.Context) error {
+	go s.worker(ctx)
+	for i := range s.cfg.RefreshTasks {
+		go s.runRefreshScheduler(ctx, s.cfg.RefreshTasks[i])
+	}
+	if s.cfg.WatchEnabled {
+		go s.watchSource(ctx)
+	}
+	mux := http.NewServeMux()
+	s.registerRoutes(mux)
+	s.server = &http.Server{
+		Addr:              fmt.Sprintf("%s:%d", s.cfg.Host, s.cfg.Port),
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = s.server.Shutdown(shutdownCtx)
+	}()
+	err := s.server.ListenAndServe()
+	if errors.Is(err, http.ErrServerClosed) {
+		return nil
+	}
+	return err
+}
+
+func (s *Service) registerRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/", s.handleIndex)
+	mux.HandleFunc("/health", s.handleHealth)
+	mux.HandleFunc("/api/state", s.handleState)
+	mux.HandleFunc("/api/builds", s.handleBuilds)
+	mux.HandleFunc("/api/refresh/", s.handleRefreshRun)
+	mux.HandleFunc("/api/releases/", s.handleReleaseAction)
+	mux.HandleFunc("/logs/", s.handleLogs)
+}
+
+func (s *Service) handleHealth(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"status": "ok",
+		"queue":  len(s.snapshotState().Queue),
+	})
+}
+
+func (s *Service) handleState(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	state := s.snapshotState()
+	_ = json.NewEncoder(w).Encode(struct {
+		State        State         `json:"state"`
+		Releases     []ReleaseView `json:"releases"`
+		CurrentID    string        `json:"current_release_id,omitempty"`
+		CurrentPath  string        `json:"current_release_path,omitempty"`
+		Config       Config        `json:"config"`
+		RefreshTasks []string      `json:"refresh_tasks"`
+	}{
+		State:        state,
+		Releases:     s.discoverReleases(),
+		CurrentID:    s.currentReleaseID(),
+		CurrentPath:  s.currentReleasePath(),
+		Config:       s.cfg,
+		RefreshTasks: s.refreshTaskNames(),
+	})
+}
+
+func (s *Service) handleBuilds(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodPost {
+		if err := s.enqueueBuild("manual-ui", "Manual build from admin UI", nil); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		http.Redirect(w, r, "/", http.StatusSeeOther)
+		return
+	}
+	http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+}
+
+func (s *Service) handleRefreshRun(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	name := strings.TrimPrefix(r.URL.Path, "/api/refresh/")
+	if name == "" {
+		http.Error(w, "missing task name", http.StatusBadRequest)
+		return
+	}
+	if err := s.enqueueRefresh(name, "manual-ui", "Manual refresh from admin UI"); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	http.Redirect(w, r, "/", http.StatusSeeOther)
+}
+
+func (s *Service) handleReleaseAction(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	trimmed := strings.TrimPrefix(r.URL.Path, "/api/releases/")
+	parts := strings.Split(strings.Trim(trimmed, "/"), "/")
+	if len(parts) != 2 || parts[1] != "rollback" {
+		http.Error(w, "unsupported release action", http.StatusBadRequest)
+		return
+	}
+	if err := s.enqueueRollback(parts[0], "manual-ui", "Rollback from admin UI"); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	http.Redirect(w, r, "/", http.StatusSeeOther)
+}
+
+func (s *Service) handleLogs(w http.ResponseWriter, r *http.Request) {
+	rel := strings.TrimPrefix(r.URL.Path, "/logs/")
+	if rel == "" || strings.Contains(rel, "..") {
+		http.NotFound(w, r)
+		return
+	}
+	path := filepath.Join(s.logDir, rel)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	_, _ = w.Write(data)
+}
+
+func (s *Service) handleIndex(w http.ResponseWriter, _ *http.Request) {
+	tmpl := template.Must(template.New("builder-admin").Funcs(template.FuncMap{
+		"msToSeconds": func(ms int64) string {
+			return fmt.Sprintf("%.2fs", float64(ms)/1000)
+		},
+		"since": func(t time.Time) string {
+			if t.IsZero() {
+				return ""
+			}
+			return t.Format(time.RFC3339)
+		},
+	}).Parse(indexHTML))
+	state := s.snapshotState()
+	data := struct {
+		State        State
+		Releases     []ReleaseView
+		CurrentID    string
+		CurrentPath  string
+		RefreshTasks []RefreshTaskConfig
+	}{
+		State:        state,
+		Releases:     s.discoverReleases(),
+		CurrentID:    s.currentReleaseID(),
+		CurrentPath:  s.currentReleasePath(),
+		RefreshTasks: s.cfg.RefreshTasks,
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_ = tmpl.Execute(w, data)
+}
+
+func (s *Service) worker(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case req := <-s.queueCh:
+			s.process(ctx, req)
+		}
+	}
+}
+
+func (s *Service) process(ctx context.Context, req queueRequest) {
+	s.setRunning(req)
+	defer s.clearRunning()
+	s.removeQueued(req.ID)
+	switch req.Kind {
+	case "build":
+		s.runBuild(ctx, req)
+	case "refresh":
+		s.runRefresh(ctx, req)
+	case "rollback":
+		s.runRollback(req)
+	}
+}
+
+func (s *Service) enqueueBuild(triggerType, detail string, changed []string) error {
+	queued := QueuedOperation{
+		ID:          nextID("build"),
+		Kind:        "build",
+		Label:       "Build",
+		TriggerType: triggerType,
+		Detail:      detail,
+		Changed:     append([]string(nil), changed...),
+		EnqueuedAt:  time.Now().UTC(),
+	}
+	s.pushQueued(queued)
+	s.queueCh <- queueRequest{QueuedOperation: queued}
+	return nil
+}
+
+func (s *Service) enqueueRefresh(name, triggerType, detail string) error {
+	task, ok := s.findRefreshTask(name)
+	if !ok {
+		return fmt.Errorf("unknown refresh task %q", name)
+	}
+	queued := QueuedOperation{
+		ID:          nextID("refresh"),
+		Kind:        "refresh",
+		Label:       "Refresh " + task.Name,
+		TriggerType: triggerType,
+		Detail:      detail,
+		EnqueuedAt:  time.Now().UTC(),
+		TaskName:    task.Name,
+	}
+	s.pushQueued(queued)
+	s.queueCh <- queueRequest{QueuedOperation: queued, commandArgs: append([]string(nil), task.Args...)}
+	return nil
+}
+
+func (s *Service) enqueueRollback(releaseID, triggerType, detail string) error {
+	if releaseID == "" {
+		return fmt.Errorf("release id is required")
+	}
+	queued := QueuedOperation{
+		ID:          nextID("rollback"),
+		Kind:        "rollback",
+		Label:       "Rollback " + releaseID,
+		TriggerType: triggerType,
+		Detail:      detail,
+		EnqueuedAt:  time.Now().UTC(),
+		ReleaseID:   releaseID,
+	}
+	s.pushQueued(queued)
+	s.queueCh <- queueRequest{QueuedOperation: queued}
+	return nil
+}
+
+func (s *Service) runBuild(ctx context.Context, req queueRequest) {
+	started := time.Now().UTC()
+	record := BuildRecord{
+		ID:            req.ID,
+		Kind:          req.Kind,
+		Status:        "running",
+		TriggerType:   req.TriggerType,
+		TriggerDetail: req.Detail,
+		ChangedPaths:  append([]string(nil), req.Changed...),
+		EnqueuedAt:    req.EnqueuedAt,
+		StartedAt:     started,
+		QueueWaitMS:   started.Sub(req.EnqueuedAt).Milliseconds(),
+	}
+	logPath, logFile, err := s.createLogFile(req.ID)
+	if err != nil {
+		record.Status = "failed"
+		record.Error = err.Error()
+		record.FinishedAt = time.Now().UTC()
+		record.TotalMS = record.FinishedAt.Sub(started).Milliseconds()
+		s.finishBuild(record)
+		return
+	}
+	defer logFile.Close()
+	record.LogPath = logPath
+	ctx, cancel := context.WithTimeout(ctx, s.cfg.BuildTimeout)
+	defer cancel()
+
+	phaseStart := time.Now()
+	s.updateRunningPhase("prepare")
+	if err := s.prepareBuild(logFile); err != nil {
+		record.Status = "failed"
+		record.Error = err.Error()
+		record.PrepareMS = time.Since(phaseStart).Milliseconds()
+		record.FinishedAt = time.Now().UTC()
+		record.TotalMS = record.FinishedAt.Sub(started).Milliseconds()
+		record.PerfSummary = extractPerfSummaryFromFile(filepath.Join(s.logDir, logPath))
+		s.finishBuild(record)
+		return
+	}
+	record.PrepareMS = time.Since(phaseStart).Milliseconds()
+
+	buildWork := filepath.Join(s.cfg.SiteDir, ".build-work")
+	phaseStart = time.Now()
+	s.updateRunningPhase("build")
+	cmdArgs, cleanup, err := s.buildCommandArgs(req.ID, buildWork)
+	if err != nil {
+		record.Status = "failed"
+		record.Error = err.Error()
+		record.BuildMS = time.Since(phaseStart).Milliseconds()
+		record.FinishedAt = time.Now().UTC()
+		record.TotalMS = record.FinishedAt.Sub(started).Milliseconds()
+		record.PerfSummary = extractPerfSummaryFromFile(filepath.Join(s.logDir, logPath))
+		s.finishBuild(record)
+		return
+	}
+	defer cleanup()
+	if err := s.runLoggedCommand(ctx, logFile, s.cfg.SourceDir, nil, cmdArgs...); err != nil {
+		record.Status = "failed"
+		record.Error = err.Error()
+		record.BuildMS = time.Since(phaseStart).Milliseconds()
+		record.FinishedAt = time.Now().UTC()
+		record.TotalMS = record.FinishedAt.Sub(started).Milliseconds()
+		record.PerfSummary = extractPerfSummaryFromFile(filepath.Join(s.logDir, logPath))
+		s.finishBuild(record)
+		return
+	}
+	record.BuildMS = time.Since(phaseStart).Milliseconds()
+
+	phaseStart = time.Now()
+	s.updateRunningPhase("promote")
+	releaseID, releasePath, err := s.promoteBuild(buildWork)
+	if err != nil {
+		record.Status = "failed"
+		record.Error = err.Error()
+		record.PromoteMS = time.Since(phaseStart).Milliseconds()
+		record.FinishedAt = time.Now().UTC()
+		record.TotalMS = record.FinishedAt.Sub(started).Milliseconds()
+		record.PerfSummary = extractPerfSummaryFromFile(filepath.Join(s.logDir, logPath))
+		s.finishBuild(record)
+		return
+	}
+	record.PromoteMS = time.Since(phaseStart).Milliseconds()
+	record.ReleaseID = releaseID
+	record.ReleasePath = releasePath
+	record.BecameLive = true
+
+	phaseStart = time.Now()
+	s.updateRunningPhase("prune")
+	_ = s.pruneReleases()
+	record.PruneMS = time.Since(phaseStart).Milliseconds()
+
+	record.Status = "success"
+	record.FinishedAt = time.Now().UTC()
+	record.TotalMS = record.FinishedAt.Sub(started).Milliseconds()
+	record.PerfSummary = extractPerfSummaryFromFile(filepath.Join(s.logDir, logPath))
+	s.finishBuild(record)
+}
+
+func (s *Service) runRefresh(ctx context.Context, req queueRequest) {
+	started := time.Now().UTC()
+	record := RefreshRecord{
+		ID:                    req.ID,
+		TaskName:              req.TaskName,
+		Status:                "running",
+		TriggerType:           req.TriggerType,
+		TriggerDetail:         req.Detail,
+		EnqueuedAt:            req.EnqueuedAt,
+		StartedAt:             started,
+		QueueWaitMS:           started.Sub(req.EnqueuedAt).Milliseconds(),
+		EnqueueBuildOnSuccess: false,
+		Command:               append([]string(nil), req.commandArgs...),
+	}
+	task, ok := s.findRefreshTask(req.TaskName)
+	if ok {
+		record.EnqueueBuildOnSuccess = task.EnqueueBuildOnSuccess
+	}
+	logPath, logFile, err := s.createLogFile(req.ID)
+	if err != nil {
+		record.Status = "failed"
+		record.Error = err.Error()
+		record.FinishedAt = time.Now().UTC()
+		record.TotalMS = record.FinishedAt.Sub(started).Milliseconds()
+		s.finishRefresh(record)
+		return
+	}
+	defer logFile.Close()
+	record.LogPath = logPath
+	ctx, cancel := context.WithTimeout(ctx, s.cfg.BuildTimeout)
+	defer cancel()
+	s.updateRunningPhase("refresh")
+	runStart := time.Now()
+	if err := s.runLoggedCommand(ctx, logFile, s.cfg.SourceDir, nil, req.commandArgs...); err != nil {
+		record.Status = "failed"
+		record.Error = err.Error()
+		record.RunMS = time.Since(runStart).Milliseconds()
+		record.FinishedAt = time.Now().UTC()
+		record.TotalMS = record.FinishedAt.Sub(started).Milliseconds()
+		s.finishRefresh(record)
+		return
+	}
+	record.RunMS = time.Since(runStart).Milliseconds()
+	record.Status = "success"
+	if task.EnqueueBuildOnSuccess {
+		buildID := nextID("build")
+		queued := QueuedOperation{
+			ID:          buildID,
+			Kind:        "build",
+			Label:       "Build",
+			TriggerType: "scheduled-refresh",
+			Detail:      "Build enqueued by refresh task " + task.Name,
+			EnqueuedAt:  time.Now().UTC(),
+		}
+		record.EnqueuedBuildID = buildID
+		s.pushQueued(queued)
+		s.queueCh <- queueRequest{QueuedOperation: queued}
+	}
+	record.FinishedAt = time.Now().UTC()
+	record.TotalMS = record.FinishedAt.Sub(started).Milliseconds()
+	s.finishRefresh(record)
+}
+
+func (s *Service) runRollback(req queueRequest) {
+	started := time.Now().UTC()
+	record := BuildRecord{
+		ID:              req.ID,
+		Kind:            req.Kind,
+		Status:          "running",
+		TriggerType:     req.TriggerType,
+		TriggerDetail:   req.Detail,
+		EnqueuedAt:      req.EnqueuedAt,
+		StartedAt:       started,
+		QueueWaitMS:     started.Sub(req.EnqueuedAt).Milliseconds(),
+		RollbackRelease: req.ReleaseID,
+	}
+	logPath, logFile, err := s.createLogFile(req.ID)
+	if err != nil {
+		record.Status = "failed"
+		record.Error = err.Error()
+		record.FinishedAt = time.Now().UTC()
+		record.TotalMS = record.FinishedAt.Sub(started).Milliseconds()
+		s.finishBuild(record)
+		return
+	}
+	defer logFile.Close()
+	record.LogPath = logPath
+	s.updateRunningPhase("promote")
+	releasePath := filepath.Join(s.cfg.SiteDir, "releases", req.ReleaseID)
+	if _, err := os.Stat(releasePath); err != nil {
+		record.Status = "failed"
+		record.Error = fmt.Sprintf("release %q not found: %v", req.ReleaseID, err)
+	} else if err := s.switchCurrentRelease(req.ReleaseID); err != nil {
+		record.Status = "failed"
+		record.Error = err.Error()
+	} else {
+		_, _ = fmt.Fprintf(logFile, "promoted release %s\n", req.ReleaseID)
+		record.Status = "success"
+		record.ReleaseID = req.ReleaseID
+		record.ReleasePath = releasePath
+		record.BecameLive = true
+	}
+	record.FinishedAt = time.Now().UTC()
+	record.PromoteMS = record.FinishedAt.Sub(started).Milliseconds()
+	record.TotalMS = record.PromoteMS
+	record.PerfSummary = extractPerfSummaryFromFile(filepath.Join(s.logDir, logPath))
+	s.finishBuild(record)
+}
+
+func (s *Service) prepareBuild(log io.Writer) error {
+	if err := os.MkdirAll(filepath.Join(s.cfg.SiteDir, "releases"), 0o755); err != nil {
+		return err
+	}
+	if s.cfg.CacheMount != "" {
+		for _, part := range []string{"build", "plugin", "xdg"} {
+			if err := os.MkdirAll(filepath.Join(s.cfg.CacheMount, part), 0o755); err != nil {
+				return err
+			}
+		}
+		for _, linkName := range []string{".markata", ".markata-cache"} {
+			_ = os.RemoveAll(filepath.Join(s.cfg.SourceDir, linkName))
+		}
+		if err := os.Symlink(filepath.Join(s.cfg.CacheMount, "build"), filepath.Join(s.cfg.SourceDir, ".markata")); err != nil {
+			return err
+		}
+		if err := os.Symlink(filepath.Join(s.cfg.CacheMount, "plugin"), filepath.Join(s.cfg.SourceDir, ".markata-cache")); err != nil {
+			return err
+		}
+	}
+	buildWork := filepath.Join(s.cfg.SiteDir, ".build-work")
+	if err := os.RemoveAll(buildWork); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(buildWork, 0o755); err != nil {
+		return err
+	}
+	current := filepath.Join(s.cfg.SiteDir, "current")
+	if _, err := os.Stat(current); err == nil {
+		_, _ = fmt.Fprintln(log, "seeding build work from current release")
+		return s.runLoggedCommand(context.Background(), log, "", nil, "cp", "-al", filepath.Join(current, "."), buildWork+string(os.PathSeparator))
+	}
+	return nil
+}
+
+func (s *Service) buildCommandArgs(id, buildWork string) ([]string, func(), error) {
+	args := make([]string, 0, 10)
+	if s.cfg.ConfigPath != "" {
+		args = append(args, "--config", s.cfg.ConfigPath)
+	}
+	cleanup := func() {}
+	if s.cfg.MermaidMode != "" {
+		overridePath := filepath.Join(s.overrideDir, id+".toml")
+		contents := fmt.Sprintf("[markata-go.mermaid]\nmode = %q\n", s.cfg.MermaidMode)
+		if err := os.WriteFile(overridePath, []byte(contents), 0o644); err != nil {
+			return nil, cleanup, err
+		}
+		args = append(args, "-m", overridePath)
+		cleanup = func() { _ = os.Remove(overridePath) }
+	}
+	args = append(args, "build")
+	if s.cfg.Fast {
+		args = append(args, "--fast")
+	}
+	args = append(args, "--output", buildWork)
+	return args, cleanup, nil
+}
+
+func (s *Service) promoteBuild(buildWork string) (string, string, error) {
+	releaseID := time.Now().UTC().Format("20060102T150405Z") + "-" + hostSuffix()
+	releasePath := filepath.Join(s.cfg.SiteDir, "releases", releaseID)
+	if err := os.RemoveAll(releasePath); err != nil {
+		return "", "", err
+	}
+	if err := os.Rename(buildWork, releasePath); err != nil {
+		return "", "", err
+	}
+	if err := s.switchCurrentRelease(releaseID); err != nil {
+		return "", "", err
+	}
+	return releaseID, releasePath, nil
+}
+
+func (s *Service) switchCurrentRelease(releaseID string) error {
+	currentNext := filepath.Join(s.cfg.SiteDir, "current.next")
+	_ = os.Remove(currentNext)
+	if err := os.Symlink(filepath.Join("releases", releaseID), currentNext); err != nil {
+		return err
+	}
+	return os.Rename(currentNext, filepath.Join(s.cfg.SiteDir, "current"))
+}
+
+func (s *Service) pruneReleases() error {
+	releases := s.discoverReleases()
+	if len(releases) <= s.cfg.ReleasesKeep {
+		return nil
+	}
+	for _, release := range releases[s.cfg.ReleasesKeep:] {
+		if release.Current {
+			continue
+		}
+		_ = os.RemoveAll(release.Path)
+	}
+	return nil
+}
+
+func (s *Service) runLoggedCommand(ctx context.Context, log io.Writer, cwd string, env []string, args ...string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("command is required")
+	}
+	cmdName := args[0]
+	cmdArgs := args[1:]
+	cmd := exec.CommandContext(ctx, cmdName, cmdArgs...)
+	if strings.HasPrefix(cmdName, "-") || cmdName == "build" || strings.HasSuffix(cmdName, "markata-go") || filepath.Base(cmdName) == filepath.Base(s.executable) {
+		cmd = exec.CommandContext(ctx, s.executable, args...)
+	}
+	cmd.Stdout = log
+	cmd.Stderr = log
+	if cwd != "" {
+		cmd.Dir = cwd
+	}
+	cmd.Env = os.Environ()
+	if len(env) > 0 {
+		cmd.Env = append(cmd.Env, env...)
+	}
+	_, _ = fmt.Fprintf(log, "$ %s\n", strings.Join(cmd.Args, " "))
+	err := cmd.Run()
+	if err == nil {
+		return nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		if ws, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+			return fmt.Errorf("command failed with exit code %d", ws.ExitStatus())
+		}
+	}
+	return err
+}
+
+func (s *Service) runRefreshScheduler(ctx context.Context, task RefreshTaskConfig) {
+	ticker := time.NewTicker(task.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			_ = s.enqueueRefresh(task.Name, "schedule", "Scheduled refresh")
+		}
+	}
+}
+
+func (s *Service) watchSource(ctx context.Context) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return
+	}
+	defer watcher.Close()
+	_ = addDirRecursive(watcher, s.cfg.SourceDir)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return
+			}
+			if ignoreWatchPath(s.cfg.SourceDir, event.Name) {
+				continue
+			}
+			if event.Op&fsnotify.Create != 0 {
+				_ = addDirRecursiveIfDir(watcher, event.Name)
+			}
+			if event.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Remove|fsnotify.Rename) == 0 {
+				continue
+			}
+			s.recordWatchPath(event.Name)
+		case _, ok := <-watcher.Errors:
+			if !ok {
+				return
+			}
+		}
+	}
+}
+
+func (s *Service) recordWatchPath(path string) {
+	rel, err := filepath.Rel(s.cfg.SourceDir, path)
+	if err != nil {
+		rel = path
+	}
+	s.watchMu.Lock()
+	defer s.watchMu.Unlock()
+	s.watchChanged[filepath.ToSlash(rel)] = struct{}{}
+	if s.watchTimer != nil {
+		if !s.watchTimer.Stop() {
+			select {
+			case <-s.watchTimer.C:
+			default:
+			}
+		}
+	}
+	s.watchTimer = time.AfterFunc(s.cfg.WatchDebounce, func() {
+		s.flushWatchBuild()
+	})
+}
+
+func (s *Service) flushWatchBuild() {
+	s.watchMu.Lock()
+	changed := make([]string, 0, len(s.watchChanged))
+	for path := range s.watchChanged {
+		changed = append(changed, path)
+	}
+	clear(s.watchChanged)
+	s.watchMu.Unlock()
+	if len(changed) == 0 {
+		return
+	}
+	sort.Strings(changed)
+	_ = s.enqueueBuild("file-watch", fmt.Sprintf("Debounced file-watch build (%d paths)", len(changed)), changed)
+}
+
+func (s *Service) findRefreshTask(name string) (RefreshTaskConfig, bool) {
+	for _, task := range s.cfg.RefreshTasks {
+		if task.Name == name {
+			return task, true
+		}
+	}
+	return RefreshTaskConfig{}, false
+}
+
+func (s *Service) refreshTaskNames() []string {
+	names := make([]string, 0, len(s.cfg.RefreshTasks))
+	for _, task := range s.cfg.RefreshTasks {
+		names = append(names, task.Name)
+	}
+	return names
+}
+
+func (s *Service) createLogFile(id string) (string, *os.File, error) {
+	rel := id + ".log"
+	path := filepath.Join(s.logDir, rel)
+	f, err := os.Create(path)
+	if err != nil {
+		return "", nil, err
+	}
+	return rel, f, nil
+}
+
+func (s *Service) snapshotState() State {
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+	clone := s.state
+	clone.Queue = append([]QueuedOperation(nil), s.state.Queue...)
+	clone.Builds = append([]BuildRecord(nil), s.state.Builds...)
+	clone.Refresh = append([]RefreshRecord(nil), s.state.Refresh...)
+	return clone
+}
+
+func (s *Service) pushQueued(queued QueuedOperation) {
+	s.stateMu.Lock()
+	s.state.Queue = append(s.state.Queue, queued)
+	s.saveStateLocked()
+	s.stateMu.Unlock()
+}
+
+func (s *Service) removeQueued(id string) {
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+	filtered := s.state.Queue[:0]
+	for _, queued := range s.state.Queue {
+		if queued.ID != id {
+			filtered = append(filtered, queued)
+		}
+	}
+	s.state.Queue = append([]QueuedOperation(nil), filtered...)
+	s.saveStateLocked()
+}
+
+func (s *Service) setRunning(req queueRequest) {
+	s.stateMu.Lock()
+	s.state.Running = &RunningOperation{
+		ID:          req.ID,
+		Kind:        req.Kind,
+		Label:       req.Label,
+		TriggerType: req.TriggerType,
+		Detail:      req.Detail,
+		StartedAt:   time.Now().UTC(),
+		Phase:       "starting",
+	}
+	s.saveStateLocked()
+	s.stateMu.Unlock()
+}
+
+func (s *Service) updateRunningPhase(phase string) {
+	s.stateMu.Lock()
+	if s.state.Running != nil {
+		s.state.Running.Phase = phase
+		s.saveStateLocked()
+	}
+	s.stateMu.Unlock()
+}
+
+func (s *Service) clearRunning() {
+	s.stateMu.Lock()
+	s.state.Running = nil
+	s.saveStateLocked()
+	s.stateMu.Unlock()
+}
+
+func (s *Service) finishBuild(record BuildRecord) {
+	s.stateMu.Lock()
+	s.state.Builds = append([]BuildRecord{record}, s.state.Builds...)
+	s.pruneBuildHistoryLocked()
+	s.saveStateLocked()
+	s.stateMu.Unlock()
+}
+
+func (s *Service) finishRefresh(record RefreshRecord) {
+	s.stateMu.Lock()
+	s.state.Refresh = append([]RefreshRecord{record}, s.state.Refresh...)
+	s.pruneRefreshHistoryLocked()
+	s.saveStateLocked()
+	s.stateMu.Unlock()
+}
+
+func (s *Service) pruneBuildHistoryLocked() {
+	kept := make([]BuildRecord, 0, len(s.state.Builds))
+	successCount := 0
+	failureCount := 0
+	for _, record := range s.state.Builds {
+		keep := false
+		switch record.Status {
+		case "success":
+			if successCount < s.cfg.SuccessfulBuildsKeep {
+				keep = true
+				successCount++
+			}
+		default:
+			if failureCount < s.cfg.FailedBuildsKeep {
+				keep = true
+				failureCount++
+			}
+		}
+		if keep {
+			kept = append(kept, record)
+			continue
+		}
+		if record.LogPath != "" {
+			_ = os.Remove(filepath.Join(s.logDir, record.LogPath))
+		}
+	}
+	s.state.Builds = kept
+}
+
+func (s *Service) pruneRefreshHistoryLocked() {
+	if len(s.state.Refresh) <= s.cfg.RefreshRunsKeep {
+		return
+	}
+	for _, record := range s.state.Refresh[s.cfg.RefreshRunsKeep:] {
+		if record.LogPath != "" {
+			_ = os.Remove(filepath.Join(s.logDir, record.LogPath))
+		}
+	}
+	s.state.Refresh = append([]RefreshRecord(nil), s.state.Refresh[:s.cfg.RefreshRunsKeep]...)
+}
+
+func (s *Service) loadState() error {
+	data, err := os.ReadFile(s.statePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			s.state = State{}
+			return nil
+		}
+		return fmt.Errorf("read state: %w", err)
+	}
+	if err := json.Unmarshal(data, &s.state); err != nil {
+		return fmt.Errorf("decode state: %w", err)
+	}
+	return nil
+}
+
+func (s *Service) saveStateLocked() {
+	data, err := json.MarshalIndent(s.state, "", "  ")
+	if err != nil {
+		return
+	}
+	tmp := s.statePath + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return
+	}
+	_ = os.Rename(tmp, s.statePath)
+}
+
+func (s *Service) discoverReleases() []ReleaseView {
+	releasesDir := filepath.Join(s.cfg.SiteDir, "releases")
+	entries, err := os.ReadDir(releasesDir)
+	if err != nil {
+		return nil
+	}
+	current := s.currentReleaseID()
+	buildByRelease := make(map[string]string)
+	for _, record := range s.snapshotState().Builds {
+		if record.ReleaseID != "" && buildByRelease[record.ReleaseID] == "" {
+			buildByRelease[record.ReleaseID] = record.ID
+		}
+	}
+	views := make([]ReleaseView, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		views = append(views, ReleaseView{
+			ID:           entry.Name(),
+			Path:         filepath.Join(releasesDir, entry.Name()),
+			CreatedAt:    info.ModTime().UTC(),
+			Current:      entry.Name() == current,
+			BuildID:      buildByRelease[entry.Name()],
+			RollbackOnly: true,
+		})
+	}
+	sort.Slice(views, func(i, j int) bool {
+		return views[i].CreatedAt.After(views[j].CreatedAt)
+	})
+	return views
+}
+
+func (s *Service) currentReleasePath() string {
+	target, err := os.Readlink(filepath.Join(s.cfg.SiteDir, "current"))
+	if err != nil {
+		return ""
+	}
+	if filepath.IsAbs(target) {
+		return target
+	}
+	return filepath.Join(s.cfg.SiteDir, target)
+}
+
+func (s *Service) currentReleaseID() string {
+	path := s.currentReleasePath()
+	if path == "" {
+		return ""
+	}
+	return filepath.Base(path)
+}
+
+func addDirRecursive(w *fsnotify.Watcher, root string) error {
+	return filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		if ignoreWatchPath(root, path) && path != root {
+			return filepath.SkipDir
+		}
+		return w.Add(path)
+	})
+}
+
+func addDirRecursiveIfDir(w *fsnotify.Watcher, path string) error {
+	info, err := os.Stat(path)
+	if err != nil || !info.IsDir() {
+		return nil
+	}
+	return addDirRecursive(w, path)
+}
+
+func ignoreWatchPath(root, path string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	rel = filepath.ToSlash(rel)
+	if rel == "." {
+		return false
+	}
+	parts := strings.Split(rel, "/")
+	for _, part := range parts {
+		switch part {
+		case ".git", ".markata", ".markata-cache", ".builder-admin":
+			return true
+		}
+	}
+	return false
+}
+
+func extractPerfSummaryFromFile(path string) []string {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+	summary := make([]string, 0, 24)
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.Contains(line, "] took ") || strings.Contains(line, "Hotspots:") || strings.Contains(line, "Duration:") {
+			summary = append(summary, line)
+		}
+	}
+	if len(summary) > 24 {
+		return summary[len(summary)-24:]
+	}
+	return summary
+}
+
+func nextID(prefix string) string {
+	return prefix + "-" + strconv.FormatInt(time.Now().UTC().UnixNano(), 10)
+}
+
+func hostSuffix() string {
+	host, err := os.Hostname()
+	if err != nil || host == "" {
+		return "host"
+	}
+	return host
+}
+
+const indexHTML = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Builder Admin</title>
+  <meta http-equiv="refresh" content="5">
+  <style>
+    body { font-family: ui-sans-serif, system-ui, sans-serif; margin: 0; background: #0b1220; color: #e5e7eb; }
+    a { color: #93c5fd; }
+    main { max-width: 1200px; margin: 0 auto; padding: 24px; }
+    h1, h2 { margin: 0 0 12px; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 16px; margin-bottom: 24px; }
+    .card { background: #111827; border: 1px solid #1f2937; border-radius: 12px; padding: 16px; }
+    .actions form { display: inline-block; margin-right: 8px; margin-bottom: 8px; }
+    button { background: #2563eb; color: white; border: 0; border-radius: 8px; padding: 10px 14px; cursor: pointer; }
+    button.secondary { background: #374151; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { text-align: left; padding: 8px; border-top: 1px solid #1f2937; vertical-align: top; }
+    code, pre { background: #0f172a; border-radius: 8px; }
+    code { padding: 2px 6px; }
+    pre { padding: 12px; overflow: auto; white-space: pre-wrap; }
+    .pill { display: inline-block; padding: 2px 8px; border-radius: 999px; background: #1f2937; }
+  </style>
+</head>
+<body>
+<main>
+  <h1>Builder Admin</h1>
+  <div class="grid">
+    <section class="card">
+      <h2>Live</h2>
+      <p><strong>Current release:</strong> <code>{{ .CurrentID }}</code></p>
+      <p><strong>Current path:</strong> <code>{{ .CurrentPath }}</code></p>
+      {{ if .State.Running }}<p><strong>Running:</strong> {{ .State.Running.Kind }} {{ .State.Running.ID }} <span class="pill">{{ .State.Running.Phase }}</span></p>{{ else }}<p>No active work.</p>{{ end }}
+      <p><strong>Queued:</strong> {{ len .State.Queue }}</p>
+    </section>
+    <section class="card actions">
+      <h2>Actions</h2>
+      <form method="post" action="/api/builds"><button type="submit">Enqueue Build</button></form>
+      {{ range .RefreshTasks }}
+      <form method="post" action="/api/refresh/{{ .Name }}"><button class="secondary" type="submit">Run {{ .Name }}</button></form>
+      {{ end }}
+    </section>
+  </div>
+
+  <section class="card">
+    <h2>Queue</h2>
+    <table>
+      <thead><tr><th>ID</th><th>Kind</th><th>Trigger</th><th>Detail</th><th>Changed</th><th>Queued</th></tr></thead>
+      <tbody>
+      {{ range .State.Queue }}
+      <tr>
+        <td><code>{{ .ID }}</code></td>
+        <td>{{ .Kind }}</td>
+        <td>{{ .TriggerType }}</td>
+        <td>{{ .Detail }}</td>
+        <td>{{ range .Changed }}<div><code>{{ . }}</code></div>{{ end }}</td>
+        <td>{{ since .EnqueuedAt }}</td>
+      </tr>
+      {{ else }}
+      <tr><td colspan="6">Queue is empty.</td></tr>
+      {{ end }}
+      </tbody>
+    </table>
+  </section>
+
+  <section class="card">
+    <h2>Builds</h2>
+    <table>
+      <thead><tr><th>ID</th><th>Status</th><th>Trigger</th><th>Total</th><th>Build</th><th>Release</th><th>Logs</th><th>Summary</th></tr></thead>
+      <tbody>
+      {{ range .State.Builds }}
+      <tr>
+        <td><code>{{ .ID }}</code></td>
+        <td>{{ .Status }}</td>
+        <td>{{ .TriggerType }}</td>
+        <td>{{ msToSeconds .TotalMS }}</td>
+        <td>{{ msToSeconds .BuildMS }}</td>
+        <td>{{ if .ReleaseID }}<code>{{ .ReleaseID }}</code>{{ end }}</td>
+        <td>{{ if .LogPath }}<a href="/logs/{{ .LogPath }}">log</a>{{ end }}</td>
+        <td>{{ if .PerfSummary }}<pre>{{ range .PerfSummary }}{{ . }}
+{{ end }}</pre>{{ end }}</td>
+      </tr>
+      {{ else }}
+      <tr><td colspan="8">No builds yet.</td></tr>
+      {{ end }}
+      </tbody>
+    </table>
+  </section>
+
+  <section class="card">
+    <h2>Refresh Runs</h2>
+    <table>
+      <thead><tr><th>ID</th><th>Task</th><th>Status</th><th>Total</th><th>Logs</th><th>Build</th></tr></thead>
+      <tbody>
+      {{ range .State.Refresh }}
+      <tr>
+        <td><code>{{ .ID }}</code></td>
+        <td>{{ .TaskName }}</td>
+        <td>{{ .Status }}</td>
+        <td>{{ msToSeconds .TotalMS }}</td>
+        <td>{{ if .LogPath }}<a href="/logs/{{ .LogPath }}">log</a>{{ end }}</td>
+        <td>{{ if .EnqueuedBuildID }}<code>{{ .EnqueuedBuildID }}</code>{{ end }}</td>
+      </tr>
+      {{ else }}
+      <tr><td colspan="6">No refresh runs yet.</td></tr>
+      {{ end }}
+      </tbody>
+    </table>
+  </section>
+
+  <section class="card">
+    <h2>Releases</h2>
+    <table>
+      <thead><tr><th>ID</th><th>Current</th><th>Created</th><th>Build</th><th>Action</th></tr></thead>
+      <tbody>
+      {{ range .Releases }}
+      <tr>
+        <td><code>{{ .ID }}</code></td>
+        <td>{{ if .Current }}live{{ end }}</td>
+        <td>{{ since .CreatedAt }}</td>
+        <td>{{ if .BuildID }}<code>{{ .BuildID }}</code>{{ end }}</td>
+        <td>{{ if not .Current }}<form method="post" action="/api/releases/{{ .ID }}/rollback"><button class="secondary" type="submit">Promote</button></form>{{ end }}</td>
+      </tr>
+      {{ else }}
+      <tr><td colspan="5">No releases found.</td></tr>
+      {{ end }}
+      </tbody>
+    </table>
+  </section>
+</main>
+</body>
+</html>`

--- a/pkg/builderadmin/service.go
+++ b/pkg/builderadmin/service.go
@@ -374,6 +374,12 @@ func (s *Service) handleIndex(w http.ResponseWriter, _ *http.Request) {
 			}
 			return t.Format(time.RFC3339)
 		},
+		"summaryPreview": func(lines []string) []string {
+			if len(lines) <= 6 {
+				return lines
+			}
+			return lines[len(lines)-6:]
+		},
 	}).Parse(indexHTML))
 	state := s.snapshotState()
 	data := struct {
@@ -1208,36 +1214,224 @@ const indexHTML = `<!doctype html>
   <title>Builder Admin</title>
   <meta http-equiv="refresh" content="5">
   <style>
-    body { font-family: ui-sans-serif, system-ui, sans-serif; margin: 0; background: #0b1220; color: #e5e7eb; }
-    a { color: #93c5fd; }
-    main { max-width: 1200px; margin: 0 auto; padding: 24px; }
-    h1, h2 { margin: 0 0 12px; }
-    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 16px; margin-bottom: 24px; }
-    .card { background: #111827; border: 1px solid #1f2937; border-radius: 12px; padding: 16px; }
-    .actions form { display: inline-block; margin-right: 8px; margin-bottom: 8px; }
-    button { background: #2563eb; color: white; border: 0; border-radius: 8px; padding: 10px 14px; cursor: pointer; }
-    button.secondary { background: #374151; }
-    table { width: 100%; border-collapse: collapse; }
-    th, td { text-align: left; padding: 8px; border-top: 1px solid #1f2937; vertical-align: top; }
-    code, pre { background: #0f172a; border-radius: 8px; }
-    code { padding: 2px 6px; }
-    pre { padding: 12px; overflow: auto; white-space: pre-wrap; }
-    .pill { display: inline-block; padding: 2px 8px; border-radius: 999px; background: #1f2937; }
+    :root {
+      color-scheme: dark;
+      --bg: #09090b;
+      --panel: rgba(24, 24, 27, 0.9);
+      --panel-strong: rgba(9, 9, 11, 0.95);
+      --line: rgba(82, 82, 91, 0.75);
+      --line-soft: rgba(63, 63, 70, 0.55);
+      --text: #f4f4f5;
+      --muted: #a1a1aa;
+      --accent: #fafafa;
+      --shadow: 0 24px 60px rgba(0, 0, 0, 0.35);
+    }
+    * { box-sizing: border-box; }
+    html { background: var(--bg); }
+    body {
+      margin: 0;
+      color: var(--text);
+      font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+      background:
+        radial-gradient(circle at top left, rgba(255,255,255,0.04), transparent 30%),
+        radial-gradient(circle at bottom right, rgba(255,255,255,0.03), transparent 35%),
+        linear-gradient(rgba(255,255,255,0.018) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255,255,255,0.018) 1px, transparent 1px),
+        var(--bg);
+      background-size: auto, auto, 11px 11px, 11px 11px, auto;
+    }
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    main {
+      width: 100%;
+      max-width: none;
+      padding: 20px 24px 48px;
+    }
+    h1, h2, h3, p { margin: 0; }
+    .topbar {
+      display: flex;
+      justify-content: space-between;
+      gap: 20px;
+      align-items: flex-start;
+      margin-bottom: 20px;
+    }
+    .titleblock h1 {
+      font-size: clamp(2rem, 4vw, 3.6rem);
+      line-height: 0.95;
+      letter-spacing: -0.06em;
+      text-transform: uppercase;
+    }
+    .titleblock p {
+      margin-top: 10px;
+      color: var(--muted);
+      max-width: 72ch;
+    }
+    .hero {
+      display: grid;
+      grid-template-columns: 1.5fr 1fr;
+      gap: 18px;
+      margin-bottom: 20px;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 18px;
+      margin-bottom: 20px;
+    }
+    .section-grid {
+      display: grid;
+      grid-template-columns: 1.3fr 1fr;
+      gap: 18px;
+      margin-bottom: 20px;
+    }
+    .card {
+      background: var(--panel);
+      border: 1px solid var(--line-soft);
+      border-radius: 28px;
+      padding: 18px 20px;
+      box-shadow: var(--shadow);
+      backdrop-filter: blur(10px);
+    }
+    .card strong, .muted-label {
+      display: block;
+      font-size: 0.72rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--muted);
+      margin-bottom: 6px;
+    }
+    .value {
+      font-size: 1.15rem;
+      line-height: 1.25;
+      word-break: break-word;
+    }
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      align-content: start;
+    }
+    .actions form { margin: 0; }
+    button {
+      background: var(--panel-strong);
+      color: var(--text);
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      padding: 10px 16px;
+      cursor: pointer;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-size: 0.75rem;
+    }
+    button.secondary { background: transparent; }
+    button:hover { background: #18181b; }
+    .stack { display: flex; flex-direction: column; gap: 10px; }
+    .panel-head {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      gap: 12px;
+      margin-bottom: 12px;
+    }
+    .panel-head h2 { font-size: 1rem; text-transform: uppercase; letter-spacing: 0.08em; }
+    .panel-head span { color: var(--muted); font-size: 0.8rem; }
+    table { width: 100%; border-collapse: collapse; table-layout: fixed; }
+    th, td {
+      text-align: left;
+      padding: 10px 8px;
+      border-top: 1px solid var(--line-soft);
+      vertical-align: top;
+      font-size: 0.9rem;
+    }
+    th {
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-size: 0.72rem;
+    }
+    code {
+      display: inline-block;
+      background: rgba(255,255,255,0.04);
+      border: 1px solid rgba(255,255,255,0.05);
+      border-radius: 999px;
+      padding: 3px 8px;
+      white-space: nowrap;
+      max-width: 100%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      color: #fafafa;
+    }
+    pre {
+      margin: 0;
+      padding: 10px 12px;
+      overflow: auto;
+      white-space: pre-wrap;
+      background: rgba(0,0,0,0.35);
+      border: 1px solid var(--line-soft);
+      border-radius: 18px;
+      max-height: 11rem;
+      line-height: 1.45;
+      color: #e4e4e7;
+      font-size: 0.82rem;
+    }
+    .pill {
+      display: inline-block;
+      padding: 4px 10px;
+      border-radius: 999px;
+      border: 1px solid var(--line);
+      background: rgba(255,255,255,0.04);
+      color: var(--text);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-size: 0.7rem;
+    }
+    .summary-cell { min-width: 0; }
+    .summary-meta { color: var(--muted); font-size: 0.76rem; margin-bottom: 6px; }
+    .summary-list { display: grid; gap: 6px; }
+    .summary-list div { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #e4e4e7; }
+    .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; }
+    .wide { overflow-x: auto; }
+    .muted { color: var(--muted); }
+    @media (max-width: 1200px) {
+      .hero, .section-grid, .grid { grid-template-columns: 1fr 1fr; }
+    }
+    @media (max-width: 800px) {
+      main { padding: 14px; }
+      .topbar, .hero, .section-grid, .grid { grid-template-columns: 1fr; display: grid; }
+      .topbar { gap: 14px; }
+      table { min-width: 860px; }
+    }
   </style>
 </head>
 <body>
 <main>
-  <h1>Builder Admin</h1>
-  <div class="grid">
+  <div class="topbar">
+    <div class="titleblock">
+      <h1>Builder Admin</h1>
+      <p>Warm queue-driven builds, release promotion, raw logs, and refresh scheduling for the live go.waylonwalker.com authoring loop.</p>
+    </div>
+  </div>
+
+  <div class="hero">
     <section class="card">
-      <h2>Live</h2>
-      <p><strong>Current release:</strong> <code>{{ .CurrentID }}</code></p>
-      <p><strong>Current path:</strong> <code>{{ .CurrentPath }}</code></p>
-      {{ if .State.Running }}<p><strong>Running:</strong> {{ .State.Running.Kind }} {{ .State.Running.ID }} <span class="pill">{{ .State.Running.Phase }}</span></p>{{ else }}<p>No active work.</p>{{ end }}
-      <p><strong>Queued:</strong> {{ len .State.Queue }}</p>
+      <div class="panel-head"><h2>Live State</h2><span>desktop-first control surface</span></div>
+      <div class="grid" style="grid-template-columns: repeat(3, minmax(0, 1fr)); margin-bottom: 0;">
+        <div>
+          <strong>Current release</strong>
+          <div class="value mono">{{ .CurrentID }}</div>
+        </div>
+        <div>
+          <strong>Current path</strong>
+          <div class="value mono">{{ .CurrentPath }}</div>
+        </div>
+        <div>
+          <strong>Active work</strong>
+          <div class="value">{{ if .State.Running }}{{ .State.Running.Kind }} <span class="pill">{{ .State.Running.Phase }}</span>{{ else }}idle{{ end }}</div>
+        </div>
+      </div>
     </section>
     <section class="card actions">
-      <h2>Actions</h2>
+      <div class="panel-head"><h2>Actions</h2><span>manual triggers</span></div>
       <form method="post" action="/api/builds"><button type="submit">Enqueue Build</button></form>
       {{ range .RefreshTasks }}
       <form method="post" action="/api/refresh/{{ .Name }}"><button class="secondary" type="submit">Run {{ .Name }}</button></form>
@@ -1245,8 +1439,28 @@ const indexHTML = `<!doctype html>
     </section>
   </div>
 
-  <section class="card">
-    <h2>Queue</h2>
+  <div class="grid">
+    <section class="card">
+      <strong>Queue</strong>
+      <div class="value">{{ len .State.Queue }}</div>
+    </section>
+    <section class="card">
+      <strong>Build history</strong>
+      <div class="value">{{ len .State.Builds }}</div>
+    </section>
+    <section class="card">
+      <strong>Refresh history</strong>
+      <div class="value">{{ len .State.Refresh }}</div>
+    </section>
+    <section class="card">
+      <strong>Releases</strong>
+      <div class="value">{{ len .Releases }}</div>
+    </section>
+  </div>
+
+  <div class="section-grid">
+  <section class="card wide">
+    <div class="panel-head"><h2>Queue</h2><span>debounced watch + manual triggers</span></div>
     <table>
       <thead><tr><th>ID</th><th>Kind</th><th>Trigger</th><th>Detail</th><th>Changed</th><th>Queued</th></tr></thead>
       <tbody>
@@ -1267,7 +1481,24 @@ const indexHTML = `<!doctype html>
   </section>
 
   <section class="card">
-    <h2>Builds</h2>
+    <div class="panel-head"><h2>Running</h2><span>live worker</span></div>
+    <div class="stack">
+      {{ if .State.Running }}
+      <div><strong>ID</strong><div class="value mono">{{ .State.Running.ID }}</div></div>
+      <div><strong>Kind</strong><div class="value">{{ .State.Running.Kind }}</div></div>
+      <div><strong>Trigger</strong><div class="value">{{ .State.Running.TriggerType }}</div></div>
+      <div><strong>Detail</strong><div class="value">{{ .State.Running.Detail }}</div></div>
+      <div><strong>Started</strong><div class="value mono">{{ since .State.Running.StartedAt }}</div></div>
+      <div><strong>Phase</strong><div class="value"><span class="pill">{{ .State.Running.Phase }}</span></div></div>
+      {{ else }}
+      <div class="muted">No build or refresh is running right now.</div>
+      {{ end }}
+    </div>
+  </section>
+  </div>
+
+  <section class="card wide">
+    <div class="panel-head"><h2>Builds</h2><span>trimmed summaries, full logs one click away</span></div>
     <table>
       <thead><tr><th>ID</th><th>Status</th><th>Trigger</th><th>Total</th><th>Build</th><th>Release</th><th>Logs</th><th>Summary</th></tr></thead>
       <tbody>
@@ -1280,8 +1511,7 @@ const indexHTML = `<!doctype html>
         <td>{{ msToSeconds .BuildMS }}</td>
         <td>{{ if .ReleaseID }}<code>{{ .ReleaseID }}</code>{{ end }}</td>
         <td>{{ if .LogPath }}<a href="/logs/{{ .LogPath }}">log</a>{{ end }}</td>
-        <td>{{ if .PerfSummary }}<pre>{{ range .PerfSummary }}{{ . }}
-{{ end }}</pre>{{ end }}</td>
+        <td class="summary-cell">{{ if .PerfSummary }}<div class="summary-meta">{{ len .PerfSummary }} perf lines</div><div class="summary-list mono">{{ range summaryPreview .PerfSummary }}<div>{{ . }}</div>{{ end }}</div>{{ end }}</td>
       </tr>
       {{ else }}
       <tr><td colspan="8">No builds yet.</td></tr>
@@ -1290,10 +1520,11 @@ const indexHTML = `<!doctype html>
     </table>
   </section>
 
-  <section class="card">
-    <h2>Refresh Runs</h2>
+  <div class="section-grid">
+  <section class="card wide">
+    <div class="panel-head"><h2>Refresh Runs</h2><span>scheduled remote freshness</span></div>
     <table>
-      <thead><tr><th>ID</th><th>Task</th><th>Status</th><th>Total</th><th>Logs</th><th>Build</th></tr></thead>
+      <thead><tr><th>ID</th><th>Task</th><th>Status</th><th>Total</th><th>Logs</th><th>Build</th><th>Command</th></tr></thead>
       <tbody>
       {{ range .State.Refresh }}
       <tr>
@@ -1303,16 +1534,17 @@ const indexHTML = `<!doctype html>
         <td>{{ msToSeconds .TotalMS }}</td>
         <td>{{ if .LogPath }}<a href="/logs/{{ .LogPath }}">log</a>{{ end }}</td>
         <td>{{ if .EnqueuedBuildID }}<code>{{ .EnqueuedBuildID }}</code>{{ end }}</td>
+        <td class="mono muted">{{ if .Command }}{{ index .Command 0 }} {{ end }}</td>
       </tr>
       {{ else }}
-      <tr><td colspan="6">No refresh runs yet.</td></tr>
+      <tr><td colspan="7">No refresh runs yet.</td></tr>
       {{ end }}
       </tbody>
     </table>
   </section>
 
   <section class="card">
-    <h2>Releases</h2>
+    <div class="panel-head"><h2>Releases</h2><span>promote prior output</span></div>
     <table>
       <thead><tr><th>ID</th><th>Current</th><th>Created</th><th>Build</th><th>Action</th></tr></thead>
       <tbody>
@@ -1330,6 +1562,7 @@ const indexHTML = `<!doctype html>
       </tbody>
     </table>
   </section>
+  </div>
 </main>
 </body>
 </html>`

--- a/pkg/builderadmin/service.go
+++ b/pkg/builderadmin/service.go
@@ -1212,7 +1212,6 @@ const indexHTML = `<!doctype html>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Builder Admin</title>
-  <meta http-equiv="refresh" content="5">
   <style>
     :root {
       color-scheme: dark;
@@ -1415,6 +1414,7 @@ const indexHTML = `<!doctype html>
       background: var(--panel-strong);
       border-color: var(--line);
     }
+    .sync-status { color: var(--muted); font-size: 0.78rem; }
     .tab-panel { display: none; }
     .tab-panel:target { display: block; }
     .tab-panel.default-panel { display: block; }
@@ -1437,6 +1437,7 @@ const indexHTML = `<!doctype html>
       <h1>Builder Admin</h1>
       <p>Warm queue-driven builds, release promotion, raw logs, and refresh scheduling for the live go.waylonwalker.com authoring loop.</p>
     </div>
+    <div class="sync-status" id="sync-status">Live polling every 2s</div>
   </div>
 
   <div class="hero">
@@ -1445,15 +1446,15 @@ const indexHTML = `<!doctype html>
       <div class="grid" style="grid-template-columns: repeat(3, minmax(0, 1fr)); margin-bottom: 0;">
         <div>
           <strong>Current release</strong>
-          <div class="value mono">{{ .CurrentID }}</div>
+          <div class="value mono" id="current-release">{{ .CurrentID }}</div>
         </div>
         <div>
           <strong>Current path</strong>
-          <div class="value mono">{{ .CurrentPath }}</div>
+          <div class="value mono" id="current-path">{{ .CurrentPath }}</div>
         </div>
         <div>
           <strong>Active work</strong>
-          <div class="value">{{ if .State.Running }}{{ .State.Running.Kind }} <span class="pill">{{ .State.Running.Phase }}</span>{{ else }}idle{{ end }}</div>
+          <div class="value" id="active-work">{{ if .State.Running }}{{ .State.Running.Kind }} <span class="pill">{{ .State.Running.Phase }}</span>{{ else }}idle{{ end }}</div>
         </div>
       </div>
     </section>
@@ -1469,19 +1470,19 @@ const indexHTML = `<!doctype html>
   <div class="grid">
     <section class="card">
       <strong>Queue</strong>
-      <div class="value">{{ len .State.Queue }}</div>
+      <div class="value" id="queue-count">{{ len .State.Queue }}</div>
     </section>
     <section class="card">
       <strong>Build history</strong>
-      <div class="value">{{ len .State.Builds }}</div>
+      <div class="value" id="build-count">{{ len .State.Builds }}</div>
     </section>
     <section class="card">
       <strong>Refresh history</strong>
-      <div class="value">{{ len .State.Refresh }}</div>
+      <div class="value" id="refresh-count">{{ len .State.Refresh }}</div>
     </section>
     <section class="card">
       <strong>Releases</strong>
-      <div class="value">{{ len .Releases }}</div>
+      <div class="value" id="release-count">{{ len .Releases }}</div>
     </section>
   </div>
 
@@ -1490,7 +1491,7 @@ const indexHTML = `<!doctype html>
     <div class="panel-head"><h2>Queue</h2><span>debounced watch + manual triggers</span></div>
     <table>
       <thead><tr><th>ID</th><th>Kind</th><th>Trigger</th><th>Detail</th><th>Changed</th><th>Queued</th></tr></thead>
-      <tbody>
+      <tbody id="queue-body">
       {{ range .State.Queue }}
       <tr>
         <td><code>{{ .ID }}</code></td>
@@ -1509,7 +1510,7 @@ const indexHTML = `<!doctype html>
 
   <section class="card">
     <div class="panel-head"><h2>Running</h2><span>live worker</span></div>
-    <div class="stack">
+    <div class="stack" id="running-panel">
       {{ if .State.Running }}
       <div><strong>ID</strong><div class="value mono">{{ .State.Running.ID }}</div></div>
       <div><strong>Kind</strong><div class="value">{{ .State.Running.Kind }}</div></div>
@@ -1527,15 +1528,15 @@ const indexHTML = `<!doctype html>
   <section class="card wide tab-shell">
     <div class="panel-head"><h2>Workspace</h2><span>switch between builds, refreshes, and releases</span></div>
     <nav class="tabs">
-      <a href="#builds" class="active">Builds</a>
-      <a href="#refresh-runs">Refresh Runs</a>
-      <a href="#releases">Releases</a>
+      <a href="#builds" class="active" data-tab-link="builds">Builds</a>
+      <a href="#refresh-runs" data-tab-link="refresh-runs">Refresh Runs</a>
+      <a href="#releases" data-tab-link="releases">Releases</a>
     </nav>
 
     <section id="builds" class="tab-panel default-panel">
       <table>
         <thead><tr><th>ID</th><th>Status</th><th>Trigger</th><th>Total</th><th>Build</th><th>Release</th><th>Logs</th><th>Summary</th></tr></thead>
-        <tbody>
+        <tbody id="builds-body">
         {{ range .State.Builds }}
         <tr>
           <td><code>{{ .ID }}</code></td>
@@ -1557,7 +1558,7 @@ const indexHTML = `<!doctype html>
     <section id="refresh-runs" class="tab-panel">
       <table>
         <thead><tr><th>ID</th><th>Task</th><th>Status</th><th>Total</th><th>Logs</th><th>Build</th><th>Command</th></tr></thead>
-        <tbody>
+        <tbody id="refresh-body">
         {{ range .State.Refresh }}
         <tr>
           <td><code>{{ .ID }}</code></td>
@@ -1578,7 +1579,7 @@ const indexHTML = `<!doctype html>
     <section id="releases" class="tab-panel">
       <table>
         <thead><tr><th>ID</th><th>Current</th><th>Created</th><th>Build</th><th>Action</th></tr></thead>
-        <tbody>
+        <tbody id="releases-body">
         {{ range .Releases }}
         <tr>
           <td><code>{{ .ID }}</code></td>
@@ -1595,5 +1596,175 @@ const indexHTML = `<!doctype html>
     </section>
   </section>
 </main>
+<script>
+  const syncStatus = document.getElementById('sync-status');
+  const currentRelease = document.getElementById('current-release');
+  const currentPath = document.getElementById('current-path');
+  const activeWork = document.getElementById('active-work');
+  const queueCount = document.getElementById('queue-count');
+  const buildCount = document.getElementById('build-count');
+  const refreshCount = document.getElementById('refresh-count');
+  const releaseCount = document.getElementById('release-count');
+  const queueBody = document.getElementById('queue-body');
+  const runningPanel = document.getElementById('running-panel');
+  const buildsBody = document.getElementById('builds-body');
+  const refreshBody = document.getElementById('refresh-body');
+  const releasesBody = document.getElementById('releases-body');
+
+  function escapeHtml(value) {
+    return String(value ?? '')
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('"', '&quot;')
+      .replaceAll("'", '&#39;');
+  }
+
+  function fmtTime(value) {
+    if (!value) return '';
+    return value;
+  }
+
+  function fmtSeconds(ms) {
+    return ((ms || 0) / 1000).toFixed(2) + 's';
+  }
+
+  function summaryPreview(lines) {
+    if (!Array.isArray(lines)) return [];
+    return lines.slice(-6);
+  }
+
+  function activateTabs() {
+    const active = (location.hash || '#builds').slice(1);
+    document.querySelectorAll('[data-tab-link]').forEach((link) => {
+      link.classList.toggle('active', link.dataset.tabLink === active);
+    });
+  }
+
+  function renderQueue(items) {
+    if (!items || !items.length) {
+      queueBody.innerHTML = '<tr><td colspan="6">Queue is empty.</td></tr>';
+      return;
+    }
+    queueBody.innerHTML = items.map((item) => {
+      const changed = (item.changed || []).map((path) => '<div><code>' + escapeHtml(path) + '</code></div>').join('');
+      return '<tr>' +
+        '<td><code>' + escapeHtml(item.id) + '</code></td>' +
+        '<td>' + escapeHtml(item.kind) + '</td>' +
+        '<td>' + escapeHtml(item.trigger_type) + '</td>' +
+        '<td>' + escapeHtml(item.detail) + '</td>' +
+        '<td>' + changed + '</td>' +
+        '<td>' + escapeHtml(fmtTime(item.enqueued_at)) + '</td>' +
+      '</tr>';
+    }).join('');
+  }
+
+  function renderRunning(running) {
+    if (!running) {
+      runningPanel.innerHTML = '<div class="muted">No build or refresh is running right now.</div>';
+      activeWork.innerHTML = 'idle';
+      return;
+    }
+    activeWork.innerHTML = escapeHtml(running.kind) + ' <span class="pill">' + escapeHtml(running.phase) + '</span>';
+    runningPanel.innerHTML = [
+      ['ID', '<div class="value mono">' + escapeHtml(running.id) + '</div>'],
+      ['Kind', '<div class="value">' + escapeHtml(running.kind) + '</div>'],
+      ['Trigger', '<div class="value">' + escapeHtml(running.trigger_type) + '</div>'],
+      ['Detail', '<div class="value">' + escapeHtml(running.detail) + '</div>'],
+      ['Started', '<div class="value mono">' + escapeHtml(fmtTime(running.started_at)) + '</div>'],
+      ['Phase', '<div class="value"><span class="pill">' + escapeHtml(running.phase) + '</span></div>']
+    ].map(([label, value]) => '<div><strong>' + label + '</strong>' + value + '</div>').join('');
+  }
+
+  function renderBuilds(items) {
+    if (!items || !items.length) {
+      buildsBody.innerHTML = '<tr><td colspan="8">No builds yet.</td></tr>';
+      return;
+    }
+    buildsBody.innerHTML = items.map((item) => {
+      const lines = summaryPreview(item.perf_summary || []).map((line) => '<div>' + escapeHtml(line) + '</div>').join('');
+      const summary = lines ? '<div class="summary-meta">' + (item.perf_summary || []).length + ' perf lines</div><div class="summary-list mono">' + lines + '</div>' : '';
+      return '<tr>' +
+        '<td><code>' + escapeHtml(item.id) + '</code></td>' +
+        '<td>' + escapeHtml(item.status) + '</td>' +
+        '<td>' + escapeHtml(item.trigger_type) + '</td>' +
+        '<td>' + escapeHtml(fmtSeconds(item.total_ms)) + '</td>' +
+        '<td>' + escapeHtml(fmtSeconds(item.build_ms)) + '</td>' +
+        '<td>' + (item.release_id ? '<code>' + escapeHtml(item.release_id) + '</code>' : '') + '</td>' +
+        '<td>' + (item.log_path ? '<a href="/logs/' + encodeURIComponent(item.log_path) + '">log</a>' : '') + '</td>' +
+        '<td class="summary-cell">' + summary + '</td>' +
+      '</tr>';
+    }).join('');
+  }
+
+  function renderRefresh(items) {
+    if (!items || !items.length) {
+      refreshBody.innerHTML = '<tr><td colspan="7">No refresh runs yet.</td></tr>';
+      return;
+    }
+    refreshBody.innerHTML = items.map((item) => {
+      const command = Array.isArray(item.command) && item.command.length ? item.command.join(' ') : '';
+      return '<tr>' +
+        '<td><code>' + escapeHtml(item.id) + '</code></td>' +
+        '<td>' + escapeHtml(item.task_name) + '</td>' +
+        '<td>' + escapeHtml(item.status) + '</td>' +
+        '<td>' + escapeHtml(fmtSeconds(item.total_ms)) + '</td>' +
+        '<td>' + (item.log_path ? '<a href="/logs/' + encodeURIComponent(item.log_path) + '">log</a>' : '') + '</td>' +
+        '<td>' + (item.enqueued_build_id ? '<code>' + escapeHtml(item.enqueued_build_id) + '</code>' : '') + '</td>' +
+        '<td class="mono muted">' + escapeHtml(command) + '</td>' +
+      '</tr>';
+    }).join('');
+  }
+
+  function renderReleases(items) {
+    if (!items || !items.length) {
+      releasesBody.innerHTML = '<tr><td colspan="5">No releases found.</td></tr>';
+      return;
+    }
+    releasesBody.innerHTML = items.map((item) => {
+      const action = item.current ? '' : '<form method="post" action="/api/releases/' + encodeURIComponent(item.id) + '/rollback"><button class="secondary" type="submit">Promote</button></form>';
+      return '<tr>' +
+        '<td><code>' + escapeHtml(item.id) + '</code></td>' +
+        '<td>' + (item.current ? 'live' : '') + '</td>' +
+        '<td>' + escapeHtml(fmtTime(item.created_at)) + '</td>' +
+        '<td>' + (item.build_id ? '<code>' + escapeHtml(item.build_id) + '</code>' : '') + '</td>' +
+        '<td>' + action + '</td>' +
+      '</tr>';
+    }).join('');
+  }
+
+  function renderState(payload) {
+    const state = payload.state || {};
+    currentRelease.textContent = payload.current_release_id || '';
+    currentPath.textContent = payload.current_release_path || '';
+    queueCount.textContent = (state.queue || []).length;
+    buildCount.textContent = (state.builds || []).length;
+    refreshCount.textContent = (state.refresh || []).length;
+    releaseCount.textContent = (payload.releases || []).length;
+    renderQueue(state.queue || []);
+    renderRunning(state.running || null);
+    renderBuilds(state.builds || []);
+    renderRefresh(state.refresh || []);
+    renderReleases(payload.releases || []);
+    syncStatus.textContent = 'Live polling every 2s';
+  }
+
+  async function pollState() {
+    try {
+      const response = await fetch('/api/state', { headers: { 'Accept': 'application/json' }, cache: 'no-store' });
+      if (!response.ok) {
+        throw new Error('HTTP ' + response.status);
+      }
+      const payload = await response.json();
+      renderState(payload);
+    } catch (error) {
+      syncStatus.textContent = 'Sync stalled: ' + error.message;
+    }
+  }
+
+  window.addEventListener('hashchange', activateTabs);
+  activateTabs();
+  window.setInterval(pollState, 2000);
+</script>
 </body>
 </html>`

--- a/pkg/builderadmin/service_test.go
+++ b/pkg/builderadmin/service_test.go
@@ -1,0 +1,31 @@
+package builderadmin
+
+import "testing"
+
+func TestIgnoreWatchPath(t *testing.T) {
+	t.Parallel()
+	root := "/tmp/site"
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{path: "/tmp/site/pages/post.md", want: false},
+		{path: "/tmp/site/.git/index", want: true},
+		{path: "/tmp/site/.markata/cache.json", want: true},
+		{path: "/tmp/site/.builder-admin/state.json", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			if got := ignoreWatchPath(root, tt.path); got != tt.want {
+				t.Fatalf("ignoreWatchPath(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractPerfSummaryFromFileMissing(t *testing.T) {
+	t.Parallel()
+	if got := extractPerfSummaryFromFile("/does/not/exist"); got != nil {
+		t.Fatalf("extractPerfSummaryFromFile() = %#v, want nil", got)
+	}
+}

--- a/pkg/buildstats/profile.go
+++ b/pkg/buildstats/profile.go
@@ -3,7 +3,9 @@ package buildstats
 import (
 	"math"
 	"net/http"
+	"net/url"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -27,6 +29,18 @@ type Hotspot struct {
 	Duration time.Duration
 }
 
+// RequestTiming records a single outbound HTTP request made during a build.
+type RequestTiming struct {
+	Stage    string
+	Plugin   string
+	Method   string
+	Host     string
+	URL      string
+	Status   int
+	Error    string
+	Duration time.Duration
+}
+
 // StageTiming records how long a lifecycle stage took.
 type StageTiming struct {
 	Stage     string
@@ -39,6 +53,7 @@ type Summary struct {
 	Total     time.Duration
 	Resources ResourceBreakdown
 	Hotspots  []Hotspot
+	Requests  []RequestTiming
 	Stages    []StageTiming
 }
 
@@ -61,6 +76,8 @@ type Profile struct {
 	stageTimes map[string]time.Duration
 	stageUsage map[string]ResourceBreakdown
 	current    string
+	plugin     string
+	requests   []RequestTiming
 
 	networkOps atomic.Int64
 	stopOnce   sync.Once
@@ -118,10 +135,25 @@ func (p *Profile) Stop() Summary {
 		stages = append(stages, StageTiming{Stage: stage, Duration: p.stageTimes[stage], Resources: p.stageUsage[stage]})
 	}
 
+	requests := append([]RequestTiming(nil), p.requests...)
+	sort.Slice(requests, func(i, j int) bool {
+		if requests[i].Duration == requests[j].Duration {
+			if requests[i].Stage == requests[j].Stage {
+				if requests[i].Plugin == requests[j].Plugin {
+					return requests[i].URL < requests[j].URL
+				}
+				return requests[i].Plugin < requests[j].Plugin
+			}
+			return requests[i].Stage < requests[j].Stage
+		}
+		return requests[i].Duration > requests[j].Duration
+	})
+
 	return Summary{
 		Total:     time.Since(p.start),
 		Resources: p.resources,
 		Hotspots:  hotspots,
+		Requests:  requests,
 		Stages:    stages,
 	}
 }
@@ -172,6 +204,18 @@ func SetActiveStage(stage string) {
 	}
 }
 
+// SetActivePlugin marks the currently running plugin hook for request attribution.
+func SetActivePlugin(plugin string) {
+	profile := activeProfile.Load()
+	if profile == nil {
+		return
+	}
+
+	profile.mu.Lock()
+	defer profile.mu.Unlock()
+	profile.plugin = plugin
+}
+
 // InstrumentHTTPClient wraps an HTTP client so active builds can estimate network wait time.
 func InstrumentHTTPClient(client *http.Client) *http.Client {
 	if client == nil {
@@ -195,11 +239,66 @@ type trackingTransport struct {
 
 func (t *trackingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	profile := activeProfile.Load()
+	start := time.Now()
 	if profile != nil {
 		profile.networkOps.Add(1)
 		defer profile.networkOps.Add(-1)
 	}
-	return t.base.RoundTrip(req)
+	resp, err := t.base.RoundTrip(req)
+	if profile != nil {
+		profile.recordRequest(req, resp, err, time.Since(start))
+	}
+	return resp, err
+}
+
+func (p *Profile) recordRequest(req *http.Request, resp *http.Response, err error, duration time.Duration) {
+	if p == nil || req == nil {
+		return
+	}
+
+	request := RequestTiming{
+		Method:   requestMethod(req.Method),
+		URL:      sanitizeURL(req.URL),
+		Duration: duration,
+	}
+	if req.URL != nil {
+		request.Host = req.URL.Host
+	}
+	if resp != nil {
+		request.Status = resp.StatusCode
+	}
+	if err != nil {
+		request.Error = err.Error()
+	}
+
+	p.mu.Lock()
+	request.Stage = p.current
+	request.Plugin = p.plugin
+	p.requests = append(p.requests, request)
+	p.mu.Unlock()
+}
+
+func sanitizeURL(raw *url.URL) string {
+	if raw == nil {
+		return ""
+	}
+	clean := *raw
+	clean.User = nil
+	clean.RawQuery = ""
+	clean.ForceQuery = false
+	clean.Fragment = ""
+	if clean.Path == "" {
+		clean.Path = "/"
+	}
+	return clean.String()
+}
+
+func requestMethod(method string) string {
+	method = strings.TrimSpace(method)
+	if method == "" {
+		return http.MethodGet
+	}
+	return method
 }
 
 func (p *Profile) sampleLoop() {

--- a/pkg/buildstats/profile_test.go
+++ b/pkg/buildstats/profile_test.go
@@ -1,6 +1,9 @@
 package buildstats
 
 import (
+	"errors"
+	"net/http"
+	"net/url"
 	"testing"
 	"time"
 )
@@ -101,5 +104,46 @@ func TestClassifyInterval_Idle(t *testing.T) {
 	}
 	if got.Idle != 90*time.Millisecond {
 		t.Fatalf("Idle = %v, want %v", got.Idle, 90*time.Millisecond)
+	}
+}
+
+func TestRecordRequest_SanitizesURLAndCapturesContext(t *testing.T) {
+	profile := &Profile{current: "collect", plugin: "blogroll"}
+	requestURL, err := url.Parse("https://user:secret@example.com/feed.xml?token=123#frag")
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	profile.recordRequest(&http.Request{Method: http.MethodGet, URL: requestURL}, &http.Response{StatusCode: http.StatusOK}, nil, 2*time.Second)
+
+	if len(profile.requests) != 1 {
+		t.Fatalf("len(requests) = %d, want 1", len(profile.requests))
+	}
+	got := profile.requests[0]
+	if got.Stage != "collect" || got.Plugin != "blogroll" {
+		t.Fatalf("request context = %+v, want stage/plugin collect/blogroll", got)
+	}
+	if got.URL != "https://example.com/feed.xml" {
+		t.Fatalf("URL = %q, want %q", got.URL, "https://example.com/feed.xml")
+	}
+	if got.Status != http.StatusOK {
+		t.Fatalf("Status = %d, want %d", got.Status, http.StatusOK)
+	}
+}
+
+func TestRecordRequest_CapturesError(t *testing.T) {
+	profile := &Profile{}
+	requestURL, err := url.Parse("https://example.com/")
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	profile.recordRequest(&http.Request{URL: requestURL}, nil, errors.New("timeout"), 500*time.Millisecond)
+
+	if len(profile.requests) != 1 {
+		t.Fatalf("len(requests) = %d, want 1", len(profile.requests))
+	}
+	if profile.requests[0].Error != "timeout" {
+		t.Fatalf("Error = %q, want %q", profile.requests[0].Error, "timeout")
 	}
 }

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -188,6 +188,9 @@ func applyEnvOverride(config *models.Config, key, value string) {
 	// Blogroll settings
 	case "blogroll_enabled":
 		config.Blogroll.Enabled = parseBool(value)
+	case "blogroll_refresh_on_build":
+		refreshOnBuild := parseBool(value)
+		config.Blogroll.RefreshOnBuild = &refreshOnBuild
 	}
 }
 

--- a/pkg/config/merge.go
+++ b/pkg/config/merge.go
@@ -1069,6 +1069,9 @@ func mergeBlogrollConfig(base, override models.BlogrollConfig) models.BlogrollCo
 	if override.CacheDuration != "" {
 		result.CacheDuration = override.CacheDuration
 	}
+	if override.RefreshOnBuild != nil {
+		result.RefreshOnBuild = override.RefreshOnBuild
+	}
 	if override.FallbackImageService != "" {
 		result.FallbackImageService = override.FallbackImageService
 	}

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -1368,6 +1368,7 @@ type tomlBlogrollConfig struct {
 	ReaderSlug           string                   `toml:"reader_slug"`
 	CacheDir             string                   `toml:"cache_dir"`
 	CacheDuration        string                   `toml:"cache_duration"`
+	RefreshOnBuild       *bool                    `toml:"refresh_on_build"`
 	Timeout              int                      `toml:"timeout"`
 	ConcurrentRequests   int                      `toml:"concurrent_requests"`
 	MaxEntriesPerFeed    int                      `toml:"max_entries_per_feed"`
@@ -1538,6 +1539,7 @@ func (b *tomlBlogrollConfig) toBlogrollConfig() models.BlogrollConfig {
 		ReaderSlug:           b.ReaderSlug,
 		CacheDir:             b.CacheDir,
 		CacheDuration:        b.CacheDuration,
+		RefreshOnBuild:       b.RefreshOnBuild,
 		Timeout:              b.Timeout,
 		ConcurrentRequests:   b.ConcurrentRequests,
 		MaxEntriesPerFeed:    b.MaxEntriesPerFeed,
@@ -3083,6 +3085,7 @@ type yamlBlogrollConfig struct {
 	ReaderSlug           string                   `yaml:"reader_slug"`
 	CacheDir             string                   `yaml:"cache_dir"`
 	CacheDuration        string                   `yaml:"cache_duration"`
+	RefreshOnBuild       *bool                    `yaml:"refresh_on_build"`
 	Timeout              int                      `yaml:"timeout"`
 	ConcurrentRequests   int                      `yaml:"concurrent_requests"`
 	MaxEntriesPerFeed    int                      `yaml:"max_entries_per_feed"`
@@ -3133,6 +3136,7 @@ func (b *yamlBlogrollConfig) toBlogrollConfig() models.BlogrollConfig {
 		ReaderSlug:           b.ReaderSlug,
 		CacheDir:             b.CacheDir,
 		CacheDuration:        b.CacheDuration,
+		RefreshOnBuild:       b.RefreshOnBuild,
 		Timeout:              b.Timeout,
 		ConcurrentRequests:   b.ConcurrentRequests,
 		MaxEntriesPerFeed:    b.MaxEntriesPerFeed,
@@ -4605,6 +4609,7 @@ type jsonBlogrollConfig struct {
 	ReaderSlug           string                   `json:"reader_slug"`
 	CacheDir             string                   `json:"cache_dir"`
 	CacheDuration        string                   `json:"cache_duration"`
+	RefreshOnBuild       *bool                    `json:"refresh_on_build"`
 	Timeout              int                      `json:"timeout"`
 	ConcurrentRequests   int                      `json:"concurrent_requests"`
 	MaxEntriesPerFeed    int                      `json:"max_entries_per_feed"`
@@ -4655,6 +4660,7 @@ func (b *jsonBlogrollConfig) toBlogrollConfig() models.BlogrollConfig {
 		ReaderSlug:           b.ReaderSlug,
 		CacheDir:             b.CacheDir,
 		CacheDuration:        b.CacheDuration,
+		RefreshOnBuild:       b.RefreshOnBuild,
 		Timeout:              b.Timeout,
 		ConcurrentRequests:   b.ConcurrentRequests,
 		MaxEntriesPerFeed:    b.MaxEntriesPerFeed,

--- a/pkg/lifecycle/hooks.go
+++ b/pkg/lifecycle/hooks.go
@@ -159,7 +159,9 @@ func executeHooks[T Plugin](
 		}
 
 		start := time.Now()
+		buildstats.SetActivePlugin(p.Name())
 		if err := execute(typed); err != nil {
+			buildstats.SetActivePlugin("")
 			// Check if the error itself is marked as critical
 			errIsCritical := critical || isCriticalError(err)
 			hookErrors.Add(stage, p.Name(), err, errIsCritical)
@@ -168,6 +170,7 @@ func executeHooks[T Plugin](
 				return hookErrors
 			}
 		}
+		buildstats.SetActivePlugin("")
 		elapsed := time.Since(start)
 		buildstats.RecordPlugin(string(stage), p.Name(), elapsed)
 		if elapsed > 50*time.Millisecond {

--- a/pkg/models/blogroll.go
+++ b/pkg/models/blogroll.go
@@ -30,6 +30,11 @@ type BlogrollConfig struct {
 	// CacheDuration is how long to cache fetched feeds (default: "24h")
 	CacheDuration string `json:"cache_duration" yaml:"cache_duration" toml:"cache_duration"`
 
+	// RefreshOnBuild controls whether normal builds may refresh blogroll feeds over the network.
+	// When nil or false, builds reuse cached feed data and `markata-go reader update` remains
+	// the explicit refresh path.
+	RefreshOnBuild *bool `json:"refresh_on_build,omitempty" yaml:"refresh_on_build,omitempty" toml:"refresh_on_build,omitempty"`
+
 	// Timeout is the HTTP request timeout in seconds (default: 30)
 	Timeout int `json:"timeout" yaml:"timeout" toml:"timeout"`
 
@@ -69,6 +74,7 @@ func NewBlogrollConfig() BlogrollConfig {
 		ReaderSlug:           "reader",
 		CacheDir:             "cache/blogroll",
 		CacheDuration:        "24h",
+		RefreshOnBuild:       nil,
 		Timeout:              30,
 		ConcurrentRequests:   5,
 		MaxEntriesPerFeed:    50,
@@ -82,6 +88,14 @@ func NewBlogrollConfig() BlogrollConfig {
 			Reader:   "reader.html",
 		},
 	}
+}
+
+// GetRefreshOnBuild returns whether normal builds may refresh remote blogroll feeds.
+func (b BlogrollConfig) GetRefreshOnBuild() bool {
+	if b.RefreshOnBuild == nil {
+		return false
+	}
+	return *b.RefreshOnBuild
 }
 
 // BlogrollTemplates specifies custom templates for blogroll pages.

--- a/pkg/plugins/blogroll.go
+++ b/pkg/plugins/blogroll.go
@@ -23,6 +23,7 @@ import (
 	"unicode"
 
 	"github.com/WaylonWalker/markata-go/pkg/blogroll"
+	"github.com/WaylonWalker/markata-go/pkg/buildstats"
 	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
 	"github.com/WaylonWalker/markata-go/pkg/models"
 	"github.com/WaylonWalker/markata-go/pkg/templates"
@@ -621,6 +622,7 @@ type BlogrollPlugin struct {
 
 type blogrollFetchOptions struct {
 	forceRefresh   bool
+	refreshOnBuild bool
 	onFeedComplete func(BlogrollCacheRefreshProgress)
 }
 
@@ -808,7 +810,7 @@ func (p *BlogrollPlugin) Write(m *lifecycle.Manager) error {
 
 // fetchFeeds fetches all configured feeds concurrently.
 func (p *BlogrollPlugin) fetchFeeds(config models.BlogrollConfig) ([]*models.ExternalFeed, []*models.ExternalEntry, error) {
-	feeds, entries, _, err := p.fetchFeedsWithOptions(config, blogrollFetchOptions{})
+	feeds, entries, _, err := p.fetchFeedsWithOptions(config, blogrollFetchOptions{refreshOnBuild: config.GetRefreshOnBuild()})
 	return feeds, entries, err
 }
 
@@ -843,6 +845,11 @@ func (p *BlogrollPlugin) fetchFeedsWithOptions(config models.BlogrollConfig, opt
 		configHash := p.aggregateConfigHash(activeFeeds)
 		if cached := p.loadAggregateCache(config.CacheDir, cacheDuration, configHash); cached != nil {
 			return cached.Feeds, cached.Entries, blogrollRefreshSummary{}, nil
+		}
+		if !options.refreshOnBuild {
+			if cached := p.loadAggregateCacheAny(config.CacheDir, configHash); cached != nil {
+				return cached.Feeds, cached.Entries, blogrollRefreshSummary{stale: len(cached.Feeds)}, nil
+			}
 		}
 	}
 
@@ -927,11 +934,22 @@ func (p *BlogrollPlugin) aggregateConfigHash(feeds []models.ExternalFeedConfig) 
 }
 
 func (p *BlogrollPlugin) loadAggregateCache(cacheDir string, maxAge time.Duration, configHash string) *blogrollAggregateCache {
+	cached := p.loadAggregateCacheAny(cacheDir, configHash)
+	if cached == nil {
+		return nil
+	}
+
 	cacheFile := filepath.Join(cacheDir, aggregateCacheFile)
 	info, err := os.Stat(cacheFile)
 	if err != nil || time.Since(info.ModTime()) > maxAge {
 		return nil
 	}
+
+	return cached
+}
+
+func (p *BlogrollPlugin) loadAggregateCacheAny(cacheDir, configHash string) *blogrollAggregateCache {
+	cacheFile := filepath.Join(cacheDir, aggregateCacheFile)
 	data, err := os.ReadFile(cacheFile)
 	if err != nil {
 		return nil
@@ -1063,6 +1081,17 @@ func (p *BlogrollPlugin) fetchFeed(config models.ExternalFeedConfig, cacheDir st
 			}
 		}
 		staleCached = p.loadFromCacheAny(config.URL, cacheDir)
+		if staleCached != nil && !options.forceRefresh && !options.refreshOnBuild {
+			cachedFeed := mergeCachedFeed(staleCached, config)
+			p.emitFetchProgress(options, config, cachedFeed, "stale", "")
+			return cachedFeed, blogrollRefreshSummary{stale: 1}
+		}
+	}
+
+	if !options.forceRefresh && !options.refreshOnBuild {
+		feed.Error = "blogroll refresh disabled and no cached feed available"
+		p.emitFetchProgress(options, config, feed, "missing_cache", feed.Error)
+		return feed, blogrollRefreshSummary{failed: 1}
 	}
 
 	// Fetch the feed
@@ -1083,6 +1112,7 @@ func (p *BlogrollPlugin) fetchFeed(config models.ExternalFeedConfig, cacheDir st
 	client := &http.Client{
 		Timeout: time.Duration(timeout) * time.Second,
 	}
+	buildstats.InstrumentHTTPClient(client)
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/pkg/plugins/blogroll_test.go
+++ b/pkg/plugins/blogroll_test.go
@@ -177,6 +177,81 @@ func TestBlogrollPlugin_AggregateCache_RoundTripAndHashCheck(t *testing.T) {
 	}
 }
 
+func TestBlogrollPlugin_LoadAggregateCacheAny_IgnoresAgeButChecksHash(t *testing.T) {
+	tmpDir := t.TempDir()
+	p := NewBlogrollPlugin()
+
+	feeds := []*models.ExternalFeed{{
+		FeedURL: "https://example.com/feed.xml",
+		Title:   "Example",
+	}}
+	entries := []*models.ExternalEntry{{
+		FeedURL: "https://example.com/feed.xml",
+		ID:      "entry-1",
+		Title:   "First Entry",
+	}}
+
+	p.saveAggregateCache(tmpDir, "hash-a", feeds, entries)
+	cachePath := filepath.Join(tmpDir, aggregateCacheFile)
+	oldTime := time.Now().Add(-7 * 24 * time.Hour)
+	if err := os.Chtimes(cachePath, oldTime, oldTime); err != nil {
+		t.Fatalf("Chtimes() error = %v", err)
+	}
+
+	cached := p.loadAggregateCacheAny(tmpDir, "hash-a")
+	if cached == nil {
+		t.Fatal("loadAggregateCacheAny() = nil, want cached snapshot")
+	}
+	if got := p.loadAggregateCacheAny(tmpDir, "hash-b"); got != nil {
+		t.Fatalf("loadAggregateCacheAny() with mismatched hash = %#v, want nil", got)
+	}
+}
+
+func TestBlogrollPlugin_FetchFeed_UsesStaleCacheWhenRefreshDisabled(t *testing.T) {
+	tmpDir := t.TempDir()
+	p := NewBlogrollPlugin()
+	oldTime := time.Now().Add(-48 * time.Hour)
+	feed := &models.ExternalFeed{
+		FeedURL:     "https://example.com/feed.xml",
+		Title:       "Cached",
+		LastFetched: &oldTime,
+	}
+	p.saveToCache(feed, tmpDir)
+
+	config := models.ExternalFeedConfig{URL: "https://example.com/feed.xml", Title: "Configured"}
+	got, summary := p.fetchFeed(config, tmpDir, time.Hour, 1, 10, blogrollFetchOptions{refreshOnBuild: false})
+
+	if got == nil {
+		t.Fatal("fetchFeed() = nil, want cached feed")
+	}
+	if got.Title != "Configured" {
+		t.Fatalf("fetchFeed().Title = %q, want config override", got.Title)
+	}
+	if summary.stale != 1 {
+		t.Fatalf("summary.stale = %d, want 1", summary.stale)
+	}
+	if summary.refreshed != 0 {
+		t.Fatalf("summary.refreshed = %d, want 0", summary.refreshed)
+	}
+}
+
+func TestBlogrollPlugin_FetchFeed_ReturnsPlaceholderWhenRefreshDisabledAndCacheMissing(t *testing.T) {
+	p := NewBlogrollPlugin()
+	config := models.ExternalFeedConfig{URL: "https://example.com/feed.xml", Title: "Configured"}
+
+	got, summary := p.fetchFeed(config, t.TempDir(), time.Hour, 1, 10, blogrollFetchOptions{refreshOnBuild: false})
+
+	if got == nil {
+		t.Fatal("fetchFeed() = nil, want placeholder feed")
+	}
+	if got.Error == "" {
+		t.Fatal("fetchFeed().Error = empty, want missing cache message")
+	}
+	if summary.failed != 1 {
+		t.Fatalf("summary.failed = %d, want 1", summary.failed)
+	}
+}
+
 func TestMergeCachedFeed_AppliesConfigOverrides(t *testing.T) {
 	cached := &models.ExternalFeed{
 		Config: models.ExternalFeedConfig{

--- a/pkg/plugins/build_cache.go
+++ b/pkg/plugins/build_cache.go
@@ -98,10 +98,18 @@ func (p *BuildCachePlugin) Configure(m *lifecycle.Manager) error {
 	if extra, ok := config.Extra["templates_dir"].(string); ok && extra != "" {
 		templatesDir = extra
 	}
-	if hash, err := buildcache.HashDirectory(templatesDir, []string{".html", ".txt", ".md"}); err == nil && hash != "" {
-		if cache.SetTemplatesHash(hash) {
-			// Templates changed - cache was invalidated
-			buildCacheLog.Phase("configure").Printf("Templates changed, full rebuild required")
+	if fingerprint, err := buildcache.HashDirectoryState(templatesDir, []string{".html", ".txt", ".md"}); err == nil && fingerprint != "" {
+		if cache.GetTemplatesFingerprint() == fingerprint && cache.GetTemplatesHash() != "" {
+			// Template tree unchanged - reuse the existing content hash.
+		} else if hash, err := buildcache.HashDirectory(templatesDir, []string{".html", ".txt", ".md"}); err == nil && hash != "" {
+			changed := cache.SetTemplatesFingerprint(fingerprint)
+			if cache.SetTemplatesHash(hash) {
+				changed = true
+			}
+			if changed {
+				// Templates changed - cache was invalidated.
+				buildCacheLog.Phase("configure").Printf("Templates changed, full rebuild required")
+			}
 		}
 	}
 

--- a/pkg/plugins/embeds.go
+++ b/pkg/plugins/embeds.go
@@ -35,6 +35,7 @@ type EmbedsPlugin struct {
 	config     models.EmbedsConfig
 	httpClient *http.Client
 	oembed     *oembedResolver
+	pageHTML   sync.Map
 }
 
 // NewEmbedsPlugin creates a new EmbedsPlugin with default settings.
@@ -44,11 +45,13 @@ func NewEmbedsPlugin() *EmbedsPlugin {
 		Timeout: time.Duration(config.Timeout) * time.Second,
 	}
 	buildstats.InstrumentHTTPClient(client)
-	return &EmbedsPlugin{
+	plugin := &EmbedsPlugin{
 		config:     config,
 		httpClient: client,
-		oembed:     newOEmbedResolver(config, client),
 	}
+	plugin.oembed = newOEmbedResolver(config, client)
+	plugin.oembed.setHTMLFetcher(plugin.fetchPageHTML)
+	return plugin
 }
 
 // Name returns the unique name of the plugin.
@@ -192,6 +195,7 @@ func (p *EmbedsPlugin) Transform(m *lifecycle.Manager) error {
 	if !p.config.Enabled {
 		return nil
 	}
+	p.pageHTML = sync.Map{}
 
 	// Use the shared PostIndex from the lifecycle manager
 	idx := m.PostIndex()
@@ -1347,32 +1351,12 @@ func (p *EmbedsPlugin) fetchMetadataFromURL(rawURL string) *OGMetadata {
 	metadata := &OGMetadata{
 		Title: p.config.FallbackTitle,
 	}
-
-	req, err := http.NewRequestWithContext(context.Background(), "GET", rawURL, http.NoBody)
+	body, err := p.fetchPageHTML(rawURL)
 	if err != nil {
 		return metadata
 	}
 
-	// Set a reasonable user agent
-	req.Header.Set("User-Agent", "markata-go/1.0 (+https://github.com/WaylonWalker/markata-go)")
-
-	resp, err := p.httpClient.Do(req)
-	if err != nil {
-		return metadata
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return metadata
-	}
-
-	// Read limited body to avoid memory issues
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 1024*1024)) // 1MB limit
-	if err != nil {
-		return metadata
-	}
-
-	htmlContent := string(body)
+	htmlContent := body
 
 	// Extract OG metadata using simple regex
 	metadata.Source = "og"
@@ -1395,6 +1379,40 @@ func (p *EmbedsPlugin) fetchMetadataFromURL(rawURL string) *OGMetadata {
 	normalizeOGMetadata(metadata)
 
 	return metadata
+}
+
+func (p *EmbedsPlugin) fetchPageHTML(rawURL string) (string, error) {
+	if cached, ok := p.pageHTML.Load(rawURL); ok {
+		if content, ok := cached.(string); ok {
+			return content, nil
+		}
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, rawURL, http.NoBody)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("User-Agent", "markata-go/1.0 (+https://github.com/WaylonWalker/markata-go)")
+	req.Header.Set("Accept", "text/html,application/xhtml+xml")
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("page fetch failed: %s", resp.Status)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
+	if err != nil {
+		return "", err
+	}
+
+	htmlContent := string(body)
+	p.pageHTML.Store(rawURL, htmlContent)
+	return htmlContent, nil
 }
 
 // extractMetaContent extracts content from a meta tag.

--- a/pkg/plugins/embeds_test.go
+++ b/pkg/plugins/embeds_test.go
@@ -374,6 +374,49 @@ func TestEmbedsPlugin_ExternalEmbed(t *testing.T) {
 	}
 }
 
+func TestEmbedsPlugin_ExternalEmbed_ReusesFetchedHTMLForDiscoveryAndOG(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "text/html")
+		//nolint:errcheck // test helper
+		w.Write([]byte(`<!DOCTYPE html>
+<html>
+<head>
+	<title>Test Page</title>
+	<meta property="og:title" content="OG Test Title">
+	<meta property="og:description" content="OG Test Description">
+</head>
+<body></body>
+</html>`))
+	}))
+	defer server.Close()
+
+	p := NewEmbedsPlugin()
+	p.config.OEmbedEnabled = true
+	p.config.OEmbedAutoDiscover = true
+	p.config.OEmbedProvidersURL = ""
+
+	m := lifecycle.NewManager()
+	sourcePost := &models.Post{
+		Path:    "source.md",
+		Slug:    "source-post",
+		Content: "Here is an external embed: ![embed](" + server.URL + ")",
+	}
+	m.SetPosts([]*models.Post{sourcePost})
+
+	if err := p.Transform(m); err != nil {
+		t.Fatalf("Transform failed: %v", err)
+	}
+
+	if requests != 1 {
+		t.Fatalf("requests = %d, want 1", requests)
+	}
+	if !containsString(sourcePost.Content, "embed-card-external") {
+		t.Fatalf("expected external embed card class, got: %s", sourcePost.Content)
+	}
+}
+
 func TestEmbedsPlugin_ExternalEmbed_HackerNewsDiscussionURL(t *testing.T) {
 	articleServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/html")

--- a/pkg/plugins/feed_rendering.go
+++ b/pkg/plugins/feed_rendering.go
@@ -2,8 +2,12 @@ package plugins
 
 import "github.com/WaylonWalker/markata-go/pkg/models"
 
-func filterFeedPagePosts(posts []*models.Post, includePrivate bool) []*models.Post {
-	visible := make([]*models.Post, 0, len(posts))
+// splitFeedRenderablePosts partitions posts into:
+// 1) pagePosts: posts visible on feed HTML pages
+// 2) outputPosts: posts with content suitable for RSS/Atom/JSON/MD/TXT output
+func splitFeedRenderablePosts(posts []*models.Post, includePrivate bool) (pagePosts, outputPosts []*models.Post) {
+	pagePosts = make([]*models.Post, 0, len(posts))
+	outputPosts = make([]*models.Post, 0, len(posts))
 	for _, post := range posts {
 		if post == nil || post.Skip || post.Draft {
 			continue
@@ -11,18 +15,23 @@ func filterFeedPagePosts(posts []*models.Post, includePrivate bool) []*models.Po
 		if post.Private && !includePrivate {
 			continue
 		}
-		visible = append(visible, post)
+
+		pagePosts = append(pagePosts, post)
+		if post.Content == "" && post.ArticleHTML == "" {
+			continue
+		}
+		outputPosts = append(outputPosts, post)
 	}
+
+	return pagePosts, outputPosts
+}
+
+func filterFeedPagePosts(posts []*models.Post, includePrivate bool) []*models.Post {
+	visible, _ := splitFeedRenderablePosts(posts, includePrivate)
 	return visible
 }
 
 func filterFeedOutputPosts(posts []*models.Post, includePrivate bool) []*models.Post {
-	renderable := make([]*models.Post, 0, len(posts))
-	for _, post := range filterFeedPagePosts(posts, includePrivate) {
-		if post.Content == "" && post.ArticleHTML == "" {
-			continue
-		}
-		renderable = append(renderable, post)
-	}
+	_, renderable := splitFeedRenderablePosts(posts, includePrivate)
 	return renderable
 }

--- a/pkg/plugins/feed_rendering_test.go
+++ b/pkg/plugins/feed_rendering_test.go
@@ -1,0 +1,41 @@
+package plugins
+
+import (
+	"testing"
+
+	"github.com/WaylonWalker/markata-go/pkg/models"
+)
+
+func TestSplitFeedRenderablePosts_PartitionsVisibleAndRenderablePosts(t *testing.T) {
+	t.Parallel()
+
+	title := "Visible"
+	posts := []*models.Post{
+		{Slug: "visible", Title: &title, Published: true, Content: "body", ArticleHTML: "<p>body</p>"},
+		{Slug: "title-only", Title: &title, Published: true},
+		{Slug: "draft", Title: &title, Draft: true, Published: false, Content: "draft"},
+		{Slug: "private", Title: &title, Private: true, Content: "private"},
+	}
+
+	pagePosts, outputPosts := splitFeedRenderablePosts(posts, false)
+	if got := len(pagePosts); got != 2 {
+		t.Fatalf("pagePosts len = %d, want 2", got)
+	}
+	if got := len(outputPosts); got != 1 {
+		t.Fatalf("outputPosts len = %d, want 1", got)
+	}
+	if pagePosts[0].Slug != "visible" || pagePosts[1].Slug != "title-only" {
+		t.Fatalf("unexpected pagePosts order: %#v", []string{pagePosts[0].Slug, pagePosts[1].Slug})
+	}
+	if outputPosts[0].Slug != "visible" {
+		t.Fatalf("unexpected outputPosts: %q", outputPosts[0].Slug)
+	}
+
+	pagePosts, outputPosts = splitFeedRenderablePosts(posts, true)
+	if got := len(pagePosts); got != 3 {
+		t.Fatalf("pagePosts len with private = %d, want 3", got)
+	}
+	if got := len(outputPosts); got != 2 {
+		t.Fatalf("outputPosts len with private = %d, want 2", got)
+	}
+}

--- a/pkg/plugins/feeds_listing.go
+++ b/pkg/plugins/feeds_listing.go
@@ -2,6 +2,8 @@
 package plugins
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"log"
 	"os"
@@ -11,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/WaylonWalker/markata-go/pkg/buildcache"
 	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
 	"github.com/WaylonWalker/markata-go/pkg/models"
 	"github.com/WaylonWalker/markata-go/pkg/templates"
@@ -130,6 +133,15 @@ func (p *FeedsListingPlugin) Write(m *lifecycle.Manager) error {
 		return nil
 	}
 	feedDefaults := getFeedDefaults(config)
+	cache := GetBuildCache(m)
+	listingHash := computeFeedsListingHash(feedConfigs, config, &feedsPage, feedDefaults, cache)
+	if cache != nil {
+		if cached := cache.GetFeedsListingHash(); cached != "" && cached == listingHash {
+			if feedsListingOutputsExist(config, &feedsPage, feedConfigs, feedDefaults) {
+				return nil
+			}
+		}
+	}
 	sparklineRange := computeSparklineWindow(m.Posts(), false)
 
 	sections, generatedFeedPages := p.collectFeedSections(feedConfigs, config, &feedsPage, feedDefaults, sparklineRange)
@@ -171,7 +183,167 @@ func (p *FeedsListingPlugin) Write(m *lifecycle.Manager) error {
 		}
 	}
 
+	if cache != nil {
+		cache.SetFeedsListingHash(listingHash)
+	}
+
 	return nil
+}
+
+func computeFeedsListingHash(
+	feedConfigs []models.FeedConfig,
+	config *lifecycle.Config,
+	feedsPage *models.FeedsPageConfig,
+	feedDefaults models.FeedDefaults,
+	cache *buildcache.Cache,
+) string {
+	h := sha256.New()
+	writeString := func(value string) {
+		fmt.Fprintf(h, "%d:", len(value))
+		h.Write([]byte(value))
+		h.Write([]byte{0})
+	}
+	writeBool := func(value bool) {
+		fmt.Fprintf(h, "%t", value)
+		h.Write([]byte{0})
+	}
+	writeInt := func(value int) {
+		fmt.Fprintf(h, "%d", value)
+		h.Write([]byte{0})
+	}
+
+	writeBool(feedsPage != nil && feedsPage.IsEnabled())
+	if feedsPage != nil {
+		writeString(feedsPage.Title)
+		writeString(feedsPage.Description)
+		writeString(feedsPage.Template)
+		writeString(feedsPage.SlugPrefix)
+		writeString(feedsPage.Robots)
+		for _, slug := range feedsPage.ShowPrivateFeeds {
+			writeString(slug)
+		}
+	}
+
+	writeInt(feedDefaults.ItemsPerPage)
+	writeInt(feedDefaults.OrphanThreshold)
+
+	configuredSlugs := configuredFeedSlugs(config)
+	configuredOrder := make([]string, 0, len(configuredSlugs))
+	for slug := range configuredSlugs {
+		configuredOrder = append(configuredOrder, slug)
+	}
+	sort.Slice(configuredOrder, func(i, j int) bool {
+		return configuredSlugs[configuredOrder[i]] < configuredSlugs[configuredOrder[j]]
+	})
+	for _, slug := range configuredOrder {
+		writeString(slug)
+	}
+
+	for i := range feedConfigs {
+		fc := &feedConfigs[i]
+		writeString(fc.Slug)
+		if cache != nil {
+			if feedHash := cache.GetFeedHash(fc.Slug); feedHash != "" {
+				writeString(feedHash)
+				continue
+			}
+		}
+		writeString(fc.Title)
+		writeString(fc.Description)
+		writeBool(fc.IncludePrivate)
+		writeBool(fc.Formats.HTML)
+		writeBool(fc.Formats.SimpleHTML)
+		writeBool(fc.Formats.RSS)
+		writeBool(fc.Formats.Atom)
+		writeBool(fc.Formats.JSON)
+		writeBool(fc.Formats.Markdown)
+		writeBool(fc.Formats.Text)
+		writeBool(fc.Formats.Sitemap)
+		for _, post := range fc.Posts {
+			if post == nil {
+				continue
+			}
+			writeString(post.Slug)
+			if post.Date != nil {
+				writeString(post.Date.UTC().Format(time.RFC3339Nano))
+			}
+			writeBool(post.Published)
+			writeBool(post.Draft)
+			writeBool(post.Private)
+			writeBool(post.Skip)
+		}
+	}
+
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func feedsListingOutputsExist(config *lifecycle.Config, feedsPage *models.FeedsPageConfig, feedConfigs []models.FeedConfig, feedDefaults models.FeedDefaults) bool {
+	for _, outputPath := range expectedFeedsListingOutputPaths(config, feedsPage, feedConfigs, feedDefaults) {
+		if _, err := os.Stat(outputPath); err != nil {
+			return false
+		}
+	}
+	return true
+}
+
+func expectedFeedsListingOutputPaths(config *lifecycle.Config, feedsPage *models.FeedsPageConfig, feedConfigs []models.FeedConfig, feedDefaults models.FeedDefaults) []string {
+	if config == nil || feedsPage == nil {
+		return nil
+	}
+
+	paths := []string{filepath.Join(config.OutputDir, filepath.FromSlash(feedsPage.SlugPrefix), "index.html")}
+	generatedCount := 0
+	configuredSlugs := configuredFeedSlugs(config)
+	for i := range feedConfigs {
+		fc := &feedConfigs[i]
+		if fc.IncludePrivate && !feedsPageAllowsPrivateFeed(feedsPage, fc.Slug) {
+			continue
+		}
+		if _, isConfigured := configuredSlugs[fc.Slug]; !isConfigured {
+			generatedCount++
+		}
+	}
+
+	generatedPages := feedListingPageCount(generatedCount, feedDefaults)
+	for pageNum := 1; pageNum <= generatedPages; pageNum++ {
+		if pageNum == 1 {
+			paths = append(paths, filepath.Join(config.OutputDir, filepath.FromSlash(feedsPage.SlugPrefix), "generated", "index.html"))
+			continue
+		}
+		paths = append(paths, filepath.Join(config.OutputDir, filepath.FromSlash(feedsPage.SlugPrefix), "generated", "page", fmt.Sprintf("%d", pageNum), "index.html"))
+	}
+
+	return paths
+}
+
+func feedListingPageCount(total int, defaults models.FeedDefaults) int {
+	if total <= 0 {
+		return 0
+	}
+	itemsPerPage := defaults.ItemsPerPage
+	if itemsPerPage <= 0 {
+		itemsPerPage = 10
+	}
+	orphanThreshold := defaults.OrphanThreshold
+	if orphanThreshold <= 0 {
+		orphanThreshold = 3
+	}
+	pages := 0
+	for i := 0; i < total; i += itemsPerPage {
+		end := i + itemsPerPage
+		if end > total {
+			end = total
+		}
+		remaining := total - end
+		if remaining > 0 && remaining < orphanThreshold {
+			end = total
+		}
+		pages++
+		if end >= total {
+			break
+		}
+	}
+	return pages
 }
 
 func (p *FeedsListingPlugin) collectFeedSections(

--- a/pkg/plugins/feeds_listing_test.go
+++ b/pkg/plugins/feeds_listing_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/WaylonWalker/markata-go/pkg/buildcache"
 	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
 	"github.com/WaylonWalker/markata-go/pkg/models"
 )
@@ -185,6 +186,61 @@ func TestFeedsListingPlugin_Write_TruncatesGeneratedFeedsOnMainPage(t *testing.T
 	}
 	if !strings.Contains(string(generatedPage2BodyBytes), "Generated 25") {
 		t.Fatalf("generated feeds page 2 should include remaining generated feeds")
+	}
+}
+
+func TestFeedsListingPlugin_Write_SkipsWhenCachedAndOutputsExist(t *testing.T) {
+	plugin := NewFeedsListingPlugin()
+	m := lifecycle.NewManager()
+	config := m.Config()
+	config.OutputDir = t.TempDir()
+	feedsPage := models.NewFeedsPageConfig()
+	defaults := models.NewFeedDefaults()
+	config.Extra = map[string]interface{}{
+		"title":         "Test Site",
+		"description":   "A test site",
+		"url":           "https://example.com",
+		"feeds_page":    feedsPage,
+		"feed_defaults": defaults,
+	}
+	m.Cache().Set("build_cache", buildcache.New(t.TempDir()))
+
+	now := time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)
+	title := "Post"
+	m.Cache().Set("feed_configs", []models.FeedConfig{{
+		Slug:        "blog",
+		Title:       "Blog",
+		Description: "All posts",
+		Formats:     models.FeedFormats{HTML: true, RSS: true},
+		Posts: []*models.Post{{
+			Slug:      "post",
+			Href:      "/post/",
+			Title:     &title,
+			Published: true,
+			Date:      &now,
+		}},
+	}})
+
+	if err := plugin.Write(m); err != nil {
+		t.Fatalf("first Write() error = %v", err)
+	}
+
+	outputPath := filepath.Join(config.OutputDir, "feeds", "index.html")
+	//nolint:gosec // test fixture simulates world-readable output file
+	if err := os.WriteFile(outputPath, []byte("sentinel"), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s) error = %v", outputPath, err)
+	}
+
+	if err := plugin.Write(m); err != nil {
+		t.Fatalf("second Write() error = %v", err)
+	}
+
+	content, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", outputPath, err)
+	}
+	if string(content) != "sentinel" {
+		t.Fatalf("expected cached write skip to preserve sentinel content, got %q", string(content))
 	}
 }
 

--- a/pkg/plugins/garden_view.go
+++ b/pkg/plugins/garden_view.go
@@ -152,7 +152,7 @@ func (p *GardenViewPlugin) Write(m *lifecycle.Manager) error {
 		if !cache.GardenDirty() {
 			return nil
 		}
-		gardenHash := computeGardenHash(m.Posts(), &gardenConfig)
+		gardenHash := computeGardenHash(m.Posts(), &gardenConfig, cache)
 		if cached := cache.GetGardenHash(); cached != "" && cached == gardenHash {
 			return nil
 		}
@@ -233,12 +233,18 @@ func (p *GardenViewPlugin) filterPosts(posts []*models.Post, config *models.Gard
 	return filtered
 }
 
-func computeGardenHash(posts []*models.Post, config *models.GardenConfig) string {
+func computeGardenHash(posts []*models.Post, config *models.GardenConfig, cache *buildcache.Cache) string {
 	if config == nil {
 		return ""
 	}
 	var b strings.Builder
 	b.WriteString(config.GetPath())
+	b.WriteByte('\x00')
+	b.WriteString(config.Title)
+	b.WriteByte('\x00')
+	b.WriteString(config.Description)
+	b.WriteByte('\x00')
+	b.WriteString(config.GetTemplate())
 	b.WriteByte('\x00')
 	b.WriteString(fmt.Sprintf("%t", config.IsEnabled()))
 	b.WriteByte('\x00')
@@ -246,14 +252,30 @@ func computeGardenHash(posts []*models.Post, config *models.GardenConfig) string
 	b.WriteByte('\x00')
 	b.WriteString(fmt.Sprintf("%t", config.IsRenderPage()))
 	b.WriteByte('\x00')
+	b.WriteString(fmt.Sprintf("%t", config.IsIncludeTags()))
+	b.WriteByte('\x00')
+	b.WriteString(fmt.Sprintf("%t", config.IsIncludePosts()))
+	b.WriteByte('\x00')
 	b.WriteString(fmt.Sprintf("%d", config.GetMaxNodes()))
 	b.WriteByte('\x00')
+	excludeTags := append([]string(nil), config.ExcludeTags...)
+	sort.Strings(excludeTags)
+	for _, tag := range excludeTags {
+		b.WriteString("exclude:")
+		b.WriteString(tag)
+		b.WriteByte('\x00')
+	}
 	for _, post := range posts {
 		if post.Skip || post.Draft || !post.Published || post.Private {
 			continue
 		}
-		b.WriteString(post.Slug)
-		b.WriteByte('\x00')
+		if cache != nil {
+			if _, _, gardenHash := cache.GetPostSemanticHashes(post.Path); gardenHash != "" {
+				b.WriteString(gardenHash)
+				b.WriteByte('\x00')
+				continue
+			}
+		}
 		b.WriteString(computePostGardenHash(post))
 		b.WriteByte('\x00')
 	}

--- a/pkg/plugins/garden_view_test.go
+++ b/pkg/plugins/garden_view_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/WaylonWalker/markata-go/pkg/buildcache"
 	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
 	"github.com/WaylonWalker/markata-go/pkg/models"
 )
@@ -867,5 +868,35 @@ func TestGardenConfig_IsTagExcluded(t *testing.T) {
 	}
 	if config.IsTagExcluded("go") {
 		t.Error("'go' should not be excluded")
+	}
+}
+
+func TestComputeGardenHash_UsesCachedSemanticHashes(t *testing.T) {
+	posts := newTestPosts()
+	cache := buildcache.New("")
+	for _, post := range posts {
+		cache.UpdatePostSemanticHashes(post.Path, "feed-"+post.Slug, computePostTagIndexHash(post), computePostGardenHash(post))
+	}
+
+	config := newTestGardenConfig()
+	want := computeGardenHash(posts, &config, nil)
+	got := computeGardenHash(posts, &config, cache)
+	if got != want {
+		t.Fatalf("computeGardenHash with cache = %q, want %q", got, want)
+	}
+}
+
+func TestComputeGardenHash_ChangesWhenConfigChanges(t *testing.T) {
+	posts := newTestPosts()
+	base := newTestGardenConfig()
+	baseHash := computeGardenHash(posts, &base, nil)
+
+	modified := newTestGardenConfig()
+	modified.Title = "Custom Garden"
+	modified.ExcludeTags = []string{"go"}
+	modifiedHash := computeGardenHash(posts, &modified, nil)
+
+	if baseHash == modifiedHash {
+		t.Fatal("computeGardenHash did not change after config update")
 	}
 }

--- a/pkg/plugins/glob.go
+++ b/pkg/plugins/glob.go
@@ -12,6 +12,8 @@ import (
 	"github.com/bmatcuk/doublestar/v4"
 )
 
+const cacheKeyGlobFileModTimes = "glob.file_mod_times"
+
 // GlobPlugin discovers content files using glob patterns.
 type GlobPlugin struct {
 	// patterns are the glob patterns to match files against.
@@ -163,10 +165,11 @@ func (p *GlobPlugin) Glob(m *lifecycle.Manager) error {
 	patternHash := buildcache.HashContent(strings.Join(p.patterns, "\n"))
 
 	if lifecycle.IsServeFullRebuild(m) {
-		files := p.scanFiles(absBaseDir)
+		files, modTimes := p.scanFiles(absBaseDir)
 		if cache != nil && len(files) > 0 {
 			cache.SetGlobCache(files, patternHash)
 		}
+		m.Cache().Set(cacheKeyGlobFileModTimes, modTimes)
 		m.SetFiles(files)
 		return nil
 	}
@@ -180,13 +183,14 @@ func (p *GlobPlugin) Glob(m *lifecycle.Manager) error {
 	}
 
 	// Full scan
-	files := p.scanFiles(absBaseDir)
+	files, modTimes := p.scanFiles(absBaseDir)
 
 	// Cache for next build
 	if cache != nil && len(files) > 0 {
 		cache.SetGlobCache(files, patternHash)
 	}
 
+	m.Cache().Set(cacheKeyGlobFileModTimes, modTimes)
 	m.SetFiles(files)
 	return nil
 }
@@ -201,9 +205,10 @@ func shouldReuseCachedGlobFiles(m *lifecycle.Manager) bool {
 		len(lifecycle.GetServeAffectedPaths(m)) > 0
 }
 
-// scanFiles performs full glob scan.
-func (p *GlobPlugin) scanFiles(absBaseDir string) []string {
+// scanFiles performs full glob scan and records file modtimes for later stages.
+func (p *GlobPlugin) scanFiles(absBaseDir string) ([]string, map[string]int64) {
 	fileSet := make(map[string]struct{})
+	modTimes := make(map[string]int64)
 
 	for _, pattern := range p.patterns {
 		fullPattern := pattern
@@ -232,6 +237,7 @@ func (p *GlobPlugin) scanFiles(absBaseDir string) []string {
 			}
 
 			fileSet[relPath] = struct{}{}
+			modTimes[relPath] = info.ModTime().UnixNano()
 		}
 	}
 
@@ -240,7 +246,7 @@ func (p *GlobPlugin) scanFiles(absBaseDir string) []string {
 		files = append(files, file)
 	}
 	sort.Strings(files)
-	return files
+	return files, modTimes
 }
 
 // SetPatterns sets the glob patterns to use for file discovery.

--- a/pkg/plugins/glob_test.go
+++ b/pkg/plugins/glob_test.go
@@ -61,3 +61,37 @@ func TestGlobPlugin_FastBuildRescansMovedFiles(t *testing.T) {
 		t.Fatalf("stale glob cache reused after move: %v", got)
 	}
 }
+
+func TestGlobPlugin_StoresFileModTimes(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "post.md")
+	if err := os.WriteFile(path, []byte("# post"), 0o600); err != nil {
+		t.Fatalf("WriteFile(post.md) error = %v", err)
+	}
+
+	m := lifecycle.NewManager()
+	m.Config().ContentDir = tmpDir
+	m.Config().GlobPatterns = []string{"**/*.md"}
+
+	plugin := NewGlobPlugin()
+	if err := plugin.Configure(m); err != nil {
+		t.Fatalf("Configure() error = %v", err)
+	}
+	if err := plugin.Glob(m); err != nil {
+		t.Fatalf("Glob() error = %v", err)
+	}
+
+	cached, ok := m.Cache().Get(cacheKeyGlobFileModTimes)
+	if !ok {
+		t.Fatal("expected glob file modtimes in manager cache")
+	}
+
+	modTimes, ok := cached.(map[string]int64)
+	if !ok {
+		t.Fatalf("cached modtimes type = %T, want map[string]int64", cached)
+	}
+
+	if modTimes["post.md"] == 0 {
+		t.Fatalf("expected non-zero modtime for post.md, got %d", modTimes["post.md"])
+	}
+}

--- a/pkg/plugins/hackernews.go
+++ b/pkg/plugins/hackernews.go
@@ -12,11 +12,19 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/WaylonWalker/markata-go/pkg/buildstats"
 )
 
 var hackerNewsItemAPIBaseURL = "https://hacker-news.firebaseio.com/v0/item/%s.json"
 
-var hackerNewsHTTPClient = &http.Client{Timeout: 10 * time.Second}
+var hackerNewsHTTPClient = instrumentedHackerNewsHTTPClient()
+
+func instrumentedHackerNewsHTTPClient() *http.Client {
+	client := &http.Client{Timeout: 10 * time.Second}
+	buildstats.InstrumentHTTPClient(client)
+	return client
+}
 
 var hackerNewsURLCache sync.Map
 

--- a/pkg/plugins/link_avatars.go
+++ b/pkg/plugins/link_avatars.go
@@ -82,6 +82,7 @@ const (
 	linkAvatarModeHosted = "hosted"
 
 	linkAvatarIconExtICO = ".ico"
+	linkAvatarMissExt    = ".missing"
 )
 
 // defaultLinkAvatarsConfig returns the default configuration.
@@ -972,6 +973,9 @@ func (p *LinkAvatarsPlugin) ensureIconForHost(assetsDir, host, origin string) (s
 	if cached, ok := findCachedIcon(assetsDir, safeHost); ok {
 		return cached, nil
 	}
+	if hasCachedIconMiss(assetsDir, safeHost) {
+		return "", fmt.Errorf("favicon request previously failed")
+	}
 
 	faviconURL, err := p.faviconURL(host, origin)
 	if err != nil {
@@ -989,6 +993,9 @@ func (p *LinkAvatarsPlugin) ensureIconForHost(assetsDir, host, origin string) (s
 	defer resp.Body.Close()
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		if resp.StatusCode >= http.StatusBadRequest && resp.StatusCode < http.StatusInternalServerError {
+			cacheIconMiss(assetsDir, safeHost)
+		}
 		return "", fmt.Errorf("favicon request failed: %s", resp.Status)
 	}
 
@@ -1039,6 +1046,16 @@ func findCachedIcon(assetsDir, safeHost string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+func hasCachedIconMiss(assetsDir, safeHost string) bool {
+	_, err := os.Stat(filepath.Join(assetsDir, safeHost+linkAvatarMissExt))
+	return err == nil
+}
+
+func cacheIconMiss(assetsDir, safeHost string) {
+	//nolint:errcheck,gosec // negative cache is best-effort and static output is intentionally readable
+	_ = os.WriteFile(filepath.Join(assetsDir, safeHost+linkAvatarMissExt), []byte("missing\n"), 0o644)
 }
 
 func iconExtension(contentType, faviconURL string) string {

--- a/pkg/plugins/link_avatars_test.go
+++ b/pkg/plugins/link_avatars_test.go
@@ -64,6 +64,64 @@ func TestLinkAvatars_Render_LocalModeInjectsAndCaches(t *testing.T) {
 	}
 }
 
+func TestLinkAvatars_Render_LocalModeCachesHTTP404Misses(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		http.NotFound(w, nil)
+	}))
+	defer server.Close()
+
+	outputDir := t.TempDir()
+	config := &lifecycle.Config{
+		OutputDir: outputDir,
+		Extra: map[string]interface{}{
+			"models_config": &models.Config{URL: "https://mysite.test"},
+			"link_avatars": map[string]any{
+				"enabled":  true,
+				"mode":     "local",
+				"service":  "custom",
+				"template": server.URL + "/favicon/{host}.png",
+				"size":     16,
+			},
+		},
+	}
+
+	plugin := NewLinkAvatarsPlugin()
+
+	newManager := func() *lifecycle.Manager {
+		m := lifecycle.NewManager()
+		m.SetConfig(config)
+		m.SetPosts([]*models.Post{{Path: "post.md", ArticleHTML: `<p><a href="https://example.com/path">Example</a></p>`}})
+		return m
+	}
+
+	m1 := newManager()
+	if err := plugin.Configure(m1); err != nil {
+		t.Fatalf("configure error: %v", err)
+	}
+	if err := plugin.Render(m1); err != nil {
+		t.Fatalf("first render error: %v", err)
+	}
+
+	m2 := newManager()
+	if err := plugin.Configure(m2); err != nil {
+		t.Fatalf("configure error: %v", err)
+	}
+	if err := plugin.Render(m2); err != nil {
+		t.Fatalf("second render error: %v", err)
+	}
+
+	if requests != 1 {
+		t.Fatalf("requests = %d, want 1", requests)
+	}
+
+	missPath := filepath.Join(outputDir, "assets", "markata", "link-avatars", "example.com.missing")
+	if _, err := os.Stat(missPath); err != nil {
+		t.Fatalf("expected cached miss marker at %s: %v", missPath, err)
+	}
+}
+
 func TestLinkAvatars_ConfigureHostedRequiresBaseURL(t *testing.T) {
 	config := &lifecycle.Config{
 		Extra: map[string]interface{}{

--- a/pkg/plugins/load.go
+++ b/pkg/plugins/load.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/WaylonWalker/markata-go/pkg/buildcache"
@@ -206,28 +207,15 @@ func (p *LoadPlugin) loadAllFiles(m *lifecycle.Manager, files []string, baseDir 
 		return p.loadSequential(m, files, baseDir, cache)
 	}
 
-	posts := make([]*models.Post, 0, len(files))
-	var firstErr error
 	affected := lifecycle.GetServeAffectedPaths(m)
 	useFastCache := lifecycle.IsServeFastMode(m) && len(affected) > 0
-
-	for _, file := range files {
+	posts, err := p.loadFilesConcurrent(m, files, func(file string) (*models.Post, error) {
 		if useFastCache {
 			if len(affected) > 0 && affected[file] {
-				post, err := p.loadFile(file, baseDir, cache)
-				if err != nil {
-					if firstErr == nil {
-						firstErr = err
-					}
-					continue
-				}
-				posts = append(posts, post)
-				continue
+				return p.loadFile(file, baseDir, cache)
 			}
-			cachedData := cache.GetCachedPostDataLatest(file)
-			if cachedData != nil {
-				posts = append(posts, p.restorePostFromCache(cachedData, cache))
-				continue
+			if cachedData := cache.GetCachedPostDataLatest(file); cachedData != nil {
+				return p.restorePostFromCache(cachedData, cache), nil
 			}
 		}
 
@@ -237,32 +225,83 @@ func (p *LoadPlugin) loadAllFiles(m *lifecycle.Manager, files []string, baseDir 
 		}
 		stat, err := os.Stat(fullPath)
 		if err != nil {
-			if firstErr == nil {
-				firstErr = fmt.Errorf("failed to stat %s: %w", file, err)
-			}
-			continue
+			return nil, fmt.Errorf("failed to stat %s: %w", file, err)
 		}
-		cachedData := cache.GetCachedPostData(file, stat.ModTime().UnixNano())
-		if cachedData != nil {
-			posts = append(posts, p.restorePostFromCache(cachedData, cache))
-			continue
+		if cachedData := cache.GetCachedPostData(file, stat.ModTime().UnixNano()); cachedData != nil {
+			return p.restorePostFromCache(cachedData, cache), nil
 		}
-		post, err := p.loadFile(file, baseDir, cache)
-		if err != nil {
-			if firstErr == nil {
-				firstErr = err
-			}
-			continue
-		}
-		posts = append(posts, post)
-	}
-	if firstErr != nil {
-		return firstErr
+		return p.loadFile(file, baseDir, cache)
+	})
+	if err != nil {
+		return err
 	}
 	for _, post := range posts {
 		m.AddPost(post)
 	}
 	return nil
+}
+
+func (p *LoadPlugin) loadFilesConcurrent(m *lifecycle.Manager, files []string, fn func(string) (*models.Post, error)) ([]*models.Post, error) {
+	if len(files) == 0 {
+		return nil, nil
+	}
+
+	type result struct {
+		index int
+		post  *models.Post
+		err   error
+	}
+
+	workers := m.Concurrency()
+	if workers > len(files) {
+		workers = len(files)
+	}
+	jobs := make(chan int, len(files))
+	results := make(chan result, len(files))
+
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for idx := range jobs {
+				post, err := fn(files[idx])
+				results <- result{index: idx, post: post, err: err}
+			}
+		}()
+	}
+
+	for i := range files {
+		jobs <- i
+	}
+	close(jobs)
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	ordered := make([]*models.Post, len(files))
+	var firstErr error
+	for res := range results {
+		if res.err != nil {
+			if firstErr == nil {
+				firstErr = res.err
+			}
+			continue
+		}
+		ordered[res.index] = res.post
+	}
+	if firstErr != nil {
+		return nil, firstErr
+	}
+
+	posts := make([]*models.Post, 0, len(ordered))
+	for _, post := range ordered {
+		if post != nil {
+			posts = append(posts, post)
+		}
+	}
+	return posts, nil
 }
 
 func (p *LoadPlugin) restoreFromCacheOrLoadChanged(

--- a/pkg/plugins/load.go
+++ b/pkg/plugins/load.go
@@ -128,7 +128,7 @@ func (p *LoadPlugin) Load(m *lifecycle.Manager) error {
 		return p.loadAllFiles(m, files, baseDir, cache)
 	}
 
-	restored, _, err := p.restoreFromCacheOrLoadChanged(files, baseDir, cache, affected)
+	restored, _, err := p.restoreFromCacheOrLoadChanged(m, files, baseDir, cache, affected)
 	if err != nil {
 		return err
 	}
@@ -148,7 +148,7 @@ func (p *LoadPlugin) loadFromCachedPosts(
 	affected := lifecycle.GetServeAffectedPaths(m)
 	useFastCache := lifecycle.IsServeFastMode(m) && len(affected) > 0
 	for _, file := range files {
-		post, err := p.loadCachedPost(file, baseDir, cachedPosts, cache, useFastCache, affected)
+		post, err := p.loadCachedPost(m, file, baseDir, cachedPosts, cache, useFastCache, affected)
 		if err != nil {
 			return err
 		}
@@ -161,6 +161,7 @@ func (p *LoadPlugin) loadFromCachedPosts(
 }
 
 func (p *LoadPlugin) loadCachedPost(
+	m *lifecycle.Manager,
 	file string,
 	baseDir string,
 	cachedPosts map[string]*models.Post,
@@ -169,11 +170,7 @@ func (p *LoadPlugin) loadCachedPost(
 	affected map[string]bool,
 ) (*models.Post, error) {
 	if existing, ok := cachedPosts[file]; ok && !useFastCache {
-		fullPath := file
-		if !filepath.IsAbs(file) {
-			fullPath = filepath.Join(baseDir, file)
-		}
-		stat, err := os.Stat(fullPath)
+		modTime, err := resolveFileModTime(m, file, baseDir)
 		if err != nil {
 			if os.IsNotExist(err) {
 				return nil, nil
@@ -181,7 +178,7 @@ func (p *LoadPlugin) loadCachedPost(
 			return nil, fmt.Errorf("failed to stat %s: %w", file, err)
 		}
 		if cache != nil {
-			if cachedData := cache.GetCachedPostData(file, stat.ModTime().UnixNano()); cachedData != nil {
+			if cachedData := cache.GetCachedPostData(file, modTime); cachedData != nil {
 				return p.restorePostFromCache(cachedData, cache), nil
 			}
 		}
@@ -190,7 +187,7 @@ func (p *LoadPlugin) loadCachedPost(
 
 	if useFastCache {
 		if len(affected) > 0 && affected[file] {
-			return p.loadFile(file, baseDir, cache)
+			return p.loadFile(m, file, baseDir, cache)
 		}
 		if cache != nil {
 			if cachedData := cache.GetCachedPostDataLatest(file); cachedData != nil {
@@ -199,7 +196,7 @@ func (p *LoadPlugin) loadCachedPost(
 		}
 	}
 
-	return p.loadFile(file, baseDir, cache)
+	return p.loadFile(m, file, baseDir, cache)
 }
 
 func (p *LoadPlugin) loadAllFiles(m *lifecycle.Manager, files []string, baseDir string, cache *buildcache.Cache) error {
@@ -212,25 +209,21 @@ func (p *LoadPlugin) loadAllFiles(m *lifecycle.Manager, files []string, baseDir 
 	posts, err := p.loadFilesConcurrent(m, files, func(file string) (*models.Post, error) {
 		if useFastCache {
 			if len(affected) > 0 && affected[file] {
-				return p.loadFile(file, baseDir, cache)
+				return p.loadFile(m, file, baseDir, cache)
 			}
 			if cachedData := cache.GetCachedPostDataLatest(file); cachedData != nil {
 				return p.restorePostFromCache(cachedData, cache), nil
 			}
 		}
 
-		fullPath := file
-		if !filepath.IsAbs(file) {
-			fullPath = filepath.Join(baseDir, file)
-		}
-		stat, err := os.Stat(fullPath)
+		modTime, err := resolveFileModTime(m, file, baseDir)
 		if err != nil {
 			return nil, fmt.Errorf("failed to stat %s: %w", file, err)
 		}
-		if cachedData := cache.GetCachedPostData(file, stat.ModTime().UnixNano()); cachedData != nil {
+		if cachedData := cache.GetCachedPostData(file, modTime); cachedData != nil {
 			return p.restorePostFromCache(cachedData, cache), nil
 		}
-		return p.loadFile(file, baseDir, cache)
+		return p.loadFile(m, file, baseDir, cache)
 	})
 	if err != nil {
 		return err
@@ -305,6 +298,7 @@ func (p *LoadPlugin) loadFilesConcurrent(m *lifecycle.Manager, files []string, f
 }
 
 func (p *LoadPlugin) restoreFromCacheOrLoadChanged(
+	m *lifecycle.Manager,
 	files []string,
 	baseDir string,
 	cache *buildcache.Cache,
@@ -319,7 +313,7 @@ func (p *LoadPlugin) restoreFromCacheOrLoadChanged(
 
 	for _, file := range files {
 		if affected[file] {
-			post, err := p.loadFile(file, baseDir, cache)
+			post, err := p.loadFile(m, file, baseDir, cache)
 			if err != nil {
 				if firstErr == nil {
 					firstErr = err
@@ -331,21 +325,16 @@ func (p *LoadPlugin) restoreFromCacheOrLoadChanged(
 			continue
 		}
 
-		fullPath := file
-		if !filepath.IsAbs(file) {
-			fullPath = filepath.Join(baseDir, file)
-		}
-		stat, err := os.Stat(fullPath)
+		modTime, err := resolveFileModTime(m, file, baseDir)
 		if err != nil {
 			if firstErr == nil {
 				firstErr = fmt.Errorf("failed to stat %s: %w", file, err)
 			}
 			continue
 		}
-		modTime := stat.ModTime().UnixNano()
 		cachedData := cache.GetCachedPostData(file, modTime)
 		if cachedData == nil {
-			post, err := p.loadFile(file, baseDir, cache)
+			post, err := p.loadFile(m, file, baseDir, cache)
 			if err != nil {
 				if firstErr == nil {
 					firstErr = err
@@ -366,19 +355,13 @@ func (p *LoadPlugin) restoreFromCacheOrLoadChanged(
 }
 
 // loadFile loads a single file, using cache if ModTime is unchanged.
-func (p *LoadPlugin) loadFile(file, baseDir string, cache *buildcache.Cache) (*models.Post, error) {
-	// Construct full path
-	fullPath := file
-	if !filepath.IsAbs(file) {
-		fullPath = filepath.Join(baseDir, file)
-	}
+func (p *LoadPlugin) loadFile(m *lifecycle.Manager, file, baseDir string, cache *buildcache.Cache) (*models.Post, error) {
+	fullPath := fullContentPath(file, baseDir)
 
-	// Stat file for ModTime
-	stat, err := os.Stat(fullPath)
+	modTime, err := resolveFileModTime(m, file, baseDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to stat %s: %w", file, err)
 	}
-	modTime := stat.ModTime().UnixNano()
 
 	// Read file content
 	content, err := os.ReadFile(fullPath)
@@ -425,6 +408,33 @@ func (p *LoadPlugin) loadFile(file, baseDir string, cache *buildcache.Cache) (*m
 	}
 
 	return post, nil
+}
+
+func fullContentPath(file, baseDir string) string {
+	if filepath.IsAbs(file) {
+		return file
+	}
+
+	return filepath.Join(baseDir, file)
+}
+
+func resolveFileModTime(m *lifecycle.Manager, file, baseDir string) (int64, error) {
+	if m != nil {
+		if cached, ok := m.Cache().Get(cacheKeyGlobFileModTimes); ok {
+			if modTimes, ok := cached.(map[string]int64); ok {
+				if modTime, ok := modTimes[file]; ok && modTime != 0 {
+					return modTime, nil
+				}
+			}
+		}
+	}
+
+	stat, err := os.Stat(fullContentPath(file, baseDir))
+	if err != nil {
+		return 0, err
+	}
+
+	return stat.ModTime().UnixNano(), nil
 }
 
 // restorePostFromCache creates a Post from cached data.
@@ -618,7 +628,7 @@ func (p *LoadPlugin) postToCachedData(post *models.Post) *buildcache.CachedPostD
 // loadSequential loads files one at a time (used for small file counts).
 func (p *LoadPlugin) loadSequential(m *lifecycle.Manager, files []string, baseDir string, cache *buildcache.Cache) error {
 	for _, file := range files {
-		post, err := p.loadFile(file, baseDir, cache)
+		post, err := p.loadFile(m, file, baseDir, cache)
 		if err != nil {
 			return err
 		}

--- a/pkg/plugins/load_test.go
+++ b/pkg/plugins/load_test.go
@@ -1,11 +1,48 @@
 package plugins
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
 	"github.com/WaylonWalker/markata-go/pkg/models"
 )
+
+func TestResolveFileModTime_UsesGlobCachedModTime(t *testing.T) {
+	m := lifecycle.NewManager()
+	m.Cache().Set(cacheKeyGlobFileModTimes, map[string]int64{"post.md": 12345})
+
+	got, err := resolveFileModTime(m, "post.md", "/does/not/exist")
+	if err != nil {
+		t.Fatalf("resolveFileModTime() error = %v", err)
+	}
+	if got != 12345 {
+		t.Fatalf("resolveFileModTime() = %d, want 12345", got)
+	}
+}
+
+func TestResolveFileModTime_FallsBackToStat(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "post.md")
+	if err := os.WriteFile(path, []byte("# post"), 0o600); err != nil {
+		t.Fatalf("WriteFile(post.md) error = %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat(post.md) error = %v", err)
+	}
+
+	got, err := resolveFileModTime(nil, "post.md", tmpDir)
+	if err != nil {
+		t.Fatalf("resolveFileModTime() error = %v", err)
+	}
+	if got != info.ModTime().UnixNano() {
+		t.Fatalf("resolveFileModTime() = %d, want %d", got, info.ModTime().UnixNano())
+	}
+}
 
 func TestParseDateString(t *testing.T) {
 	tests := []struct {

--- a/pkg/plugins/mentions.go
+++ b/pkg/plugins/mentions.go
@@ -13,10 +13,13 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/WaylonWalker/markata-go/pkg/buildcache"
+	"github.com/WaylonWalker/markata-go/pkg/buildstats"
 	"github.com/WaylonWalker/markata-go/pkg/filter"
 	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
 	"github.com/WaylonWalker/markata-go/pkg/models"
@@ -28,6 +31,8 @@ type MentionsPlugin struct {
 	// cssClass is the CSS class applied to mention links
 	cssClass string
 }
+
+const mentionsCacheVersion = "mentions:v1"
 
 // NewMentionsPlugin creates a new MentionsPlugin.
 func NewMentionsPlugin() *MentionsPlugin {
@@ -99,18 +104,123 @@ func (p *MentionsPlugin) Transform(m *lifecycle.Manager) error {
 	// Attach metadata to mention entries
 	p.attachMetadataToEntries(handleMap, domainMap)
 
+	cache := GetBuildCache(m)
+	cacheSignature := p.computeCacheSignature(handleMap)
 	posts := m.FilterPosts(func(post *models.Post) bool {
 		return !post.Skip && post.Content != ""
 	})
 
 	log.Printf("[mentions] Processing %d posts", len(posts))
 
-	return m.ProcessPostsSliceConcurrently(posts, func(post *models.Post) error {
+	var needProcessing []*models.Post
+	if cache != nil {
+		for _, post := range posts {
+			contentHash := p.computePostHash(post, cacheSignature)
+			if cachedContent, ok := cache.GetCachedMentionsContent(post.Path, contentHash); ok {
+				post.Content = cachedContent
+				continue
+			}
+			needProcessing = append(needProcessing, post)
+		}
+	} else {
+		needProcessing = posts
+	}
+
+	if len(needProcessing) == 0 {
+		return nil
+	}
+
+	return m.ProcessPostsSliceConcurrently(needProcessing, func(post *models.Post) error {
+		contentHash := p.computePostHash(post, cacheSignature)
 		content := p.processChatAdmonitionTitles(post, handleMap)
 		content = p.processMentionsWithMetadata(content, handleMap)
 		post.Content = content
+		if cache != nil {
+			cache.CacheMentionsContent(post.Path, contentHash, content)
+		}
 		return nil
 	})
+}
+
+func (p *MentionsPlugin) computePostHash(post *models.Post, cacheSignature string) string {
+	authorName, authorAvatar := getPrimaryAuthorDisplay(post)
+	var b strings.Builder
+	b.WriteString(post.Content)
+	b.WriteByte('\x00')
+	b.WriteString(cacheSignature)
+	b.WriteByte('\x00')
+	b.WriteString(authorName)
+	b.WriteByte('\x00')
+	b.WriteString(authorAvatar)
+	return buildcache.ContentHash(b.String())
+}
+
+func (p *MentionsPlugin) computeCacheSignature(handleMap map[string]*mentionEntry) string {
+	type cacheMetadata struct {
+		Name   string `json:"name,omitempty"`
+		Bio    string `json:"bio,omitempty"`
+		Avatar string `json:"avatar,omitempty"`
+		URL    string `json:"url,omitempty"`
+		Error  string `json:"error,omitempty"`
+	}
+
+	type cacheEntry struct {
+		Key      string         `json:"key"`
+		Handle   string         `json:"handle"`
+		SiteURL  string         `json:"site_url"`
+		Title    string         `json:"title,omitempty"`
+		Internal bool           `json:"internal,omitempty"`
+		Metadata *cacheMetadata `json:"metadata,omitempty"`
+	}
+
+	keys := make([]string, 0, len(handleMap))
+	for key := range handleMap {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+
+	entries := make([]cacheEntry, 0, len(keys))
+	for _, key := range keys {
+		entry := handleMap[key]
+		if entry == nil {
+			continue
+		}
+
+		cachedEntry := cacheEntry{
+			Key:      key,
+			Handle:   entry.Handle,
+			SiteURL:  entry.SiteURL,
+			Title:    entry.Title,
+			Internal: entry.Internal,
+		}
+		if entry.Metadata != nil {
+			cachedEntry.Metadata = &cacheMetadata{
+				Name:   entry.Metadata.Name,
+				Bio:    entry.Metadata.Bio,
+				Avatar: entry.Metadata.Avatar,
+				URL:    entry.Metadata.URL,
+				Error:  entry.Metadata.Error,
+			}
+		}
+		entries = append(entries, cachedEntry)
+	}
+
+	payload := struct {
+		Version  string       `json:"version"`
+		CSSClass string       `json:"css_class"`
+		Entries  []cacheEntry `json:"entries"`
+	}{
+		Version:  mentionsCacheVersion,
+		CSSClass: p.cssClass,
+		Entries:  entries,
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return mentionsCacheVersion
+	}
+
+	return buildcache.ContentHash(string(data))
 }
 
 // mentionEntry holds resolved information for a handle.
@@ -383,6 +493,7 @@ func (p *MentionsPlugin) fetchMetadata(domain, cacheDir string, maxAge, timeout 
 	client := &http.Client{
 		Timeout: timeout,
 	}
+	buildstats.InstrumentHTTPClient(client)
 
 	ctx := context.Background()
 	req, err := http.NewRequestWithContext(ctx, "GET", url, http.NoBody)

--- a/pkg/plugins/mentions_test.go
+++ b/pkg/plugins/mentions_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/WaylonWalker/markata-go/pkg/buildcache"
 	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
 	"github.com/WaylonWalker/markata-go/pkg/models"
 )
@@ -745,6 +746,132 @@ func TestMentionsPlugin_Transform_FromPosts(t *testing.T) {
 	want := `I recently collaborated with <a href="/contact/alice/" class="mention" data-name="Alice Smith" data-handle="@alice">@alice</a> on a project.`
 	if transformedPost.Content != want {
 		t.Errorf("Content = %q, want %q", transformedPost.Content, want)
+	}
+}
+
+func TestMentionsPlugin_Transform_CachesContent(t *testing.T) {
+	p := NewMentionsPlugin()
+	m := lifecycle.NewManager()
+	cache := buildcache.New(t.TempDir())
+	m.Cache().Set("build_cache", cache)
+
+	config := m.Config()
+	config.Extra = map[string]interface{}{
+		"mentions": models.MentionsConfig{
+			CSSClass: "mention",
+			FromPosts: []models.MentionPostSource{
+				{
+					Filter:      "'contact' in tags",
+					HandleField: "handle",
+				},
+			},
+		},
+	}
+
+	aliceTitle := "Alice Smith"
+	m.AddPost(&models.Post{
+		Path:      "pages/contact/alice.md",
+		Slug:      "contact/alice",
+		Href:      "/contact/alice/",
+		Title:     &aliceTitle,
+		Tags:      []string{"contact"},
+		Published: true,
+		Extra: map[string]interface{}{
+			"handle": "alice",
+		},
+	})
+
+	blogPost := &models.Post{
+		Path:      "posts/working-with-alice.md",
+		Slug:      "working-with-alice",
+		Href:      "/working-with-alice/",
+		Title:     &aliceTitle,
+		Tags:      []string{"blog"},
+		Published: true,
+		Content:   "I recently collaborated with @alice on a project.",
+	}
+	m.AddPost(blogPost)
+
+	if err := p.Transform(m); err != nil {
+		t.Fatalf("Transform() error = %v", err)
+	}
+
+	cachedPost, ok := cache.Posts[blogPost.Path]
+	if !ok {
+		t.Fatalf("expected cache entry for %s", blogPost.Path)
+	}
+	if cachedPost.MentionsHash == "" {
+		t.Fatal("expected mentions hash to be cached")
+	}
+	if cachedPost.MentionsContent != blogPost.Content {
+		t.Fatalf("cached mentions content = %q, want %q", cachedPost.MentionsContent, blogPost.Content)
+	}
+}
+
+func TestMentionsPlugin_Transform_InvalidatesCacheWhenMentionMetadataChanges(t *testing.T) {
+	cache := buildcache.New(t.TempDir())
+
+	newManager := func(contactName string) (*lifecycle.Manager, *models.Post) {
+		m := lifecycle.NewManager()
+		m.Cache().Set("build_cache", cache)
+
+		config := m.Config()
+		config.Extra = map[string]interface{}{
+			"mentions": models.MentionsConfig{
+				CSSClass: "mention",
+				FromPosts: []models.MentionPostSource{
+					{
+						Filter:      "'contact' in tags",
+						HandleField: "handle",
+					},
+				},
+			},
+		}
+
+		m.AddPost(&models.Post{
+			Path:      "pages/contact/alice.md",
+			Slug:      "contact/alice",
+			Href:      "/contact/alice/",
+			Title:     &contactName,
+			Tags:      []string{"contact"},
+			Published: true,
+			Extra: map[string]interface{}{
+				"handle": "alice",
+			},
+		})
+
+		blogTitle := "Working with Alice"
+		blogPost := &models.Post{
+			Path:      "posts/working-with-alice.md",
+			Slug:      "working-with-alice",
+			Href:      "/working-with-alice/",
+			Title:     &blogTitle,
+			Tags:      []string{"blog"},
+			Published: true,
+			Content:   "I recently collaborated with @alice on a project.",
+		}
+		m.AddPost(blogPost)
+
+		return m, blogPost
+	}
+
+	plugin := NewMentionsPlugin()
+	firstManager, _ := newManager("Alice Smith")
+	if err := plugin.Transform(firstManager); err != nil {
+		t.Fatalf("first Transform() error = %v", err)
+	}
+
+	plugin = NewMentionsPlugin()
+	secondManager, secondBlogPost := newManager("Alice Johnson")
+	if err := plugin.Transform(secondManager); err != nil {
+		t.Fatalf("second Transform() error = %v", err)
+	}
+
+	if !strings.Contains(secondBlogPost.Content, `data-name="Alice Johnson"`) {
+		t.Fatalf("expected rebuilt content to include updated metadata, got %q", secondBlogPost.Content)
+	}
+	if strings.Contains(secondBlogPost.Content, `data-name="Alice Smith"`) {
+		t.Fatalf("expected cache invalidation to drop stale metadata, got %q", secondBlogPost.Content)
 	}
 }
 

--- a/pkg/plugins/oembed.go
+++ b/pkg/plugins/oembed.go
@@ -84,6 +84,7 @@ type oembedResolver struct {
 	jsonProvidersMu sync.RWMutex
 	jsonFetchedAt   time.Time
 	markdown        goldmark.Markdown
+	htmlFetcher     func(rawURL string) (string, error)
 }
 
 const jsonProvidersCacheDuration = 24 * time.Hour
@@ -111,6 +112,10 @@ func (r *oembedResolver) updateConfig(config models.EmbedsConfig) {
 
 func (r *oembedResolver) setMarkdownRenderer(md goldmark.Markdown) {
 	r.markdown = md
+}
+
+func (r *oembedResolver) setHTMLFetcher(fetcher func(rawURL string) (string, error)) {
+	r.htmlFetcher = fetcher
 }
 
 func newEmbedMarkdownRenderer(extra map[string]interface{}) goldmark.Markdown {
@@ -521,32 +526,12 @@ func (r *oembedResolver) discoverEndpoint(rawURL string) (string, error) {
 		return "", errOEmbedDiscoveryDisabled
 	}
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, rawURL, http.NoBody)
+	htmlContent, err := r.fetchPageHTML(rawURL)
 	if err != nil {
 		return "", err
 	}
 
-	req.Header.Set("User-Agent", "markata-go/1.0 (+https://github.com/WaylonWalker/markata-go)")
-	req.Header.Set("Accept", "text/html,application/xhtml+xml")
-
-	resp, err := r.client.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("oembed discovery failed: %s", resp.Status)
-	}
-
-	const maxBody = 512 * 1024
-	limited := io.LimitReader(resp.Body, maxBody)
-	body, err := io.ReadAll(limited)
-	if err != nil {
-		return "", err
-	}
-
-	endpoint := findOEmbedLink(string(body))
+	endpoint := findOEmbedLink(htmlContent)
 	if endpoint == "" {
 		return "", fmt.Errorf("oembed discovery: endpoint not found")
 	}
@@ -564,6 +549,36 @@ func (r *oembedResolver) discoverEndpoint(rawURL string) (string, error) {
 	}
 
 	return endpoint, nil
+}
+
+func (r *oembedResolver) fetchPageHTML(rawURL string) (string, error) {
+	if r.htmlFetcher != nil {
+		return r.htmlFetcher(rawURL)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, rawURL, http.NoBody)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("User-Agent", "markata-go/1.0 (+https://github.com/WaylonWalker/markata-go)")
+	req.Header.Set("Accept", "text/html,application/xhtml+xml")
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("oembed discovery failed: %s", resp.Status)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 512*1024))
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
 }
 
 func findOEmbedLink(html string) string {

--- a/pkg/plugins/pagefind_installer.go
+++ b/pkg/plugins/pagefind_installer.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/WaylonWalker/markata-go/pkg/buildstats"
 	"github.com/WaylonWalker/markata-go/pkg/logging"
 )
 
@@ -137,12 +138,15 @@ var platformMapping = map[string]map[string]string{
 
 // NewPagefindInstaller creates a new PagefindInstaller with default settings.
 func NewPagefindInstaller() *PagefindInstaller {
+	client := &http.Client{
+		Timeout: defaultHTTPTimeout,
+	}
+	buildstats.InstrumentHTTPClient(client)
+
 	return &PagefindInstaller{
 		CacheDir: "",
 		Version:  Latest,
-		client: &http.Client{
-			Timeout: defaultHTTPTimeout,
-		},
+		client:   client,
 	}
 }
 

--- a/pkg/plugins/publish_feeds.go
+++ b/pkg/plugins/publish_feeds.go
@@ -516,29 +516,30 @@ func (p *PublishFeedsPlugin) expectedFeedOutputPaths(fc *models.FeedConfig, outp
 	feedDir := p.determineFeedDir(outputDir, fc.Slug)
 	syndication := getSyndicationConfig(config)
 	paths := make([]string, 0, len(fc.Pages)*2+8)
+	htmlPages := fc.Pages
+	if fc.Formats.HTML || fc.Formats.SimpleHTML {
+		htmlPages = feedConfigWithRenderablePosts(fc).Pages
+	}
 	add := func(path string) {
 		if path != "" {
 			paths = append(paths, path)
 		}
 	}
 
-	if fc.Formats.HTML {
-		for i := range fc.Pages {
-			if fc.Pages[i].Number == 1 {
-				add(filepath.Join(feedDir, "index.html"))
-			} else {
-				add(filepath.Join(feedDir, "page", fmt.Sprintf("%d", fc.Pages[i].Number), "index.html"))
-			}
+	if fc.Formats.HTML && len(htmlPages) > 0 {
+		add(filepath.Join(feedDir, "index.html"))
+		if lastPage := htmlPages[len(htmlPages)-1].Number; lastPage > 1 {
+			// The feed hash already covers page count and pagination structure, so
+			// checking the first and last HTML pages is enough to catch missing
+			// outputs without repeating every paginated page stat on warm builds.
+			add(filepath.Join(feedDir, "page", fmt.Sprintf("%d", lastPage), "index.html"))
 		}
 	}
 
-	if fc.Formats.SimpleHTML {
-		for i := range fc.Pages {
-			if fc.Pages[i].Number == 1 {
-				add(filepath.Join(feedDir, "simple", "index.html"))
-			} else {
-				add(filepath.Join(feedDir, "simple", "page", fmt.Sprintf("%d", fc.Pages[i].Number), "index.html"))
-			}
+	if fc.Formats.SimpleHTML && len(htmlPages) > 0 {
+		add(filepath.Join(feedDir, "simple", "index.html"))
+		if lastPage := htmlPages[len(htmlPages)-1].Number; lastPage > 1 {
+			add(filepath.Join(feedDir, "simple", "page", fmt.Sprintf("%d", lastPage), "index.html"))
 		}
 	}
 

--- a/pkg/plugins/publish_feeds.go
+++ b/pkg/plugins/publish_feeds.go
@@ -32,12 +32,17 @@ type PublishFeedsPlugin struct {
 	// engineCache caches template engines to avoid re-parsing templates for each feed
 	engineMu    sync.RWMutex
 	engineCache map[string]*templates.Engine
+
+	// postFeedHashCache memoizes per-post feed semantic hashes for the current build.
+	postFeedHashMu    sync.RWMutex
+	postFeedHashCache map[string]string
 }
 
 // NewPublishFeedsPlugin creates a new PublishFeedsPlugin.
 func NewPublishFeedsPlugin() *PublishFeedsPlugin {
 	return &PublishFeedsPlugin{
-		engineCache: make(map[string]*templates.Engine),
+		engineCache:       make(map[string]*templates.Engine),
+		postFeedHashCache: make(map[string]string),
 	}
 }
 
@@ -123,6 +128,8 @@ func (p *PublishFeedsPlugin) Configure(m *lifecycle.Manager) error {
 // Feed generation is parallelized for better performance with many feeds.
 // Uses incremental build cache to skip feeds with unchanged content.
 func (p *PublishFeedsPlugin) Write(m *lifecycle.Manager) error {
+	p.resetPostFeedHashCache()
+
 	config := m.Config()
 	feedConfigs := getCachedFeedConfigs(m)
 	if len(feedConfigs) == 0 {
@@ -334,10 +341,14 @@ func (p *PublishFeedsPlugin) publishFeedsAsync(m *lifecycle.Manager, feedConfigs
 // It includes post slugs (in feed order to detect sort changes), and all
 // configuration fields that affect feed output.
 func (p *PublishFeedsPlugin) computeFeedHash(fc *models.FeedConfig) string {
-	return p.computeFeedHashWithConfig(fc, nil)
+	return p.computeFeedHashWithConfigAndCache(fc, nil, nil)
 }
 
 func (p *PublishFeedsPlugin) computeFeedHashWithConfig(fc *models.FeedConfig, config *lifecycle.Config) string {
+	return p.computeFeedHashWithConfigAndCache(fc, config, nil)
+}
+
+func (p *PublishFeedsPlugin) computeFeedHashWithConfigAndCache(fc *models.FeedConfig, config *lifecycle.Config, cache *buildcache.Cache) string {
 	h := sha256.New()
 	syndication := getSyndicationConfig(config)
 	writeStringField := func(value string) {
@@ -358,7 +369,7 @@ func (p *PublishFeedsPlugin) computeFeedHashWithConfig(fc *models.FeedConfig, co
 	// This ensures sort order changes are detected.
 	for _, post := range fc.Posts {
 		writeStringField(post.Slug)
-		writeStringField(computePostFeedItemHash(post))
+		writeStringField(p.getPostFeedItemHash(post, cache))
 	}
 
 	for i := range fc.Pages {
@@ -423,6 +434,40 @@ func (p *PublishFeedsPlugin) computeFeedHashWithConfig(fc *models.FeedConfig, co
 	return hex.EncodeToString(h.Sum(nil))
 }
 
+func (p *PublishFeedsPlugin) resetPostFeedHashCache() {
+	p.postFeedHashMu.Lock()
+	defer p.postFeedHashMu.Unlock()
+	p.postFeedHashCache = make(map[string]string)
+}
+
+func (p *PublishFeedsPlugin) getPostFeedItemHash(post *models.Post, cache *buildcache.Cache) string {
+	if post == nil {
+		return ""
+	}
+	if post.Path == "" || cache == nil {
+		return computePostFeedItemHash(post)
+	}
+
+	p.postFeedHashMu.RLock()
+	if cachedHash, ok := p.postFeedHashCache[post.Path]; ok {
+		p.postFeedHashMu.RUnlock()
+		return cachedHash
+	}
+	p.postFeedHashMu.RUnlock()
+
+	feedHash := ""
+	feedHash, _, _ = cache.GetPostSemanticHashes(post.Path)
+	if feedHash == "" {
+		return computePostFeedItemHash(post)
+	}
+
+	p.postFeedHashMu.Lock()
+	p.postFeedHashCache[post.Path] = feedHash
+	p.postFeedHashMu.Unlock()
+
+	return feedHash
+}
+
 // shouldSkipFeed checks if a feed can be skipped (incremental build).
 // Returns (skip bool, hash string) - hash is returned so callers can reuse it
 // for caching without recomputing.
@@ -431,17 +476,17 @@ func (p *PublishFeedsPlugin) shouldSkipFeed(fc *models.FeedConfig, cache interfa
 }
 
 func (p *PublishFeedsPlugin) shouldSkipFeedWithConfig(fc *models.FeedConfig, cache interface{}, outputDir string, config *lifecycle.Config) (skip bool, hash string) {
-	// Always compute hash since we return it for caching
-	currentHash := p.computeFeedHashWithConfig(fc, config)
-
 	if cache == nil {
-		return false, currentHash
+		return false, p.computeFeedHashWithConfigAndCache(fc, config, nil)
 	}
 
 	bc, ok := cache.(*buildcache.Cache)
 	if !ok || bc == nil {
-		return false, currentHash
+		return false, p.computeFeedHashWithConfigAndCache(fc, config, nil)
 	}
+
+	// Always compute hash since we return it for caching.
+	currentHash := p.computeFeedHashWithConfigAndCache(fc, config, bc)
 
 	// Check if feed hash changed (membership, order, page structure, content)
 	cachedHash := bc.GetFeedHash(fc.Slug)
@@ -558,6 +603,17 @@ type feedFormatPublisher struct {
 	targetFile string // Target file name for redirect
 }
 
+type feedRenderContext struct {
+	totalPosts       int
+	latestPostDate   string
+	sparklinePoints  string
+	sparklineData    []SparklinePoint
+	sparklineTitle   string
+	sparklineSummary string
+	sparklineStart   string
+	sparklineEnd     string
+}
+
 // publishFeed publishes a single feed in all configured formats.
 func (p *PublishFeedsPlugin) publishFeed(fc *models.FeedConfig, config *lifecycle.Config, outputDir string) error {
 	feedDir := p.determineFeedDir(outputDir, fc.Slug)
@@ -565,6 +621,7 @@ func (p *PublishFeedsPlugin) publishFeed(fc *models.FeedConfig, config *lifecycl
 	syndication := getSyndicationConfig(config)
 	htmlFC := feedConfigWithRenderablePosts(fc)
 	syndicationFC := feedConfigWithOutputPosts(fc)
+	renderCtx := buildFeedRenderContext(htmlFC)
 
 	if err := os.MkdirAll(feedDir, 0o755); err != nil {
 		return fmt.Errorf("creating feed directory: %w", err)
@@ -572,8 +629,8 @@ func (p *PublishFeedsPlugin) publishFeed(fc *models.FeedConfig, config *lifecycl
 
 	// Define all format publishers with their configurations
 	publishers := []feedFormatPublisher{
-		{name: "HTML", enabled: fc.Formats.HTML, publish: func() error { return p.publishHTMLPages(htmlFC, config, modelsConfig, feedDir) }},
-		{name: "SimpleHTML", enabled: fc.Formats.SimpleHTML, publish: func() error { return p.publishSimpleHTMLPages(htmlFC, config, modelsConfig, feedDir) }},
+		{name: "HTML", enabled: fc.Formats.HTML, publish: func() error { return p.publishHTMLPages(htmlFC, config, modelsConfig, feedDir, renderCtx) }},
+		{name: "SimpleHTML", enabled: fc.Formats.SimpleHTML, publish: func() error { return p.publishSimpleHTMLPages(htmlFC, config, modelsConfig, feedDir, renderCtx) }},
 		{name: "RSS", enabled: fc.Formats.RSS, publish: func() error { return p.publishRSS(syndicationFC, config, feedDir, false) }},
 		{name: "Atom", enabled: fc.Formats.Atom, publish: func() error { return p.publishAtom(syndicationFC, config, feedDir, false) }},
 		{name: "JSON", enabled: fc.Formats.JSON, publish: func() error { return p.publishJSON(syndicationFC, config, feedDir, false) }, ext: "json", targetFile: "feed.json"},
@@ -687,7 +744,7 @@ func (p *PublishFeedsPlugin) publishFormat(pub feedFormatPublisher, slug, output
 }
 
 // publishHTMLPages publishes HTML pages for a paginated feed.
-func (p *PublishFeedsPlugin) publishHTMLPages(fc *models.FeedConfig, config *lifecycle.Config, modelsConfig *models.Config, feedDir string) error {
+func (p *PublishFeedsPlugin) publishHTMLPages(fc *models.FeedConfig, config *lifecycle.Config, modelsConfig *models.Config, feedDir string, renderCtx *feedRenderContext) error {
 	if err := p.cleanupPaginatedFeedDirs(feedDir, "", fc.Pages); err != nil {
 		return fmt.Errorf("cleaning html pagination dirs: %w", err)
 	}
@@ -707,7 +764,7 @@ func (p *PublishFeedsPlugin) publishHTMLPages(fc *models.FeedConfig, config *lif
 		}
 
 		// Generate HTML content
-		html, err := p.generateFeedPageHTML(fc, page, config, modelsConfig)
+		html, err := p.generateFeedPageHTML(fc, page, config, modelsConfig, renderCtx)
 		if err != nil {
 			return fmt.Errorf("generating page %d: %w", page.Number, err)
 		}
@@ -722,7 +779,7 @@ func (p *PublishFeedsPlugin) publishHTMLPages(fc *models.FeedConfig, config *lif
 
 // publishSimpleHTMLPages publishes the simple (compact list) HTML pages for a feed.
 // Output is written to feedDir/simple/ with pagination at feedDir/simple/page/N/.
-func (p *PublishFeedsPlugin) publishSimpleHTMLPages(fc *models.FeedConfig, config *lifecycle.Config, modelsConfig *models.Config, feedDir string) error {
+func (p *PublishFeedsPlugin) publishSimpleHTMLPages(fc *models.FeedConfig, config *lifecycle.Config, modelsConfig *models.Config, feedDir string, renderCtx *feedRenderContext) error {
 	simpleDir := filepath.Join(feedDir, "simple")
 	if err := p.cleanupPaginatedFeedDirs(feedDir, "simple", fc.Pages); err != nil {
 		return fmt.Errorf("cleaning simple pagination dirs: %w", err)
@@ -758,7 +815,7 @@ func (p *PublishFeedsPlugin) publishSimpleHTMLPages(fc *models.FeedConfig, confi
 		}
 
 		// Generate HTML content using simple-feed.html template
-		htmlContent, err := p.generateSimpleFeedPageHTML(fc, &adjustedPage, config, modelsConfig)
+		htmlContent, err := p.generateSimpleFeedPageHTML(fc, &adjustedPage, config, modelsConfig, renderCtx)
 		if err != nil {
 			return fmt.Errorf("generating simple page %d: %w", adjustedPage.Number, err)
 		}
@@ -842,7 +899,7 @@ func (p *PublishFeedsPlugin) adjustPageURLsForSimple(page *models.FeedPage, simp
 }
 
 // generateSimpleFeedPageHTML generates HTML for a simple feed page using the simple-feed.html template.
-func (p *PublishFeedsPlugin) generateSimpleFeedPageHTML(fc *models.FeedConfig, page *models.FeedPage, config *lifecycle.Config, modelsConfig *models.Config) (string, error) {
+func (p *PublishFeedsPlugin) generateSimpleFeedPageHTML(fc *models.FeedConfig, page *models.FeedPage, config *lifecycle.Config, modelsConfig *models.Config, renderCtx *feedRenderContext) (string, error) {
 	// Get templates directory from config
 	templatesDir := PluginNameTemplates
 	if extra, ok := config.Extra["templates_dir"].(string); ok && extra != "" {
@@ -880,7 +937,7 @@ func (p *PublishFeedsPlugin) generateSimpleFeedPageHTML(fc *models.FeedConfig, p
 			modelsConfig = ToModelsConfig(config)
 		}
 		ctx := templates.NewFeedContext(fc, page, modelsConfig)
-		p.addFeedStatsContext(&ctx, fc)
+		p.addFeedStatsContext(&ctx, fc, renderCtx)
 
 		// Feed pages always need cards CSS
 		ctx.Set("needs_cards_css", true)
@@ -898,7 +955,7 @@ func (p *PublishFeedsPlugin) generateSimpleFeedPageHTML(fc *models.FeedConfig, p
 }
 
 // generateFeedPageHTML generates HTML for a feed page.
-func (p *PublishFeedsPlugin) generateFeedPageHTML(fc *models.FeedConfig, page *models.FeedPage, config *lifecycle.Config, modelsConfig *models.Config) (string, error) {
+func (p *PublishFeedsPlugin) generateFeedPageHTML(fc *models.FeedConfig, page *models.FeedPage, config *lifecycle.Config, modelsConfig *models.Config, renderCtx *feedRenderContext) (string, error) {
 	templateName := fc.Templates.HTML
 	if templateName == "" {
 		templateName = "feed.html"
@@ -943,7 +1000,7 @@ func (p *PublishFeedsPlugin) generateFeedPageHTML(fc *models.FeedConfig, page *m
 		// Create feed context
 		ctx := templates.NewFeedContext(fc, page, modelsConfig)
 		ctx.Set("feed_robots", fc.Robots)
-		p.addFeedStatsContext(&ctx, fc)
+		p.addFeedStatsContext(&ctx, fc, renderCtx)
 
 		// Feed pages always need cards CSS
 		ctx.Set("needs_cards_css", true)
@@ -970,20 +1027,36 @@ func (p *PublishFeedsPlugin) generateFeedPageHTML(fc *models.FeedConfig, page *m
 	return p.generateFeedPageHTMLFallback(fc, page, config)
 }
 
-func (p *PublishFeedsPlugin) addFeedStatsContext(ctx *templates.Context, fc *models.FeedConfig) {
-	if ctx == nil || fc == nil {
-		return
+func buildFeedRenderContext(fc *models.FeedConfig) *feedRenderContext {
+	if fc == nil {
+		return nil
 	}
 	totalPosts, latestPostDate, _ := feedStats(fc.Posts, fc.IncludePrivate)
 	window := computeSparklineWindow(fc.Posts, fc.IncludePrivate)
-	ctx.Set("feed_stats_total_posts", totalPosts)
-	ctx.Set("feed_stats_latest_post", latestPostDate)
-	ctx.Set("feed_sparkline_points", buildFeedSparkline(fc.Posts, window, fc.IncludePrivate))
-	ctx.Set("feed_sparkline_data", buildFeedSparklineData(fc.Posts, window, fc.IncludePrivate))
-	ctx.Set("feed_sparkline_title", buildFeedSparklineTitle(fc.Posts, window, fc.IncludePrivate))
-	ctx.Set("feed_sparkline_summary", buildFeedSparklineSummary(fc.Posts, window, fc.IncludePrivate))
-	ctx.Set("feed_sparkline_start", buildFeedSparklineStart(window))
-	ctx.Set("feed_sparkline_end", buildFeedSparklineEnd(window))
+	return &feedRenderContext{
+		totalPosts:       totalPosts,
+		latestPostDate:   latestPostDate,
+		sparklinePoints:  buildFeedSparkline(fc.Posts, window, fc.IncludePrivate),
+		sparklineData:    buildFeedSparklineData(fc.Posts, window, fc.IncludePrivate),
+		sparklineTitle:   buildFeedSparklineTitle(fc.Posts, window, fc.IncludePrivate),
+		sparklineSummary: buildFeedSparklineSummary(fc.Posts, window, fc.IncludePrivate),
+		sparklineStart:   buildFeedSparklineStart(window),
+		sparklineEnd:     buildFeedSparklineEnd(window),
+	}
+}
+
+func (p *PublishFeedsPlugin) addFeedStatsContext(ctx *templates.Context, fc *models.FeedConfig, renderCtx *feedRenderContext) {
+	if ctx == nil || fc == nil || renderCtx == nil {
+		return
+	}
+	ctx.Set("feed_stats_total_posts", renderCtx.totalPosts)
+	ctx.Set("feed_stats_latest_post", renderCtx.latestPostDate)
+	ctx.Set("feed_sparkline_points", renderCtx.sparklinePoints)
+	ctx.Set("feed_sparkline_data", renderCtx.sparklineData)
+	ctx.Set("feed_sparkline_title", renderCtx.sparklineTitle)
+	ctx.Set("feed_sparkline_summary", renderCtx.sparklineSummary)
+	ctx.Set("feed_sparkline_start", renderCtx.sparklineStart)
+	ctx.Set("feed_sparkline_end", renderCtx.sparklineEnd)
 }
 
 // generateFeedPageHTMLFallback generates HTML using a built-in Go template.

--- a/pkg/plugins/publish_feeds.go
+++ b/pkg/plugins/publish_feeds.go
@@ -344,10 +344,6 @@ func (p *PublishFeedsPlugin) computeFeedHash(fc *models.FeedConfig) string {
 	return p.computeFeedHashWithConfigAndCache(fc, nil, nil)
 }
 
-func (p *PublishFeedsPlugin) computeFeedHashWithConfig(fc *models.FeedConfig, config *lifecycle.Config) string {
-	return p.computeFeedHashWithConfigAndCache(fc, config, nil)
-}
-
 func (p *PublishFeedsPlugin) computeFeedHashWithConfigAndCache(fc *models.FeedConfig, config *lifecycle.Config, cache *buildcache.Cache) string {
 	h := sha256.New()
 	syndication := getSyndicationConfig(config)
@@ -695,9 +691,9 @@ func (p *PublishFeedsPlugin) determineFeedDir(outputDir, slug string) string {
 	return filepath.Join(outputDir, slug)
 }
 
-// safeWriteFile writes content to a file, removing any existing directory at that path.
+// prepareWriteFile removes any existing directory at a file path.
 // This handles the case where a previous build created a directory where a file should be.
-func (p *PublishFeedsPlugin) safeWriteFile(path string, content []byte) error {
+func (p *PublishFeedsPlugin) prepareWriteFile(path string) error {
 	// Check if path exists as a directory
 	info, err := os.Stat(path)
 	if err == nil && info.IsDir() {
@@ -706,9 +702,28 @@ func (p *PublishFeedsPlugin) safeWriteFile(path string, content []byte) error {
 			return fmt.Errorf("removing directory at file path %s: %w", path, err)
 		}
 	}
+	return nil
+}
+
+// safeWriteFile writes content to a file, removing any existing directory at that path.
+// If the file already exists with identical content, it is left untouched.
+func (p *PublishFeedsPlugin) safeWriteFile(path string, content []byte) error {
+	if err := p.prepareWriteFile(path); err != nil {
+		return err
+	}
 
 	if existing, err := os.ReadFile(path); err == nil && bytes.Equal(existing, content) {
 		return nil
+	}
+
+	return p.writeFile(path, content)
+}
+
+// writeFile writes content directly without a read-before-write check.
+// Use this only when the caller already knows the output is dirty.
+func (p *PublishFeedsPlugin) writeFile(path string, content []byte) error {
+	if err := p.prepareWriteFile(path); err != nil {
+		return err
 	}
 
 	//nolint:gosec // G306: Output files need 0644 for web serving
@@ -769,7 +784,7 @@ func (p *PublishFeedsPlugin) publishHTMLPages(fc *models.FeedConfig, config *lif
 			return fmt.Errorf("generating page %d: %w", page.Number, err)
 		}
 
-		if err := p.safeWriteFile(pagePath, []byte(html)); err != nil {
+		if err := p.writeFile(pagePath, []byte(html)); err != nil {
 			return fmt.Errorf("writing page %d: %w", page.Number, err)
 		}
 	}
@@ -820,7 +835,7 @@ func (p *PublishFeedsPlugin) publishSimpleHTMLPages(fc *models.FeedConfig, confi
 			return fmt.Errorf("generating simple page %d: %w", adjustedPage.Number, err)
 		}
 
-		if err := p.safeWriteFile(pagePath, []byte(htmlContent)); err != nil {
+		if err := p.writeFile(pagePath, []byte(htmlContent)); err != nil {
 			return fmt.Errorf("writing simple page %d: %w", adjustedPage.Number, err)
 		}
 	}
@@ -1165,7 +1180,7 @@ func (p *PublishFeedsPlugin) publishRSS(fc *models.FeedConfig, config *lifecycle
 	}
 
 	rssPath := filepath.Join(feedDir, "rss.xml")
-	return p.safeWriteFile(rssPath, []byte(rss))
+	return p.writeFile(rssPath, []byte(rss))
 }
 
 // publishAtom generates and writes an Atom feed.
@@ -1177,7 +1192,7 @@ func (p *PublishFeedsPlugin) publishAtom(fc *models.FeedConfig, config *lifecycl
 	}
 
 	atomPath := filepath.Join(feedDir, "atom.xml")
-	return p.safeWriteFile(atomPath, []byte(atom))
+	return p.writeFile(atomPath, []byte(atom))
 }
 
 // publishJSON generates and writes a JSON feed.
@@ -1189,7 +1204,7 @@ func (p *PublishFeedsPlugin) publishJSON(fc *models.FeedConfig, config *lifecycl
 	}
 
 	jsonPath := filepath.Join(feedDir, "feed.json")
-	return p.safeWriteFile(jsonPath, []byte(jsonFeed))
+	return p.writeFile(jsonPath, []byte(jsonFeed))
 }
 
 func (p *PublishFeedsPlugin) syndicationFeedConfig(fc *models.FeedConfig, config *lifecycle.Config, archive bool) *models.FeedConfig {
@@ -1250,7 +1265,7 @@ func (p *PublishFeedsPlugin) publishMarkdown(fc *models.FeedConfig, slug, output
 	} else {
 		mdPath = filepath.Join(outputDir, slug+".md")
 	}
-	return p.safeWriteFile(mdPath, []byte(sb.String()))
+	return p.writeFile(mdPath, []byte(sb.String()))
 }
 
 // publishText generates and writes a plain text feed listing.
@@ -1296,7 +1311,7 @@ func (p *PublishFeedsPlugin) publishText(fc *models.FeedConfig, slug, outputDir 
 	} else {
 		txtPath = filepath.Join(outputDir, slug+".txt")
 	}
-	return p.safeWriteFile(txtPath, []byte(sb.String()))
+	return p.writeFile(txtPath, []byte(sb.String()))
 }
 
 // publishSitemap generates and writes a sitemap XML file for feed posts.
@@ -1363,7 +1378,7 @@ func (p *PublishFeedsPlugin) publishSitemap(fc *models.FeedConfig, config *lifec
 
 	// Write sitemap.xml
 	sitemapPath := filepath.Join(feedDir, "sitemap.xml")
-	return p.safeWriteFile(sitemapPath, []byte(xmlContent))
+	return p.writeFile(sitemapPath, []byte(xmlContent))
 }
 
 // writeFeedFormatRedirect writes a redirect from /slug.ext to /slug/targetFile.
@@ -1400,7 +1415,7 @@ func (p *PublishFeedsPlugin) writeFeedFormatRedirect(slug, ext, targetFile, outp
 	// Write index.html inside the directory
 	// This allows /slug.ext to be served without trailing slash on most static hosts
 	outputPath := filepath.Join(redirectDir, "index.html")
-	if err := p.safeWriteFile(outputPath, []byte(redirectHTML)); err != nil {
+	if err := p.writeFile(outputPath, []byte(redirectHTML)); err != nil {
 		return fmt.Errorf("writing redirect %s: %w", outputPath, err)
 	}
 
@@ -1441,7 +1456,7 @@ func (p *PublishFeedsPlugin) writeReversedFeedRedirect(slug, ext, outputDir stri
 	// Write index.html inside the directory
 	// This allows /slug/index.ext to be served without trailing slash on most static hosts
 	outputPath := filepath.Join(redirectDir, "index.html")
-	if err := p.safeWriteFile(outputPath, []byte(redirectHTML)); err != nil {
+	if err := p.writeFile(outputPath, []byte(redirectHTML)); err != nil {
 		return fmt.Errorf("writing redirect %s: %w", outputPath, err)
 	}
 

--- a/pkg/plugins/publish_feeds.go
+++ b/pkg/plugins/publish_feeds.go
@@ -614,11 +614,30 @@ type feedRenderContext struct {
 // publishFeed publishes a single feed in all configured formats.
 func (p *PublishFeedsPlugin) publishFeed(fc *models.FeedConfig, config *lifecycle.Config, outputDir string) error {
 	feedDir := p.determineFeedDir(outputDir, fc.Slug)
-	modelsConfig := ToModelsConfig(config)
 	syndication := getSyndicationConfig(config)
-	htmlFC := feedConfigWithRenderablePosts(fc)
-	syndicationFC := feedConfigWithOutputPosts(fc)
-	renderCtx := buildFeedRenderContext(htmlFC)
+	pagePosts, outputPosts := splitFeedRenderablePosts(fc.Posts, fc.IncludePrivate)
+	needsHTML := fc.Formats.HTML || fc.Formats.SimpleHTML
+	needsOutputPosts := fc.Formats.RSS || fc.Formats.Atom || fc.Formats.JSON || fc.Formats.Markdown || fc.Formats.Text || fc.Formats.Sitemap
+
+	var modelsConfig *models.Config
+	var htmlFC *models.FeedConfig
+	var syndicationFC *models.FeedConfig
+	var renderCtx *feedRenderContext
+
+	if needsHTML {
+		modelsConfig = ToModelsConfig(config)
+		htmlFC = cloneFeedConfigWithPosts(fc, pagePosts)
+		baseURL := "/" + htmlFC.Slug
+		if htmlFC.Slug == "" {
+			baseURL = "/"
+		}
+		htmlFC.Paginate(baseURL)
+		renderCtx = buildFeedRenderContext(htmlFC)
+	}
+
+	if needsOutputPosts {
+		syndicationFC = cloneFeedConfigWithPosts(fc, outputPosts)
+	}
 
 	if err := os.MkdirAll(feedDir, 0o755); err != nil {
 		return fmt.Errorf("creating feed directory: %w", err)

--- a/pkg/plugins/publish_feeds_test.go
+++ b/pkg/plugins/publish_feeds_test.go
@@ -56,7 +56,7 @@ func TestGenerateFeedPageHTML_UsesConfiguredHTMLTemplate(t *testing.T) {
 	}
 	page := &models.FeedPage{Posts: fc.Posts, TotalPages: 1}
 
-	html, err := p.generateFeedPageHTML(fc, page, config, nil)
+	html, err := p.generateFeedPageHTML(fc, page, config, nil, buildFeedRenderContext(fc))
 	if err != nil {
 		t.Fatalf("generateFeedPageHTML() error = %v", err)
 	}

--- a/pkg/plugins/publish_feeds_test.go
+++ b/pkg/plugins/publish_feeds_test.go
@@ -788,3 +788,69 @@ func TestPublishFeedsPlugin_GeneratesArchiveVariants(t *testing.T) {
 		t.Fatalf("archive json not written: %v", err)
 	}
 }
+
+func TestPublishFeedsPlugin_ShouldSkipFeed_UsesRenderableHTMLPagination(t *testing.T) {
+	tempDir := t.TempDir()
+	plugin := NewPublishFeedsPlugin()
+	config := lifecycle.NewManager().Config()
+	config.OutputDir = tempDir
+	config.Extra = map[string]interface{}{
+		"url":   "https://example.com",
+		"title": "Test Site",
+	}
+
+	titleA := "Published"
+	titleB := "Draft"
+	feed := &models.FeedConfig{
+		Slug:         "published",
+		Title:        "Published",
+		Description:  "Published posts",
+		ItemsPerPage: 1,
+		Formats: models.FeedFormats{
+			HTML: true,
+		},
+		Posts: []*models.Post{
+			{
+				Path:        "pages/published.md",
+				Slug:        "published",
+				Href:        "/published/",
+				Title:       &titleA,
+				Published:   true,
+				ArticleHTML: "<p>published</p>",
+			},
+			{
+				Path:        "pages/draft.md",
+				Slug:        "draft",
+				Href:        "/draft/",
+				Title:       &titleB,
+				Draft:       true,
+				Published:   false,
+				ArticleHTML: "<p>draft</p>",
+			},
+		},
+	}
+	feed.Pages = []models.FeedPage{
+		{Number: 1, Posts: []*models.Post{feed.Posts[0]}, TotalPages: 2, TotalItems: 2, ItemsPerPage: 1, PageURLs: []string{"/published/", "/published/page/2/"}, HasNext: true, NextURL: "/published/page/2/"},
+		{Number: 2, Posts: []*models.Post{feed.Posts[1]}, TotalPages: 2, TotalItems: 2, ItemsPerPage: 1, PageURLs: []string{"/published/", "/published/page/2/"}, HasPrev: true, PrevURL: "/published/"},
+	}
+
+	if err := plugin.publishFeed(feed, config, tempDir); err != nil {
+		t.Fatalf("publishFeed() error = %v", err)
+	}
+
+	cache := buildcache.New(t.TempDir())
+	hash := plugin.computeFeedHash(feed)
+	cache.SetFeedHash(feed.Slug, hash)
+
+	skip, gotHash := plugin.shouldSkipFeed(feed, cache, tempDir)
+	if !skip {
+		t.Fatalf("shouldSkipFeed() = false, want true")
+	}
+	if gotHash != hash {
+		t.Fatalf("shouldSkipFeed() hash = %q, want %q", gotHash, hash)
+	}
+
+	if _, err := os.Stat(filepath.Join(tempDir, "published", "page", "2", "index.html")); !os.IsNotExist(err) {
+		t.Fatalf("expected renderable pagination to omit page 2, stat err = %v", err)
+	}
+}

--- a/pkg/plugins/tags_listing.go
+++ b/pkg/plugins/tags_listing.go
@@ -106,7 +106,7 @@ func (p *TagsListingPlugin) Write(m *lifecycle.Manager) error {
 		if !cache.TagsDirty() {
 			return nil
 		}
-		tagsHash := computeTagsListingHash(m.Posts(), &tagsConfig)
+		tagsHash := computeTagsListingHash(m.Posts(), &tagsConfig, cache)
 		if cached := cache.GetTagsListingHash(); cached != "" && cached == tagsHash {
 			return nil
 		}
@@ -173,7 +173,7 @@ func (p *TagsListingPlugin) collectTags(posts []*models.Post, tagsConfig *models
 	return tagInfos
 }
 
-func computeTagsListingHash(posts []*models.Post, tagsConfig *models.TagsConfig) string {
+func computeTagsListingHash(posts []*models.Post, tagsConfig *models.TagsConfig, cache *buildcache.Cache) string {
 	if tagsConfig == nil {
 		return ""
 	}
@@ -186,6 +186,20 @@ func computeTagsListingHash(posts []*models.Post, tagsConfig *models.TagsConfig)
 	b.WriteByte('\x00')
 	b.WriteString(tagsConfig.Template)
 	b.WriteByte('\x00')
+	blacklist := append([]string(nil), tagsConfig.Blacklist...)
+	sort.Strings(blacklist)
+	for _, tag := range blacklist {
+		b.WriteString("blacklist:")
+		b.WriteString(tag)
+		b.WriteByte('\x00')
+	}
+	privateTags := append([]string(nil), tagsConfig.Private...)
+	sort.Strings(privateTags)
+	for _, tag := range privateTags {
+		b.WriteString("private:")
+		b.WriteString(tag)
+		b.WriteByte('\x00')
+	}
 	b.WriteString(fmt.Sprintf("%t", tagsConfig.IsEnabled()))
 	b.WriteByte('\x00')
 
@@ -193,19 +207,14 @@ func computeTagsListingHash(posts []*models.Post, tagsConfig *models.TagsConfig)
 		if post.Skip || post.Draft || !post.Published || post.Private {
 			continue
 		}
-		b.WriteString(post.Slug)
-		b.WriteByte('\x00')
-		if len(post.Tags) > 0 {
-			tags := append([]string(nil), post.Tags...)
-			sort.Strings(tags)
-			for _, tag := range tags {
-				if tagsConfig.IsBlacklisted(tag) || tagsConfig.IsPrivate(tag) {
-					continue
-				}
-				b.WriteString(tag)
-				b.WriteByte('\x01')
+		if cache != nil {
+			if _, tagHash, _ := cache.GetPostSemanticHashes(post.Path); tagHash != "" {
+				b.WriteString(tagHash)
+				b.WriteByte('\x00')
+				continue
 			}
 		}
+		b.WriteString(computePostTagIndexHash(post))
 		b.WriteByte('\x00')
 	}
 

--- a/pkg/plugins/tags_listing_test.go
+++ b/pkg/plugins/tags_listing_test.go
@@ -1,0 +1,49 @@
+package plugins
+
+import (
+	"testing"
+
+	"github.com/WaylonWalker/markata-go/pkg/buildcache"
+	"github.com/WaylonWalker/markata-go/pkg/models"
+)
+
+func strPtrTags(s string) *string { return &s }
+
+func TestComputeTagsListingHash_UsesCachedSemanticHashes(t *testing.T) {
+	post := models.NewPost("posts/test.md")
+	post.Slug = "test"
+	post.Href = "/test/"
+	post.Title = strPtrTags("Test")
+	post.Published = true
+	post.Tags = []string{"go", "perf"}
+
+	tagsConfig := models.NewTagsConfig()
+	cache := buildcache.New("")
+	cache.UpdatePostSemanticHashes(post.Path, "feed-hash", computePostTagIndexHash(post), "garden-hash")
+
+	want := computeTagsListingHash([]*models.Post{post}, &tagsConfig, nil)
+	got := computeTagsListingHash([]*models.Post{post}, &tagsConfig, cache)
+	if got != want {
+		t.Fatalf("computeTagsListingHash with cache = %q, want %q", got, want)
+	}
+}
+
+func TestComputeTagsListingHash_ChangesWhenConfigChanges(t *testing.T) {
+	post := models.NewPost("posts/test.md")
+	post.Slug = "test"
+	post.Href = "/test/"
+	post.Title = strPtrTags("Test")
+	post.Published = true
+	post.Tags = []string{"go", "perf"}
+
+	base := models.NewTagsConfig()
+	baseHash := computeTagsListingHash([]*models.Post{post}, &base, nil)
+
+	modified := models.NewTagsConfig()
+	modified.Blacklist = []string{"perf"}
+	modifiedHash := computeTagsListingHash([]*models.Post{post}, &modified, nil)
+
+	if baseHash == modifiedHash {
+		t.Fatal("computeTagsListingHash did not change after blacklist update")
+	}
+}

--- a/pkg/plugins/tailwind_installer.go
+++ b/pkg/plugins/tailwind_installer.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/WaylonWalker/markata-go/pkg/buildstats"
 	"github.com/WaylonWalker/markata-go/pkg/logging"
 )
 
@@ -108,12 +109,15 @@ var tailwindPlatformMapping = map[string]map[string]string{
 
 // NewTailwindInstaller creates a new TailwindInstaller with default settings.
 func NewTailwindInstaller() *TailwindInstaller {
+	client := &http.Client{
+		Timeout: tailwindHTTPTimeout,
+	}
+	buildstats.InstrumentHTTPClient(client)
+
 	return &TailwindInstaller{
 		CacheDir: "",
 		Version:  Latest,
-		client: &http.Client{
-			Timeout: tailwindHTTPTimeout,
-		},
+		client:   client,
 	}
 }
 

--- a/pkg/plugins/tailwind_manifest.go
+++ b/pkg/plugins/tailwind_manifest.go
@@ -78,7 +78,16 @@ func (p *TailwindPlugin) buildTailwindManifest(m *lifecycle.Manager) string {
 	manifestTokens := make(map[string]struct{}, 512)
 
 	for _, post := range posts {
-		if post == nil || post.Skip || strings.TrimSpace(post.HTML) == "" {
+		if post == nil || post.Skip {
+			continue
+		}
+
+		if strings.TrimSpace(post.HTML) == "" {
+			if tokens, ok := getStoredTailwindTokens(cache, post.Path); ok {
+				for _, token := range strings.Fields(tokens) {
+					manifestTokens[token] = struct{}{}
+				}
+			}
 			continue
 		}
 
@@ -190,6 +199,13 @@ func getCachedTailwindTokens(cache *buildcache.Cache, path, htmlHash string) (st
 		return "", false
 	}
 	return cache.GetCachedTailwindTokens(path, htmlHash)
+}
+
+func getStoredTailwindTokens(cache *buildcache.Cache, path string) (string, bool) {
+	if cache == nil {
+		return "", false
+	}
+	return cache.GetStoredTailwindTokens(path)
 }
 
 func extractTailwindTokens(content string) string {

--- a/pkg/plugins/templates.go
+++ b/pkg/plugins/templates.go
@@ -414,11 +414,16 @@ func (p *TemplatesPlugin) batchRestoreCachedHTML(
 
 	resultCh := make(chan result, concurrency)
 
-	// Keep restore fan-out modest to avoid PVC read thrash and heap spikes when
-	// restoring thousands of cached full-page HTML blobs in fresh pods.
-	numWorkers := min(concurrency, 4)
-	if numWorkers < 1 {
-		numWorkers = 1
+	// Use a wider restore fan-out than the general build concurrency. On the
+	// live notes workload the global concurrency is intentionally conservative
+	// for memory, but cached HTML restore is mostly file I/O and benefits from
+	// additional parallelism once caches live on node-local storage.
+	numWorkers := concurrency
+	if numWorkers < 8 {
+		numWorkers = 8
+	}
+	if numWorkers > 16 {
+		numWorkers = 16
 	}
 	if numWorkers > len(posts) {
 		numWorkers = len(posts)

--- a/pkg/plugins/templates.go
+++ b/pkg/plugins/templates.go
@@ -412,11 +412,14 @@ func (p *TemplatesPlugin) batchRestoreCachedHTML(
 		html string
 	}
 
-	results := make([]result, 0, len(posts))
-	resultCh := make(chan result, len(posts))
+	resultCh := make(chan result, concurrency)
 
-	// Use a worker pool with bounded concurrency for parallel file reads
-	numWorkers := concurrency
+	// Keep restore fan-out modest to avoid PVC read thrash and heap spikes when
+	// restoring thousands of cached full-page HTML blobs in fresh pods.
+	numWorkers := min(concurrency, 4)
+	if numWorkers < 1 {
+		numWorkers = 1
+	}
 	if numWorkers > len(posts) {
 		numWorkers = len(posts)
 	}
@@ -446,12 +449,9 @@ func (p *TemplatesPlugin) batchRestoreCachedHTML(
 		close(resultCh)
 	}()
 
+	// Assign HTML immediately as results arrive instead of buffering all restored
+	// pages in memory first.
 	for r := range resultCh {
-		results = append(results, r)
-	}
-
-	// Assign HTML to posts, moving cache misses to postsNeedingRender
-	for _, r := range results {
 		if r.html != "" {
 			posts[r.idx].post.HTML = r.html
 		} else {

--- a/pkg/plugins/templates.go
+++ b/pkg/plugins/templates.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/WaylonWalker/markata-go/pkg/buildcache"
@@ -312,7 +311,8 @@ func ensureFeedConfigsCached(config *lifecycle.Config, m *lifecycle.Manager) {
 }
 
 // Phase 1a: Quick single-threaded pass to classify posts (no disk I/O)
-// Phase 1b: Concurrent batch read of cached HTML files for unchanged posts
+// Phase 1b: No-op for unchanged posts; cached full-page HTML is restored lazily
+// only when a later stage truly needs it.
 // Phase 2: Concurrent rendering only for posts that need it
 func (p *TemplatesPlugin) Render(m *lifecycle.Manager) error {
 	if p.engine == nil {
@@ -337,9 +337,8 @@ func (p *TemplatesPlugin) Render(m *lifecycle.Manager) error {
 	feedMembershipHashes := precomputeFeedMembershipHashes(config, m)
 
 	// Phase 1a: Classify posts into "cacheable" vs "needs rendering" without disk I/O.
-	// For cacheable posts, we collect the source path so we can batch-read HTML later.
 	t0 := time.Now()
-	var cacheablePosts []cacheablePost
+	cacheableCount := 0
 	var postsNeedingRender []*models.Post
 
 	for _, post := range m.Posts() {
@@ -350,20 +349,16 @@ func (p *TemplatesPlugin) Render(m *lifecycle.Manager) error {
 
 		// Check if we can use cached HTML (no disk I/O -- just map lookups)
 		if canUseCachedHTML(post, cache, changedSlugs, feedMembershipHashes) {
-			cacheablePosts = append(cacheablePosts, cacheablePost{post: post, path: post.Path})
+			cacheableCount++
 		} else {
 			postsNeedingRender = append(postsNeedingRender, post)
 		}
 	}
 	t1 := time.Now()
-	templatesLog.Printf("Phase 1a classify: %d cacheable, %d need render (took %v)", len(cacheablePosts), len(postsNeedingRender), t1.Sub(t0))
+	templatesLog.Printf("Phase 1a classify: %d cacheable, %d need render (took %v)", cacheableCount, len(postsNeedingRender), t1.Sub(t0))
 
-	// Phase 1b: Batch-read all cached HTML files concurrently.
-	// This converts ~2900 sequential os.ReadFile calls into a parallel batch,
-	// significantly reducing wall-clock time for the cache restore phase.
-	if len(cacheablePosts) > 0 && cache != nil {
-		p.batchRestoreCachedHTML(cacheablePosts, cache, &postsNeedingRender, m.Concurrency())
-	}
+	// Phase 1b: Intentionally skip eager full-page HTML restore for unchanged posts.
+	// Later stages can use cached derivatives or restore lazily when truly needed.
 	t2 := time.Now()
 	templatesLog.Printf("Phase 1b batch restore: took %v, %d now need render", t2.Sub(t1), len(postsNeedingRender))
 
@@ -391,78 +386,6 @@ func (p *TemplatesPlugin) Render(m *lifecycle.Manager) error {
 	t3 := time.Now()
 	templatesLog.Printf("Phase 2 render: took %v", t3.Sub(t2))
 	return err
-}
-
-// cacheablePost pairs a post with its source path for batch cache operations.
-type cacheablePost struct {
-	post *models.Post
-	path string // source path for cache lookup
-}
-
-// batchRestoreCachedHTML reads cached HTML files concurrently and assigns them to posts.
-// Posts whose cache files are missing or unreadable are moved to postsNeedingRender.
-func (p *TemplatesPlugin) batchRestoreCachedHTML(
-	posts []cacheablePost,
-	cache *buildcache.Cache,
-	postsNeedingRender *[]*models.Post,
-	concurrency int,
-) {
-	type result struct {
-		idx  int
-		html string
-	}
-
-	resultCh := make(chan result, concurrency)
-
-	// Use a wider restore fan-out than the general build concurrency. On the
-	// live notes workload the global concurrency is intentionally conservative
-	// for memory, but cached HTML restore is mostly file I/O and benefits from
-	// additional parallelism once caches live on node-local storage.
-	numWorkers := concurrency
-	if numWorkers < 8 {
-		numWorkers = 8
-	}
-	if numWorkers > 16 {
-		numWorkers = 16
-	}
-	if numWorkers > len(posts) {
-		numWorkers = len(posts)
-	}
-	jobs := make(chan int, len(posts))
-	var wg sync.WaitGroup
-
-	for w := 0; w < numWorkers; w++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for idx := range jobs {
-				html := cache.GetCachedFullHTML(posts[idx].path)
-				resultCh <- result{idx: idx, html: html}
-			}
-		}()
-	}
-
-	// Send all jobs
-	for i := range posts {
-		jobs <- i
-	}
-	close(jobs)
-
-	// Collect results in background
-	go func() {
-		wg.Wait()
-		close(resultCh)
-	}()
-
-	// Assign HTML immediately as results arrive instead of buffering all restored
-	// pages in memory first.
-	for r := range resultCh {
-		if r.html != "" {
-			posts[r.idx].post.HTML = r.html
-		} else {
-			*postsNeedingRender = append(*postsNeedingRender, posts[r.idx].post)
-		}
-	}
 }
 
 // canUseCachedHTML checks if a post can use cached HTML without doing any disk I/O.

--- a/pkg/plugins/templates_test.go
+++ b/pkg/plugins/templates_test.go
@@ -550,6 +550,50 @@ func TestTemplatesPlugin_Render_NoTemplate(t *testing.T) {
 	}
 }
 
+func TestTemplatesPlugin_Render_StartsWebAwesomeLoader(t *testing.T) {
+	p := NewTemplatesPlugin()
+	m := lifecycle.NewManager()
+	config := m.Config()
+	config.Extra["templates_dir"] = "/nonexistent"
+	config.Extra["webawesome_css_url"] = "https://cdn.example.test/webawesome/styles/themes/default.css"
+	config.Extra["webawesome_loader_url"] = "https://cdn.example.test/webawesome/webawesome.loader.js"
+	config.Extra["webawesome_base_path"] = "https://cdn.example.test/webawesome"
+
+	if err := p.Configure(m); err != nil {
+		t.Fatalf("Configure() error = %v", err)
+	}
+
+	title := "Web Awesome Post"
+	post := &models.Post{
+		Title:       &title,
+		Template:    "post.html",
+		ArticleHTML: `<wa-carousel><wa-carousel-item>Slide</wa-carousel-item></wa-carousel>`,
+		Extra: map[string]interface{}{
+			"needs_webawesome": true,
+		},
+	}
+	m.AddPost(post)
+
+	if err := p.Render(m); err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+
+	want := []string{
+		`import { setBasePath, startLoader } from "https://cdn.example.test/webawesome/webawesome.loader.js";`,
+		`setBasePath("https://cdn.example.test/webawesome");`,
+		`startLoader();`,
+		`width: min(72rem, calc(100vw - 2rem));`,
+	}
+	for _, expected := range want {
+		if !strings.Contains(post.HTML, expected) {
+			t.Fatalf("rendered HTML missing %q\nGot: %s", expected, post.HTML)
+		}
+	}
+	if strings.Contains(post.HTML, `type="module" src="https://cdn.example.test/webawesome/webawesome.loader.js"`) {
+		t.Fatalf("rendered HTML should start the loader explicitly, got passive module script: %s", post.HTML)
+	}
+}
+
 func TestTemplatesPlugin_Render_PostGraphScriptOnlyWhenGraphRenders(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/pkg/plugins/templates_test.go
+++ b/pkg/plugins/templates_test.go
@@ -583,6 +583,9 @@ func TestTemplatesPlugin_Render_StartsWebAwesomeLoader(t *testing.T) {
 		`setBasePath("https://cdn.example.test/webawesome");`,
 		`startLoader();`,
 		`width: min(72rem, calc(100vw - 2rem));`,
+		`wa-carousel::part(base)`,
+		`box-shadow: none;`,
+		`border-radius: var(--radius-lg);`,
 	}
 	for _, expected := range want {
 		if !strings.Contains(post.HTML, expected) {

--- a/pkg/plugins/webawesome.go
+++ b/pkg/plugins/webawesome.go
@@ -751,7 +751,7 @@ func defaultString(value, fallback string) string {
 }
 
 func mergeCarouselImageStyle(style string) string {
-	fitStyle := "object-fit: contain !important;"
+	fitStyle := "display: block; max-width: 100%; max-height: 100%; width: auto !important; height: auto !important; object-fit: contain !important; border-radius: var(--radius-lg);"
 	if strings.TrimSpace(style) == "" {
 		return fitStyle
 	}

--- a/pkg/plugins/webawesome.go
+++ b/pkg/plugins/webawesome.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	webAwesomeDefaultVersion = "3.5.0"
-	webAwesomeDefaultCDNBase = "https://cdn.jsdelivr.net/npm/@awesome.me/webawesome@3.5.0/dist"
+	webAwesomeDefaultCDNBase = "https://cdn.jsdelivr.net/npm/@awesome.me/webawesome@3.5.0/dist-cdn"
 	webAwesomeAssetName      = "webawesome"
 	webAwesomeSourceCDN      = "cdn"
 	webAwesomeSourceVendor   = "vendor"
@@ -106,7 +106,7 @@ func (p *WebAwesomePlugin) parseConfigMap(cfgMap map[string]interface{}) bool {
 	}
 	if version, ok := cfgMap["version"].(string); ok && version != "" {
 		p.config.Version = version
-		p.config.CDNBase = "https://cdn.jsdelivr.net/npm/@awesome.me/webawesome@" + version + "/dist"
+		p.config.CDNBase = "https://cdn.jsdelivr.net/npm/@awesome.me/webawesome@" + version + "/dist-cdn"
 	}
 	if source, ok := cfgMap["source"].(string); ok && source != "" {
 		p.config.Source = source
@@ -157,9 +157,8 @@ func (p *WebAwesomePlugin) Render(m *lifecycle.Manager) error {
 		if post.Skip || post.ArticleHTML == "" {
 			return false
 		}
-		return strings.Contains(post.ArticleHTML, `class="webawesome`) ||
-			strings.Contains(post.ArticleHTML, "wa-comparison") ||
-			strings.Contains(post.ArticleHTML, "<wa-")
+		return webAwesomeContainerOpenRegex.MatchString(post.ArticleHTML) ||
+			webAwesomeElementRegex.MatchString(post.ArticleHTML)
 	})
 
 	if err := m.ProcessPostsSliceConcurrently(posts, p.processPost); err != nil {
@@ -189,6 +188,7 @@ var webAwesomeNestedTabOpenRegex = regexp.MustCompile(`<div([^>]*)class="([^"]*(
 var webAwesomeContainerOpenRegex = regexp.MustCompile(`<div([^>]*)class="([^"]*(?:\bwebawesome\b|\bwa-[a-z0-9-]+\b)[^"]*)"([^>]*)>`)
 var webAwesomeTabMarkerRegex = regexp.MustCompile(`(?s)(?:<hr>\s*<p>tab\s+&quot;([^&]+)&quot;</p>|<p>&mdash; tab &ldquo;([^&]+)&rdquo;</p>)\s*`)
 var webAwesomeFirstParagraphRegex = regexp.MustCompile(`(?s)^\s*<p>(.*?)</p>\s*`)
+var webAwesomeFigcaptionRegex = regexp.MustCompile(`(?s)<figcaption[^>]*>(.*?)</figcaption>`)
 var webAwesomeImageRegex = regexp.MustCompile(`(?s)<img\s+[^>]*>`)
 var webAwesomeCodeTextRegex = regexp.MustCompile(`(?s)<code[^>]*>(.*?)</code>`)
 var webAwesomeTagRegex = regexp.MustCompile(`<[^>]+>`)
@@ -669,21 +669,93 @@ func nextWebAwesomeTooltipOrdinal() int64 {
 }
 
 func renderWebAwesomeCarousel(attrs map[string]string, body string) string {
-	images := webAwesomeImageRegex.FindAllString(body, -1)
-	if len(images) == 0 {
+	imageMatches := webAwesomeImageRegex.FindAllStringIndex(body, -1)
+	if len(imageMatches) == 0 {
 		return ""
 	}
 	var b strings.Builder
 	b.WriteString(`<wa-carousel`)
 	writeAllowedAttrs(&b, attrs)
 	b.WriteString(`>`)
-	for _, image := range images {
+	for i, imageMatch := range imageMatches {
+		image := body[imageMatch[0]:imageMatch[1]]
+		captionEnd := len(body)
+		if i+1 < len(imageMatches) {
+			captionEnd = imageMatches[i+1][0]
+		}
+		caption := webAwesomeCarouselCaption(body[imageMatch[1]:captionEnd])
+
 		b.WriteString(`<wa-carousel-item>`)
-		b.WriteString(image)
+		if caption != "" {
+			b.WriteString(`<figure class="markata-wa-carousel-figure">`)
+			b.WriteString(renderWebAwesomeCarouselImage(image))
+			b.WriteString(`<figcaption>`)
+			b.WriteString(html.EscapeString(caption))
+			b.WriteString(`</figcaption></figure>`)
+		} else {
+			b.WriteString(renderWebAwesomeCarouselImage(image))
+		}
 		b.WriteString(`</wa-carousel-item>`)
 	}
 	b.WriteString(`</wa-carousel>`)
 	return b.String()
+}
+
+func webAwesomeCarouselCaption(segment string) string {
+	if match := webAwesomeFigcaptionRegex.FindStringSubmatch(segment); len(match) == 2 {
+		return normalizeWebAwesomeCaption(match[1])
+	}
+	return normalizeWebAwesomeCaption(segment)
+}
+
+func normalizeWebAwesomeCaption(caption string) string {
+	caption = webAwesomeTagRegex.ReplaceAllString(caption, " ")
+	caption = html.UnescapeString(caption)
+	return strings.Join(strings.Fields(caption), " ")
+}
+
+func renderWebAwesomeCarouselImage(image string) string {
+	attrs := parseHTMLAttrs(image)
+	if attrs["src"] == "" {
+		return image
+	}
+
+	var b strings.Builder
+	b.WriteString(`<img`)
+	writeImageAttr(&b, "src", attrs["src"])
+	writeImageAttr(&b, "alt", attrs["alt"])
+	writeImageAttr(&b, "title", attrs["title"])
+	writeImageAttr(&b, "loading", defaultString(attrs["loading"], "lazy"))
+	writeImageAttr(&b, "decoding", defaultString(attrs["decoding"], "async"))
+	writeImageAttr(&b, "style", mergeCarouselImageStyle(attrs["style"]))
+	b.WriteString(`>`)
+	return b.String()
+}
+
+func writeImageAttr(b *strings.Builder, name, value string) {
+	if value == "" {
+		return
+	}
+	b.WriteByte(' ')
+	b.WriteString(name)
+	b.WriteString(`="`)
+	b.WriteString(html.EscapeString(value))
+	b.WriteByte('"')
+}
+
+func defaultString(value, fallback string) string {
+	if value != "" {
+		return value
+	}
+	return fallback
+}
+
+func mergeCarouselImageStyle(style string) string {
+	fitStyle := "object-fit: contain !important;"
+	if strings.TrimSpace(style) == "" {
+		return fitStyle
+	}
+	return strings.TrimSpace(style) + " " + fitStyle
 }
 
 func renderWebAwesomeAnimatedImage(attrs map[string]string, body string) string {

--- a/pkg/plugins/webawesome_test.go
+++ b/pkg/plugins/webawesome_test.go
@@ -146,7 +146,7 @@ func TestWebAwesomePlugin_ProcessUsefulContentContainers(t *testing.T) {
 		`>SSG</span><wa-tooltip for="`,
 		`>Static Site Generator</wa-tooltip>`,
 		`<wa-carousel navigation="true">`,
-		`<wa-carousel-item><img src="/one.webp" alt="One" loading="lazy" decoding="async" style="object-fit: contain !important;"></wa-carousel-item>`,
+		`<wa-carousel-item><img src="/one.webp" alt="One" loading="lazy" decoding="async" style="display: block; max-width: 100%; max-height: 100%; width: auto !important; height: auto !important; object-fit: contain !important; border-radius: var(--radius-lg);"></wa-carousel-item>`,
 		`<wa-animated-image src="/demo.webp" alt="Animation demo"></wa-animated-image>`,
 	}
 	for _, expected := range want {
@@ -172,8 +172,8 @@ func TestWebAwesomePlugin_RenderProcessesWaCarouselContainerWithLeadingClass(t *
 	got := m.Posts()[0].ArticleHTML
 	want := []string{
 		`<wa-carousel navigation="true" pagination="true">`,
-		`<wa-carousel-item><img src="/one.webp" alt="One" loading="lazy" decoding="async" style="object-fit: contain !important;"></wa-carousel-item>`,
-		`<wa-carousel-item><img src="/two.webp" alt="Two" loading="lazy" decoding="async" style="object-fit: contain !important;"></wa-carousel-item>`,
+		`<wa-carousel-item><img src="/one.webp" alt="One" loading="lazy" decoding="async" style="display: block; max-width: 100%; max-height: 100%; width: auto !important; height: auto !important; object-fit: contain !important; border-radius: var(--radius-lg);"></wa-carousel-item>`,
+		`<wa-carousel-item><img src="/two.webp" alt="Two" loading="lazy" decoding="async" style="display: block; max-width: 100%; max-height: 100%; width: auto !important; height: auto !important; object-fit: contain !important; border-radius: var(--radius-lg);"></wa-carousel-item>`,
 	}
 	for _, expected := range want {
 		if !strings.Contains(got, expected) {
@@ -202,9 +202,9 @@ Wyatt 13</p>
 
 	want := []string{
 		`<wa-carousel navigation="true" pagination="true">`,
-		`<figure class="markata-wa-carousel-figure"><img src="/family.webp" alt="Family" loading="lazy" decoding="async" style="object-fit: contain !important;"><figcaption>family</figcaption></figure>`,
-		`<figure class="markata-wa-carousel-figure"><img src="/ayla.webp" alt="Ayla" loading="lazy" decoding="async" style="object-fit: contain !important;"><figcaption>Ayla 11</figcaption></figure>`,
-		`<figure class="markata-wa-carousel-figure"><img src="/wyatt.webp" alt="Wyatt" loading="lazy" decoding="async" style="object-fit: contain !important;"><figcaption>Wyatt 13</figcaption></figure>`,
+		`<figure class="markata-wa-carousel-figure"><img src="/family.webp" alt="Family" loading="lazy" decoding="async" style="display: block; max-width: 100%; max-height: 100%; width: auto !important; height: auto !important; object-fit: contain !important; border-radius: var(--radius-lg);"><figcaption>family</figcaption></figure>`,
+		`<figure class="markata-wa-carousel-figure"><img src="/ayla.webp" alt="Ayla" loading="lazy" decoding="async" style="display: block; max-width: 100%; max-height: 100%; width: auto !important; height: auto !important; object-fit: contain !important; border-radius: var(--radius-lg);"><figcaption>Ayla 11</figcaption></figure>`,
+		`<figure class="markata-wa-carousel-figure"><img src="/wyatt.webp" alt="Wyatt" loading="lazy" decoding="async" style="display: block; max-width: 100%; max-height: 100%; width: auto !important; height: auto !important; object-fit: contain !important; border-radius: var(--radius-lg);"><figcaption>Wyatt 13</figcaption></figure>`,
 	}
 	for _, expected := range want {
 		if !strings.Contains(post.ArticleHTML, expected) {

--- a/pkg/plugins/webawesome_test.go
+++ b/pkg/plugins/webawesome_test.go
@@ -146,8 +146,65 @@ func TestWebAwesomePlugin_ProcessUsefulContentContainers(t *testing.T) {
 		`>SSG</span><wa-tooltip for="`,
 		`>Static Site Generator</wa-tooltip>`,
 		`<wa-carousel navigation="true">`,
-		`<wa-carousel-item><img src="/one.webp" alt="One"></wa-carousel-item>`,
+		`<wa-carousel-item><img src="/one.webp" alt="One" loading="lazy" decoding="async" style="object-fit: contain !important;"></wa-carousel-item>`,
 		`<wa-animated-image src="/demo.webp" alt="Animation demo"></wa-animated-image>`,
+	}
+	for _, expected := range want {
+		if !strings.Contains(post.ArticleHTML, expected) {
+			t.Fatalf("ArticleHTML missing %q\nGot: %s", expected, post.ArticleHTML)
+		}
+	}
+}
+
+func TestWebAwesomePlugin_RenderProcessesWaCarouselContainerWithLeadingClass(t *testing.T) {
+	plugin := NewWebAwesomePlugin()
+	plugin.config.Source = "cdn"
+	m := lifecycle.NewManager()
+	m.SetConfig(&lifecycle.Config{Extra: map[string]interface{}{}})
+	m.SetPosts([]*models.Post{{ArticleHTML: `<div class="not-prose wa-carousel" navigation="true" pagination="true">
+<figure><img src="/one.webp" alt="One"><img src="/two.webp" alt="Two"></figure>
+</div>`}})
+
+	if err := plugin.Render(m); err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+
+	got := m.Posts()[0].ArticleHTML
+	want := []string{
+		`<wa-carousel navigation="true" pagination="true">`,
+		`<wa-carousel-item><img src="/one.webp" alt="One" loading="lazy" decoding="async" style="object-fit: contain !important;"></wa-carousel-item>`,
+		`<wa-carousel-item><img src="/two.webp" alt="Two" loading="lazy" decoding="async" style="object-fit: contain !important;"></wa-carousel-item>`,
+	}
+	for _, expected := range want {
+		if !strings.Contains(got, expected) {
+			t.Fatalf("ArticleHTML missing %q\nGot: %s", expected, got)
+		}
+	}
+	if enabled, ok := m.Config().Extra["webawesome_enabled"].(bool); !ok || !enabled {
+		t.Fatalf("webawesome_enabled = %v, want true", m.Config().Extra["webawesome_enabled"])
+	}
+}
+
+func TestWebAwesomePlugin_ProcessCarouselCaptions(t *testing.T) {
+	plugin := NewWebAwesomePlugin()
+	post := &models.Post{ArticleHTML: `<div class="wa-carousel" navigation="true" pagination="true">
+<p><img src="/family.webp" alt="Family">
+family
+<img src="/ayla.webp" alt="Ayla">
+<figcaption>Ayla 11</figcaption>
+<img src="/wyatt.webp" alt="Wyatt">
+Wyatt 13</p>
+</div>`}
+
+	if err := plugin.processPost(post); err != nil {
+		t.Fatalf("processPost() error = %v", err)
+	}
+
+	want := []string{
+		`<wa-carousel navigation="true" pagination="true">`,
+		`<figure class="markata-wa-carousel-figure"><img src="/family.webp" alt="Family" loading="lazy" decoding="async" style="object-fit: contain !important;"><figcaption>family</figcaption></figure>`,
+		`<figure class="markata-wa-carousel-figure"><img src="/ayla.webp" alt="Ayla" loading="lazy" decoding="async" style="object-fit: contain !important;"><figcaption>Ayla 11</figcaption></figure>`,
+		`<figure class="markata-wa-carousel-figure"><img src="/wyatt.webp" alt="Wyatt" loading="lazy" decoding="async" style="object-fit: contain !important;"><figcaption>Wyatt 13</figcaption></figure>`,
 	}
 	for _, expected := range want {
 		if !strings.Contains(post.ArticleHTML, expected) {

--- a/pkg/plugins/webmentions.go
+++ b/pkg/plugins/webmentions.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/WaylonWalker/markata-go/pkg/buildstats"
 	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
 	"github.com/WaylonWalker/markata-go/pkg/models"
 )
@@ -115,6 +116,7 @@ func (p *WebMentionsPlugin) Configure(m *lifecycle.Manager) error {
 			return nil
 		},
 	}
+	buildstats.InstrumentHTTPClient(p.httpClient)
 
 	// Load sent cache from disk
 	if p.config.CacheDir != "" {

--- a/pkg/plugins/webmentions_fetch.go
+++ b/pkg/plugins/webmentions_fetch.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/WaylonWalker/markata-go/pkg/buildcache"
+	"github.com/WaylonWalker/markata-go/pkg/buildstats"
 	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
 	"github.com/WaylonWalker/markata-go/pkg/models"
 )
@@ -43,11 +44,14 @@ type WebmentionsFetchPlugin struct {
 
 // NewWebmentionsFetchPlugin creates a new WebmentionsFetchPlugin.
 func NewWebmentionsFetchPlugin() *WebmentionsFetchPlugin {
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+	buildstats.InstrumentHTTPClient(client)
+
 	return &WebmentionsFetchPlugin{
-		config: models.NewWebMentionsConfig(),
-		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
-		},
+		config:        models.NewWebMentionsConfig(),
+		httpClient:    client,
 		mentions:      make([]ReceivedWebMention, 0),
 		mentionsByURL: make(map[string][]ReceivedWebMention),
 	}

--- a/pkg/themes/default/templates/base.html
+++ b/pkg/themes/default/templates/base.html
@@ -115,8 +115,10 @@
       --wa-color-danger-border-quiet: color-mix(in srgb, var(--color-error, #ef4444) 55%, var(--color-border, #e5e7eb));
       --wa-color-danger-on-quiet: var(--color-text, #1f2937);
       --wa-color-neutral-fill-quiet: color-mix(in srgb, var(--color-text, #1f2937) 12%, var(--color-surface, #f9fafb));
+      --wa-color-neutral-fill-normal: color-mix(in srgb, var(--color-text, #1f2937) 28%, var(--color-surface, #f9fafb));
       --wa-color-neutral-border-quiet: var(--color-border, #e5e7eb);
       --wa-color-neutral-on-quiet: var(--color-text, #1f2937);
+      --wa-form-control-activated-color: var(--color-primary, #3b82f6);
       --wa-border-radius-s: var(--radius-sm, var(--radius, 0.375rem));
       --wa-border-radius-m: var(--radius, 0.375rem);
       --wa-border-radius-l: var(--radius-lg, 0.5rem);
@@ -192,6 +194,76 @@
       border-color: var(--color-primary, var(--wa-color-brand-fill-loud));
       color: var(--color-primary, var(--wa-color-brand-fill-loud));
     }
+    wa-carousel {
+      --aspect-ratio: 4 / 3;
+      display: block;
+      margin: 2.5rem 0 2.5rem 50%;
+      max-width: calc(100vw - 2rem);
+      transform: translateX(-50%);
+      width: min(72rem, calc(100vw - 2rem));
+    }
+    wa-carousel + wa-carousel {
+      margin-top: 2.5rem;
+    }
+    wa-carousel::part(base) {
+      padding: 0.75rem;
+    }
+    wa-carousel::part(scroll-container) {
+      background: var(--color-background, var(--wa-color-surface-default));
+    }
+    wa-carousel::part(navigation-button) {
+      backdrop-filter: blur(6px);
+      background: color-mix(in srgb, var(--color-surface, #f9fafb) 78%, transparent);
+      border: 1px solid var(--color-border, var(--wa-color-surface-border));
+      box-shadow: var(--shadow-sm, var(--wa-shadow-s));
+      opacity: 0.82;
+      position: absolute;
+      top: 50%;
+      transform: translateY(-50%);
+      z-index: 2;
+    }
+    wa-carousel::part(navigation-button-previous) {
+      left: 1rem;
+    }
+    wa-carousel::part(navigation-button-next) {
+      right: 1rem;
+    }
+    wa-carousel::part(pagination) {
+      padding: 0.25rem 0 0.125rem;
+    }
+    wa-carousel::part(pagination-item) {
+      background: var(--wa-color-neutral-fill-normal);
+      border: 1px solid var(--color-border, var(--wa-color-surface-border));
+      box-shadow: var(--shadow-sm, var(--wa-shadow-s));
+      height: 0.75rem;
+      width: 0.75rem;
+    }
+    wa-carousel::part(pagination-item-active) {
+      background: var(--wa-form-control-activated-color);
+      border-color: var(--wa-form-control-activated-color);
+    }
+    wa-carousel .markata-wa-carousel-figure {
+      align-items: center;
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+      height: 100%;
+      justify-content: center;
+      margin: 0;
+      width: 100%;
+    }
+    wa-carousel .markata-wa-carousel-figure img {
+      flex: 1 1 auto;
+      min-height: 0;
+      width: 100%;
+    }
+    wa-carousel .markata-wa-carousel-figure figcaption {
+      color: var(--color-text-muted, var(--wa-color-text-quiet));
+      flex: 0 0 auto;
+      font-size: 0.95rem;
+      line-height: 1.4;
+      text-align: center;
+    }
     wa-badge {
       --wa-color-brand-fill-normal: var(--color-primary, #3b82f6);
       --wa-color-brand-border-normal: var(--color-primary, #3b82f6);
@@ -260,7 +332,11 @@
       width: 100%;
     }
   </style>
-  <script type="module" src="{{ config.Extra.webawesome_loader_url }}"></script>
+  <script type="module">
+    import { setBasePath, startLoader } from "{{ config.Extra.webawesome_loader_url }}";
+    setBasePath("{{ config.Extra.webawesome_base_path }}");
+    startLoader();
+  </script>
   {% endif %}
 
   {% if config.Extra.lite_youtube_enabled %}

--- a/pkg/themes/default/templates/base.html
+++ b/pkg/themes/default/templates/base.html
@@ -206,10 +206,13 @@
       margin-top: 2.5rem;
     }
     wa-carousel::part(base) {
-      padding: 0.75rem;
+      background: transparent;
+      border: 0;
+      box-shadow: none;
+      padding: 0;
     }
     wa-carousel::part(scroll-container) {
-      background: var(--color-background, var(--wa-color-surface-default));
+      background: transparent;
     }
     wa-carousel::part(navigation-button) {
       backdrop-filter: blur(6px);
@@ -253,9 +256,14 @@
       width: 100%;
     }
     wa-carousel .markata-wa-carousel-figure img {
+      border-radius: var(--radius-lg);
       flex: 1 1 auto;
       min-height: 0;
       width: 100%;
+    }
+    wa-carousel > img,
+    wa-carousel wa-carousel-item > img {
+      border-radius: var(--radius-lg);
     }
     wa-carousel .markata-wa-carousel-figure figcaption {
       color: var(--color-text-muted, var(--wa-color-text-quiet));

--- a/spec/spec/BUILDER_ADMIN.md
+++ b/spec/spec/BUILDER_ADMIN.md
@@ -1,0 +1,184 @@
+# Builder Admin Specification
+
+This document specifies the long-lived builder admin service for markata-go Kubernetes deployments.
+
+## Goals
+
+- Provide a warm, long-lived build worker so authoring builds avoid per-Job startup cost.
+- Expose an operator-facing HTTP UI and API for builds, releases, logs, refresh tasks, and rollback.
+- Preserve the existing release model based on `releases/<id>/` plus a `current` symlink.
+- Keep remote-content refresh work out of normal content builds unless explicitly configured otherwise.
+
+## Scope
+
+The builder admin service is intended for self-hosted and Kubernetes workflows, especially hostPath-backed authoring deployments.
+
+The first required capabilities are:
+
+- serialized build queue
+- manual HTTP-triggered builds
+- file-watch triggered builds that enqueue through the same queue
+- build history with full raw logs
+- release history with current/live indicator
+- promote-previous-release rollback
+- scheduled refresh tasks for reader/blogroll/other external data commands
+- operator UI that shows running, queued, successful, and failed work
+
+## Runtime Model
+
+The builder admin service MUST run as a long-lived HTTP process.
+
+It MUST mount the same site-authoring paths as the existing build workflow:
+
+- source tree
+- rendered site root
+- optional dedicated cache volume
+
+The service MUST process queued work one item at a time for a given site.
+
+Triggers MUST enqueue work rather than executing builds directly.
+
+Required trigger sources:
+
+- manual UI action
+- manual HTTP API call
+- file watch
+- scheduled refresh completion when configured to enqueue a build
+- rollback action
+
+## Build Workflow
+
+Successful builds MUST preserve the existing atomic release publication model:
+
+1. prepare cache symlinks when a dedicated cache mount is configured
+2. seed a stable work directory from the current release when one exists
+3. run `markata-go build` into the work directory
+4. move the finished output into `releases/<release-id>/`
+5. atomically repoint `current` to the new release
+6. prune old releases according to retention policy
+
+The service MUST record phase timings for at least:
+
+- queue wait
+- prepare
+- build
+- promote
+- prune
+- total
+
+The service MUST store the full raw build log and a parsed performance summary that includes any `Duration:` and `Hotspots:` lines emitted by markata-go.
+
+## File Watching
+
+When file watching is enabled, the service MUST watch the configured source roots recursively.
+
+Watch events MUST be debounced and coalesced into a single queued build request.
+
+The recorded build trigger MUST include:
+
+- trigger type `file-watch`
+- the set of changed paths captured during the debounce window
+
+The watcher SHOULD ignore internal cache and admin-state paths.
+
+## Build History
+
+Each build record MUST include:
+
+- unique build id
+- operation kind: `build`, `refresh`, or `rollback`
+- status: `queued`, `running`, `success`, `failed`, `cancelled`
+- trigger type
+- trigger detail text
+- changed paths when available
+- enqueue, start, and finish timestamps
+- per-phase timings
+- total duration
+- raw log path
+- parsed performance summary
+- produced release id, when applicable
+- whether the result became live
+
+The UI MUST show current queue state, running build state, and the current live release.
+
+## Releases And Rollback
+
+The service MUST discover releases from the site root `releases/` directory and the `current` symlink.
+
+Rollback in the first version is defined as:
+
+- selecting a previously successful rendered release directory
+- atomically repointing `current` to that release
+- recording a rollback operation in history
+
+The UI MUST clearly indicate that rollback promotes a prior rendered release rather than restoring the historical source tree.
+
+## Refresh Tasks
+
+The builder admin service MUST support configured scheduled refresh commands.
+
+Each refresh task MUST define:
+
+- stable task name
+- command argv
+- interval duration
+- whether a successful run enqueues a build
+
+The first version MAY use fixed interval durations instead of cron expressions.
+
+Refresh runs MUST have their own history with:
+
+- task name
+- status
+- duration
+- raw log path
+- optional follow-up build id when a build was enqueued
+
+## Persistence
+
+The service MUST persist operator state on disk so restarts do not lose build history.
+
+Required persisted data:
+
+- build records
+- refresh records
+- release metadata derived from disk and linked build ids when known
+- full raw logs
+
+The first version MAY use a JSON state file plus log files instead of a relational database.
+
+## HTTP UI And API
+
+The service MUST expose an HTTP admin interface.
+
+Required UI views:
+
+- dashboard summary
+- build history list
+- build detail/log view
+- release list with current/live indicator
+- refresh task list and refresh history
+
+Required actions:
+
+- enqueue manual build
+- trigger refresh task immediately
+- promote a prior release to live
+
+The service SHOULD also expose JSON endpoints for the same core operations.
+
+## Helm Integration
+
+The Helm chart MUST support enabling the builder admin service independently of the scheduled build CronJob.
+
+Required chart configuration includes:
+
+- service enable/disable
+- host/port
+- file-watch enable/disable and debounce
+- release retention
+- build history retention
+- refresh task definitions
+- optional ingress/auth settings for future protected access
+
+The first deployment target SHOULD work via `kubectl port-forward` even when no ingress is enabled.

--- a/spec/spec/CLI_UX.md
+++ b/spec/spec/CLI_UX.md
@@ -169,6 +169,9 @@ Unexpected diagnostic detail belongs in verbose/debug modes, not normal output.
 - `build` SHOULD include a concise benchmark summary in its final result output,
   including estimated wall-time spent on CPU work, network wait, disk read wait,
   disk write wait, and idle time, plus the slowest lifecycle hotspots.
+- When outbound HTTP requests occur during a build, the benchmark summary SHOULD
+  also include the slowest requests with enough context to identify the owning
+  stage/plugin and remote endpoint without exposing query-string secrets.
 - `build` SHOULD offer an explicit machine-readable benchmark mode such as
   `--benchmark-json` for scripting and regression analysis.
 - Detailed per-stage benchmark summaries SHOULD be opt-in via verbose mode or a

--- a/spec/spec/FEEDS.md
+++ b/spec/spec/FEEDS.md
@@ -517,6 +517,11 @@ Behavior requirements:
 - the command MUST write primary results to `stdout`
 - the next `markata-go build` MUST reuse the refreshed cache data through the existing blogroll cache path
 
+When `markata-go.blogroll.refresh_on_build = false`, normal builds MUST reuse cached
+reader/blogroll data without making remote refresh requests. In that mode,
+`markata-go reader update` is the explicit refresh path and builds MAY use stale cached
+blogroll data when it is available.
+
 ---
 
 ## Manual Pagination

--- a/spec/spec/MENTIONS.md
+++ b/spec/spec/MENTIONS.md
@@ -196,6 +196,21 @@ A post with `slug: my-project` registers `@my-project`.
    - If not found: leave as-is
 4. Restore code blocks
 
+### Warm-Build Caching
+
+Implementations MAY restore previously transformed post content from the build cache
+when the raw post content and the effective mention-resolution state are unchanged.
+The cache key MUST include any data that affects emitted HTML, including:
+
+- the raw post content
+- the configured mention CSS class
+- resolved handle targets and aliases
+- mention metadata used for hovercard attributes
+- post author display data used for chat-reply title enrichment
+
+Metadata cache timestamps alone MUST NOT invalidate transformed post content unless
+the rendered mention attributes themselves change.
+
 ### Email Protection
 
 Email addresses are not transformed. The regex matches `@` only when:

--- a/spec/spec/WEBAWESOME.md
+++ b/spec/spec/WEBAWESOME.md
@@ -19,7 +19,7 @@ hooks = ["default", "webawesome"]
 enabled = true
 version = "3.5.0"
 source = "vendor" # "vendor" (default) or "cdn"
-cdn_base_url = "https://cdn.jsdelivr.net/npm/@awesome.me/webawesome@3.5.0/dist"
+cdn_base_url = "https://cdn.jsdelivr.net/npm/@awesome.me/webawesome@3.5.0/dist-cdn"
 output_dir = "assets/vendor/webawesome"
 theme = "default"
 palette = "default"
@@ -28,7 +28,7 @@ brand = "blue"
 
 ## Markdown Syntax
 
-All shortcuts use container syntax. The recommended form is `::: wa-<component>`. The longer `::: webawesome <component>` form remains supported as an alias.
+All shortcuts use container syntax. The recommended form is `::: wa-<component>`. The longer `::: webawesome <component>` form remains supported as an alias. Additional classes may be combined with the Web Awesome class; the `wa-*` class or `webawesome <component>` class pair may appear anywhere in the generated `class` attribute.
 
 ### Image Comparison
 
@@ -173,11 +173,13 @@ default slot is the popup itself):
 ```markdown
 ::: wa-carousel {navigation="true" pagination="true"}
 ![First](/images/one.webp)
+First image caption
 ![Second](/images/two.webp)
+Second image caption
 :::
 ```
 
-Generated HTML includes `wa-carousel` and one `wa-carousel-item` per image.
+Generated HTML includes `wa-carousel` and one `wa-carousel-item` per image. Optional plain text or `<figcaption>` content immediately after an image becomes that slide's caption.
 
 ### Animated Image
 
@@ -211,18 +213,26 @@ When `source = "vendor"`, the plugin registers a shared archive asset for the We
 
 ```html
 <link rel="stylesheet" href="/assets/vendor/webawesome/styles/themes/default.css">
-<script type="module" src="/assets/vendor/webawesome/webawesome.loader.js"></script>
+<script type="module">
+  import { setBasePath, startLoader } from "/assets/vendor/webawesome/webawesome.loader.js";
+  setBasePath("/assets/vendor/webawesome");
+  startLoader();
+</script>
 ```
 
 The vendored payload MUST be the browser-ready Web Awesome `dist-cdn` subtree from the npm tarball so the autoloader and components can resolve their modules and dependent assets without a bundler.
 
 `markata-go assets download` SHOULD prefetch the Web Awesome tarball whenever the `webawesome` plugin is enabled with `source = "vendor"`.
 
-When `source = "cdn"`, the plugin loads the same files from the configured CDN base URL (default: `https://cdn.jsdelivr.net/npm/@awesome.me/webawesome@<version>/dist`):
+When `source = "cdn"`, the plugin loads the same browser-ready files from the configured CDN base URL (default: `https://cdn.jsdelivr.net/npm/@awesome.me/webawesome@<version>/dist-cdn`):
 
 ```html
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@awesome.me/webawesome@3.5.0/dist/styles/themes/default.css">
-<script type="module" src="https://cdn.jsdelivr.net/npm/@awesome.me/webawesome@3.5.0/dist/webawesome.loader.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@awesome.me/webawesome@3.5.0/dist-cdn/styles/themes/default.css">
+<script type="module">
+  import { setBasePath, startLoader } from "https://cdn.jsdelivr.net/npm/@awesome.me/webawesome@3.5.0/dist-cdn/webawesome.loader.js";
+  setBasePath("https://cdn.jsdelivr.net/npm/@awesome.me/webawesome@3.5.0/dist-cdn");
+  startLoader();
+</script>
 ```
 
 The autoloader uses a MutationObserver to discover `<wa-*>` tags in the document and lazy-imports the matching component module on demand. Pages without any `<wa-*>` tags do not load Web Awesome CSS or JavaScript.

--- a/templates/base.html
+++ b/templates/base.html
@@ -103,8 +103,10 @@
       --wa-color-danger-border-quiet: color-mix(in srgb, var(--color-error, #ef4444) 55%, var(--color-border, #e5e7eb));
       --wa-color-danger-on-quiet: var(--color-text, #1f2937);
       --wa-color-neutral-fill-quiet: color-mix(in srgb, var(--color-text, #1f2937) 12%, var(--color-surface, #f9fafb));
+      --wa-color-neutral-fill-normal: color-mix(in srgb, var(--color-text, #1f2937) 28%, var(--color-surface, #f9fafb));
       --wa-color-neutral-border-quiet: var(--color-border, #e5e7eb);
       --wa-color-neutral-on-quiet: var(--color-text, #1f2937);
+      --wa-form-control-activated-color: var(--color-primary, #3b82f6);
       --wa-border-radius-s: var(--radius-sm, var(--radius, 0.375rem));
       --wa-border-radius-m: var(--radius, 0.375rem);
       --wa-border-radius-l: var(--radius-lg, 0.5rem);
@@ -180,6 +182,76 @@
       border-color: var(--color-primary, var(--wa-color-brand-fill-loud));
       color: var(--color-primary, var(--wa-color-brand-fill-loud));
     }
+    wa-carousel {
+      --aspect-ratio: 4 / 3;
+      display: block;
+      margin: 2.5rem 0 2.5rem 50%;
+      max-width: calc(100vw - 2rem);
+      transform: translateX(-50%);
+      width: min(72rem, calc(100vw - 2rem));
+    }
+    wa-carousel + wa-carousel {
+      margin-top: 2.5rem;
+    }
+    wa-carousel::part(base) {
+      padding: 0.75rem;
+    }
+    wa-carousel::part(scroll-container) {
+      background: var(--color-background, var(--wa-color-surface-default));
+    }
+    wa-carousel::part(navigation-button) {
+      backdrop-filter: blur(6px);
+      background: color-mix(in srgb, var(--color-surface, #f9fafb) 78%, transparent);
+      border: 1px solid var(--color-border, var(--wa-color-surface-border));
+      box-shadow: var(--shadow-sm, var(--wa-shadow-s));
+      opacity: 0.82;
+      position: absolute;
+      top: 50%;
+      transform: translateY(-50%);
+      z-index: 2;
+    }
+    wa-carousel::part(navigation-button-previous) {
+      left: 1rem;
+    }
+    wa-carousel::part(navigation-button-next) {
+      right: 1rem;
+    }
+    wa-carousel::part(pagination) {
+      padding: 0.25rem 0 0.125rem;
+    }
+    wa-carousel::part(pagination-item) {
+      background: var(--wa-color-neutral-fill-normal);
+      border: 1px solid var(--color-border, var(--wa-color-surface-border));
+      box-shadow: var(--shadow-sm, var(--wa-shadow-s));
+      height: 0.75rem;
+      width: 0.75rem;
+    }
+    wa-carousel::part(pagination-item-active) {
+      background: var(--wa-form-control-activated-color);
+      border-color: var(--wa-form-control-activated-color);
+    }
+    wa-carousel .markata-wa-carousel-figure {
+      align-items: center;
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+      height: 100%;
+      justify-content: center;
+      margin: 0;
+      width: 100%;
+    }
+    wa-carousel .markata-wa-carousel-figure img {
+      flex: 1 1 auto;
+      min-height: 0;
+      width: 100%;
+    }
+    wa-carousel .markata-wa-carousel-figure figcaption {
+      color: var(--color-text-muted, var(--wa-color-text-quiet));
+      flex: 0 0 auto;
+      font-size: 0.95rem;
+      line-height: 1.4;
+      text-align: center;
+    }
     wa-badge {
       --wa-color-brand-fill-normal: var(--color-primary, #3b82f6);
       --wa-color-brand-border-normal: var(--color-primary, #3b82f6);
@@ -248,7 +320,11 @@
       width: 100%;
     }
   </style>
-  <script type="module" src="{{ config.Extra.webawesome_loader_url }}"></script>
+  <script type="module">
+    import { setBasePath, startLoader } from "{{ config.Extra.webawesome_loader_url }}";
+    setBasePath("{{ config.Extra.webawesome_base_path }}");
+    startLoader();
+  </script>
   {% endif %}
 
   {% if config.Extra.lite_youtube_enabled %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -194,10 +194,13 @@
       margin-top: 2.5rem;
     }
     wa-carousel::part(base) {
-      padding: 0.75rem;
+      background: transparent;
+      border: 0;
+      box-shadow: none;
+      padding: 0;
     }
     wa-carousel::part(scroll-container) {
-      background: var(--color-background, var(--wa-color-surface-default));
+      background: transparent;
     }
     wa-carousel::part(navigation-button) {
       backdrop-filter: blur(6px);
@@ -241,9 +244,14 @@
       width: 100%;
     }
     wa-carousel .markata-wa-carousel-figure img {
+      border-radius: var(--radius-lg);
       flex: 1 1 auto;
       min-height: 0;
       width: 100%;
+    }
+    wa-carousel > img,
+    wa-carousel wa-carousel-item > img {
+      border-radius: var(--radius-lg);
     }
     wa-carousel .markata-wa-carousel-figure figcaption {
       color: var(--color-text-muted, var(--wa-color-text-quiet));


### PR DESCRIPTION
- **feat: add dedicated notes cache pvc**
- **perf: stream cached template restore**
- **feat: add notes build notifications**
- **fix: render notes notify payload safely**
- **perf: raise cached template restore fanout**
- **perf: defer cached html restore**
- **perf: reuse feed render context**
- **feat: add build fast mode to notes chart**
- **perf: profile requests and separate blogroll refresh**
- **perf: skip false-positive feed rebuilds**
- **perf: cache missing link avatars**
- **perf: skip feeds listing and share embed fetches**
- **perf: parallelize cached load restores**
- **perf: tighten hot cache invalidation and dev loop Refs #944**
- **perf: reuse feed partitions and glob modtimes Refs #944**
- **feat: add builder admin service Refs #944**
- **fix: stabilize builder admin warm builds Refs #944**
- **fix: clear stale builder admin queue state Refs #944**
- **fix: recreate builder admin on rollout Refs #944**
- **fix: avoid double markata-go refresh exec Refs #944**
- **feat: restyle builder admin dashboard Refs #944**
- **feat: tab builder admin workspace Refs #944**
- **feat: live sync builder admin dashboard Refs #944**
