### PR TITLE
fix(builder-admin): pull configured webhook branch

### DIFF
--- a/docs/guides/deployment/builder-admin.md
+++ b/docs/guides/deployment/builder-admin.md
@@ -299,7 +299,7 @@ Forgejo uses the same URL and secret; select its push event. Builder admin accep
 `X-Hub-Signature-256` and Forgejo's `X-Gitea-Signature` headers. Invalid signatures, events other
 than push, and pushes to another branch are ignored or rejected without running a build.
 
-For an accepted matching push, builder admin runs `git -C <source-dir> pull --ff-only`. It queues
+For an accepted matching push, builder admin runs `git -C <source-dir> pull --ff-only origin <branch>`. It queues
 a build only when that changes the checkout. Ensure the deployed source directory is a clean clone
 with an authenticated `origin` remote and that its checked-out branch tracks the configured branch.
 The normal source watcher remains active during the pull so a local author edit is never ignored.
@@ -325,7 +325,7 @@ Point each repository webhook at its matching builder-admin host. Do not share a
 secret with preview environments.
 
 If GitHub or Forgejo reports a successful delivery but no build appears, verify the delivery branch,
-the service's configured branch, the HMAC secret, and that `git -C <source-dir> pull --ff-only`
+the service's configured branch, the HMAC secret, and that `git -C <source-dir> pull --ff-only origin <branch>`
 succeeds in the builder container. A delivery for an unchanged commit intentionally does not queue
 a build.
 

--- a/pkg/builderadmin/service.go
+++ b/pkg/builderadmin/service.go
@@ -615,7 +615,7 @@ func (s *Service) pullSource(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	cmd := exec.CommandContext(ctx, "git", "-C", s.cfg.SourceDir, "pull", "--ff-only")
+	cmd := exec.CommandContext(ctx, "git", "-C", s.cfg.SourceDir, "pull", "--ff-only", "origin", s.cfg.Webhook.Branch)
 	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return false, fmt.Errorf("%w: %s", err, strings.TrimSpace(string(output)))

--- a/pkg/builderadmin/service.go
+++ b/pkg/builderadmin/service.go
@@ -615,7 +615,7 @@ func (s *Service) pullSource(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	cmd := exec.CommandContext(ctx, "git", "-C", s.cfg.SourceDir, "pull", "--ff-only", "origin", s.cfg.Webhook.Branch)
+	cmd := s.gitCommand(ctx, "pull", "--ff-only", "origin", s.cfg.Webhook.Branch)
 	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return false, fmt.Errorf("%w: %s", err, strings.TrimSpace(string(output)))
@@ -628,7 +628,7 @@ func (s *Service) pullSource(ctx context.Context) (bool, error) {
 }
 
 func gitBranch(sourceDir string) (string, error) {
-	output, err := exec.Command("git", "-C", sourceDir, "branch", "--show-current").Output()
+	output, err := gitCommandForSource(context.Background(), sourceDir, "branch", "--show-current").Output()
 	if err != nil {
 		return "", fmt.Errorf("read checked-out git branch: %w", err)
 	}
@@ -640,11 +640,20 @@ func gitBranch(sourceDir string) (string, error) {
 }
 
 func gitHead(sourceDir string) (string, error) {
-	output, err := exec.Command("git", "-C", sourceDir, "rev-parse", "HEAD").Output()
+	output, err := gitCommandForSource(context.Background(), sourceDir, "rev-parse", "HEAD").Output()
 	if err != nil {
 		return "", fmt.Errorf("read git HEAD: %w", err)
 	}
 	return strings.TrimSpace(string(output)), nil
+}
+
+func (s *Service) gitCommand(ctx context.Context, args ...string) *exec.Cmd {
+	return gitCommandForSource(ctx, s.cfg.SourceDir, args...)
+}
+
+func gitCommandForSource(ctx context.Context, sourceDir string, args ...string) *exec.Cmd {
+	gitArgs := append([]string{"-c", "safe.directory=" + sourceDir, "-C", sourceDir}, args...)
+	return exec.CommandContext(ctx, "git", gitArgs...)
 }
 
 func (s *Service) handleHealth(w http.ResponseWriter, _ *http.Request) {

--- a/spec/spec/BUILDER_ADMIN.md
+++ b/spec/spec/BUILDER_ADMIN.md
@@ -125,7 +125,7 @@ push deliveries for every other branch. Deployments for production, development,
 MUST use separate builder-admin instances with independent source checkouts, site roots, webhook
 secrets, and branch configuration.
 
-For an accepted matching push, the active leader MUST run `git -C <source-dir> pull --ff-only`.
+For an accepted matching push, the active leader MUST run `git -C <source-dir> pull --ff-only origin <branch>`.
 It MUST enqueue a build only when the checked-out commit changes. Pull failures and non-fast-forward
 updates MUST not enqueue a build. The corresponding build record MUST use trigger type `webhook`
 and retain provider, repository, branch, commit, and delivery metadata when supplied.


### PR DESCRIPTION
Avoid requiring source checkouts to have upstream tracking configured for webhook pulls.