### PR TITLE
feat(builder-admin): add signed GitHub/Forgejo webhooks

### DIFF
--- a/cmd/markata-go/cmd/builder_admin.go
+++ b/cmd/markata-go/cmd/builder_admin.go
@@ -151,7 +151,6 @@ func resolveBuilderAdminWebhook(cmd *cobra.Command, configPath string) (buildera
 	webhook := builderadmin.WebhookConfig{
 		Branch: "main",
 	}
-	applyBuilderAdminExtraWebhook(&webhook, siteConfig.Extra)
 	if configured.Enabled != nil {
 		webhook.Enabled = *configured.Enabled
 	}
@@ -179,26 +178,6 @@ func resolveBuilderAdminWebhook(cmd *cobra.Command, configPath string) (buildera
 	return webhook, nil
 }
 
-func applyBuilderAdminExtraWebhook(webhook *builderadmin.WebhookConfig, extra map[string]any) {
-	builderAdmin, ok := stringMap(extra["builder_admin"])
-	if !ok {
-		return
-	}
-	configured, ok := stringMap(builderAdmin["webhook"])
-	if !ok {
-		return
-	}
-	if enabled, ok := configured["enabled"].(bool); ok {
-		webhook.Enabled = enabled
-	}
-	if branch, ok := configured["branch"].(string); ok {
-		webhook.Branch = branch
-	}
-	if secret, ok := configured["secret"].(string); ok {
-		webhook.Secret = secret
-	}
-}
-
 func resolveBuilderAdminConfigPath(configPath, sourceDir string) string {
 	if configPath != "" {
 		if filepath.IsAbs(configPath) {
@@ -223,7 +202,6 @@ func resolveBuilderAdminAuthHeaders(cmd *cobra.Command, configPath string) (buil
 		return builderadmin.AuthHeaders{}, fmt.Errorf("load builder-admin configuration: %w", err)
 	}
 	headers := builderadmin.DefaultAuthHeaders()
-	applyBuilderAdminExtraHeaders(&headers, siteConfig.Extra)
 	applyBuilderAdminConfigHeaders(&headers, siteConfig.BuilderAdmin.Auth.Headers)
 	for _, flag := range []struct {
 		name   string
@@ -243,42 +221,6 @@ func resolveBuilderAdminAuthHeaders(cmd *cobra.Command, configPath string) (buil
 		}
 	}
 	return headers, nil
-}
-
-func applyBuilderAdminExtraHeaders(headers *builderadmin.AuthHeaders, extra map[string]any) {
-	builderAdmin, ok := stringMap(extra["builder_admin"])
-	if !ok {
-		return
-	}
-	auth, ok := stringMap(builderAdmin["auth"])
-	if !ok {
-		return
-	}
-	configured, ok := stringMap(auth["headers"])
-	if !ok {
-		return
-	}
-	for _, field := range []struct {
-		key    string
-		target *string
-	}{
-		{"user_id", &headers.UserID},
-		{"username", &headers.Username},
-		{"display_name", &headers.DisplayName},
-		{"email", &headers.Email},
-		{"groups", &headers.Groups},
-		{"roles", &headers.Roles},
-		{"scopes", &headers.Scopes},
-	} {
-		if value, ok := configured[field.key].(string); ok {
-			*field.target = value
-		}
-	}
-}
-
-func stringMap(value any) (map[string]any, bool) {
-	result, ok := value.(map[string]any)
-	return result, ok
 }
 
 func applyBuilderAdminConfigHeaders(headers *builderadmin.AuthHeaders, configured models.BuilderAdminAuthHeadersConfig) {

--- a/cmd/markata-go/cmd/builder_admin.go
+++ b/cmd/markata-go/cmd/builder_admin.go
@@ -44,6 +44,9 @@ var (
 	builderAdminPublicAuthOrigin      string
 	builderAdminPublicOrigin          string
 	builderAdminPreviewOrigin         string
+	builderAdminWebhookEnabled        bool
+	builderAdminWebhookBranch         string
+	builderAdminWebhookSecret         string
 )
 
 var builderAdminCmd = &cobra.Command{
@@ -85,6 +88,9 @@ func init() {
 	builderAdminCmd.Flags().StringVar(&builderAdminPublicAuthOrigin, "public-auth-origin", "", "optional HTTPS hlab-auth origin used for the signed-in operator profile picture")
 	builderAdminCmd.Flags().StringVar(&builderAdminPublicOrigin, "public-origin", "", "exact HTTPS public origin used to validate browser mutations")
 	builderAdminCmd.Flags().StringVar(&builderAdminPreviewOrigin, "preview-origin", "", "HTTPS site origin used for retained release previews")
+	builderAdminCmd.Flags().BoolVar(&builderAdminWebhookEnabled, "webhook-enabled", false, "enable signed GitHub and Forgejo push webhooks")
+	builderAdminCmd.Flags().StringVar(&builderAdminWebhookBranch, "webhook-branch", "main", "Git branch accepted by the webhook")
+	builderAdminCmd.Flags().StringVar(&builderAdminWebhookSecret, "webhook-secret", "", "HMAC-SHA256 secret for GitHub and Forgejo webhooks")
 }
 
 func runBuilderAdmin(cmd *cobra.Command, _ []string) error {
@@ -94,6 +100,10 @@ func runBuilderAdmin(cmd *cobra.Command, _ []string) error {
 	}
 	configPath := resolveBuilderAdminConfigPath(cfgFile, builderAdminSourceDir)
 	authHeaders, err := resolveBuilderAdminAuthHeaders(cmd, configPath)
+	if err != nil {
+		return err
+	}
+	webhook, err := resolveBuilderAdminWebhook(cmd, configPath)
 	if err != nil {
 		return err
 	}
@@ -120,6 +130,7 @@ func runBuilderAdmin(cmd *cobra.Command, _ []string) error {
 		PublicAuthOrigin:     builderAdminPublicAuthOrigin,
 		PublicOrigin:         builderAdminPublicOrigin,
 		PreviewOrigin:        builderAdminPreviewOrigin,
+		Webhook:              webhook,
 	})
 	if err != nil {
 		return err
@@ -127,6 +138,65 @@ func runBuilderAdmin(cmd *cobra.Command, _ []string) error {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 	return svc.Start(ctx)
+}
+
+// resolveBuilderAdminWebhook applies site configuration and MARKATA_GO_ overrides,
+// then applies explicitly supplied CLI flags as the highest-precedence source.
+func resolveBuilderAdminWebhook(cmd *cobra.Command, configPath string) (builderadmin.WebhookConfig, error) {
+	siteConfig, err := config.Load(configPath)
+	if err != nil {
+		return builderadmin.WebhookConfig{}, fmt.Errorf("load builder-admin configuration: %w", err)
+	}
+	configured := siteConfig.BuilderAdmin.Webhook
+	webhook := builderadmin.WebhookConfig{
+		Branch: "main",
+	}
+	applyBuilderAdminExtraWebhook(&webhook, siteConfig.Extra)
+	if configured.Enabled != nil {
+		webhook.Enabled = *configured.Enabled
+	}
+	if configured.Branch != nil {
+		webhook.Branch = *configured.Branch
+	}
+	if configured.Secret != nil {
+		webhook.Secret = *configured.Secret
+	}
+	if webhook.Branch == "" {
+		webhook.Branch = "main"
+	}
+	for _, flag := range []struct {
+		name string
+		set  func()
+	}{
+		{"webhook-enabled", func() { webhook.Enabled = builderAdminWebhookEnabled }},
+		{"webhook-branch", func() { webhook.Branch = builderAdminWebhookBranch }},
+		{"webhook-secret", func() { webhook.Secret = builderAdminWebhookSecret }},
+	} {
+		if cmd.Flags().Changed(flag.name) {
+			flag.set()
+		}
+	}
+	return webhook, nil
+}
+
+func applyBuilderAdminExtraWebhook(webhook *builderadmin.WebhookConfig, extra map[string]any) {
+	builderAdmin, ok := stringMap(extra["builder_admin"])
+	if !ok {
+		return
+	}
+	configured, ok := stringMap(builderAdmin["webhook"])
+	if !ok {
+		return
+	}
+	if enabled, ok := configured["enabled"].(bool); ok {
+		webhook.Enabled = enabled
+	}
+	if branch, ok := configured["branch"].(string); ok {
+		webhook.Branch = branch
+	}
+	if secret, ok := configured["secret"].(string); ok {
+		webhook.Secret = secret
+	}
 }
 
 func resolveBuilderAdminConfigPath(configPath, sourceDir string) string {

--- a/cmd/markata-go/cmd/builder_admin_test.go
+++ b/cmd/markata-go/cmd/builder_admin_test.go
@@ -46,23 +46,6 @@ display_name = ""
 	}
 }
 
-func TestApplyBuilderAdminExtraHeaders(t *testing.T) {
-	headers := builderadmin.DefaultAuthHeaders()
-	applyBuilderAdminExtraHeaders(&headers, map[string]any{
-		"builder_admin": map[string]any{
-			"auth": map[string]any{
-				"headers": map[string]any{
-					"user_id":      "X-Authentik-Uid",
-					"display_name": "",
-				},
-			},
-		},
-	})
-	if headers.UserID != "X-Authentik-Uid" || headers.DisplayName != "" {
-		t.Fatalf("headers = %#v", headers)
-	}
-}
-
 func TestResolveBuilderAdminConfigPath(t *testing.T) {
 	sourceDir := t.TempDir()
 	configPath := filepath.Join(sourceDir, "markata-go.toml")
@@ -114,5 +97,35 @@ secret = "file-secret"
 	}
 	if !webhook.Enabled || webhook.Branch != "qa" || webhook.Secret != "environment-secret" {
 		t.Fatalf("webhook = %#v", webhook)
+	}
+}
+
+func TestResolveBuilderAdminWebhook_ExplicitCLIOverridesEnvironment(t *testing.T) {
+	t.Setenv("MARKATA_GO_BUILDER_ADMIN_WEBHOOK_BRANCH", "environment")
+	configPath := filepath.Join(t.TempDir(), "markata-go.toml")
+	if err := os.WriteFile(configPath, []byte(`
+[markata-go.builder_admin.webhook]
+branch = "file"
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	flag := builderAdminCmd.Flags().Lookup("webhook-branch")
+	previousValue, previousChanged := flag.Value.String(), flag.Changed
+	if err := flag.Value.Set("cli"); err != nil {
+		t.Fatal(err)
+	}
+	flag.Changed = true
+	t.Cleanup(func() {
+		_ = flag.Value.Set(previousValue)
+		flag.Changed = previousChanged
+	})
+
+	webhook, err := resolveBuilderAdminWebhook(builderAdminCmd, configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if webhook.Branch != "cli" {
+		t.Fatalf("Branch = %q, want explicit CLI value", webhook.Branch)
 	}
 }

--- a/cmd/markata-go/cmd/builder_admin_test.go
+++ b/cmd/markata-go/cmd/builder_admin_test.go
@@ -76,3 +76,43 @@ func TestResolveBuilderAdminConfigPath(t *testing.T) {
 		t.Fatalf("relative config path = %q", got)
 	}
 }
+
+func TestResolveBuilderAdminWebhook_ConfigFile(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "markata-go.toml")
+	if err := os.WriteFile(configPath, []byte(`
+[markata-go.builder_admin.webhook]
+enabled = true
+branch = "dev"
+secret = "test-secret"
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	webhook, err := resolveBuilderAdminWebhook(builderAdminCmd, configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !webhook.Enabled || webhook.Branch != "dev" || webhook.Secret != "test-secret" {
+		t.Fatalf("webhook = %#v", webhook)
+	}
+}
+
+func TestResolveBuilderAdminWebhook_EnvironmentOverridesConfigFile(t *testing.T) {
+	t.Setenv("MARKATA_GO_BUILDER_ADMIN_WEBHOOK_BRANCH", "qa")
+	t.Setenv("MARKATA_GO_BUILDER_ADMIN_WEBHOOK_SECRET", "environment-secret")
+	configPath := filepath.Join(t.TempDir(), "markata-go.toml")
+	if err := os.WriteFile(configPath, []byte(`
+[markata-go.builder_admin.webhook]
+enabled = true
+branch = "dev"
+secret = "file-secret"
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	webhook, err := resolveBuilderAdminWebhook(builderAdminCmd, configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !webhook.Enabled || webhook.Branch != "qa" || webhook.Secret != "environment-secret" {
+		t.Fatalf("webhook = %#v", webhook)
+	}
+}

--- a/cmd/markata-go/cmd/builder_admin_test.go
+++ b/cmd/markata-go/cmd/builder_admin_test.go
@@ -117,7 +117,9 @@ branch = "file"
 	}
 	flag.Changed = true
 	t.Cleanup(func() {
-		_ = flag.Value.Set(previousValue)
+		if err := flag.Value.Set(previousValue); err != nil {
+			t.Errorf("restore flag %s: %v", flag.Name, err)
+		}
 		flag.Changed = previousChanged
 	})
 

--- a/cmd/markata-go/cmd/config.go
+++ b/cmd/markata-go/cmd/config.go
@@ -211,7 +211,7 @@ func runConfigShowCommand(cmd *cobra.Command, _ []string) error {
 		outln(string(data))
 
 	case formatTOML:
-		if err := toml.NewEncoder(outWriter()).Encode(cfg); err != nil {
+		if err := toml.NewEncoder(outWriter()).Encode(displayMap); err != nil {
 			return fmt.Errorf("failed to marshal TOML: %w", err)
 		}
 
@@ -284,6 +284,7 @@ func runConfigShowWithSources(merged *models.Config, configPaths []string) error
 	if err != nil {
 		return err
 	}
+	redactBuilderAdminWebhookSecret(userMap)
 
 	if configShowDiff {
 		// Show only values that differ from defaults
@@ -292,6 +293,24 @@ func runConfigShowWithSources(merged *models.Config, configPaths []string) error
 
 	// Show annotated config
 	return showAnnotatedConfig(mergedMap, userMap, configPaths)
+}
+
+// redactBuilderAdminWebhookSecret removes the credential from raw user config
+// before config show --diff or --annotate writes it to the terminal.
+func redactBuilderAdminWebhookSecret(config map[string]interface{}) {
+	markata, ok := config["markata-go"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	builderAdmin, ok := markata["builder_admin"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	webhook, ok := builderAdmin["webhook"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	delete(webhook, "secret")
 }
 
 // configToMap converts a Config struct to a map[string]interface{}.

--- a/docs/guides/deployment/builder-admin.md
+++ b/docs/guides/deployment/builder-admin.md
@@ -302,6 +302,8 @@ than push, and pushes to another branch are ignored or rejected without running 
 For an accepted matching push, builder admin runs `git -C <source-dir> pull --ff-only`. It queues
 a build only when that changes the checkout. Ensure the deployed source directory is a clean clone
 with an authenticated `origin` remote and that its checked-out branch tracks the configured branch.
+The normal source watcher remains active during the pull so a local author edit is never ignored.
+That safety measure can produce a follow-up file-watch build after a push.
 
 ### Helm setup
 

--- a/docs/guides/deployment/builder-admin.md
+++ b/docs/guides/deployment/builder-admin.md
@@ -22,6 +22,7 @@ Instead of starting a new Kubernetes Job for every authoring build, it keeps one
 - release history and current live release
 - rollback by promoting an older rendered release
 - scheduled refresh tasks for reader, blogroll, or other remote-content commands
+- signed GitHub and Forgejo push webhooks that pull and build matching branches
 
 ## What It Is Good For
 
@@ -270,6 +271,61 @@ Builder admin can enqueue builds from:
 - HTTP API calls
 - debounced file-watch events
 - successful refresh task runs when configured to enqueue a build
+- GitHub or Forgejo push webhooks
+
+## Build on Git Push
+
+Enable one builder-admin service for each environment. Each service owns one checked-out branch,
+source directory, site directory, and webhook secret. The branch defaults to `main`.
+
+```toml
+# markata-go.toml
+[markata-go.builder_admin.webhook]
+enabled = true
+branch = "main"
+```
+
+Set the HMAC secret outside version control. Environment variables override the config file, and
+explicit flags override both:
+
+```bash
+export MARKATA_GO_BUILDER_ADMIN_WEBHOOK_SECRET='replace-with-a-random-secret'
+markata-go builder-admin --webhook-enabled --webhook-branch main
+```
+
+The endpoint is `https://<builder-admin-host>/webhook`. In GitHub, create a repository webhook
+with that payload URL, set the same secret, select JSON payloads, and subscribe to **Push** events.
+Forgejo uses the same URL and secret; select its push event. Builder admin accepts GitHub's
+`X-Hub-Signature-256` and Forgejo's `X-Gitea-Signature` headers. Invalid signatures, events other
+than push, and pushes to another branch are ignored or rejected without running a build.
+
+For an accepted matching push, builder admin runs `git -C <source-dir> pull --ff-only`. It queues
+a build only when that changes the checkout. Ensure the deployed source directory is a clean clone
+with an authenticated `origin` remote and that its checked-out branch tracks the configured branch.
+
+### Helm setup
+
+The chart exposes `/webhook` without the operator ForwardAuth middleware; HMAC validation protects
+that endpoint. Create a Kubernetes Secret, then reference it in the environment's Helm values:
+
+```yaml
+builderAdmin:
+  webhook:
+    enabled: true
+    branch: main
+    existingSecretName: builder-webhook
+    existingSecretKey: webhook-secret
+```
+
+Create separate releases for `main`, `dev`, and `qa` when they publish different domains. Give each
+release a distinct source checkout, site storage, builder-admin ingress host, and webhook secret.
+Point each repository webhook at its matching builder-admin host. Do not share a production webhook
+secret with preview environments.
+
+If GitHub or Forgejo reports a successful delivery but no build appears, verify the delivery branch,
+the service's configured branch, the HMAC secret, and that `git -C <source-dir> pull --ff-only`
+succeeds in the builder container. A delivery for an unchanged commit intentionally does not queue
+a build.
 
 ## Rollback
 

--- a/helm-chart/templates/builder-admin-ingress.yaml
+++ b/helm-chart/templates/builder-admin-ingress.yaml
@@ -1,4 +1,30 @@
 {{- if .Values.builderAdmin.enabled }}
+{{- if .Values.builderAdmin.webhook.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: "{{ .Values.project_identifier }}-notes-builder-admin-webhook"
+  namespace: "{{ include "markata-notes.namespace" . }}"
+spec:
+  ingressClassName: {{ required "builderAdmin.ingress.ingressClassName is required when builder-admin ingress is enabled" .Values.builderAdmin.ingress.ingressClassName | quote }}
+  tls:
+    - secretName: {{ .Values.builderAdmin.ingress.tls.secretName | quote }}
+      hosts:
+        - {{ required "builderAdmin.ingress.host is required when builder-admin ingress is enabled" .Values.builderAdmin.ingress.host | quote }}
+  rules:
+    - host: {{ required "builderAdmin.ingress.host is required when builder-admin ingress is enabled" .Values.builderAdmin.ingress.host | quote }}
+      http:
+        paths:
+          # Webhook authentication is HMAC-SHA256 at the application layer.
+          - path: /webhook
+            pathType: Exact
+            backend:
+              service:
+                name: "{{ .Values.project_identifier }}-notes-builder-admin"
+                port:
+                  number: {{ .Values.builderAdmin.port }}
+---
+{{- end }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/helm-chart/templates/builder-admin.yaml
+++ b/helm-chart/templates/builder-admin.yaml
@@ -8,6 +8,7 @@
 {{- include "markata-notes.validateBuilderAdminAuthInternalURL" . }}
 {{- $_ := required "builderAdmin.auth.trustedProxyCIDRs must be non-empty when builder-admin is enabled" (first .Values.builderAdmin.auth.trustedProxyCIDRs) }}
 {{- $_ := required "builderAdmin.auth.headers.userID is required when builder-admin is enabled" .Values.builderAdmin.auth.headers.userID }}
+{{- if .Values.builderAdmin.webhook.enabled }}{{- $_ := required "builderAdmin.webhook.existingSecretName is required when builderAdmin.webhook.enabled" .Values.builderAdmin.webhook.existingSecretName }}{{- $_ := required "builderAdmin.webhook.existingSecretKey is required when builderAdmin.webhook.enabled" .Values.builderAdmin.webhook.existingSecretKey }}{{- end }}
 {{- range .Values.builderAdmin.auth.trustedProxyCIDRs }}
 {{- $trustedCIDR := trim . }}
 {{- if or (eq $trustedCIDR "0.0.0.0/0") (eq $trustedCIDR "::/0") }}{{ fail "builderAdmin.auth.trustedProxyCIDRs must not include a universal CIDR" }}{{ end }}
@@ -101,6 +102,9 @@ spec:
             - --watch={{ ternary "true" "false" .Values.builderAdmin.watch.enabled }}
             - --watch-debounce
             - {{ .Values.builderAdmin.watch.debounce | quote }}
+            - --webhook-enabled={{ ternary "true" "false" .Values.builderAdmin.webhook.enabled }}
+            - --webhook-branch
+            - {{ .Values.builderAdmin.webhook.branch | quote }}
             - --releases-keep
             - {{ .Values.builderAdmin.releases.keep | quote }}
             - --successful-builds-keep
@@ -182,6 +186,13 @@ spec:
               value: {{ .Values.offline.bundledMermaidDir | quote }}
             - name: XDG_CACHE_HOME
               value: {{ .Values.build.cacheDir | quote }}
+            {{- if .Values.builderAdmin.webhook.enabled }}
+            - name: MARKATA_GO_BUILDER_ADMIN_WEBHOOK_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.builderAdmin.webhook.existingSecretName | quote }}
+                  key: {{ .Values.builderAdmin.webhook.existingSecretKey | quote }}
+            {{- end }}
             {{- with .Values.build.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -101,6 +101,13 @@ builderAdmin:
     refreshRuns: 100
   buildTimeoutSeconds: 7200
   historyDir: /data/site/.builder-admin
+  webhook:
+    enabled: false
+    branch: main
+    # Required when webhook.enabled. The secret is injected as
+    # MARKATA_GO_BUILDER_ADMIN_WEBHOOK_SECRET and is never placed in args.
+    existingSecretName: ""
+    existingSecretKey: webhook-secret
   # Builder admin is fail-closed: only source addresses in this list may supply
   # the identity headers injected by the protected Traefik route.
   auth:

--- a/pkg/agentskill/bundle/markata-go-site/topics/build-deployment.md
+++ b/pkg/agentskill/bundle/markata-go-site/topics/build-deployment.md
@@ -131,3 +131,12 @@ Good preview strategy:
 - output path settings in config
 - asset or CDN self-hosting settings when debugging missing static files
 - any `static/CNAME`, `static/_headers`, or `static/_redirects` files
+# Git Push Rebuilds
+
+For deployments using builder-admin, GitHub and Forgejo push webhooks can pull and rebuild a
+single configured branch. Read the site's `[markata-go.builder_admin.webhook]` configuration before
+changing deployment behavior. Each production, development, QA, or preview environment should use
+an independent builder-admin deployment, source checkout, release root, ingress host, and webhook
+secret. The webhook endpoint is `/webhook`; configure its secret through
+`MARKATA_GO_BUILDER_ADMIN_WEBHOOK_SECRET` or a Kubernetes Secret, never commit it to the site
+repository. See the Builder Admin deployment guide for Git-provider and Helm setup.

--- a/pkg/builderadmin/service.go
+++ b/pkg/builderadmin/service.go
@@ -194,7 +194,6 @@ type Service struct {
 	watchMu              sync.Mutex
 	watchChanged         map[string]struct{}
 	watchTimer           *time.Timer
-	watchSuppressUntil   time.Time
 	stateMu              sync.Mutex
 	state                State
 	leaderMu             sync.RWMutex
@@ -648,23 +647,6 @@ func gitHead(sourceDir string) (string, error) {
 	return strings.TrimSpace(string(output)), nil
 }
 
-func (s *Service) beginSourceSync() {
-	s.watchMu.Lock()
-	defer s.watchMu.Unlock()
-	s.watchSuppressUntil = time.Now().Add(s.cfg.BuildTimeout)
-	clear(s.watchChanged)
-	if s.watchTimer != nil {
-		s.watchTimer.Stop()
-		s.watchTimer = nil
-	}
-}
-
-func (s *Service) endSourceSync() {
-	s.watchMu.Lock()
-	defer s.watchMu.Unlock()
-	s.watchSuppressUntil = time.Now().Add(2 * s.cfg.WatchDebounce)
-}
-
 func (s *Service) handleHealth(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	state := s.viewState()
@@ -924,11 +906,9 @@ func (s *Service) process(ctx context.Context, req queueRequest) {
 	case "build":
 		if req.SyncSource {
 			s.updateRunningPhase("sync source")
-			s.beginSourceSync()
 			syncCtx, cancel := context.WithTimeout(ctx, s.cfg.BuildTimeout)
 			changed, err := s.pullSource(syncCtx)
 			cancel()
-			s.endSourceSync()
 			if err != nil {
 				s.finishWebhookSyncFailure(req, err)
 				return
@@ -1442,9 +1422,6 @@ func (s *Service) watchSource(ctx context.Context) {
 			if event.Op&fsnotify.Create != 0 {
 				_ = addDirRecursiveIfDir(watcher, event.Name)
 			}
-			if s.watchEventsSuppressed() {
-				continue
-			}
 			if event.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Remove|fsnotify.Rename) == 0 {
 				continue
 			}
@@ -1476,12 +1453,6 @@ func (s *Service) recordWatchPath(path string) {
 	s.watchTimer = time.AfterFunc(s.cfg.WatchDebounce, func() {
 		s.flushWatchBuild()
 	})
-}
-
-func (s *Service) watchEventsSuppressed() bool {
-	s.watchMu.Lock()
-	defer s.watchMu.Unlock()
-	return time.Now().Before(s.watchSuppressUntil)
 }
 
 func (s *Service) flushWatchBuild() {

--- a/pkg/builderadmin/service.go
+++ b/pkg/builderadmin/service.go
@@ -39,6 +39,8 @@ const (
 	maxWebhookBodyBytes = 1 << 20
 )
 
+var ErrBuildQueueFull = errors.New("build queue is full")
+
 type Config struct {
 	Host                 string
 	Port                 int
@@ -341,6 +343,7 @@ func (s *Service) Start(ctx context.Context) error {
 		Addr:              fmt.Sprintf("%s:%d", s.cfg.Host, s.cfg.Port),
 		Handler:           mux,
 		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       15 * time.Second,
 	}
 	go s.runLeadershipLoop(ctx)
 	go func() {
@@ -560,6 +563,11 @@ func (s *Service) handleWebhook(w http.ResponseWriter, r *http.Request) {
 		detail += " (delivery " + deliveryID + ")"
 	}
 	if err := s.enqueueWebhookBuild(detail); err != nil {
+		if errors.Is(err, ErrBuildQueueFull) {
+			w.Header().Set("Retry-After", "30")
+			http.Error(w, err.Error(), http.StatusServiceUnavailable)
+			return
+		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -948,8 +956,14 @@ func (s *Service) enqueueBuild(triggerType, detail string, changed []string) err
 		EnqueuedAt:  time.Now().UTC(),
 	}
 	s.pushQueued(queued)
-	s.queueCh <- queueRequest{QueuedOperation: queued}
-	return nil
+	request := queueRequest{QueuedOperation: queued}
+	select {
+	case s.queueCh <- request:
+		return nil
+	default:
+		s.removeQueued(queued.ID)
+		return ErrBuildQueueFull
+	}
 }
 
 func (s *Service) enqueueWebhookBuild(detail string) error {
@@ -963,8 +977,14 @@ func (s *Service) enqueueWebhookBuild(detail string) error {
 		SyncSource:  true,
 	}
 	s.pushQueued(queued)
-	s.queueCh <- queueRequest{QueuedOperation: queued}
-	return nil
+	request := queueRequest{QueuedOperation: queued}
+	select {
+	case s.queueCh <- request:
+		return nil
+	default:
+		s.removeQueued(queued.ID)
+		return ErrBuildQueueFull
+	}
 }
 
 func (s *Service) finishWebhookSyncFailure(req queueRequest, err error) {

--- a/pkg/builderadmin/service.go
+++ b/pkg/builderadmin/service.go
@@ -2,7 +2,10 @@ package builderadmin
 
 import (
 	"bufio"
+	"bytes"
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -33,6 +36,7 @@ const (
 	defaultListenHost   = "127.0.0.1"
 	defaultListenPort   = 8080
 	defaultReleaseKeep  = 25
+	maxWebhookBodyBytes = 1 << 20
 )
 
 type Config struct {
@@ -58,6 +62,15 @@ type Config struct {
 	PublicAuthOrigin     string
 	PublicOrigin         string
 	PreviewOrigin        string
+	Webhook              WebhookConfig
+}
+
+// WebhookConfig configures a signed GitHub or Forgejo push webhook.
+// Secret is deliberately excluded from JSON responses served by the admin API.
+type WebhookConfig struct {
+	Enabled bool   `json:"enabled"`
+	Branch  string `json:"branch"`
+	Secret  string `json:"-"`
 }
 
 type RefreshTaskConfig struct {
@@ -86,6 +99,7 @@ type QueuedOperation struct {
 	EnqueuedAt  time.Time `json:"enqueued_at"`
 	ReleaseID   string    `json:"release_id,omitempty"`
 	TaskName    string    `json:"task_name,omitempty"`
+	SyncSource  bool      `json:"sync_source,omitempty"`
 }
 
 type RunningOperation struct {
@@ -178,6 +192,7 @@ type Service struct {
 	watchMu              sync.Mutex
 	watchChanged         map[string]struct{}
 	watchTimer           *time.Timer
+	watchSuppressUntil   time.Time
 	stateMu              sync.Mutex
 	state                State
 	leaderMu             sync.RWMutex
@@ -255,6 +270,12 @@ func New(cfg Config) (*Service, error) {
 	}
 	if cfg.BuildTimeout <= 0 {
 		cfg.BuildTimeout = 2 * time.Hour
+	}
+	if cfg.Webhook.Enabled && strings.TrimSpace(cfg.Webhook.Secret) == "" {
+		return nil, fmt.Errorf("webhook secret is required when webhooks are enabled")
+	}
+	if cfg.Webhook.Branch == "" {
+		cfg.Webhook.Branch = "main"
 	}
 	for i := range cfg.RefreshTasks {
 		if cfg.RefreshTasks[i].Name == "" {
@@ -368,8 +389,8 @@ func (s *Service) tryBecomeLeader(ctx context.Context) {
 	s.leader = true
 	s.leaderCancel = cancel
 	s.leaderMu.Unlock()
-	s.resumeLeaderSession()
 	go s.worker(leaderCtx)
+	s.resumeLeaderSession()
 	for i := range s.cfg.RefreshTasks {
 		go s.runRefreshScheduler(leaderCtx, s.cfg.RefreshTasks[i])
 	}
@@ -470,6 +491,7 @@ func (s *Service) queueRequestFromQueued(queued QueuedOperation) (queueRequest, 
 
 func (s *Service) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/health", s.handleHealth)
+	mux.HandleFunc("/webhook", s.handleWebhook)
 	protected := http.NewServeMux()
 	protected.HandleFunc("/builds/", s.handleBuildDetail)
 	protected.HandleFunc("/", s.handleIndex)
@@ -479,6 +501,160 @@ func (s *Service) registerRoutes(mux *http.ServeMux) {
 	protected.HandleFunc("/api/releases/", s.handleReleaseAction)
 	protected.HandleFunc("/logs/", s.handleLogs)
 	mux.Handle("/", s.requireTrustedOperator(protected))
+}
+
+type pushWebhookPayload struct {
+	Ref        string `json:"ref"`
+	After      string `json:"after"`
+	Repository struct {
+		FullName string `json:"full_name"`
+	} `json:"repository"`
+}
+
+func (s *Service) handleWebhook(w http.ResponseWriter, r *http.Request) {
+	if !s.cfg.Webhook.Enabled {
+		http.NotFound(w, r)
+		return
+	}
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxWebhookBodyBytes))
+	if err != nil {
+		http.Error(w, "invalid webhook body", http.StatusRequestEntityTooLarge)
+		return
+	}
+	if !validWebhookSignature(r, body, s.cfg.Webhook.Secret) {
+		http.Error(w, "invalid webhook signature", http.StatusUnauthorized)
+		return
+	}
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	if s.handleStandbyMutation(w, r) {
+		return
+	}
+	if webhookEvent(r) != "push" {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	var payload pushWebhookPayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		http.Error(w, "invalid push webhook payload", http.StatusBadRequest)
+		return
+	}
+	branch := strings.TrimPrefix(payload.Ref, "refs/heads/")
+	if branch != s.cfg.Webhook.Branch {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	deliveryID := r.Header.Get("X-GitHub-Delivery")
+	if deliveryID == "" {
+		deliveryID = r.Header.Get("X-Gitea-Delivery")
+	}
+	detail := fmt.Sprintf("%s push %s on %s", webhookProvider(r), payload.After, branch)
+	if payload.Repository.FullName != "" {
+		detail += " from " + payload.Repository.FullName
+	}
+	if deliveryID != "" {
+		detail += " (delivery " + deliveryID + ")"
+	}
+	if err := s.enqueueWebhookBuild(detail); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusAccepted)
+}
+
+func validWebhookSignature(r *http.Request, body []byte, secret string) bool {
+	signature := r.Header.Get("X-Hub-Signature-256")
+	if signature == "" {
+		signature = r.Header.Get("X-Gitea-Signature")
+	}
+	signature = strings.TrimPrefix(signature, "sha256=")
+	if signature == "" {
+		return false
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write(body)
+	expected := fmt.Sprintf("%x", mac.Sum(nil))
+	return hmac.Equal([]byte(signature), []byte(expected))
+}
+
+func webhookEvent(r *http.Request) string {
+	event := r.Header.Get("X-GitHub-Event")
+	if event == "" {
+		event = r.Header.Get("X-Gitea-Event")
+	}
+	return strings.ToLower(event)
+}
+
+func webhookProvider(r *http.Request) string {
+	if r.Header.Get("X-GitHub-Event") != "" {
+		return "GitHub"
+	}
+	return "Forgejo"
+}
+
+func (s *Service) pullSource(ctx context.Context) (bool, error) {
+	branch, err := gitBranch(s.cfg.SourceDir)
+	if err != nil {
+		return false, err
+	}
+	if branch != s.cfg.Webhook.Branch {
+		return false, fmt.Errorf("checked-out branch %q does not match webhook branch %q", branch, s.cfg.Webhook.Branch)
+	}
+	before, err := gitHead(s.cfg.SourceDir)
+	if err != nil {
+		return false, err
+	}
+	cmd := exec.CommandContext(ctx, "git", "-C", s.cfg.SourceDir, "pull", "--ff-only")
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return false, fmt.Errorf("%w: %s", err, strings.TrimSpace(string(output)))
+	}
+	after, err := gitHead(s.cfg.SourceDir)
+	if err != nil {
+		return false, err
+	}
+	return before != after, nil
+}
+
+func gitBranch(sourceDir string) (string, error) {
+	output, err := exec.Command("git", "-C", sourceDir, "branch", "--show-current").Output()
+	if err != nil {
+		return "", fmt.Errorf("read checked-out git branch: %w", err)
+	}
+	branch := strings.TrimSpace(string(output))
+	if branch == "" {
+		return "", fmt.Errorf("source directory has a detached HEAD")
+	}
+	return branch, nil
+}
+
+func gitHead(sourceDir string) (string, error) {
+	output, err := exec.Command("git", "-C", sourceDir, "rev-parse", "HEAD").Output()
+	if err != nil {
+		return "", fmt.Errorf("read git HEAD: %w", err)
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func (s *Service) beginSourceSync() {
+	s.watchMu.Lock()
+	defer s.watchMu.Unlock()
+	s.watchSuppressUntil = time.Now().Add(s.cfg.BuildTimeout)
+	clear(s.watchChanged)
+	if s.watchTimer != nil {
+		s.watchTimer.Stop()
+		s.watchTimer = nil
+	}
+}
+
+func (s *Service) endSourceSync() {
+	s.watchMu.Lock()
+	defer s.watchMu.Unlock()
+	s.watchSuppressUntil = time.Now().Add(2 * s.cfg.WatchDebounce)
 }
 
 func (s *Service) handleHealth(w http.ResponseWriter, _ *http.Request) {
@@ -738,6 +914,21 @@ func (s *Service) process(ctx context.Context, req queueRequest) {
 	s.removeQueued(req.ID)
 	switch req.Kind {
 	case "build":
+		if req.SyncSource {
+			s.updateRunningPhase("sync source")
+			s.beginSourceSync()
+			syncCtx, cancel := context.WithTimeout(ctx, s.cfg.BuildTimeout)
+			changed, err := s.pullSource(syncCtx)
+			cancel()
+			s.endSourceSync()
+			if err != nil {
+				s.finishWebhookSyncFailure(req, err)
+				return
+			}
+			if !changed {
+				return
+			}
+		}
 		s.runBuild(ctx, req)
 	case "refresh":
 		s.runRefresh(ctx, req)
@@ -759,6 +950,37 @@ func (s *Service) enqueueBuild(triggerType, detail string, changed []string) err
 	s.pushQueued(queued)
 	s.queueCh <- queueRequest{QueuedOperation: queued}
 	return nil
+}
+
+func (s *Service) enqueueWebhookBuild(detail string) error {
+	queued := QueuedOperation{
+		ID:          nextID("build"),
+		Kind:        "build",
+		Label:       "Build",
+		TriggerType: "webhook",
+		Detail:      detail,
+		EnqueuedAt:  time.Now().UTC(),
+		SyncSource:  true,
+	}
+	s.pushQueued(queued)
+	s.queueCh <- queueRequest{QueuedOperation: queued}
+	return nil
+}
+
+func (s *Service) finishWebhookSyncFailure(req queueRequest, err error) {
+	finished := time.Now().UTC()
+	s.finishBuild(BuildRecord{
+		ID:            req.ID,
+		Kind:          req.Kind,
+		Status:        "failed",
+		TriggerType:   req.TriggerType,
+		TriggerDetail: req.Detail,
+		EnqueuedAt:    req.EnqueuedAt,
+		StartedAt:     req.EnqueuedAt,
+		FinishedAt:    finished,
+		TotalMS:       finished.Sub(req.EnqueuedAt).Milliseconds(),
+		Error:         fmt.Sprintf("git pull failed: %v", err),
+	})
 }
 
 func (s *Service) enqueueRefresh(name, triggerType, detail string) error {
@@ -1200,6 +1422,9 @@ func (s *Service) watchSource(ctx context.Context) {
 			if event.Op&fsnotify.Create != 0 {
 				_ = addDirRecursiveIfDir(watcher, event.Name)
 			}
+			if s.watchEventsSuppressed() {
+				continue
+			}
 			if event.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Remove|fsnotify.Rename) == 0 {
 				continue
 			}
@@ -1231,6 +1456,12 @@ func (s *Service) recordWatchPath(path string) {
 	s.watchTimer = time.AfterFunc(s.cfg.WatchDebounce, func() {
 		s.flushWatchBuild()
 	})
+}
+
+func (s *Service) watchEventsSuppressed() bool {
+	s.watchMu.Lock()
+	defer s.watchMu.Unlock()
+	return time.Now().Before(s.watchSuppressUntil)
 }
 
 func (s *Service) flushWatchBuild() {

--- a/pkg/builderadmin/service_test.go
+++ b/pkg/builderadmin/service_test.go
@@ -1,15 +1,135 @@
 package builderadmin
 
 import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 )
+
+func TestBuilderAdminWebhook_RejectsInvalidSignatureAndIgnoresOtherBranches(t *testing.T) {
+	t.Parallel()
+	svc, err := New(Config{
+		SiteDir: t.TempDir(),
+		Webhook: WebhookConfig{Enabled: true, Branch: "main", Secret: "test-secret"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = svc.leaderLock.Close() })
+	svc.leader = true
+	mux := http.NewServeMux()
+	svc.registerRoutes(mux)
+	body := []byte(`{"ref":"refs/heads/dev","after":"abcdef"}`)
+
+	invalid := httptest.NewRequest(http.MethodPost, "/webhook", strings.NewReader(string(body)))
+	invalid.Header.Set("X-GitHub-Event", "push")
+	invalid.Header.Set("X-Hub-Signature-256", "sha256=invalid")
+	invalidRecorder := httptest.NewRecorder()
+	mux.ServeHTTP(invalidRecorder, invalid)
+	if invalidRecorder.Code != http.StatusUnauthorized {
+		t.Fatalf("invalid signature status=%d, want %d", invalidRecorder.Code, http.StatusUnauthorized)
+	}
+
+	branchMismatch := httptest.NewRequest(http.MethodPost, "/webhook", strings.NewReader(string(body)))
+	branchMismatch.Header.Set("X-GitHub-Event", "push")
+	branchMismatch.Header.Set("X-Hub-Signature-256", webhookSignature(body, "test-secret"))
+	branchMismatchRecorder := httptest.NewRecorder()
+	mux.ServeHTTP(branchMismatchRecorder, branchMismatch)
+	if branchMismatchRecorder.Code != http.StatusNoContent {
+		t.Fatalf("branch mismatch status=%d, want %d", branchMismatchRecorder.Code, http.StatusNoContent)
+	}
+	if len(svc.snapshotState().Queue) != 0 {
+		t.Fatal("branch mismatch queued a build")
+	}
+}
+
+func TestNew_RejectsEnabledWebhookWithoutSecret(t *testing.T) {
+	t.Parallel()
+	_, err := New(Config{SiteDir: t.TempDir(), Webhook: WebhookConfig{Enabled: true}})
+	if err == nil {
+		t.Fatal("New() accepted an enabled webhook without a secret")
+	}
+}
+
+func TestBuilderAdminPullSource_ReportsChangedCommit(t *testing.T) {
+	t.Parallel()
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	runGit(t, "init", "--bare", remote)
+	source := filepath.Join(t.TempDir(), "source")
+	runGit(t, "clone", remote, source)
+	runGitAt(t, source, "config", "user.email", "builder@example.com")
+	runGitAt(t, source, "config", "user.name", "Builder")
+	runGitAt(t, source, "checkout", "-b", "main")
+	if err := os.WriteFile(filepath.Join(source, "post.md"), []byte("first"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGitAt(t, source, "add", "post.md")
+	runGitAt(t, source, "commit", "-m", "initial")
+	runGitAt(t, source, "push", "-u", "origin", "main")
+
+	updater := filepath.Join(t.TempDir(), "updater")
+	runGit(t, "clone", "--branch", "main", remote, updater)
+	runGitAt(t, updater, "config", "user.email", "updater@example.com")
+	runGitAt(t, updater, "config", "user.name", "Updater")
+	if err := os.WriteFile(filepath.Join(updater, "post.md"), []byte("second"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGitAt(t, updater, "add", "post.md")
+	runGitAt(t, updater, "commit", "-m", "update")
+	runGitAt(t, updater, "push")
+
+	svc, err := New(Config{SourceDir: source, SiteDir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = svc.leaderLock.Close() })
+	changed, err := svc.pullSource(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("pullSource() = unchanged, want changed")
+	}
+	changed, err = svc.pullSource(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Fatal("pullSource() = changed after synchronization")
+	}
+}
+
+func runGit(t *testing.T, args ...string) {
+	t.Helper()
+	if output, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, output)
+	}
+}
+
+func runGitAt(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git -C %s %s: %v\n%s", dir, strings.Join(args, " "), err, output)
+	}
+}
+
+func webhookSignature(body []byte, secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write(body)
+	return fmt.Sprintf("sha256=%x", mac.Sum(nil))
+}
 
 func TestBuilderAdminAuthentication_RejectsUntrustedOrMissingIdentity(t *testing.T) {
 	t.Parallel()

--- a/pkg/builderadmin/service_test.go
+++ b/pkg/builderadmin/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -58,6 +59,24 @@ func TestNew_RejectsEnabledWebhookWithoutSecret(t *testing.T) {
 	_, err := New(Config{SiteDir: t.TempDir(), Webhook: WebhookConfig{Enabled: true}})
 	if err == nil {
 		t.Fatal("New() accepted an enabled webhook without a secret")
+	}
+}
+
+func TestBuilderAdminWebhook_RejectsQueueWhenFull(t *testing.T) {
+	t.Parallel()
+	svc, err := New(Config{SiteDir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = svc.leaderLock.Close() })
+	for range cap(svc.queueCh) {
+		svc.queueCh <- queueRequest{}
+	}
+	if err := svc.enqueueWebhookBuild("GitHub push"); !errors.Is(err, ErrBuildQueueFull) {
+		t.Fatalf("enqueueWebhookBuild() error = %v, want ErrBuildQueueFull", err)
+	}
+	if len(svc.snapshotState().Queue) != 0 {
+		t.Fatal("full queue left a persisted webhook operation")
 	}
 }
 

--- a/pkg/config/composition.go
+++ b/pkg/config/composition.go
@@ -317,7 +317,7 @@ func populateExtra(config *models.Config, rawWrapper map[string]any) {
 		"tag_aggregator": true, "websub": true, "shortcuts": true, "view_transitions": true,
 		"encryption": true, "authors": true, "garden": true, "feeds_page": true,
 		"assets": true, "resource_hints": true, "error_pages": true, "theme_calendar": true,
-		"include": true,
+		"builder_admin": true, "include": true,
 	}
 
 	if config.Extra == nil {
@@ -329,6 +329,8 @@ func populateExtra(config *models.Config, rawWrapper map[string]any) {
 			config.Extra[key] = value
 		}
 	}
+
+	populateBuilderAdminExtra(config, markataGoRaw)
 }
 
 func mergeRawMaps(path []string, base, override map[string]any) map[string]any {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -138,6 +138,29 @@ display_name = ""
 	}
 }
 
+func TestLoadFromString_BuilderAdminWebhook(t *testing.T) {
+	cfg, err := LoadFromString(`
+[markata-go.builder_admin.webhook]
+enabled = true
+branch = "qa"
+secret = "test-secret"
+`, FormatTOML)
+	if err != nil {
+		t.Fatalf("LoadFromString() error = %v", err)
+	}
+	builderAdmin, ok := cfg.Extra["builder_admin"].(map[string]any)
+	if !ok {
+		t.Fatalf("builder_admin = %#v, want config map", cfg.Extra["builder_admin"])
+	}
+	webhook, ok := builderAdmin["webhook"].(map[string]any)
+	if !ok {
+		t.Fatalf("webhook = %#v, want config map", builderAdmin["webhook"])
+	}
+	if webhook["enabled"] != true || webhook["branch"] != "qa" || webhook["secret"] != "test-secret" {
+		t.Fatalf("webhook = %#v", webhook)
+	}
+}
+
 // =============================================================================
 // Environment Variable Override Tests
 // =============================================================================

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,9 +1,11 @@
 package config
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/WaylonWalker/markata-go/pkg/models"
@@ -112,52 +114,92 @@ func TestConfig_DefaultValues(t *testing.T) {
 	}
 }
 
-func TestLoadFromString_BuilderAdminAuthHeaders(t *testing.T) {
-	cfg, err := LoadFromString(`
+func TestLoadFromString_BuilderAdminTypedAndSecretSafe(t *testing.T) {
+	tests := []struct {
+		name   string
+		format Format
+		data   string
+	}{
+		{
+			name:   "toml",
+			format: FormatTOML,
+			data: `
+[markata-go]
+custom_plugin = { enabled = true }
+[markata-go.builder_admin]
+unrecognized_setting = "kept"
 [markata-go.builder_admin.auth.headers]
 user_id = "X-Authentik-Uid"
 display_name = ""
-`, FormatTOML)
-	if err != nil {
-		t.Fatalf("LoadFromString() error = %v", err)
-	}
-	builderAdmin, ok := cfg.Extra["builder_admin"].(map[string]any)
-	if !ok {
-		t.Fatalf("builder_admin = %#v, want config map", cfg.Extra["builder_admin"])
-	}
-	auth, ok := builderAdmin["auth"].(map[string]any)
-	if !ok {
-		t.Fatalf("auth = %#v, want config map", builderAdmin["auth"])
-	}
-	headers, ok := auth["headers"].(map[string]any)
-	if !ok {
-		t.Fatalf("headers = %#v, want config map", auth["headers"])
-	}
-	if headers["user_id"] != "X-Authentik-Uid" || headers["display_name"] != "" {
-		t.Fatalf("headers = %#v", headers)
-	}
-}
-
-func TestLoadFromString_BuilderAdminWebhook(t *testing.T) {
-	cfg, err := LoadFromString(`
 [markata-go.builder_admin.webhook]
 enabled = true
 branch = "qa"
 secret = "test-secret"
-`, FormatTOML)
-	if err != nil {
-		t.Fatalf("LoadFromString() error = %v", err)
+endpoint = "/hooks/build"
+`,
+		},
+		{
+			name:   "yaml",
+			format: FormatYAML,
+			data: `
+markata-go:
+  custom_plugin:
+    enabled: true
+  builder_admin:
+    unrecognized_setting: kept
+    auth:
+      headers:
+        user_id: X-Authentik-Uid
+        display_name: ""
+    webhook:
+      enabled: true
+      branch: qa
+      secret: test-secret
+      endpoint: /hooks/build
+`,
+		},
+		{
+			name:   "json",
+			format: FormatJSON,
+			data:   `{"markata-go":{"custom_plugin":{"enabled":true},"builder_admin":{"unrecognized_setting":"kept","auth":{"headers":{"user_id":"X-Authentik-Uid","display_name":""}},"webhook":{"enabled":true,"branch":"qa","secret":"test-secret","endpoint":"/hooks/build"}}}}`,
+		},
 	}
-	builderAdmin, ok := cfg.Extra["builder_admin"].(map[string]any)
-	if !ok {
-		t.Fatalf("builder_admin = %#v, want config map", cfg.Extra["builder_admin"])
-	}
-	webhook, ok := builderAdmin["webhook"].(map[string]any)
-	if !ok {
-		t.Fatalf("webhook = %#v, want config map", builderAdmin["webhook"])
-	}
-	if webhook["enabled"] != true || webhook["branch"] != "qa" || webhook["secret"] != "test-secret" {
-		t.Fatalf("webhook = %#v", webhook)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := LoadFromString(tt.data, tt.format)
+			if err != nil {
+				t.Fatalf("LoadFromString() error = %v", err)
+			}
+			headers := cfg.BuilderAdmin.Auth.Headers
+			webhook := cfg.BuilderAdmin.Webhook
+			if headers.UserID == nil || *headers.UserID != "X-Authentik-Uid" || headers.DisplayName == nil || *headers.DisplayName != "" {
+				t.Fatalf("headers = %#v", headers)
+			}
+			if webhook.Enabled == nil || !*webhook.Enabled || webhook.Branch == nil || *webhook.Branch != "qa" || webhook.Secret == nil || *webhook.Secret != "test-secret" {
+				t.Fatalf("webhook = %#v", webhook)
+			}
+			if _, ok := cfg.Extra["builder_admin"]; ok {
+				t.Fatalf("builder_admin must not be in Extra: %#v", cfg.Extra["builder_admin"])
+			}
+			if _, ok := cfg.Extra["custom_plugin"]; !ok {
+				t.Fatalf("unrelated top-level config missing from Extra: %#v", cfg.Extra)
+			}
+			if cfg.BuilderAdmin.Extra["unrecognized_setting"] != "kept" {
+				t.Fatalf("unrecognized builder_admin field missing: %#v", cfg.BuilderAdmin.Extra)
+			}
+			webhookExtra, ok := cfg.BuilderAdmin.Extra["webhook"].(map[string]any)
+			if !ok || webhookExtra["endpoint"] != "/hooks/build" {
+				t.Fatalf("unrecognized webhook field missing: %#v", cfg.BuilderAdmin.Extra)
+			}
+			encoded, err := json.Marshal(cfg)
+			if err != nil {
+				t.Fatalf("json.Marshal() error = %v", err)
+			}
+			if strings.Contains(string(encoded), "test-secret") {
+				t.Fatalf("serialized config exposed webhook secret: %s", encoded)
+			}
+		})
 	}
 }
 

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -205,6 +205,13 @@ func applyEnvOverride(config *models.Config, key, value string) {
 		config.BuilderAdmin.Auth.Headers.Roles = &value
 	case "builder_admin_auth_headers_scopes":
 		config.BuilderAdmin.Auth.Headers.Scopes = &value
+	case "builder_admin_webhook_enabled":
+		enabled := parseBool(value)
+		config.BuilderAdmin.Webhook.Enabled = &enabled
+	case "builder_admin_webhook_branch":
+		config.BuilderAdmin.Webhook.Branch = &value
+	case "builder_admin_webhook_secret":
+		config.BuilderAdmin.Webhook.Secret = &value
 	}
 }
 

--- a/pkg/config/env_test.go
+++ b/pkg/config/env_test.go
@@ -82,6 +82,19 @@ func TestApplyEnvOverrides_BuilderAdminAuthHeaders(t *testing.T) {
 	}
 }
 
+func TestApplyEnvOverrides_BuilderAdminWebhook(t *testing.T) {
+	t.Setenv("MARKATA_GO_BUILDER_ADMIN_WEBHOOK_ENABLED", "true")
+	t.Setenv("MARKATA_GO_BUILDER_ADMIN_WEBHOOK_BRANCH", "qa")
+	t.Setenv("MARKATA_GO_BUILDER_ADMIN_WEBHOOK_SECRET", "test-secret")
+	config := models.NewConfig()
+	if err := ApplyEnvOverrides(config); err != nil {
+		t.Fatal(err)
+	}
+	if config.BuilderAdmin.Webhook.Enabled == nil || !*config.BuilderAdmin.Webhook.Enabled || config.BuilderAdmin.Webhook.Branch == nil || *config.BuilderAdmin.Webhook.Branch != "qa" || config.BuilderAdmin.Webhook.Secret == nil || *config.BuilderAdmin.Webhook.Secret != "test-secret" {
+		t.Fatalf("webhook = %#v", config.BuilderAdmin.Webhook)
+	}
+}
+
 func TestApplyEnvOverrides_BoolFields(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -39,6 +39,7 @@ type configSource interface {
 	getAuthors() authorsConverter
 	getGarden() gardenConverter
 	getTemplates() templatesConverter
+	getBuilderAdmin() models.BuilderAdminConfig
 }
 
 // baseConfigData holds the basic config fields that are directly assignable.
@@ -293,6 +294,9 @@ func buildConfig(src configSource) *models.Config {
 	// Convert Templates config
 	config.Templates = src.getTemplates().toTemplatesConfig()
 
+	// BuilderAdmin uses the shared model because it contains only scalar settings.
+	config.BuilderAdmin = src.getBuilderAdmin()
+
 	return config
 }
 
@@ -321,6 +325,7 @@ func ParseTOML(data []byte) (*models.Config, error) {
 		if globRaw, ok := markataGoRaw["glob"].(map[string]any); ok && len(config.GlobConfig.SlugRules) == 0 {
 			config.GlobConfig.SlugRules = extractSlugRules(globRaw["slug_rules"])
 		}
+		populateBuilderAdminExtra(config, markataGoRaw)
 
 		// Initialize Extra if needed
 		if config.Extra == nil {
@@ -342,7 +347,7 @@ func ParseTOML(data []byte) (*models.Config, error) {
 			"content_templates": true, "footer_layout": true, "search": true,
 			"plugins": true, "thoughts": true, "wikilinks": true, "tags": true,
 			"tag_aggregator": true, "websub": true, "shortcuts": true, "view_transitions": true, "encryption": true,
-			"authors": true, "garden": true, "include": true, "tailwind": false, "css_purge": false,
+			"authors": true, "garden": true, "builder_admin": true, "include": true, "tailwind": false, "css_purge": false,
 		}
 
 		// Copy unknown sections to Extra
@@ -354,6 +359,53 @@ func ParseTOML(data []byte) (*models.Config, error) {
 	}
 
 	return config, nil
+}
+
+// populateBuilderAdminExtra retains unrecognized builder_admin settings while
+// excluding recognized authentication and webhook fields, including the secret.
+func populateBuilderAdminExtra(config *models.Config, markataGoRaw map[string]any) {
+	builderAdmin, ok := markataGoRaw["builder_admin"].(map[string]any)
+	if !ok {
+		return
+	}
+
+	extra := unknownMap(builderAdmin, map[string]bool{"auth": true, "webhook": true})
+	if auth, ok := builderAdmin["auth"].(map[string]any); ok {
+		if authExtra := unknownMap(auth, map[string]bool{"headers": true}); len(authExtra) > 0 {
+			extra["auth"] = authExtra
+		}
+		if headers, ok := auth["headers"].(map[string]any); ok {
+			if headersExtra := unknownMap(headers, map[string]bool{
+				"user_id": true, "username": true, "display_name": true, "email": true,
+				"groups": true, "roles": true, "scopes": true,
+			}); len(headersExtra) > 0 {
+				authExtra, _ := extra["auth"].(map[string]any)
+				if authExtra == nil {
+					authExtra = make(map[string]any)
+					extra["auth"] = authExtra
+				}
+				authExtra["headers"] = headersExtra
+			}
+		}
+	}
+	if webhook, ok := builderAdmin["webhook"].(map[string]any); ok {
+		if webhookExtra := unknownMap(webhook, map[string]bool{"enabled": true, "branch": true, "secret": true}); len(webhookExtra) > 0 {
+			extra["webhook"] = webhookExtra
+		}
+	}
+	if len(extra) > 0 {
+		config.BuilderAdmin.Extra = extra
+	}
+}
+
+func unknownMap(values map[string]any, known map[string]bool) map[string]any {
+	result := make(map[string]any)
+	for key, value := range values {
+		if !known[key] {
+			result[key] = value
+		}
+	}
+	return result
 }
 
 func extractSlugRules(raw any) []models.SlugRule {
@@ -462,6 +514,7 @@ type tomlConfig struct {
 	Authors         tomlAuthorsConfig         `toml:"authors"`
 	Garden          tomlGardenConfig          `toml:"garden"`
 	Templates       tomlTemplatesConfig       `toml:"templates"`
+	BuilderAdmin    models.BuilderAdminConfig `toml:"builder_admin"`
 	UnknownFields   map[string]any            `toml:"-"`
 }
 
@@ -1791,6 +1844,7 @@ func (c *tomlConfig) getViewTransitions() viewTransitionsConverter { return &c.V
 func (c *tomlConfig) getAuthors() authorsConverter                 { return &c.Authors }
 func (c *tomlConfig) getGarden() gardenConverter                   { return &c.Garden }
 func (c *tomlConfig) getTemplates() templatesConverter             { return &c.Templates }
+func (c *tomlConfig) getBuilderAdmin() models.BuilderAdminConfig   { return c.BuilderAdmin }
 
 func (c *tomlConfig) toConfig() *models.Config {
 	return buildConfig(c)
@@ -1996,6 +2050,7 @@ type yamlConfig struct {
 	Authors         yamlAuthorsConfig         `yaml:"authors"`
 	Garden          yamlGardenConfig          `yaml:"garden"`
 	Templates       yamlTemplatesConfig       `yaml:"templates"`
+	BuilderAdmin    models.BuilderAdminConfig `yaml:"builder_admin"`
 }
 
 type yamlNavItem struct {
@@ -3357,6 +3412,7 @@ func (c *yamlConfig) getViewTransitions() viewTransitionsConverter { return &c.V
 func (c *yamlConfig) getAuthors() authorsConverter                 { return &c.Authors }
 func (c *yamlConfig) getGarden() gardenConverter                   { return &c.Garden }
 func (c *yamlConfig) getTemplates() templatesConverter             { return &c.Templates }
+func (c *yamlConfig) getBuilderAdmin() models.BuilderAdminConfig   { return c.BuilderAdmin }
 
 func (c *yamlConfig) toConfig() *models.Config {
 	return buildConfig(c)
@@ -3496,6 +3552,7 @@ type jsonConfig struct {
 	Authors         jsonAuthorsConfig         `json:"authors"`
 	Garden          jsonGardenConfig          `json:"garden"`
 	Templates       jsonTemplatesConfig       `json:"templates"`
+	BuilderAdmin    models.BuilderAdminConfig `json:"builder_admin"`
 }
 
 type jsonNavItem struct {
@@ -4881,6 +4938,7 @@ func (c *jsonConfig) getViewTransitions() viewTransitionsConverter { return &c.V
 func (c *jsonConfig) getAuthors() authorsConverter                 { return &c.Authors }
 func (c *jsonConfig) getGarden() gardenConverter                   { return &c.Garden }
 func (c *jsonConfig) getTemplates() templatesConverter             { return &c.Templates }
+func (c *jsonConfig) getBuilderAdmin() models.BuilderAdminConfig   { return c.BuilderAdmin }
 
 func (c *jsonConfig) toConfig() *models.Config {
 	return buildConfig(c)

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -379,8 +379,8 @@ func populateBuilderAdminExtra(config *models.Config, markataGoRaw map[string]an
 				"user_id": true, "username": true, "display_name": true, "email": true,
 				"groups": true, "roles": true, "scopes": true,
 			}); len(headersExtra) > 0 {
-				authExtra, _ := extra["auth"].(map[string]any)
-				if authExtra == nil {
+				authExtra, ok := extra["auth"].(map[string]any)
+				if !ok {
 					authExtra = make(map[string]any)
 					extra["auth"] = authExtra
 				}

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -654,7 +654,15 @@ type Config struct {
 
 // BuilderAdminConfig configures builder-admin settings shared by CLI, environment, and site config.
 type BuilderAdminConfig struct {
-	Auth BuilderAdminAuthConfig `json:"auth" yaml:"auth" toml:"auth"`
+	Auth    BuilderAdminAuthConfig    `json:"auth" yaml:"auth" toml:"auth"`
+	Webhook BuilderAdminWebhookConfig `json:"webhook" yaml:"webhook" toml:"webhook"`
+}
+
+// BuilderAdminWebhookConfig configures signed GitHub and Forgejo push webhooks.
+type BuilderAdminWebhookConfig struct {
+	Enabled *bool   `json:"enabled" yaml:"enabled" toml:"enabled"`
+	Branch  *string `json:"branch" yaml:"branch" toml:"branch"`
+	Secret  *string `json:"-" yaml:"secret" toml:"secret"`
 }
 
 // BuilderAdminAuthConfig configures identity assertions from a trusted ForwardAuth proxy.

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -1,6 +1,9 @@
 package models
 
-import "strings"
+import (
+	"encoding/json"
+	"strings"
+)
 
 // NavItem represents a navigation link.
 type NavItem struct {
@@ -656,13 +659,29 @@ type Config struct {
 type BuilderAdminConfig struct {
 	Auth    BuilderAdminAuthConfig    `json:"auth" yaml:"auth" toml:"auth"`
 	Webhook BuilderAdminWebhookConfig `json:"webhook" yaml:"webhook" toml:"webhook"`
+
+	// Extra preserves unrecognized builder_admin settings without exposing them
+	// through configuration serialization or template context.
+	Extra map[string]any `json:"-" yaml:"-" toml:"-"`
 }
 
 // BuilderAdminWebhookConfig configures signed GitHub and Forgejo push webhooks.
 type BuilderAdminWebhookConfig struct {
 	Enabled *bool   `json:"enabled" yaml:"enabled" toml:"enabled"`
 	Branch  *string `json:"branch" yaml:"branch" toml:"branch"`
-	Secret  *string `json:"-" yaml:"secret" toml:"secret"`
+	Secret  *string `json:"secret" yaml:"secret" toml:"secret"`
+}
+
+// MarshalJSON excludes the webhook secret from serialized configuration while
+// retaining JSON decoding support for configuration files.
+func (c BuilderAdminWebhookConfig) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Enabled *bool   `json:"enabled"`
+		Branch  *string `json:"branch"`
+	}{
+		Enabled: c.Enabled,
+		Branch:  c.Branch,
+	})
 }
 
 // BuilderAdminAuthConfig configures identity assertions from a trusted ForwardAuth proxy.

--- a/spec/spec/BUILDER_ADMIN.md
+++ b/spec/spec/BUILDER_ADMIN.md
@@ -130,6 +130,10 @@ It MUST enqueue a build only when the checked-out commit changes. Pull failures 
 updates MUST not enqueue a build. The corresponding build record MUST use trigger type `webhook`
 and retain provider, repository, branch, commit, and delivery metadata when supplied.
 
+Filesystem changes remain visible to the source watcher while a webhook pull runs. This prioritizes
+local author edits over deduplicating watcher events: a concurrent or delayed filesystem change MAY
+enqueue a follow-up file-watch build.
+
 Webhook configuration MUST be available in `[markata-go.builder_admin.webhook]`, through
 `MARKATA_GO_BUILDER_ADMIN_WEBHOOK_*` environment variables, and through builder-admin flags.
 Environment values MUST override file configuration; explicitly supplied flags MUST override both.

--- a/spec/spec/BUILDER_ADMIN.md
+++ b/spec/spec/BUILDER_ADMIN.md
@@ -49,6 +49,7 @@ Required trigger sources:
 - file watch
 - scheduled refresh completion when configured to enqueue a build
 - rollback action
+- signed GitHub or Forgejo push webhook after a successful source update
 
 ## Leadership And Handoff
 
@@ -111,6 +112,28 @@ The recorded build trigger MUST include:
 - the set of changed paths captured during the debounce window
 
 The watcher SHOULD ignore internal cache and admin-state paths.
+
+## Git Push Webhooks
+
+Builder-admin MAY expose `POST /webhook` when webhook support is enabled. The endpoint MUST
+accept GitHub and Forgejo push deliveries, validate their HMAC-SHA256 signature in constant time,
+and reject deliveries with missing or invalid signatures. It MUST not require the operator
+ForwardAuth identity because Git providers cannot supply it.
+
+Each builder-admin instance MUST have one configured branch, defaulting to `main`. It MUST ignore
+push deliveries for every other branch. Deployments for production, development, QA, or previews
+MUST use separate builder-admin instances with independent source checkouts, site roots, webhook
+secrets, and branch configuration.
+
+For an accepted matching push, the active leader MUST run `git -C <source-dir> pull --ff-only`.
+It MUST enqueue a build only when the checked-out commit changes. Pull failures and non-fast-forward
+updates MUST not enqueue a build. The corresponding build record MUST use trigger type `webhook`
+and retain provider, repository, branch, commit, and delivery metadata when supplied.
+
+Webhook configuration MUST be available in `[markata-go.builder_admin.webhook]`, through
+`MARKATA_GO_BUILDER_ADMIN_WEBHOOK_*` environment variables, and through builder-admin flags.
+Environment values MUST override file configuration; explicitly supplied flags MUST override both.
+An enabled webhook MUST have a non-empty secret.
 
 ## Build History
 
@@ -335,5 +358,9 @@ Required chart configuration includes:
 
 The first protected deployment target MUST use the dedicated authenticated ingress; `kubectl
 port-forward` is intentionally not an operator-access path because it bypasses proxy provenance.
+
+When webhook support is enabled, the chart MUST render a separate exact `/webhook` ingress path
+without the operator ForwardAuth middleware. Its HMAC secret MUST be supplied from a Kubernetes
+Secret rather than a command-line argument.
 
 The default rendered-release retention MUST keep at least 25 releases, including the current live release, so operators have more than ten rollback targets by default.


### PR DESCRIPTION
## Summary
- add branch-scoped, HMAC-validated GitHub/Forgejo webhook builds
- isolate builder-admin configuration and redact webhook secrets from template/config output
- add Helm webhook ingress and Kubernetes Secret wiring

## Validation
- go test ./cmd/markata-go/cmd ./pkg/config ./pkg/models ./pkg/templates ./pkg/builderadmin
- helm template with webhook configuration

Refs #944