### PR TITLE
feat(cli): theme help and section rendering

### DIFF
--- a/cmd/markata-go/cmd/cli_color.go
+++ b/cmd/markata-go/cmd/cli_color.go
@@ -12,10 +12,6 @@ func colorizeOutput(text, color string) string {
 	return colorize(text, color, colorEnabledOnOutput())
 }
 
-func colorizeError(text, color string) string {
-	return colorize(text, color, colorEnabledFor(errorOutputIsTerminal()))
-}
-
 func colorize(text, color string, enabled bool) string {
 	if !enabled {
 		return text

--- a/cmd/markata-go/cmd/cli_color.go
+++ b/cmd/markata-go/cmd/cli_color.go
@@ -6,17 +6,18 @@ import (
 	"github.com/WaylonWalker/markata-go/pkg/palettes"
 )
 
-const (
-	ansiBlueBold  = "\033[1;34m"
-	ansiCyan      = "\033[36m"
-	ansiGreenBold = "\033[1;32m"
-	ansiMagenta   = "\033[35m"
-	ansiReset     = "\033[0m"
-	ansiYellow    = "\033[33m"
-)
+const ansiReset = "\033[0m"
 
 func colorizeOutput(text, color string) string {
-	if !colorEnabledOnOutput() {
+	return colorize(text, color, colorEnabledOnOutput())
+}
+
+func colorizeError(text, color string) string {
+	return colorize(text, color, colorEnabledFor(errorOutputIsTerminal()))
+}
+
+func colorize(text, color string, enabled bool) string {
+	if !enabled {
 		return text
 	}
 	if rgb := ansiTrueColor(color); rgb != "" {

--- a/cmd/markata-go/cmd/cli_render.go
+++ b/cmd/markata-go/cmd/cli_render.go
@@ -1,0 +1,171 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/WaylonWalker/markata-go/pkg/logging"
+	"github.com/WaylonWalker/markata-go/pkg/models"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+const (
+	cliPreferredRuleWidth = 80
+	cliNarrowRuleWidth    = 32
+)
+
+var cliTerminalWidth = func(writer io.Writer) int {
+	file, ok := writer.(*os.File)
+	if !ok {
+		return cliPreferredRuleWidth
+	}
+	width, _, err := term.GetSize(int(file.Fd()))
+	if err != nil || width <= 0 {
+		return cliPreferredRuleWidth
+	}
+	return width
+}
+
+// cliSectionRule returns a terminal-width-aware Unicode section separator.
+// It caps rules at 80 columns and uses a compact label on narrow terminals.
+func cliSectionRule(label string) string {
+	width := min(cliTerminalWidth(outWriter()), cliPreferredRuleWidth)
+	if width <= 4 {
+		return "─"
+	}
+	if width < cliNarrowRuleWidth {
+		return "─ " + truncateCLILabel(label, width-4) + " ─"
+	}
+
+	label = " " + label + " "
+	labelWidth := utf8.RuneCountInString(label)
+	if labelWidth+4 > width {
+		return "─ " + truncateCLILabel(strings.TrimSpace(label), width-4) + " ─"
+	}
+	left := 3
+	right := width - left - labelWidth
+	return strings.Repeat("─", left) + label + strings.Repeat("─", right)
+}
+
+func truncateCLILabel(label string, maxWidth int) string {
+	runes := []rune(label)
+	if len(runes) <= maxWidth {
+		return label
+	}
+	if maxWidth <= 1 {
+		return "…"
+	}
+	return string(runes[:maxWidth-1]) + "…"
+}
+
+// cliSection writes a themed Unicode section rule for interactive CLI output.
+func cliSection(label string) {
+	outln(colorizeOutput(cliSectionRule(label), currentLogTheme.Component))
+}
+
+func resolveCLITheme(cfg *models.Config, configPaths []string) logging.Theme {
+	if cfg == nil {
+		return logging.DefaultTheme()
+	}
+	extra := make(map[string]any)
+	if len(configPaths) > 0 {
+		extra["config_path"] = configPaths[0]
+	}
+	if palette, ok := loadLoggerPalette(cfg.Theme, extra); ok {
+		return logging.ThemeFromPalette(palette)
+	}
+	return logging.DefaultTheme()
+}
+
+func resolveCLIThemeFromConfig() logging.Theme {
+	cfg, _, configPaths, err := loadManagerConfig(cfgFile)
+	if err != nil {
+		return logging.DefaultTheme()
+	}
+	return resolveCLITheme(cfg, configPaths)
+}
+
+func renderCommandHelp(cmd *cobra.Command) {
+	currentCmd = cmd
+	theme := resolveCLIThemeFromConfig()
+	writer := cmd.OutOrStdout()
+
+	if cmd.Long != "" {
+		renderHelpDescription(writer, cmd.Long, theme)
+	} else if cmd.Short != "" {
+		_, _ = fmt.Fprintln(writer, colorizeOutput(cmd.Short, theme.Component))
+	}
+	_, _ = fmt.Fprintln(writer)
+	_, _ = fmt.Fprintln(writer, colorizeOutput("Usage:", theme.Component))
+	_, _ = fmt.Fprintf(writer, "  %s\n", cmd.UseLine())
+	if len(cmd.Aliases) > 0 {
+		_, _ = fmt.Fprintln(writer)
+		_, _ = fmt.Fprintln(writer, colorizeOutput("Aliases:", theme.Component))
+		_, _ = fmt.Fprintf(writer, "  %s, %s\n", cmd.Name(), strings.Join(cmd.Aliases, ", "))
+	}
+
+	if cmd.HasAvailableSubCommands() {
+		_, _ = fmt.Fprintln(writer)
+		_, _ = fmt.Fprintln(writer, colorizeOutput("Commands:", theme.Component))
+		for _, child := range cmd.Commands() {
+			if !child.IsAvailableCommand() || child.IsAdditionalHelpTopicCommand() {
+				continue
+			}
+			_, _ = fmt.Fprintf(writer, "  %-16s %s\n", colorizeOutput(child.Name(), theme.Success), child.Short)
+		}
+	}
+
+	if cmd.HasAvailableLocalFlags() || cmd.HasAvailableInheritedFlags() {
+		helpWidth := min(cliTerminalWidth(writer), cliPreferredRuleWidth)
+		_, _ = fmt.Fprintln(writer)
+		_, _ = fmt.Fprintln(writer, colorizeOutput("Flags:", theme.Component))
+		_, _ = fmt.Fprint(writer, cmd.LocalFlags().FlagUsagesWrapped(helpWidth))
+		if cmd.HasAvailableInheritedFlags() {
+			_, _ = fmt.Fprintln(writer)
+			_, _ = fmt.Fprintln(writer, colorizeOutput("Global Flags:", theme.Component))
+			_, _ = fmt.Fprint(writer, cmd.InheritedFlags().FlagUsagesWrapped(helpWidth))
+		}
+	}
+
+	var helpTopics []*cobra.Command
+	for _, child := range cmd.Commands() {
+		if child.IsAdditionalHelpTopicCommand() {
+			helpTopics = append(helpTopics, child)
+		}
+	}
+	if len(helpTopics) > 0 {
+		_, _ = fmt.Fprintln(writer)
+		_, _ = fmt.Fprintln(writer, colorizeOutput("Additional help topics:", theme.Component))
+		for _, topic := range helpTopics {
+			_, _ = fmt.Fprintf(writer, "  %-16s %s\n", colorizeOutput(topic.Name(), theme.Success), topic.Short)
+		}
+	}
+
+	if cmd.HasAvailableSubCommands() {
+		_, _ = fmt.Fprintln(writer)
+		_, _ = fmt.Fprintln(writer, "Run '"+cmd.CommandPath()+" <command> --help' for detailed command help.")
+	}
+}
+
+func renderHelpDescription(writer io.Writer, description string, theme logging.Theme) {
+	for _, line := range strings.Split(description, "\n") {
+		if isHelpSectionHeading(line) {
+			heading := strings.TrimSuffix(strings.TrimSpace(line), ":")
+			_, _ = fmt.Fprintln(writer, colorizeOutput(cliSectionRule(heading), theme.Component))
+			continue
+		}
+		_, _ = fmt.Fprintln(writer, line)
+	}
+}
+
+func isHelpSectionHeading(line string) bool {
+	line = strings.TrimSpace(line)
+	if !strings.HasSuffix(line, ":") || len(line) < 3 || len(line) > 40 {
+		return false
+	}
+	return !strings.Contains(line, "://")
+}

--- a/cmd/markata-go/cmd/cli_render_test.go
+++ b/cmd/markata-go/cmd/cli_render_test.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"io"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/WaylonWalker/markata-go/pkg/logging"
+	"github.com/spf13/cobra"
+)
+
+func TestCLISectionRule_UsesPreferredTerminalWidth(t *testing.T) {
+	oldTerminalWidth := cliTerminalWidth
+	defer func() { cliTerminalWidth = oldTerminalWidth }()
+	cliTerminalWidth = func(io.Writer) int { return 120 }
+
+	rule := cliSectionRule("Neovim")
+	if got := utf8.RuneCountInString(rule); got != cliPreferredRuleWidth {
+		t.Errorf("rule width = %d, want %d", got, cliPreferredRuleWidth)
+	}
+	if !strings.HasPrefix(rule, "───") {
+		t.Errorf("rule = %q, want Unicode box-drawing separator", rule)
+	}
+}
+
+func TestCLISectionRule_UsesCompactFormOnNarrowTerminal(t *testing.T) {
+	oldTerminalWidth := cliTerminalWidth
+	defer func() { cliTerminalWidth = oldTerminalWidth }()
+	cliTerminalWidth = func(io.Writer) int { return 20 }
+
+	if got, want := cliSectionRule("Helix"), "─ Helix ─"; got != want {
+		t.Errorf("rule = %q, want %q", got, want)
+	}
+}
+
+func TestCLISectionRule_TruncatesLongLabelsOnNarrowTerminal(t *testing.T) {
+	oldTerminalWidth := cliTerminalWidth
+	defer func() { cliTerminalWidth = oldTerminalWidth }()
+	cliTerminalWidth = func(io.Writer) int { return 20 }
+
+	rule := cliSectionRule("Theme/Palette Configuration")
+	if got := utf8.RuneCountInString(rule); got > 20 {
+		t.Errorf("rule width = %d, want at most 20", got)
+	}
+	if !strings.Contains(rule, "…") {
+		t.Errorf("rule = %q, want truncated label", rule)
+	}
+}
+
+func TestCLISectionRule_TruncatesLongLabelsAtTerminalBoundary(t *testing.T) {
+	oldTerminalWidth := cliTerminalWidth
+	defer func() { cliTerminalWidth = oldTerminalWidth }()
+	cliTerminalWidth = func(io.Writer) int { return cliNarrowRuleWidth }
+
+	rule := cliSectionRule("A separator label that is wider than the terminal")
+	if got := utf8.RuneCountInString(rule); got > cliNarrowRuleWidth {
+		t.Errorf("rule width = %d, want at most %d", got, cliNarrowRuleWidth)
+	}
+}
+
+func TestRenderCommandHelp_IncludesAliases(t *testing.T) {
+	oldCmd := currentCmd
+	defer func() { currentCmd = oldCmd }()
+	command := &cobra.Command{Use: "remove", Short: "Remove a skill", Aliases: []string{"uninstall"}}
+	output := &strings.Builder{}
+	command.SetOut(output)
+
+	renderCommandHelp(command)
+	if !strings.Contains(output.String(), "remove, uninstall") {
+		t.Errorf("help output = %q, want aliases", output.String())
+	}
+}
+
+func TestRenderHelpDescription_UsesThemedUnicodeSections(t *testing.T) {
+	oldCmd := currentCmd
+	defer func() { currentCmd = oldCmd }()
+	command := &cobra.Command{Use: "help"}
+	output := &strings.Builder{}
+	command.SetOut(output)
+	currentCmd = command
+
+	renderHelpDescription(output, "Overview text\n\nExamples:\n  markata-go build", logging.DefaultTheme())
+	if !strings.Contains(output.String(), "─") || !strings.Contains(output.String(), "Examples") {
+		t.Errorf("help output = %q, want Unicode Examples section", output.String())
+	}
+}

--- a/cmd/markata-go/cmd/init.go
+++ b/cmd/markata-go/cmd/init.go
@@ -259,8 +259,7 @@ func backupConfig(path string) error {
 // addFeatureTheme prompts for theme/palette configuration.
 func addFeatureTheme(reader *bufio.Reader, cfg *models.Config) error {
 	outln()
-	outln("Theme/Palette Configuration")
-	outln("----------------------------")
+	cliSection("Theme/Palette Configuration")
 
 	// List some available palettes
 	loader := palettes.NewLoader()
@@ -291,8 +290,7 @@ func addFeatureTheme(reader *bufio.Reader, cfg *models.Config) error {
 // addFeatureSEO prompts for SEO configuration.
 func addFeatureSEO(reader *bufio.Reader, cfg *models.Config) error {
 	outln()
-	outln("SEO Configuration")
-	outln("-----------------")
+	cliSection("SEO Configuration")
 
 	handle := prompt(reader, "Twitter/X handle (without @)", cfg.SEO.TwitterHandle)
 	if handle != "" {
@@ -313,8 +311,7 @@ func addFeatureSEO(reader *bufio.Reader, cfg *models.Config) error {
 // addFeaturePostFormats prompts for post format configuration.
 func addFeaturePostFormats(reader *bufio.Reader, cfg *models.Config) error {
 	outln()
-	outln("Post Output Formats")
-	outln("-------------------")
+	cliSection("Post Output Formats")
 
 	htmlEnabled := promptRadioBool(reader, "HTML output", cfg.PostFormats.IsHTMLEnabled())
 	cfg.PostFormats.HTML = &htmlEnabled
@@ -329,8 +326,7 @@ func addFeaturePostFormats(reader *bufio.Reader, cfg *models.Config) error {
 // addFeatureAdvancedFeeds prompts for advanced feed configuration.
 func addFeatureAdvancedFeeds(reader *bufio.Reader, cfg *models.Config) error {
 	outln()
-	outln("Advanced Feed Formats")
-	outln("---------------------")
+	cliSection("Advanced Feed Formats")
 
 	cfg.FeedDefaults.Formats.HTML = promptRadioBool(reader, "HTML feed output", cfg.FeedDefaults.Formats.HTML)
 	cfg.FeedDefaults.Formats.RSS = promptRadioBool(reader, "RSS feed output", cfg.FeedDefaults.Formats.RSS)
@@ -359,8 +355,7 @@ func addFeature(reader *bufio.Reader, feature string, cfg *models.Config) error 
 // displayCurrentConfig shows the current configuration.
 func displayCurrentConfig(cfg *models.Config) {
 	outln()
-	outln("Current Configuration")
-	outln("=====================")
+	cliSection("Current Configuration")
 	outln()
 	outln("Site Information:")
 	outlnf("  Title:       %s", cfg.Title)

--- a/cmd/markata-go/cmd/root.go
+++ b/cmd/markata-go/cmd/root.go
@@ -79,7 +79,7 @@ Profiling:
   markata-go build --cpuprofile cpu.prof   # Write CPU profile
   markata-go build --memprofile mem.prof   # Write memory profile
 
-  # Analyze with:
+  Analyze with:
   go tool pprof cpu.prof
   go tool pprof -http=:8080 cpu.prof`,
 	SilenceUsage:  true,
@@ -146,6 +146,9 @@ func Execute() error {
 
 func init() {
 	cobra.OnInitialize(initConfig)
+	rootCmd.SetHelpFunc(func(cmd *cobra.Command, _ []string) {
+		renderCommandHelp(cmd)
+	})
 	rootCmd.SetFlagErrorFunc(func(_ *cobra.Command, err error) error {
 		return newUsageError(err)
 	})

--- a/docs/guides/cli-output.md
+++ b/docs/guides/cli-output.md
@@ -1,0 +1,25 @@
+---
+title: "CLI Output"
+description: "Understand Markata's terminal colors, themed help, and plain output behavior."
+date: 2026-07-29
+published: true
+tags:
+  - documentation
+  - cli
+  - themes
+---
+
+# CLI Output
+
+Markata uses your configured site palette for interactive help, status output,
+and section headings. Help sections use Unicode box-drawing rules sized to your
+terminal, up to 80 columns.
+
+```bash
+markata-go --help
+markata-go lsp --help
+```
+
+When output is redirected, or when you pass `--no-color`, Markata keeps the
+same text and separators but removes ANSI color codes. Structured output such
+as JSON, YAML, and TOML remains suitable for scripts.

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -18,6 +18,7 @@ const (
 	ansiBlue   = "\033[34m"
 	ansiCyan   = "\033[36m"
 	ansiDim    = "\033[2m"
+	ansiGreen  = "\033[32m"
 	ansiRed    = "\033[31m"
 	ansiReset  = "\033[0m"
 	ansiYellow = "\033[33m"
@@ -37,6 +38,7 @@ const (
 type Theme struct {
 	Timestamp  string
 	Component  string
+	Success    string
 	Warning    string
 	Error      string
 	PhaseColor map[string]string
@@ -129,6 +131,7 @@ func DefaultTheme() Theme {
 	return Theme{
 		Timestamp: ansiDim,
 		Component: ansiCyan,
+		Success:   ansiGreen,
 		Warning:   ansiYellow,
 		Error:     ansiRed,
 		PhaseColor: map[string]string{
@@ -165,6 +168,9 @@ func ThemeFromPalette(palette *palettes.Palette) Theme {
 	}
 	if value := resolve("primary", "info", "text-primary", "text"); value != "" {
 		theme.Component = value
+	}
+	if value := resolve("success", "primary", "secondary"); value != "" {
+		theme.Success = value
 	}
 	if value := resolve("warning", "secondary", "primary"); value != "" {
 		theme.Warning = value

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -93,6 +93,9 @@ func TestThemeFromPaletteUsesPaletteColors(t *testing.T) {
 	if theme.Component != "#112233" {
 		t.Fatalf("Component = %q, want %q", theme.Component, "#112233")
 	}
+	if theme.Success != "#778899" {
+		t.Fatalf("Success = %q, want %q", theme.Success, "#778899")
+	}
 	if theme.PhaseColor["transform"] != "#334455" {
 		t.Fatalf("transform color = %q, want %q", theme.PhaseColor["transform"], "#334455")
 	}

--- a/spec/spec/CLI_UX.md
+++ b/spec/spec/CLI_UX.md
@@ -85,6 +85,12 @@ colored when `stdout` is piped.
 When color is enabled for an interactive stream, human-facing summaries SHOULD
 use color by default to improve scannability.
 
+When a site configuration and palette are available, human-facing CLI headings,
+statuses, setup snippets, and help text MUST use palette-derived semantic
+colors. Commands MUST fall back to the default CLI theme if configuration or
+palette resolution fails. Primary structured output such as JSON, YAML, TOML,
+and line-oriented data MUST remain uncolored.
+
 Commands MUST preserve readable plain output when color is disabled.
 
 ## Output Modes
@@ -140,6 +146,20 @@ Subcommand help SHOULD lead with the common workflow and examples before edge
 cases.
 
 Running `markata-go` with no arguments MUST display help.
+
+Interactive help MUST use the resolved CLI theme for headings and command
+names. Help rendering MAY load the nearest site configuration to resolve the
+palette, but MUST fall back cleanly when it cannot be loaded.
+Clear section labels in long-form help text (for example, `Examples:` and
+`Documentation:`) MUST render as themed Unicode section separators.
+
+## Section Separators
+
+Human-facing section separators MUST use Unicode box-drawing characters rather
+than ASCII `-` or `=` rules. A separator SHOULD be 80 columns when space allows
+and MUST not exceed the current terminal width. On terminals narrower than 32
+columns, commands MUST use a compact labeled separator instead of a padded
+rule. Redirected output retains the Unicode separator but has no ANSI color.
 
 ## Error Handling
 


### PR DESCRIPTION
Fixes #1131\n\n## Summary\n- add palette-aware help headings and command names\n- add terminal-width-aware Unicode section rules\n- add a semantic success color token\n\n## Validation\n- go test ./...\n- go vet ./...\n- just lint-fast