### PR TITLE
fix(lsp): restore verification hint text

### DIFF
--- a/cmd/markata-go/cmd/lsp.go
+++ b/cmd/markata-go/cmd/lsp.go
@@ -164,7 +164,7 @@ func lspDoctorLine(theme logging.Theme, status, message string) {
 }
 
 func lspDoctorVerificationHint(theme logging.Theme) {
-	errln(colorize(text, theme.Warning, colorEnabledFor(errorOutputIsTerminal())))
+	errln(colorize("Editor verification was skipped. Run the default doctor command to verify detected editors:", theme.Warning, colorEnabledFor(errorOutputIsTerminal())))
 	errln("  markata-go lsp doctor")
 	errln("  This may load editor startup and plugin code.")
 }


### PR DESCRIPTION
Fixes #1126\n\nRestores the doctor hint string after the LSP PR rebase dropped it.\n\nValidation: go test ./..., go vet ./..., just lint-fast.