### PR TITLE
Fix photo cards in JS pagination

### DIFF
--- a/pkg/themes/default/static/js/pagination.js
+++ b/pkg/themes/default/static/js/pagination.js
@@ -30,7 +30,7 @@
     let currentPage = getPageFromHash() || 1;
 
     const postsList = document.querySelector('.posts-list');
-    const allPosts = postsList ? Array.from(postsList.querySelectorAll('.card')) : [];
+    const allPosts = postsList ? Array.from(postsList.querySelectorAll('.card, [data-card]')) : [];
 
     if (allPosts.length === 0) return;
 

--- a/pkg/themes/default/templates/partials/cards/photo-card.html
+++ b/pkg/themes/default/templates/partials/cards/photo-card.html
@@ -2,7 +2,7 @@
 {# NOTE: No indentation on media elements — indented HTML inside pongo2 {% %} #}
 {# blocks creates blank-line + 4-space patterns that goldmark treats as code blocks #}
 {# when this template is used inside render_feed() (output injected into markdown). #}
-{% with post.image|media_url:post.video as media_src %}{% if media_src %}{% with media_src|with_size:"600" as sized_media %}<figure class="photo-figure h-entry">
+{% with post.image|media_url:post.video as media_src %}{% if media_src %}{% with media_src|with_size:"600" as sized_media %}<figure class="photo-figure h-entry" data-card>
 <a href="{{ post.href }}" class="u-url" aria-label="{{ post.description | default:post.title | default:'Photo' }}">
 {% if media_src|is_video %}{% set poster_candidate = post | poster_url:media_src %}<video class="u-video" autoplay muted loop playsinline{% if poster_candidate %} poster="{{ poster_candidate | with_size:"600" }}"{% endif %}>
 <source src="{{ sized_media }}"{% with media_src|video_mime as mime %}{% if mime %} type="{{ mime }}"{% endif %}{% endwith %}>

--- a/pkg/themes/embed_test.go
+++ b/pkg/themes/embed_test.go
@@ -2,6 +2,7 @@ package themes
 
 import (
 	"io/fs"
+	"strings"
 	"testing"
 )
 
@@ -192,6 +193,24 @@ func TestReadStatic_ExistingFile(t *testing.T) {
 				t.Errorf("ReadStatic(%q) returned empty content", tt.file)
 			}
 		})
+	}
+}
+
+func TestDefaultTheme_PhotoCardsAreIncludedInPagination(t *testing.T) {
+	template, err := fs.ReadFile(DefaultTheme(), "templates/partials/cards/photo-card.html")
+	if err != nil {
+		t.Fatalf("read photo-card template: %v", err)
+	}
+	if !strings.Contains(string(template), "data-card") {
+		t.Fatal("photo-card template must mark photo figures as cards")
+	}
+
+	pagination, err := ReadStatic("js/pagination.js")
+	if err != nil {
+		t.Fatalf("read pagination script: %v", err)
+	}
+	if !strings.Contains(string(pagination), "[data-card]") {
+		t.Fatal("pagination script must include data-card elements")
 	}
 }
 

--- a/templates/partials/cards/photo-card.html
+++ b/templates/partials/cards/photo-card.html
@@ -2,7 +2,7 @@
 {# NOTE: No indentation on media elements — indented HTML inside pongo2 {% %} #}
 {# blocks creates blank-line + 4-space patterns that goldmark treats as code blocks #}
 {# when this template is used inside render_feed() (output injected into markdown). #}
-{% with post.image|media_url:post.video as media_src %}{% if media_src %}{% with media_src|with_size:"600" as sized_media %}<figure class="photo-figure h-entry">
+{% with post.image|media_url:post.video as media_src %}{% if media_src %}{% with media_src|with_size:"600" as sized_media %}<figure class="photo-figure h-entry" data-card>
 <a href="{{ post.href }}" class="u-url" aria-label="{{ post.description | default:post.title | default:'Photo' }}">
 {% if media_src|is_video %}{% set poster_candidate = post | poster_url:media_src %}<video class="u-video" autoplay muted loop playsinline{% if poster_candidate %} poster="{{ poster_candidate | with_size:"600" }}"{% endif %}>
 <source src="{{ sized_media }}"{% with media_src|video_mime as mime %}{% if mime %} type="{{ mime }}"{% endif %}{% endwith %}>


### PR DESCRIPTION
## Summary
- include photo figures marked with `data-card` in client-side pagination
- add a regression test covering the shared photo-card template and paginator selector

## Notes
- keeps the default and embedded photo-card templates aligned with the JS paginator

Fixes #1143