### PR TITLE
feat(encryption): add decrypt-posts command

### DIFF
--- a/cmd/markata-go/cmd/encryption.go
+++ b/cmd/markata-go/cmd/encryption.go
@@ -19,14 +19,14 @@ var (
 	encryptionPasswordLength int
 	encryptionCheckKey       string
 	encryptionDryRun         bool
+	decryptionDryRun         bool
 )
 
 var encryptionCmd = &cobra.Command{
 	Use:   "encryption",
 	Short: "Utilities for encryption keys and passwords",
 	Long: `Encryption utilities help you manage passwords and source-encrypted private posts.
-`,
-}
+`}
 
 var generatePasswordCmd = &cobra.Command{
 	Use:     "generate-password",
@@ -65,11 +65,30 @@ changes without modifying files.
 	RunE: runEncryptPostsCommand,
 }
 
+var decryptPostsCmd = &cobra.Command{
+	Use:   "decrypt-posts [path...]",
+	Short: "Decrypt source-encrypted Markdown bodies back to plaintext",
+	Long: `Decrypt source-encrypted Markdown bodies back to plaintext.
+
+This is the inverse of ` + "`encryption encrypt-posts`" + `. With no arguments it scans the
+active content glob configuration; with explicit paths it only processes those files.
+
+Files are decrypted in place by default. Files that are not source-encrypted are
+reported but not rewritten. Use --dry-run to preview changes without modifying files.
+
+The key name is read from the encrypted source marker, falling back to
+encryption.default_key. The password is read from MARKATA_GO_ENCRYPTION_KEY_<KEY>.
+`,
+	Args: cobra.ArbitraryArgs,
+	RunE: runDecryptPostsCommand,
+}
+
 func init() {
-	encryptionCmd.AddCommand(generatePasswordCmd, checkPasswordCmd, encryptPostsCmd)
+	encryptionCmd.AddCommand(generatePasswordCmd, checkPasswordCmd, encryptPostsCmd, decryptPostsCmd)
 	generatePasswordCmd.Flags().IntVar(&encryptionPasswordLength, "length", encryption.DefaultMinPasswordLength, "password length (must be at least the configured minimum)")
 	checkPasswordCmd.Flags().StringVar(&encryptionCheckKey, "key", "", "specific key name to check (default: all required keys)")
 	encryptPostsCmd.Flags().BoolVar(&encryptionDryRun, "dry-run", false, "report files that would be encrypted without modifying them")
+	decryptPostsCmd.Flags().BoolVar(&decryptionDryRun, "dry-run", false, "report files that would be decrypted without modifying them")
 	rootCmd.AddCommand(encryptionCmd)
 }
 
@@ -180,6 +199,177 @@ func runEncryptPostsCommand(cmd *cobra.Command, _ []string) error {
 		action, stats.Encrypted, stats.AlreadyEncrypted, stats.Public, stats.DraftOrSkip)
 
 	return nil
+}
+
+func runDecryptPostsCommand(cmd *cobra.Command, args []string) error {
+	cfg, err := config.Load(cfgFile)
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	files, err := decryptionTargetFiles(cfg, args)
+	if err != nil {
+		return err
+	}
+
+	stats := decryptPostsStats{}
+	candidates := make([]decryptPostResult, 0)
+	for _, file := range files {
+		result, err := decryptPostSourceFile(file, cfg, true)
+		if err != nil {
+			return err
+		}
+		stats.add(result)
+		if result.Action == decryptPostActionDecrypted {
+			candidates = append(candidates, result)
+			if decryptionDryRun {
+				fmt.Fprintf(cmd.OutOrStdout(), "WOULD DECRYPT %s key=%s\n", result.Path, result.KeyName)
+			}
+		}
+	}
+
+	if !decryptionDryRun {
+		for _, candidate := range candidates {
+			result, err := decryptPostSourceFile(candidate.Path, cfg, false)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "DECRYPTED %s key=%s\n", result.Path, result.KeyName)
+		}
+	}
+
+	action := "Decrypted"
+	if decryptionDryRun {
+		action = "Would decrypt"
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "%s %d post(s); skipped %d not encrypted.\n",
+		action, stats.Decrypted, stats.NotEncrypted)
+
+	return nil
+}
+
+// decryptionTargetFiles resolves explicit path arguments, falling back to the
+// active content glob configuration when no paths are supplied.
+func decryptionTargetFiles(cfg *models.Config, args []string) ([]string, error) {
+	if len(args) == 0 {
+		return encryptionContentFiles(cfg)
+	}
+
+	paths := make([]string, 0, len(args))
+	for _, arg := range args {
+		abs, err := filepath.Abs(arg)
+		if err != nil {
+			return nil, fmt.Errorf("resolve %s: %w", arg, err)
+		}
+		info, err := os.Stat(abs)
+		if err != nil {
+			return nil, fmt.Errorf("stat %s: %w", arg, err)
+		}
+		if !info.IsDir() {
+			paths = append(paths, abs)
+			continue
+		}
+		err = filepath.WalkDir(abs, func(path string, entry os.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if entry.IsDir() || !strings.EqualFold(filepath.Ext(path), ".md") {
+				return nil
+			}
+			paths = append(paths, path)
+			return nil
+		})
+		if err != nil {
+			return nil, fmt.Errorf("scan %s: %w", arg, err)
+		}
+	}
+	return paths, nil
+}
+
+type decryptPostAction string
+
+const (
+	decryptPostActionDecrypted    decryptPostAction = "decrypted"
+	decryptPostActionNotEncrypted decryptPostAction = "not-encrypted"
+)
+
+type decryptPostResult struct {
+	Path    string
+	KeyName string
+	Action  decryptPostAction
+}
+
+type decryptPostsStats struct {
+	Decrypted    int
+	NotEncrypted int
+}
+
+func (s *decryptPostsStats) add(result decryptPostResult) {
+	switch result.Action {
+	case decryptPostActionDecrypted:
+		s.Decrypted++
+	case decryptPostActionNotEncrypted:
+		s.NotEncrypted++
+	}
+}
+
+func decryptPostSourceFile(path string, cfg *models.Config, dryRun bool) (decryptPostResult, error) {
+	contentBytes, err := os.ReadFile(path)
+	if err != nil {
+		return decryptPostResult{}, fmt.Errorf("read %s: %w", path, err)
+	}
+	content := string(contentBytes)
+
+	_, body, rawFrontmatter, err := plugins.ParseFrontmatterWithRaw(content)
+	if err != nil {
+		return decryptPostResult{}, fmt.Errorf("parse frontmatter %s: %w", path, err)
+	}
+	if !encryption.IsSourceEncrypted(body) {
+		return decryptPostResult{Path: path, Action: decryptPostActionNotEncrypted}, nil
+	}
+
+	envelope, _, err := encryption.ParseSourceEnvelope(body)
+	if err != nil {
+		return decryptPostResult{}, fmt.Errorf("parse encrypted source %s: %w", path, err)
+	}
+
+	keyName := strings.TrimSpace(envelope.KeyName)
+	if keyName == "" {
+		keyName = strings.TrimSpace(cfg.Encryption.DefaultKey)
+	}
+	if keyName == "" {
+		return decryptPostResult{}, fmt.Errorf("encrypted post %s has no key name; set encryption.default_key", path)
+	}
+	envName := plugins.EncryptionEnvPrefix + strings.ToUpper(keyName)
+	password := os.Getenv(envName)
+	if password == "" {
+		return decryptPostResult{}, fmt.Errorf("encrypted post %s requires %s", path, envName)
+	}
+
+	plaintext, _, err := encryption.DecryptSourceMarkdown(body, password)
+	if err != nil {
+		return decryptPostResult{}, fmt.Errorf("decrypt source body for %s: %w", path, err)
+	}
+	if dryRun {
+		return decryptPostResult{Path: path, KeyName: keyName, Action: decryptPostActionDecrypted}, nil
+	}
+
+	nextContent := decryptedSourceDocument(rawFrontmatter, plaintext)
+	mode := os.FileMode(0o600)
+	if stat, err := os.Stat(path); err == nil {
+		mode = stat.Mode().Perm()
+	}
+	if err := os.WriteFile(path, []byte(nextContent), mode); err != nil {
+		return decryptPostResult{}, fmt.Errorf("write decrypted source %s: %w", path, err)
+	}
+	return decryptPostResult{Path: path, KeyName: keyName, Action: decryptPostActionDecrypted}, nil
+}
+
+func decryptedSourceDocument(rawFrontmatter, body string) string {
+	if rawFrontmatter == "" {
+		return body
+	}
+	return "---\n" + rawFrontmatter + "\n---\n" + body
 }
 
 func failOnEncryptionKeyPolicyFailures(results []encryptionKeyPolicyResult, minDuration time.Duration, minLength int) error {

--- a/cmd/markata-go/cmd/encryption_test.go
+++ b/cmd/markata-go/cmd/encryption_test.go
@@ -311,3 +311,143 @@ func TestFormatCrackDurationHuman(t *testing.T) {
 		})
 	}
 }
+
+func TestDecryptPostSourceFile_RoundTrip(t *testing.T) {
+	cfg := testEncryptPostsConfig()
+	t.Setenv("MARKATA_GO_ENCRYPTION_KEY_DEFAULT", "h7Qm!2Vx9#Lp4@Td")
+	original := `---
+title: Secret
+private: true
+---
+# Secret
+body
+`
+	path := writeMarkdownFile(t, original)
+
+	if _, err := encryptPostSourceFile(path, cfg, false); err != nil {
+		t.Fatalf("encryptPostSourceFile() error = %v", err)
+	}
+
+	result, err := decryptPostSourceFile(path, cfg, false)
+	if err != nil {
+		t.Fatalf("decryptPostSourceFile() error = %v", err)
+	}
+	if result.Action != decryptPostActionDecrypted {
+		t.Fatalf("action = %q, want %q", result.Action, decryptPostActionDecrypted)
+	}
+	if result.KeyName != "default" {
+		t.Fatalf("keyName = %q, want default", result.KeyName)
+	}
+	if got := readFileString(t, path); got != original {
+		t.Fatalf("round trip mismatch:\ngot  %q\nwant %q", got, original)
+	}
+}
+
+func TestDecryptPostSourceFile_SkipsPlaintext(t *testing.T) {
+	cfg := testEncryptPostsConfig()
+	original := `---
+title: Public
+---
+plain body
+`
+	path := writeMarkdownFile(t, original)
+
+	result, err := decryptPostSourceFile(path, cfg, false)
+	if err != nil {
+		t.Fatalf("decryptPostSourceFile() error = %v", err)
+	}
+	if result.Action != decryptPostActionNotEncrypted {
+		t.Fatalf("action = %q, want %q", result.Action, decryptPostActionNotEncrypted)
+	}
+	if got := readFileString(t, path); got != original {
+		t.Fatalf("plaintext file was modified: got %q", got)
+	}
+}
+
+func TestDecryptPostSourceFile_DryRunDoesNotWrite(t *testing.T) {
+	cfg := testEncryptPostsConfig()
+	t.Setenv("MARKATA_GO_ENCRYPTION_KEY_DEFAULT", "h7Qm!2Vx9#Lp4@Td")
+	path := writeMarkdownFile(t, `---
+title: Secret
+private: true
+---
+secret body
+`)
+	if _, err := encryptPostSourceFile(path, cfg, false); err != nil {
+		t.Fatalf("encryptPostSourceFile() error = %v", err)
+	}
+	encrypted := readFileString(t, path)
+
+	result, err := decryptPostSourceFile(path, cfg, true)
+	if err != nil {
+		t.Fatalf("decryptPostSourceFile() error = %v", err)
+	}
+	if result.Action != decryptPostActionDecrypted {
+		t.Fatalf("action = %q, want %q", result.Action, decryptPostActionDecrypted)
+	}
+	if got := readFileString(t, path); got != encrypted {
+		t.Fatalf("dry run modified file: got %q", got)
+	}
+}
+
+func TestDecryptPostSourceFile_MissingKeyEnvFails(t *testing.T) {
+	cfg := testEncryptPostsConfig()
+	t.Setenv("MARKATA_GO_ENCRYPTION_KEY_DEFAULT", "h7Qm!2Vx9#Lp4@Td")
+	path := writeMarkdownFile(t, `---
+title: Secret
+private: true
+---
+secret body
+`)
+	if _, err := encryptPostSourceFile(path, cfg, false); err != nil {
+		t.Fatalf("encryptPostSourceFile() error = %v", err)
+	}
+
+	t.Setenv("MARKATA_GO_ENCRYPTION_KEY_DEFAULT", "")
+	if _, err := decryptPostSourceFile(path, cfg, true); err == nil {
+		t.Fatal("expected error when key env var is unset")
+	}
+}
+
+func TestDecryptPostSourceFile_WrongPasswordFails(t *testing.T) {
+	cfg := testEncryptPostsConfig()
+	t.Setenv("MARKATA_GO_ENCRYPTION_KEY_DEFAULT", "h7Qm!2Vx9#Lp4@Td")
+	path := writeMarkdownFile(t, `---
+title: Secret
+private: true
+---
+secret body
+`)
+	if _, err := encryptPostSourceFile(path, cfg, false); err != nil {
+		t.Fatalf("encryptPostSourceFile() error = %v", err)
+	}
+
+	t.Setenv("MARKATA_GO_ENCRYPTION_KEY_DEFAULT", "wrong-password-value-1")
+	if _, err := decryptPostSourceFile(path, cfg, true); err == nil {
+		t.Fatal("expected error when password is wrong")
+	}
+}
+
+func TestDecryptionTargetFiles_ExplicitPathsAndDirs(t *testing.T) {
+	cfg := testEncryptPostsConfig()
+	dir := t.TempDir()
+	nested := filepath.Join(dir, "nested")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	mdFile := filepath.Join(nested, "a.md")
+	txtFile := filepath.Join(nested, "b.txt")
+	for _, p := range []string{mdFile, txtFile} {
+		if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+
+	files, err := decryptionTargetFiles(cfg, []string{dir})
+	if err != nil {
+		t.Fatalf("decryptionTargetFiles() error = %v", err)
+	}
+	if len(files) != 1 || files[0] != mdFile {
+		t.Fatalf("files = %v, want [%s]", files, mdFile)
+	}
+}

--- a/docs/guides/encryption.md
+++ b/docs/guides/encryption.md
@@ -175,6 +175,33 @@ private: true
 BASE64_AES_GCM_CIPHERTEXT
 ```
 
+### Decrypt Posts Back To Plaintext
+
+Use `decrypt-posts` when you need to edit a source-encrypted post. It is the inverse of `encrypt-posts`:
+
+```
+export MARKATA_GO_ENCRYPTION_KEY_DEFAULT='your-password'
+
+# preview every encrypted post that would be decrypted
+markata-go encryption decrypt-posts --dry-run
+
+# decrypt one file
+markata-go encryption decrypt-posts pages/my-secret-post.md
+
+# decrypt a whole directory tree
+markata-go encryption decrypt-posts pages/private/
+
+# decrypt everything matched by glob.patterns
+markata-go encryption decrypt-posts
+```
+
+The key name comes from the `key=` value in the encrypted marker, falling back to `encryption.default_key`. The
+password is read from `MARKATA_GO_ENCRYPTION_KEY_<KEY>` (uppercased). Files that are not source-encrypted are
+skipped, frontmatter is preserved exactly, and a missing env var or wrong password fails before anything is
+written.
+
+A typical edit cycle is `decrypt-posts <file>`, edit the Markdown, then `encrypt-posts` before committing.
+
 ## Lint Rule
 
 `markata-go lint` now includes an encryption policy check. When encryption is enabled, lint reports an error if configured keys are missing or fail strength thresholds.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2011,6 +2011,25 @@ markata-go encryption encrypt-posts [--dry-run]
 
 The command rewrites matching private posts in place by default. It skips draft, skipped, public, and already source-encrypted posts. Missing or weak keys fail before any files are written.
 
+##### decrypt-posts
+
+Decrypt source-encrypted Markdown bodies back to plaintext. This is the inverse of `encrypt-posts`.
+
+```
+markata-go encryption decrypt-posts [path...] [--dry-run]
+```
+
+| Flag | Short | Description | Default |
+|------|-------|-------------|---------|
+| `--dry-run` | | Report files that would be decrypted without modifying them | `false` |
+
+With no path arguments the command scans the active content glob configuration. Explicit paths may be files or
+directories (directories are scanned recursively for `.md` files).
+
+The key name is read from the `<!-- markata-encrypted-source:v1 key=... -->` marker, falling back to
+`encryption.default_key`. The password is read from `MARKATA_GO_ENCRYPTION_KEY_<KEY>`. Files that are not
+source-encrypted are skipped, and frontmatter is preserved exactly as written.
+
 #### Examples
 
 ```
@@ -2019,6 +2038,13 @@ markata-go encryption encrypt-posts --dry-run
 
 # Encrypt private post source bodies in place
 markata-go encryption encrypt-posts
+
+# Decrypt a single file so you can edit it
+export MARKATA_GO_ENCRYPTION_KEY_DEFAULT='your-password'
+markata-go encryption decrypt-posts pages/ar-calibration.md
+
+# Preview decrypting every encrypted post
+markata-go encryption decrypt-posts --dry-run
 ```
 
 ---

--- a/pkg/agentskill/bundle/markata-go-site/topics/cli-usage.md
+++ b/pkg/agentskill/bundle/markata-go-site/topics/cli-usage.md
@@ -66,6 +66,8 @@ Bare `markata-go config` behaves like `markata-go config show`.
 - `markata-go encryption check` (verify configured encryption keys)
 - `markata-go encryption encrypt-posts --dry-run` (preview source encryption for private posts)
 - `markata-go encryption encrypt-posts` (encrypt private Markdown bodies in place)
+- `markata-go encryption decrypt-posts --dry-run` (preview decrypting source-encrypted posts)
+- `markata-go encryption decrypt-posts [path...]` (decrypt source-encrypted Markdown bodies in place)
 
 ### Theme And Palette
 
@@ -157,6 +159,7 @@ markata-go encryption encrypt-posts --dry-run
 - create new content: `markata-go new`
 - lint content before committing: `markata-go lint`
 - source-encrypt private Markdown before committing: `markata-go encryption encrypt-posts --dry-run`, then `markata-go encryption encrypt-posts`
+- edit an already source-encrypted post: `markata-go encryption decrypt-posts <path>`, edit, then `markata-go encryption encrypt-posts`
 - validate config before deploy: `markata-go config validate`
 - validate palette contrast: `markata-go palette check <name>`
 - interactive local editing: `markata-go serve --fast`
@@ -176,6 +179,7 @@ markata-go encryption encrypt-posts --dry-run
 - use `-v` when debugging plugin order, missing outputs, or config resolution issues
 - use `--dry-run` on build or lint to preview behavior without side effects
 - use `encryption encrypt-posts --dry-run` before rewriting private source files; make sure required `MARKATA_GO_ENCRYPTION_KEY_*` environment variables are set first
+- use `encryption decrypt-posts --dry-run` before decrypting; it is the inverse of `encrypt-posts` and needs the same `MARKATA_GO_ENCRYPTION_KEY_*` variables
 
 ## Guidance
 

--- a/spec/spec/ENCRYPTION.md
+++ b/spec/spec/ENCRYPTION.md
@@ -253,6 +253,26 @@ markata-go encryption encrypt-posts --dry-run
 - Posts that are draft, skipped, public, or already source-encrypted are not rewritten.
 - Missing or weak keys cause the command to fail before writing changed files.
 
+### `encryption decrypt-posts`
+
+Decrypt source-encrypted Markdown bodies back to plaintext. This is the inverse of `encryption encrypt-posts`.
+
+```
+markata-go encryption decrypt-posts
+markata-go encryption decrypt-posts --dry-run
+markata-go encryption decrypt-posts path/to/post.md
+markata-go encryption decrypt-posts content/private/
+```
+
+- With no path arguments the command scans the active content glob configuration.
+- Explicit path arguments MAY be files or directories; directories are scanned recursively for `.md` files.
+- The command rewrites matching files in place by default, replacing the encrypted body with plaintext and preserving the original frontmatter block verbatim.
+- `--dry-run` reports which files would be decrypted without modifying the filesystem.
+- Files whose bodies are not source-encrypted are counted as skipped and never rewritten.
+- The key name is read from the encrypted source marker (`key=...`), falling back to `encryption.default_key`.
+- The password is read from `MARKATA_GO_ENCRYPTION_KEY_<KEY>`. A missing env var or an incorrect password MUST fail before any file is written.
+- Key strength policy is NOT enforced for decryption; only the correct password matters.
+
 ## Lint Integration
 
 The `markata-go lint` command MUST include an encryption policy rule when encryption is enabled:


### PR DESCRIPTION
Closes #1135

## Summary

`markata-go encryption encrypt-posts` rewrites private Markdown bodies in place with a `<!-- markata-encrypted-source:v1 key=... -->` envelope, but there was no inverse command. Once a file was source-encrypted there was no supported CLI path back to plaintext for editing.

## Changes

- new `markata-go encryption decrypt-posts [path...] [--dry-run]` subcommand
  - decrypts source-encrypted Markdown bodies in place, preserving the frontmatter block verbatim
  - optional path args may be files or directories (directories scanned recursively for `.md`); with no args it uses the active content glob
  - `--dry-run` previews without writing
  - files that are not source-encrypted are skipped and counted
  - key resolved from the envelope `key=` value, falling back to `encryption.default_key`; password read from `MARKATA_GO_ENCRYPTION_KEY_<KEY>`
  - fails before writing on missing env var or wrong password
  - key strength policy is intentionally not enforced on decrypt — only the correct password matters
- spec: `spec/spec/ENCRYPTION.md` `encryption decrypt-posts` section
- docs: `docs/reference/cli.md` and `docs/guides/encryption.md`
- bundled site skill: `topics/cli-usage.md` updated per the skill maintenance requirement

## Testing

- 6 new tests in `cmd/markata-go/cmd/encryption_test.go` covering round trip, plaintext skip, dry run, missing env var, wrong password, and explicit path/directory resolution
- manual end-to-end: encrypted a post matching the real-world format, then decrypted it back to a byte-identical original
- `go vet`, `just lint-new`, and `go test ./cmd/markata-go/... ./pkg/encryption/...` all pass