### PR TITLE
feat(lsp): add editor setup diagnostics

### DIFF
--- a/cmd/markata-go/cmd/lsp.go
+++ b/cmd/markata-go/cmd/lsp.go
@@ -3,12 +3,24 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io"
 	"log"
 	"os"
+	"os/exec"
 	"os/signal"
+	"sort"
+	"strings"
 	"syscall"
+	"time"
 
+	"github.com/WaylonWalker/markata-go/pkg/config"
+	"github.com/WaylonWalker/markata-go/pkg/logging"
 	"github.com/WaylonWalker/markata-go/pkg/lsp"
+	"github.com/WaylonWalker/markata-go/pkg/models"
+	"github.com/WaylonWalker/markata-go/pkg/palettes"
+	"github.com/alecthomas/chroma/v2/formatters"
+	"github.com/alecthomas/chroma/v2/lexers"
+	"github.com/alecthomas/chroma/v2/styles"
 	"github.com/spf13/cobra"
 )
 
@@ -26,23 +38,43 @@ The LSP server provides IDE features for markdown files with wikilink support:
 
 The server communicates over stdin/stdout using the Language Server Protocol.
 
-Example usage with VS Code:
-  1. Install the markata-go extension
-  2. The extension will automatically start this server
-
-Example usage with Neovim (nvim-lspconfig):
-  require('lspconfig').markata.setup{
-    cmd = { "markata-go", "lsp" },
-    filetypes = { "markdown" },
-  }
-
-Example usage with other editors:
-  Configure your editor's LSP client to run "markata-go lsp" for markdown files.`,
+Set up an editor with "markata-go lsp setup --editor <editor>".
+Check your project and LSP installation with "markata-go lsp doctor".`,
 	RunE: runLSPCommand,
+}
+
+var lspSetupEditor string
+var lspSkipEditorVerification bool
+
+var lspDoctorCmd = &cobra.Command{
+	Use:   "doctor",
+	Short: "Check local LSP prerequisites",
+	Long: `Check whether this markata-go binary can serve LSP requests and whether
+the current project has a usable markata-go configuration and verifies installed
+editors that support headless checks. This can load user startup and plugin code.
+Pass --no-verify-editor to detect editors without loading their configuration.`,
+	RunE: runLSPDoctor,
+}
+
+var lspSetupCmd = &cobra.Command{
+	Use:   "setup",
+	Short: "Print editor LSP setup guidance",
+	Long: `Print copy-paste setup snippets for installed editors, or for a selected
+editor. The command never edits editor configuration because editor clients and
+configuration layouts vary.
+
+Examples:
+  markata-go lsp setup
+  markata-go lsp setup --editor neovim
+  markata-go lsp setup --editor helix`,
+	RunE: runLSPSetup,
 }
 
 func init() {
 	rootCmd.AddCommand(lspCmd)
+	lspCmd.AddCommand(lspDoctorCmd, lspSetupCmd)
+	lspSetupCmd.Flags().StringVarP(&lspSetupEditor, "editor", "e", "", "editor: generic, neovim, helix, emacs, zed, or vscode (default: all installed editors)")
+	lspDoctorCmd.Flags().BoolVar(&lspSkipEditorVerification, "no-verify-editor", false, "detect installed editors without loading their configuration")
 }
 
 func runLSPCommand(_ *cobra.Command, _ []string) error {
@@ -74,4 +106,398 @@ func runLSPCommand(_ *cobra.Command, _ []string) error {
 	}
 
 	return nil
+}
+
+func runLSPDoctor(cmd *cobra.Command, _ []string) error {
+	currentCmd = cmd
+	doctorTheme := logging.DefaultTheme()
+
+	cfg, _, configPaths, err := loadManagerConfig(cfgFile)
+	if err != nil {
+		failure := fmt.Errorf("configuration is invalid: %w", err)
+		lspDoctorHeader(doctorTheme, "markata-go LSP diagnostics")
+		lspDoctorLine(doctorTheme, "PASS", "LSP command: this binary can run 'markata-go lsp'.")
+		lspDoctorLine(doctorTheme, "FAIL", failure.Error())
+		return failure
+	}
+	validationErrors, _ := config.SplitErrorsAndWarnings(config.ValidateConfig(cfg))
+	if len(validationErrors) > 0 {
+		failure := fmt.Errorf("configuration is invalid: %w", validationErrors[0])
+		lspDoctorHeader(doctorTheme, "markata-go LSP diagnostics")
+		lspDoctorLine(doctorTheme, "PASS", "LSP command: this binary can run 'markata-go lsp'.")
+		lspDoctorLine(doctorTheme, "FAIL", failure.Error())
+		return failure
+	}
+
+	doctorTheme = resolveLSPDoctorTheme(cfg, configPaths)
+	lspDoctorHeader(doctorTheme, "markata-go LSP diagnostics")
+	lspDoctorLine(doctorTheme, "PASS", "LSP command: this binary can run 'markata-go lsp'.")
+	if len(configPaths) == 0 {
+		lspDoctorLine(doctorTheme, "INFO", "Configuration: none found; the LSP will use the workspace and available Markdown files.")
+		lspDoctorLine(doctorTheme, "INFO", "Workspace root: supplied by your editor.")
+	} else {
+		lspDoctorLine(doctorTheme, "PASS", fmt.Sprintf("Configuration: %s is valid.", strings.Join(configPaths, ", ")))
+		for _, configPath := range configPaths {
+			if strings.HasSuffix(configPath, ".yml") || strings.HasSuffix(configPath, ".json") {
+				lspDoctorLine(doctorTheme, "WARN", fmt.Sprintf("Configuration: %s is valid for builds, but LSP mention indexing reads only TOML and .yaml files.", configPath))
+			}
+		}
+	}
+
+	if runLSPEditorDiagnostics(!lspSkipEditorVerification, outWriter(), doctorTheme) && lspSkipEditorVerification {
+		lspDoctorVerificationHint(doctorTheme)
+	}
+	lspDoctorLine(doctorTheme, "PASS", "LSP prerequisites are ready.")
+	return nil
+}
+
+func resolveLSPDoctorTheme(cfg *models.Config, configPaths []string) logging.Theme {
+	return resolveCLITheme(cfg, configPaths)
+}
+
+func lspDoctorHeader(theme logging.Theme, title string) {
+	outln(colorizeOutput(title, theme.Component))
+}
+
+func lspDoctorLine(theme logging.Theme, status, message string) {
+	outlnf("%s  %s", colorizeOutput(status, lspDoctorStatusColor(theme, status)), message)
+}
+
+func lspDoctorVerificationHint(theme logging.Theme) {
+	errln(colorize(text, theme.Warning, colorEnabledFor(errorOutputIsTerminal())))
+	errln("  markata-go lsp doctor")
+	errln("  This may load editor startup and plugin code.")
+}
+
+type lspEditor struct {
+	name             string
+	executable       string
+	supportsHeadless bool
+	verify           func(context.Context) lspEditorVerification
+}
+
+type lspEditorVerification struct {
+	status  lspEditorStatus
+	message string
+}
+
+type lspEditorStatus string
+
+const (
+	lspEditorConfigured   lspEditorStatus = "configured"
+	lspEditorUnconfigured lspEditorStatus = "unconfigured"
+	lspEditorInconclusive lspEditorStatus = "inconclusive"
+)
+
+var lspEditors = []lspEditor{
+	{name: "Neovim", executable: "nvim", supportsHeadless: true, verify: verifyNeovimLSP},
+	{name: "Helix", executable: "hx", supportsHeadless: true, verify: verifyHelixLSP},
+	{name: "Emacs", executable: "emacs", supportsHeadless: true, verify: verifyEmacsLSP},
+	{name: "VS Code", executable: "code"},
+	{name: "Cursor", executable: "cursor"},
+	{name: "Zed", executable: "zed"},
+}
+
+var lspLookPath = exec.LookPath
+var lspRunCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, args...).CombinedOutput()
+}
+
+func runLSPEditorDiagnostics(verify bool, outputWriter io.Writer, theme logging.Theme) bool {
+	installed := installedLSPEditors(lspEditors, lspLookPath)
+	if len(installed) == 0 {
+		lspDoctorWriterLine(outputWriter, theme, "INFO", "Editors: no supported editor executable found on PATH.")
+		return false
+	}
+
+	hasHeadlessEditor := false
+	for _, editor := range installed {
+		hasHeadlessEditor = hasHeadlessEditor || editor.supportsHeadless
+		if !verify {
+			if editor.supportsHeadless {
+				lspDoctorWriterLine(outputWriter, theme, "INFO", fmt.Sprintf("Editor: %s is installed. Run doctor without --no-verify-editor to validate its LSP configuration.", editor.name))
+			} else {
+				lspDoctorWriterLine(outputWriter, theme, "INFO", fmt.Sprintf("Editor: %s is installed; runtime verification is not supported.", editor.name))
+			}
+			continue
+		}
+		if !editor.supportsHeadless {
+			lspDoctorWriterLine(outputWriter, theme, "INFO", fmt.Sprintf("Editor: %s is installed; runtime verification is not supported.", editor.name))
+			continue
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		result := editor.verify(ctx)
+		cancel()
+		switch result.status {
+		case lspEditorConfigured:
+			lspDoctorWriterLine(outputWriter, theme, "PASS", fmt.Sprintf("Editor: %s configured: %s", editor.name, result.message))
+		case lspEditorUnconfigured:
+			lspDoctorWriterLine(outputWriter, theme, "WARN", fmt.Sprintf("Editor: %s unconfigured: %s", editor.name, result.message))
+		default:
+			lspDoctorWriterLine(outputWriter, theme, "WARN", fmt.Sprintf("Editor: %s inconclusive: %s", editor.name, result.message))
+		}
+	}
+	return hasHeadlessEditor
+}
+
+func lspDoctorWriterLine(writer io.Writer, theme logging.Theme, status, message string) {
+	_, _ = fmt.Fprintf(writer, "%s  %s\n", colorizeOutput(status, lspDoctorStatusColor(theme, status)), message)
+}
+
+func lspDoctorStatusColor(theme logging.Theme, status string) string {
+	switch status {
+	case "PASS":
+		return theme.Success
+	case "INFO":
+		return theme.Component
+	case "WARN":
+		return theme.Warning
+	case "FAIL":
+		return theme.Error
+	default:
+		return theme.Component
+	}
+}
+
+func installedLSPEditors(editors []lspEditor, lookPath func(string) (string, error)) []lspEditor {
+	installed := make([]lspEditor, 0, len(editors))
+	for _, editor := range editors {
+		if _, err := lookPath(editor.executable); err == nil {
+			installed = append(installed, editor)
+		}
+	}
+	return installed
+}
+
+func verifyNeovimLSP(ctx context.Context) lspEditorVerification {
+	const script = `local c=vim.lsp.config["markata"]; if not c then io.stderr:write("MARKATA_NOT_CONFIGURED\n"); vim.cmd("cquit 2") end; local cmd=c.cmd or {}; local filetypes=c.filetypes or {}; local markdown=false; for _, ft in ipairs(filetypes) do if ft == "markdown" then markdown=true end end; if cmd[1] ~= "markata-go" or cmd[2] ~= "lsp" or not markdown then io.stderr:write("MARKATA_CONFIG_INVALID\n"); vim.cmd("cquit 2") end; print("MARKATA_CONFIGURED"); vim.cmd("qa")`
+	output, err := lspRunCommand(ctx, "nvim", "--headless", "+lua "+script)
+	if err != nil {
+		if strings.Contains(string(output), "MARKATA_NOT_CONFIGURED") || strings.Contains(string(output), "MARKATA_CONFIG_INVALID") {
+			return lspEditorVerification{status: lspEditorUnconfigured, message: "run 'markata-go lsp setup --editor neovim'."}
+		}
+		return lspEditorVerification{status: lspEditorInconclusive, message: "could not load a Neovim LSP configuration."}
+	}
+	if strings.Contains(string(output), "MARKATA_CONFIGURED") {
+		return lspEditorVerification{status: lspEditorConfigured, message: "markata-go LSP is registered for Markdown."}
+	}
+	return lspEditorVerification{status: lspEditorInconclusive, message: "did not return a recognized verification result."}
+}
+
+func verifyHelixLSP(ctx context.Context) lspEditorVerification {
+	output, err := lspRunCommand(ctx, "hx", "--health", "markdown")
+	if err != nil {
+		return lspEditorVerification{status: lspEditorInconclusive, message: "could not run 'hx --health markdown'."}
+	}
+	if strings.Contains(string(output), "markata-go") {
+		return lspEditorVerification{status: lspEditorConfigured, message: "health check recognizes markata-go for Markdown."}
+	}
+	return lspEditorVerification{status: lspEditorUnconfigured, message: "health check does not recognize markata-go for Markdown; run 'markata-go lsp setup --editor helix'."}
+}
+
+func verifyEmacsLSP(ctx context.Context) lspEditorVerification {
+	const expression = `(progn (require 'eglot nil t) (if (boundp 'eglot-server-programs) (princ (prin1-to-string eglot-server-programs)) (princ "NO_EGLOT")))`
+	output, err := lspRunCommand(ctx, "emacs", "--batch", "--eval", expression)
+	if err != nil {
+		return lspEditorVerification{status: lspEditorInconclusive, message: "could not load Eglot configuration in batch mode."}
+	}
+	if strings.Contains(string(output), "markata-go") && strings.Contains(string(output), "lsp") {
+		return lspEditorVerification{status: lspEditorConfigured, message: "Eglot configuration references markata-go lsp."}
+	}
+	return lspEditorVerification{status: lspEditorUnconfigured, message: "does not expose a recognized Eglot markata-go LSP configuration."}
+}
+
+func runLSPSetup(cmd *cobra.Command, _ []string) error {
+	currentCmd = cmd
+	if lspSetupEditor != "" {
+		_, ok := lspSetupSnippets[lspSetupEditor]
+		if !ok {
+			return newUsageError(fmt.Errorf("unsupported editor %q; supported editors: %s", lspSetupEditor, strings.Join(supportedLSPEditors(), ", ")))
+		}
+		outText(renderLSPSetupSnippets([]string{lspSetupEditor}))
+		return nil
+	}
+
+	setupEditors := installedLSPSetupEditors(installedLSPEditors(lspEditors, lspLookPath))
+	if len(setupEditors) == 0 {
+		outText(lspSetupSnippets["generic"])
+		return nil
+	}
+
+	outText(renderLSPSetupSnippets(setupEditors))
+	return nil
+}
+
+func renderLSPSetupSnippets(editors []string) string {
+	theme, chromaStyle := resolveLSPSetupRendering()
+	if len(editors) == 1 {
+		editor := editors[0]
+		return highlightLSPSetupSnippet(lspSetupSnippets[editor], lspSetupLanguages[editor], chromaStyle)
+	}
+
+	sections := make([]string, 0, len(editors))
+	for _, editor := range editors {
+		header := cliSectionRule(lspSetupEditorNames[editor])
+		if colorEnabledOnOutput() {
+			header = colorizeOutput(header, theme.Component)
+		}
+		sections = append(sections, header+"\n"+highlightLSPSetupSnippet(lspSetupSnippets[editor], lspSetupLanguages[editor], chromaStyle))
+	}
+	return strings.Join(sections, "\n\n")
+}
+
+func resolveLSPSetupRendering() (theme logging.Theme, chromaStyle string) {
+	theme = logging.DefaultTheme()
+	cfg, _, configPaths, err := loadManagerConfig(cfgFile)
+	if err == nil && cfg != nil {
+		extra := make(map[string]any)
+		if len(configPaths) > 0 {
+			extra["config_path"] = configPaths[0]
+		}
+		if palette, ok := loadLoggerPalette(cfg.Theme, extra); ok {
+			theme = logging.ThemeFromPalette(palette)
+			if style := palettes.ChromaTheme(palette.Name); style != "" {
+				return theme, style
+			}
+			return theme, palettes.ChromaThemeForVariant(palette.Variant)
+		}
+	}
+	return theme, palettes.DefaultChromaThemeDark
+}
+
+func highlightLSPSetupSnippet(snippet, language, chromaStyle string) string {
+	if !colorEnabledOnOutput() {
+		return snippet
+	}
+	lexer := lexers.Get(language)
+	if lexer == nil {
+		lexer = lexers.Get("plaintext")
+	}
+	style := styles.Get(chromaStyle)
+	if style == nil {
+		style = styles.Fallback
+	}
+	iterator, err := lexer.Tokenise(nil, snippet)
+	if err != nil {
+		return snippet
+	}
+	var output strings.Builder
+	formatter := formatters.Get("terminal16m")
+	if formatter == nil {
+		return snippet
+	}
+	if err := formatter.Format(&output, style, iterator); err != nil {
+		return snippet
+	}
+	return output.String()
+}
+
+func installedLSPSetupEditors(editors []lspEditor) []string {
+	setupEditorByExecutable := map[string]string{
+		"nvim":   "neovim",
+		"hx":     "helix",
+		"emacs":  "emacs",
+		"code":   "vscode",
+		"cursor": "vscode",
+		"zed":    "zed",
+	}
+	seen := make(map[string]bool)
+	setupEditors := make([]string, 0, len(editors))
+	for _, editor := range editors {
+		setupEditor, ok := setupEditorByExecutable[editor.executable]
+		if !ok || seen[setupEditor] {
+			continue
+		}
+		seen[setupEditor] = true
+		setupEditors = append(setupEditors, setupEditor)
+	}
+	return setupEditors
+}
+
+func supportedLSPEditors() []string {
+	editors := make([]string, 0, len(lspSetupSnippets))
+	for editor := range lspSetupSnippets {
+		editors = append(editors, editor)
+	}
+	sort.Strings(editors)
+	return editors
+}
+
+var lspSetupSnippets = map[string]string{
+	"generic": `# markata-go LSP generic client configuration
+#
+# Start this command over stdio for Markdown files. Set the workspace root to
+# the directory containing markata-go.toml (or your site's content directory).
+command: markata-go lsp
+filetypes: markdown
+root: markata-go configuration directory
+`,
+	"neovim": `-- Neovim 0.11+ (init.lua)
+-- Add this before opening Markdown files. The root marker makes each site a workspace.
+vim.lsp.config("markata", {
+  cmd = { "markata-go", "lsp" },
+  filetypes = { "markdown" },
+  root_markers = { "markata-go.toml", "markata-go.yaml", "markata-go.yml", "markata-go.json", ".git" },
+})
+vim.lsp.enable("markata")
+`,
+	"helix": `# Helix languages.toml (usually ~/.config/helix/languages.toml)
+[language-server.markata-go]
+command = "markata-go"
+args = ["lsp"]
+
+[[language]]
+name = "markdown"
+language-servers = ["markata-go"]
+`,
+	"emacs": `;; Emacs with Eglot (init.el)
+;; Install/enable eglot, then register markata-go for Markdown buffers.
+(with-eval-after-load 'eglot
+  (add-to-list 'eglot-server-programs
+               '((markdown-mode gfm-mode) . ("markata-go" "lsp"))))
+`,
+	"zed": `// Zed settings.json
+// Zed configuration evolves quickly. Register the command with your installed
+// Markdown LSP client/extension using these stable values:
+// command: "markata-go"
+// arguments: ["lsp"]
+// language: Markdown
+// workspace root: directory containing markata-go.toml
+//
+// See the Zed language-server settings for your installed version, then run:
+// markata-go lsp doctor
+`,
+	"vscode": `// VS Code / Cursor
+// VS Code does not let settings.json register an arbitrary stdio LSP server by
+// itself. Install an LSP-client extension or a Markata-aware extension, then
+// configure its server launch values as:
+//
+// command: "markata-go"
+// args: ["lsp"]
+// filetypes/language: ["markdown"]
+// workspace root: ${workspaceFolder} (the directory with markata-go.toml)
+//
+// Do not add a task as a substitute: tasks run once and are not LSP clients.
+// Ask an agent to adapt these values to the LSP extension already installed in
+// this workspace, then run "markata-go lsp doctor".
+`,
+}
+
+var lspSetupEditorNames = map[string]string{
+	"emacs":   "Emacs",
+	"generic": "Generic LSP client",
+	"helix":   "Helix",
+	"neovim":  "Neovim",
+	"vscode":  "VS Code / Cursor",
+	"zed":     "Zed",
+}
+
+var lspSetupLanguages = map[string]string{
+	"emacs":   "emacs-lisp",
+	"generic": "yaml",
+	"helix":   "toml",
+	"neovim":  "lua",
+	"vscode":  "json",
+	"zed":     "json",
 }

--- a/cmd/markata-go/cmd/lsp_test.go
+++ b/cmd/markata-go/cmd/lsp_test.go
@@ -1,0 +1,411 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/WaylonWalker/markata-go/pkg/logging"
+	"github.com/spf13/cobra"
+)
+
+func TestRunLSPSetup_PrintsRequestedEditorSnippet(t *testing.T) {
+	oldEditor := lspSetupEditor
+	defer func() { lspSetupEditor = oldEditor }()
+
+	command := &cobra.Command{Use: "setup"}
+	stdout := bytes.NewBuffer(nil)
+	command.SetOut(stdout)
+
+	lspSetupEditor = "helix"
+	if err := runLSPSetup(command, nil); err != nil {
+		t.Fatalf("runLSPSetup() error = %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "[language-server.markata-go]") {
+		t.Errorf("setup output = %q, want Helix language server configuration", output)
+	}
+	if !strings.Contains(output, `args = ["lsp"]`) {
+		t.Errorf("setup output = %q, want LSP command arguments", output)
+	}
+}
+
+func TestRunLSPSetup_PrintsSeparatedInstalledEditorSnippets(t *testing.T) {
+	oldEditor := lspSetupEditor
+	oldEditors := lspEditors
+	oldLookPath := lspLookPath
+	defer func() {
+		lspSetupEditor = oldEditor
+		lspEditors = oldEditors
+		lspLookPath = oldLookPath
+	}()
+
+	lspSetupEditor = ""
+	lspEditors = []lspEditor{
+		{name: "Neovim", executable: "nvim"},
+		{name: "Helix", executable: "hx"},
+	}
+	lspLookPath = func(string) (string, error) { return "/usr/bin/editor", nil }
+	command := &cobra.Command{Use: "setup"}
+	stdout := bytes.NewBuffer(nil)
+	command.SetOut(stdout)
+
+	if err := runLSPSetup(command, nil); err != nil {
+		t.Fatalf("runLSPSetup() error = %v", err)
+	}
+	output := stdout.String()
+	for _, want := range []string{"Neovim", "Helix", `vim.lsp.config("markata"`, "[language-server.markata-go]"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("setup output = %q, want %q", output, want)
+		}
+	}
+}
+
+func TestRenderLSPSetupSnippets_SyntaxHighlightsInteractiveOutput(t *testing.T) {
+	oldForceColor := forceColor
+	defer func() { forceColor = oldForceColor }()
+	forceColor = true
+
+	output := renderLSPSetupSnippets([]string{"neovim", "helix"})
+	if !strings.Contains(output, "\x1b[") {
+		t.Errorf("setup output = %q, want ANSI syntax highlighting", output)
+	}
+	if !strings.Contains(output, "Neovim") || !strings.Contains(output, "Helix") {
+		t.Errorf("setup output = %q, want editor headings", output)
+	}
+}
+
+func TestRunLSPSetup_RejectsUnsupportedEditor(t *testing.T) {
+	oldEditor := lspSetupEditor
+	defer func() { lspSetupEditor = oldEditor }()
+
+	lspSetupEditor = "unknown"
+	err := runLSPSetup(&cobra.Command{Use: "setup"}, nil)
+	if err == nil {
+		t.Fatal("runLSPSetup() error = nil, want unsupported editor error")
+	}
+	if !strings.Contains(err.Error(), "supported editors: emacs, generic, helix, neovim, vscode, zed") {
+		t.Errorf("error = %q, want supported editor list", err)
+	}
+	if got := ExitCodeForError(err); got != exitCodeUsage {
+		t.Errorf("ExitCodeForError() = %d, want %d", got, exitCodeUsage)
+	}
+}
+
+func TestRunLSPDoctor_ReportsValidConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "markata-go.toml")
+	if err := os.WriteFile(configPath, []byte("[markata-go]\ntitle = \"Test\"\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	oldConfigFile := cfgFile
+	oldCmd := currentCmd
+	defer func() {
+		cfgFile = oldConfigFile
+		currentCmd = oldCmd
+	}()
+
+	command := &cobra.Command{Use: "doctor"}
+	stdout := bytes.NewBuffer(nil)
+	command.SetOut(stdout)
+	cfgFile = configPath
+
+	if err := runLSPDoctor(command, nil); err != nil {
+		t.Fatalf("runLSPDoctor() error = %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "Configuration: "+configPath+" is valid.") {
+		t.Errorf("doctor output = %q, want valid configuration", output)
+	}
+	if !strings.Contains(output, "LSP prerequisites are ready.") {
+		t.Errorf("doctor output = %q, want success summary", output)
+	}
+}
+
+func TestRunLSPDoctor_AllowsMissingConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("change working directory: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(oldWd); err != nil {
+			t.Errorf("restore working directory: %v", err)
+		}
+	}()
+
+	oldConfigFile := cfgFile
+	oldCmd := currentCmd
+	defer func() {
+		cfgFile = oldConfigFile
+		currentCmd = oldCmd
+	}()
+
+	command := &cobra.Command{Use: "doctor"}
+	stdout := bytes.NewBuffer(nil)
+	command.SetOut(stdout)
+	cfgFile = ""
+
+	if err := runLSPDoctor(command, nil); err != nil {
+		t.Fatalf("runLSPDoctor() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "Configuration: none found") {
+		t.Errorf("doctor output = %q, want missing configuration information", stdout.String())
+	}
+}
+
+func TestRunLSPDoctor_RejectsInvalidConfig(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "markata-go.toml")
+	if err := os.WriteFile(configPath, []byte("[markata-go\ntitle = \"broken\"\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	oldConfigFile := cfgFile
+	oldCmd := currentCmd
+	defer func() {
+		cfgFile = oldConfigFile
+		currentCmd = oldCmd
+	}()
+	cfgFile = configPath
+
+	command := &cobra.Command{Use: "doctor"}
+	stdout := bytes.NewBuffer(nil)
+	command.SetOut(stdout)
+
+	err := runLSPDoctor(command, nil)
+	if err == nil {
+		t.Fatal("runLSPDoctor() error = nil, want invalid configuration error")
+	}
+	if !strings.Contains(err.Error(), "configuration is invalid") {
+		t.Errorf("error = %q, want invalid configuration error", err)
+	}
+	if !strings.Contains(stdout.String(), "FAIL  configuration is invalid") {
+		t.Errorf("doctor output = %q, want failure diagnostic", stdout.String())
+	}
+}
+
+func TestInstalledLSPEditors_FiltersUnavailableEditors(t *testing.T) {
+	editors := []lspEditor{
+		{name: "Available", executable: "available"},
+		{name: "Missing", executable: "missing"},
+	}
+	lookup := func(name string) (string, error) {
+		if name == "available" {
+			return "/usr/bin/available", nil
+		}
+		return "", os.ErrNotExist
+	}
+
+	installed := installedLSPEditors(editors, lookup)
+	if len(installed) != 1 || installed[0].name != "Available" {
+		t.Errorf("installedLSPEditors() = %#v, want only Available", installed)
+	}
+}
+
+func TestRunLSPEditorDiagnostics_ReportsAvailableVerification(t *testing.T) {
+	oldEditors := lspEditors
+	oldLookPath := lspLookPath
+	defer func() {
+		lspEditors = oldEditors
+		lspLookPath = oldLookPath
+	}()
+
+	lspLookPath = func(string) (string, error) { return "/usr/bin/test-editor", nil }
+
+	output := bytes.NewBuffer(nil)
+	lspEditors = []lspEditor{{name: "Test editor", executable: "test-editor", supportsHeadless: true}}
+	runLSPEditorDiagnostics(false, output, logging.DefaultTheme())
+	if !strings.Contains(output.String(), "without --no-verify-editor") {
+		t.Errorf("default diagnostics = %q, want verification hint", output.String())
+	}
+
+	for _, tt := range []struct {
+		status lspEditorStatus
+		want   string
+	}{
+		{lspEditorConfigured, "PASS  Editor: Test editor configured"},
+		{lspEditorUnconfigured, "WARN  Editor: Test editor unconfigured"},
+		{lspEditorInconclusive, "WARN  Editor: Test editor inconclusive"},
+	} {
+		t.Run(string(tt.status), func(t *testing.T) {
+			lspEditors[0].verify = func(context.Context) lspEditorVerification {
+				return lspEditorVerification{status: tt.status, message: "test result"}
+			}
+			output.Reset()
+			runLSPEditorDiagnostics(true, output, logging.DefaultTheme())
+			if !strings.Contains(output.String(), tt.want) {
+				t.Errorf("verification diagnostics = %q, want %q", output.String(), tt.want)
+			}
+		})
+	}
+}
+
+func TestRunLSPDoctor_WarnsForUnsupportedLSPConfigFormat(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "markata-go.yml")
+	if err := os.WriteFile(configPath, []byte("title: Test\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	oldConfigFile := cfgFile
+	oldCmd := currentCmd
+	defer func() {
+		cfgFile = oldConfigFile
+		currentCmd = oldCmd
+	}()
+	cfgFile = configPath
+	command := &cobra.Command{Use: "doctor"}
+	stdout := bytes.NewBuffer(nil)
+	command.SetOut(stdout)
+
+	if err := runLSPDoctor(command, nil); err != nil {
+		t.Fatalf("runLSPDoctor() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "LSP mention indexing reads only TOML and .yaml files") {
+		t.Errorf("doctor output = %q, want unsupported LSP config format warning", stdout.String())
+	}
+}
+
+func TestVerifyNeovimLSP_ClassifiesCommandResults(t *testing.T) {
+	oldRunCommand := lspRunCommand
+	defer func() { lspRunCommand = oldRunCommand }()
+
+	tests := []struct {
+		name       string
+		output     string
+		err        error
+		wantStatus lspEditorStatus
+	}{
+		{"configured", "MARKATA_CONFIGURED\n", nil, lspEditorConfigured},
+		{"not configured", "MARKATA_NOT_CONFIGURED\n", errors.New("exit status 2"), lspEditorUnconfigured},
+		{"invalid", "MARKATA_CONFIG_INVALID\n", errors.New("exit status 2"), lspEditorUnconfigured},
+		{"command failure", "startup failure", errors.New("exit status 1"), lspEditorInconclusive},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lspRunCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+				if name != "nvim" || len(args) != 2 || args[0] != "--headless" {
+					t.Fatalf("command = %q %q, want nvim --headless <script>", name, args)
+				}
+				return []byte(tt.output), tt.err
+			}
+			result := verifyNeovimLSP(context.Background())
+			if result.status != tt.wantStatus {
+				t.Errorf("status = %q, want %q", result.status, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestVerifyHelixLSP_ClassifiesCommandResults(t *testing.T) {
+	oldRunCommand := lspRunCommand
+	defer func() { lspRunCommand = oldRunCommand }()
+
+	tests := []struct {
+		name       string
+		output     string
+		err        error
+		wantStatus lspEditorStatus
+	}{
+		{"configured", "markdown markata-go", nil, lspEditorConfigured},
+		{"not configured", "markdown marksman", nil, lspEditorUnconfigured},
+		{"command failure", "", errors.New("exit status 1"), lspEditorInconclusive},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lspRunCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+				if name != "hx" || len(args) != 2 || args[0] != "--health" || args[1] != "markdown" {
+					t.Fatalf("command = %q %q, want hx --health markdown", name, args)
+				}
+				return []byte(tt.output), tt.err
+			}
+			if result := verifyHelixLSP(context.Background()); result.status != tt.wantStatus {
+				t.Errorf("status = %q, want %q", result.status, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestVerifyEmacsLSP_ClassifiesCommandResults(t *testing.T) {
+	oldRunCommand := lspRunCommand
+	defer func() { lspRunCommand = oldRunCommand }()
+
+	tests := []struct {
+		name       string
+		output     string
+		err        error
+		wantStatus lspEditorStatus
+	}{
+		{"configured", "((markdown-mode . (markata-go lsp)))", nil, lspEditorConfigured},
+		{"not configured", "NO_EGLOT", nil, lspEditorUnconfigured},
+		{"command failure", "", errors.New("exit status 1"), lspEditorInconclusive},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lspRunCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+				if name != "emacs" || len(args) != 3 || args[0] != "--batch" || args[1] != "--eval" {
+					t.Fatalf("command = %q %q, want emacs --batch --eval <expression>", name, args)
+				}
+				return []byte(tt.output), tt.err
+			}
+			if result := verifyEmacsLSP(context.Background()); result.status != tt.wantStatus {
+				t.Errorf("status = %q, want %q", result.status, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestLSPDoctorVerificationHint_WritesToStandardError(t *testing.T) {
+	oldCmd := currentCmd
+	defer func() { currentCmd = oldCmd }()
+
+	command := &cobra.Command{Use: "doctor"}
+	stdout := bytes.NewBuffer(nil)
+	stderr := bytes.NewBuffer(nil)
+	command.SetOut(stdout)
+	command.SetErr(stderr)
+	currentCmd = command
+
+	lspDoctorVerificationHint(logging.DefaultTheme())
+	if stdout.Len() != 0 {
+		t.Errorf("stdout = %q, want no verification hint", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "markata-go lsp doctor") {
+		t.Errorf("stderr = %q, want verification command", stderr.String())
+	}
+}
+
+func TestLSPDoctorStatusColor_UsesSemanticThemeColors(t *testing.T) {
+	theme := logging.Theme{
+		Component: "#111111",
+		Success:   "#222222",
+		Warning:   "#333333",
+		Error:     "#444444",
+	}
+
+	for _, tt := range []struct {
+		status string
+		want   string
+	}{
+		{"PASS", "#222222"},
+		{"INFO", "#111111"},
+		{"WARN", "#333333"},
+		{"FAIL", "#444444"},
+	} {
+		if got := lspDoctorStatusColor(theme, tt.status); got != tt.want {
+			t.Errorf("lspDoctorStatusColor(%q) = %q, want %q", tt.status, got, tt.want)
+		}
+	}
+}

--- a/docs/guides/quality-assurance/editor-integration.md
+++ b/docs/guides/quality-assurance/editor-integration.md
@@ -1,6 +1,6 @@
 ---
 title: "Editor Integration"
-description: "Use markata-go lint output with your favorite editor's quickfix and problem matching features"
+description: "Set up markata-go LSP features and lint feedback in your editor"
 date: 2026-01-24
 published: true
 tags:
@@ -14,7 +14,137 @@ tags:
 
 # Editor Integration
 
-The `markata-go lint` command outputs issues in a format compatible with many editors' error navigation features. This guide shows how to integrate lint output with popular editors.
+Use the Language Server Protocol (LSP) for live wikilink completions, broken-link diagnostics, hover details, and go-to-definition. Use `markata-go lint` when you also need content-quality checks in an editor's quickfix or Problems panel.
+
+## Start With A Health Check
+
+From the root of your site, run:
+
+```bash
+markata-go lsp doctor
+```
+
+The command verifies the local binary and validates any discovered
+markata-go configuration. It does not modify your editor configuration. Your
+editor—not the configuration file—supplies the LSP workspace root.
+
+It also detects supported editors installed on your `PATH`. For Neovim, Helix,
+and Emacs, it loads the editor configuration for a deeper check by default:
+
+```bash
+markata-go lsp doctor
+```
+
+This can run editor startup and plugin code. Skip it when needed while still
+detecting editors:
+
+```bash
+markata-go lsp doctor --no-verify-editor
+```
+
+The report labels each detected editor as configured, unconfigured, or
+inconclusive. VS Code, Cursor, and Zed are detected but do not have stable
+headless LSP verification APIs.
+
+When verification is skipped and a headless-verifiable editor is detected, the
+report prints the default doctor follow-up command to stderr. This keeps the
+primary diagnostic report on stdout while making the next interactive action
+easy to spot.
+
+In an interactive terminal, the report uses your configured site palette for
+pass, information, warning, and failure states. The textual labels remain
+present for accessibility and plain output.
+
+Every LSP client uses the same stable values:
+
+| Setting | Value |
+| --- | --- |
+| Command | `markata-go lsp` |
+| File type | Markdown |
+| Workspace root | Directory containing `markata-go.toml` (or the site root) |
+
+Print a maintained starting snippet with:
+
+```bash
+markata-go lsp setup --editor neovim
+```
+
+Omit `--editor` to print snippets for every supported editor installed on your
+`PATH`:
+
+```bash
+markata-go lsp setup
+```
+
+When more than one editor is found, each snippet has a clear heading. Interactive
+terminal output is syntax highlighted; redirected output remains plain text for
+copying into configuration files.
+
+Available editors are `generic`, `neovim`, `helix`, `emacs`, `zed`, and
+`vscode`. The command only prints guidance: it deliberately does not rewrite
+editor settings because editor versions, extensions, and configuration layouts
+vary. When using an agent, have it inspect the editor configuration already in
+the repository or home directory, then adapt the generated snippet.
+
+## Language Server Setup
+
+### Neovim
+
+For Neovim 0.11 or later, add the output of this command to `init.lua` or a
+loaded Lua module:
+
+```bash
+markata-go lsp setup --editor neovim
+```
+
+### Helix
+
+Append the generated TOML to `~/.config/helix/languages.toml`:
+
+```bash
+markata-go lsp setup --editor helix
+```
+
+Restart Helix after changing the file.
+
+### Emacs
+
+With Eglot enabled, add the generated Elisp to your Emacs init file:
+
+```bash
+markata-go lsp setup --editor emacs
+```
+
+### VS Code, Cursor, And Zed
+
+These editors need an installed LSP client or a Markata-aware extension before
+they can launch an arbitrary stdio language server. Print the required command,
+arguments, file type, and workspace-root values, then apply them using the
+configuration format required by the installed extension:
+
+```bash
+markata-go lsp setup --editor vscode
+markata-go lsp setup --editor zed
+```
+
+Do not use an editor task as an LSP replacement: tasks run once and cannot
+provide completion, hover, or navigation.
+
+### Other Editors
+
+Use the generic contract when your editor is not listed:
+
+```bash
+markata-go lsp setup --editor generic
+```
+
+Configure the editor's LSP client to launch `markata-go lsp` over standard I/O
+for Markdown documents. Use its native workspace-root setting to point at the
+site root.
+
+## Lint Integration
+
+The `markata-go lint` command outputs issues in a format compatible with many editors' error navigation features. The remaining sections show how to integrate those checks with popular editors.
 
 ## Vim / Neovim Quickfix
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -75,6 +75,59 @@ Issues: https://github.com/WaylonWalker/markata-go/issues
 
 ## Commands
 
+### lsp
+
+Start the Markdown language server, check its local prerequisites, or print
+editor setup guidance.
+
+```bash
+markata-go lsp
+markata-go lsp doctor
+markata-go lsp doctor --no-verify-editor
+markata-go lsp setup
+markata-go lsp setup --editor neovim
+```
+
+`markata-go lsp` communicates using LSP over standard input and output. It
+provides wikilink completion, broken-wikilink diagnostics, hover information,
+and go-to-definition for Markdown files.
+
+| Subcommand | Description |
+| --- | --- |
+| `doctor` | Read-only check of the LSP binary, active project configuration, and installed editors |
+| `setup --editor <name>` | Print a copy-paste editor configuration snippet without editing files |
+
+`setup` supports `generic`, `neovim`, `helix`, `emacs`, `zed`, and `vscode`.
+Use `generic` for another client. Editor recipes are guidance for documented
+client configuration surfaces, not a guarantee that every editor version can be
+configured automatically. See [[editor-integration|Editor Integration]] for
+full instructions.
+
+By default, `doctor` performs headless validation for installed Neovim, Helix,
+and Emacs configurations. This can load user startup/plugin code. Pass
+`--no-verify-editor` to only detect installed editors. VS Code, Cursor, and
+Zed detection is advisory because their LSP clients do not expose stable
+headless verification APIs.
+
+When verification is skipped and a deeper check is available, `doctor` prints
+the default follow-up command to stderr.
+
+On an interactive terminal, the doctor report derives its status colors from
+the configured site palette while retaining text labels for each status.
+
+Interactive help and human-facing setup headings also use the configured site
+palette. If a site palette cannot be resolved, Markata falls back to its default
+CLI theme; structured command output remains uncolored for scripting.
+
+When `--editor` is omitted, `setup` prints snippets for each supported editor
+installed on `PATH`; it prints the generic integration contract if none are
+found. Multiple snippets have editor headings and are syntax highlighted on an
+interactive terminal; redirected output remains plain text.
+
+The LSP server reads TOML and `.yaml` configuration for mention indexing. If
+your valid site configuration is `.yml` or `.json`, `doctor` warns that those
+LSP-specific mentions are unavailable.
+
 ### agent
 
 Install bundled agent integrations for markata-go site repositories.

--- a/pkg/agentskill/bundle/markata-go-site/SKILL.md
+++ b/pkg/agentskill/bundle/markata-go-site/SKILL.md
@@ -24,8 +24,9 @@ Before making changes:
 2. Inspect content with `markata-go list posts`, `markata-go list feeds`, and `markata-go list tags`.
 3. Search for content by keyword with `markata-go search <query>`.
 4. Use `markata-go explain <topic>` for built-in CLI context.
-5. Use `markata-go build --fast` or `markata-go serve --fast` while iterating.
-6. Only reach for Go plugin work after checking whether the change belongs in config, frontmatter, templates, CSS, or feeds.
+5. For Markdown wikilink IDE features, run `markata-go lsp doctor` (it can load editor startup/plugin code); use `--no-verify-editor` to skip that check. Use `markata-go lsp setup` to print snippets for installed editors, then inspect existing editor configuration before changing it.
+6. Use `markata-go build --fast` or `markata-go serve --fast` while iterating.
+7. Only reach for Go plugin work after checking whether the change belongs in config, frontmatter, templates, CSS, or feeds.
 
 ## Topic Files
 

--- a/pkg/agentskill/bundle/markata-go-site/topics/cli-usage.md
+++ b/pkg/agentskill/bundle/markata-go-site/topics/cli-usage.md
@@ -21,7 +21,7 @@ Use this topic for everyday site work and safe project inspection.
 ### Config And Inspection
 
 - `markata-go config show`
-- `markata-go config show --annotate`
+- `markata-go config show` (annotated YAML by default; use `--no-annotate` for plain YAML)
 - `markata-go config show --diff`
 - `markata-go config get <key>`
 - `markata-go config validate`
@@ -58,6 +58,9 @@ Bare `markata-go config` behaves like `markata-go config show`.
 - `markata-go lint` (lint markdown files for common issues)
 - `markata-go lint --fix` (auto-fix fixable issues)
 - `markata-go lint --dry-run` (show files without linting)
+- `markata-go lsp doctor` (check local LSP command and project configuration)
+- `markata-go lsp doctor --no-verify-editor` (detect installed editors without loading their configuration)
+- `markata-go lsp setup` (print setup guidance for each installed supported editor; use `--editor <editor>` for `generic`, `neovim`, `helix`, `emacs`, `zed`, or `vscode`)
 
 ### Encryption
 
@@ -155,6 +158,7 @@ markata-go encryption encrypt-posts --dry-run
 - inspect resolved configuration: `markata-go config show`
 - create new content: `markata-go new`
 - lint content before committing: `markata-go lint`
+- set up Markdown wikilink IDE support: `markata-go lsp doctor`, then `markata-go lsp setup --editor <editor>`; inspect existing editor configuration before applying the printed values
 - source-encrypt private Markdown before committing: `markata-go encryption encrypt-posts --dry-run`, then `markata-go encryption encrypt-posts`
 - validate config before deploy: `markata-go config validate`
 - validate palette contrast: `markata-go palette check <name>`

--- a/spec/README.md
+++ b/spec/README.md
@@ -47,6 +47,7 @@ The docs explain *why* and *usage* - user-friendly guides, examples, tutorials.
 | [SPEC.md](./spec/SPEC.md) | Core architecture, CLI, concurrency |
 | [CLI_LIST.md](./spec/CLI_LIST.md) | CLI list command and output formats |
 | [CLI_UX.md](./spec/CLI_UX.md) | Shared CLI UX rules for streams, color, and prompts |
+| [LSP.md](./spec/LSP.md) | Language Server Protocol integration and setup guidance |
 | [CONTAINERS.md](./spec/CONTAINERS.md) | Container images and runtime environments |
 | [CONFIG.md](./spec/CONFIG.md) | Configuration system, file discovery, env vars, CLI |
 | [AGENTS.md](./spec/AGENTS.md) | Agent skill packaging, install targets, and CLI |

--- a/spec/spec/LSP.md
+++ b/spec/spec/LSP.md
@@ -1,0 +1,84 @@
+# Language Server Protocol Specification
+
+## Overview
+
+`markata-go lsp` starts the markata-go Language Server Protocol (LSP) server on
+standard input and standard output. It provides Markdown wikilink completion,
+diagnostics, hover information, and go-to-definition.
+
+The LSP server is editor-neutral. Editor clients MUST start it with:
+
+```text
+markata-go lsp
+```
+
+The client MUST communicate using LSP over stdio and register the server for
+Markdown files. The workspace root SHOULD be the site directory that contains
+the active markata-go configuration.
+
+## Setup Guidance
+
+The CLI MUST provide editor-configuration snippets without mutating editor
+configuration files:
+
+```text
+markata-go lsp setup --editor <editor>
+```
+
+Supported editor identifiers are `generic`, `neovim`, `helix`, `emacs`, `zed`,
+and `vscode`. The output MUST state the command, Markdown filetype, and
+workspace-root requirements. It MUST identify when an editor requires a
+third-party LSP client or an extension rather than implying native support.
+
+The command MUST reject an unsupported editor identifier with a usage error and
+list the supported identifiers. It MUST write snippets to stdout so agents and
+users can copy or redirect them safely.
+
+When `--editor` is omitted, the command MUST detect supported editors on
+`PATH` and print setup snippets for each installed editor. If no supported
+editor is installed, it MUST print the generic integration contract.
+When multiple snippets are printed, they MUST have clear editor headings. On
+an interactive terminal, snippets SHOULD use syntax highlighting; redirected
+output MUST remain uncolored copyable text.
+
+## Diagnostics
+
+The CLI MUST provide a read-only diagnostic command:
+
+```text
+markata-go lsp doctor
+```
+
+`doctor` MUST check that the current binary can serve LSP requests and validate
+an explicit or auto-discovered markata-go configuration. A missing
+configuration is informational because the LSP can still start; an invalid
+explicitly selected or discovered configuration is an error. LSP mention
+indexing reads TOML and `.yaml` configuration only; the command MUST warn when
+a valid `.yml` or `.json` site configuration is selected.
+
+The command MUST detect supported editor executables on `PATH` and, by default,
+load supported editor configuration in headless or batch mode. It MUST report
+configured, unconfigured, and inconclusive results without modifying
+configuration. `--no-verify-editor` MUST opt out of loading editor
+configuration and report only installed editor detection. Loading editor
+configuration can execute user plugin startup code.
+
+The command MUST write its report to stdout and return exit code 0 when all
+required checks pass. It MUST return exit code 1 when a required check fails.
+It MUST not start a long-running LSP server or modify editor configuration.
+Human-oriented reports SHOULD use semantic status color when stdout is a
+terminal and MUST honor the CLI color-disable controls. When verification is
+skipped and a detected editor supports it, the report MUST print the default
+doctor follow-up on stderr.
+
+When a site palette is available, the report MUST derive its title, pass,
+information, warning, and failure colors from that palette. It MUST retain the
+same status labels so color is an enhancement rather than the only signal.
+
+## Version Support
+
+Editor-specific snippets are examples for current, documented client
+configuration surfaces. They are not a promise to automatically configure all
+editor versions. The generic integration contract is the stable compatibility
+surface; agents SHOULD inspect a repository's existing editor configuration and
+adapt the snippet to the installed client.


### PR DESCRIPTION
Fixes #1126\n\nDepends on #1133 for shared themed CLI rendering.\n\n## Summary\n- add LSP doctor with installed-editor detection and headless verification\n- print setup snippets for detected editors\n- document editor integration and update the bundled site skill\n\n## Validation\n- go test ./...\n- go vet ./...\n- just lint-fast