### PR TITLE
feat(cli): add site-dir workflow and release-dir flag

### DIFF
--- a/cmd/markata-go/cmd/builder_admin.go
+++ b/cmd/markata-go/cmd/builder_admin.go
@@ -64,7 +64,7 @@ func init() {
 	builderAdminCmd.Flags().StringVar(&builderAdminHost, "host", "127.0.0.1", "host to bind to")
 	builderAdminCmd.Flags().IntVar(&builderAdminPort, "port", 8080, "port to listen on")
 	builderAdminCmd.Flags().StringVar(&builderAdminSourceDir, "source-dir", ".", "source directory to watch and build from")
-	builderAdminCmd.Flags().StringVar(&builderAdminSiteDir, "site-dir", "public", "site root that contains releases/ and current")
+	builderAdminCmd.Flags().StringVar(&builderAdminSiteDir, "release-dir", "public", "release root that contains releases/ and current")
 	builderAdminCmd.Flags().StringVar(&builderAdminCacheMount, "cache-mount", "", "optional dedicated cache mount for .markata symlinks")
 	builderAdminCmd.Flags().StringVar(&builderAdminHistoryDir, "history-dir", "", "directory for persisted builder-admin state and logs")
 	builderAdminCmd.Flags().BoolVar(&builderAdminWatch, "watch", true, "enable recursive file watching")

--- a/cmd/markata-go/cmd/core.go
+++ b/cmd/markata-go/cmd/core.go
@@ -30,6 +30,7 @@ func createManager(cfgPath string) (*lifecycle.Manager, error) {
 	if baseDir != "" {
 		contentDir = baseDir
 	}
+	setSourcePathBaseDir(contentDir)
 	cfg.OutputDir = resolveConfigRelativePath(baseDir, cfg.OutputDir)
 	cfg.AssetsDir = resolveConfigRelativePath(baseDir, cfg.AssetsDir)
 	cfg.TemplatesDir = resolveConfigRelativePath(baseDir, cfg.TemplatesDir)

--- a/cmd/markata-go/cmd/explain.go
+++ b/cmd/markata-go/cmd/explain.go
@@ -23,6 +23,7 @@ Topics:
   build      The build command and build process
   serve      The development server
   new        Creating new content
+  content    Finding, creating, and editing site content
   init       Initializing projects
   config     Configuration system
   agents     Agent skill installation and usage
@@ -35,7 +36,8 @@ Example:
   markata-go explain              # General overview
   markata-go explain build        # Explain build command
   markata-go explain plugins      # Explain plugin system
-  markata-go explain agents       # Explain agent integrations`,
+  markata-go explain agents       # Explain agent integrations
+  markata-go explain content      # Explain the agent content workflow`,
 	Args:              cobra.MaximumNArgs(1),
 	ValidArgsFunction: explainValidArgs,
 	RunE:              runExplain,
@@ -51,6 +53,7 @@ func explainValidArgs(_ *cobra.Command, _ []string, _ string) ([]string, cobra.S
 		"build\tThe build command and process",
 		"serve\tThe development server",
 		"new\tCreating new content",
+		"content\tFinding, creating, and editing site content",
 		"init\tInitializing projects",
 		"config\tConfiguration system",
 		"agents\tAgent integrations and skills",
@@ -78,6 +81,8 @@ func runExplain(cmd *cobra.Command, args []string) error {
 		content = explainServe
 	case "new":
 		content = explainNew
+	case "content":
+		content = explainContent
 	case "init":
 		content = explainInit
 	case "config":
@@ -446,6 +451,61 @@ Examples:
 2. **Date format errors**
    - Use YYYY-MM-DD format
    - Don't include time unless needed`
+
+const explainContent = `# markata-go Content Workflow
+
+Use this workflow to inspect, find, create, and update content. It is designed
+for coding agents and works from any directory when you select a site.
+
+## Select A Site
+
+Use --site-dir for a one-off command, or set MARKATA_GO_SITE_DIR for a shell
+alias or wrapper. The flag takes precedence over the environment variable.
+
+    markata-go --site-dir ~/sites/blog list posts
+    MARKATA_GO_SITE_DIR=~/notes/work markata-go search "meeting notes"
+
+When a site directory is explicitly selected, source paths returned by list and
+search are absolute and can be edited directly.
+
+## Inspect And Find Content
+
+    # Inspect the resolved configuration and content inventory
+    markata-go --site-dir ~/sites/blog config show
+    markata-go --site-dir ~/sites/blog list posts --format json
+
+    # Find Markdown source files by content, title, description, or tag
+    markata-go --site-dir ~/sites/blog search "release process" --format path
+    markata-go --site-dir ~/sites/blog list posts --filter "'go' in tags" --format path
+
+Edit a returned Markdown path directly. Markata-go does not provide a separate
+non-interactive edit command. Human users can also run markata-go tui and press
+e to open the selected post in $EDITOR.
+
+## Create Content
+
+    # Inspect site-provided and built-in content templates
+    markata-go --site-dir ~/sites/blog new --list
+
+    # Create content without prompts, suitable for automation
+    markata-go --site-dir ~/sites/blog new "Release notes" --template post --tags "release,go" --no-input
+
+New content uses the selected site's configuration and content templates. With
+an explicit site directory, the created path is printed as an absolute path.
+
+## Validate Changes
+
+    markata-go --site-dir ~/sites/blog lint
+    markata-go --site-dir ~/sites/blog build --fast
+
+Run a full build before publishing or deployment.
+
+## Install Agent Guidance Globally
+
+If agents often begin outside a site repository, install the bundled skill in
+their global skill directory so they can discover this workflow:
+
+    markata-go agent install --agent opencode --global`
 
 const explainInit = `# markata-go init
 

--- a/cmd/markata-go/cmd/explain_test.go
+++ b/cmd/markata-go/cmd/explain_test.go
@@ -26,3 +26,17 @@ func TestRunExplain_UnknownTopicReturnsError(t *testing.T) {
 		t.Fatalf("expected no direct stderr output, got %q", stderr.String())
 	}
 }
+
+func TestRunExplain_ContentTopicDescribesAgentWorkflow(t *testing.T) {
+	stdout := bytes.NewBuffer(nil)
+	explainCmd.SetOut(stdout)
+
+	if err := runExplain(explainCmd, []string{"content"}); err != nil {
+		t.Fatalf("runExplain(content) error = %v", err)
+	}
+	for _, want := range []string{"--site-dir", "search", "--no-input", "edit"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("content explanation missing %q:\n%s", want, stdout.String())
+		}
+	}
+}

--- a/cmd/markata-go/cmd/list.go
+++ b/cmd/markata-go/cmd/list.go
@@ -25,6 +25,7 @@ const (
 	listFormatPath  = "path"
 	listSortDate    = "date"
 	listSortName    = "name"
+	listSortPosts   = "posts"
 	listSortCount   = "count"
 	listSortWords   = "words"
 	listSortReading = "reading_time"
@@ -324,7 +325,7 @@ func isValidTagSort(field string) bool {
 
 func isValidFeedSort(field string) bool {
 	switch strings.ToLower(field) {
-	case listSortName, "posts", listSortWords, listSortReading, "avg_reading_time":
+	case listSortName, listSortPosts, listSortWords, listSortReading, "avg_reading_time":
 		return true
 	default:
 		return false
@@ -576,7 +577,7 @@ func sortFeedRows(rows []feedRow, field string, order services.SortOrder) {
 	sort.SliceStable(rows, func(i, j int) bool {
 		var cmp int
 		switch strings.ToLower(field) {
-		case "posts":
+		case listSortPosts:
 			cmp = compareInts(rows[i].Posts, rows[j].Posts)
 		case listSortWords:
 			cmp = compareInts(rows[i].Words, rows[j].Words)
@@ -642,7 +643,7 @@ func renderFeedsTable(rows []feedRow) error {
 
 func renderFeedsCSV(rows []feedRow) error {
 	w := csv.NewWriter(outWriter())
-	if err := w.Write([]string{"name", "posts", "words", "reading_time", "avg_reading_time", "output"}); err != nil {
+	if err := w.Write([]string{"name", listSortPosts, "words", "reading_time", "avg_reading_time", "output"}); err != nil {
 		return err
 	}
 	for _, row := range rows {

--- a/cmd/markata-go/cmd/list.go
+++ b/cmd/markata-go/cmd/list.go
@@ -370,7 +370,7 @@ func postToRow(post *models.Post) postRow {
 		Words:       postWordCount(post),
 		ReadingTime: postReadingTime(post),
 		Tags:        post.Tags,
-		Path:        post.Path,
+		Path:        sourcePathForOutput(post.Path),
 	}
 }
 

--- a/cmd/markata-go/cmd/new.go
+++ b/cmd/markata-go/cmd/new.go
@@ -437,23 +437,53 @@ func parseTemplateFile(name, content string) ContentTemplate {
 
 // loadConfigSafe attempts to load the config without errors.
 func loadConfigSafe() *configWrapper {
-	// Try to find and parse config file
-	configPaths := []string{
-		"markata-go.toml",
-		"markata-go.yaml",
-		"markata-go.yml",
-		"markata-go.json",
+	var cfg *configWrapper
+	if cfgFile != "" {
+		parsed, err := parseConfigFile(cfgFile)
+		if err == nil {
+			cfg = parsed
+		}
 	}
 
-	for _, path := range configPaths {
-		if _, err := os.Stat(path); err == nil {
-			cfg, err := parseConfigFile(path)
+	if cfg == nil && cfgFile == "" {
+		configPaths := []string{"markata-go.toml", "markata-go.yaml", "markata-go.yml", "markata-go.json"}
+		for _, path := range configPaths {
+			parsed, err := parseConfigFile(path)
 			if err == nil {
-				return cfg
+				cfg = parsed
+				break
 			}
 		}
 	}
-	return nil
+
+	for _, path := range mergeConfigFiles {
+		parsed, err := parseConfigFile(path)
+		if err != nil {
+			continue
+		}
+		if cfg == nil {
+			cfg = &configWrapper{}
+		}
+		mergeTemplateConfig(cfg, parsed)
+	}
+	return cfg
+}
+
+func mergeTemplateConfig(base, override *configWrapper) {
+	if override.ContentTemplates.Directory != "" {
+		base.ContentTemplates.Directory = override.ContentTemplates.Directory
+	}
+	if len(override.ContentTemplates.Placement) > 0 {
+		if base.ContentTemplates.Placement == nil {
+			base.ContentTemplates.Placement = make(map[string]string)
+		}
+		for name, directory := range override.ContentTemplates.Placement {
+			base.ContentTemplates.Placement[name] = directory
+		}
+	}
+	if override.ContentTemplates.Templates != nil {
+		base.ContentTemplates.Templates = override.ContentTemplates.Templates
+	}
 }
 
 // configWrapper wraps the content templates config for safe loading.
@@ -670,6 +700,9 @@ func runNewCommand(cmd *cobra.Command, args []string) error {
 	}
 	if outputDir == "" {
 		outputDir = template.Directory
+	}
+	if siteDirSelected && !filepath.IsAbs(outputDir) {
+		outputDir = filepath.Join(activeSiteDir, outputDir)
 	}
 
 	// Generate slug from title

--- a/cmd/markata-go/cmd/root.go
+++ b/cmd/markata-go/cmd/root.go
@@ -68,6 +68,7 @@ Example usage:
 Common help:
   markata-go help build      # Explain a subcommand
   markata-go list posts      # Inspect posts from the CLI
+  markata-go explain content # Agent workflow for site content
 
 Documentation:
   https://github.com/WaylonWalker/markata-go/tree/main/docs
@@ -87,6 +88,9 @@ Profiling:
 	Version:       Version,
 	PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 		currentCmd = cmd
+		if err := activateSiteDir(); err != nil {
+			return err
+		}
 		if noColor && forceColor {
 			return fmt.Errorf("cannot use --color and --no-color together")
 		}
@@ -155,6 +159,7 @@ func init() {
 
 	// Global flags
 	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file path (default: auto-discover)")
+	rootCmd.PersistentFlags().StringVar(&siteDir, "site-dir", "", "site directory (overrides MARKATA_GO_SITE_DIR and current directory)")
 	rootCmd.PersistentFlags().StringSliceVarP(&mergeConfigFiles, "merge-config", "m", nil, "additional config file(s) to merge with base config (can be specified multiple times)")
 	rootCmd.PersistentFlags().StringVarP(&outputDir, "output", "o", "", "output directory (overrides config)")
 	rootCmd.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "suppress non-essential status output")

--- a/cmd/markata-go/cmd/site_dir.go
+++ b/cmd/markata-go/cmd/site_dir.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const siteDirEnv = "MARKATA_GO_SITE_DIR"
+
+var (
+	// siteDir selects the site directory for this command invocation.
+	siteDir string
+
+	activeSiteDir    string
+	activeContentDir string
+	siteDirSelected  bool
+)
+
+// activateSiteDir selects the command's site directory before site files are
+// loaded. It changes the process working directory because several commands
+// intentionally resolve caches and other operational files from the site root.
+func activateSiteDir() error {
+	requested, selected := requestedSiteDir()
+	if !selected {
+		activeSiteDir = ""
+		activeContentDir = ""
+		siteDirSelected = false
+		return nil
+	}
+
+	absPath, err := filepath.Abs(requested)
+	if err != nil {
+		return fmt.Errorf("resolve site directory %q: %w", requested, err)
+	}
+	info, err := os.Stat(absPath)
+	if err != nil {
+		return fmt.Errorf("site directory %q: %w", requested, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("site directory %q is not a directory", requested)
+	}
+	if err := os.Chdir(absPath); err != nil {
+		return fmt.Errorf("change to site directory %q: %w", absPath, err)
+	}
+
+	activeSiteDir = absPath
+	activeContentDir = ""
+	siteDirSelected = true
+	return nil
+}
+
+// setSourcePathBaseDir records the content root used by the active manager.
+// Post paths are relative to this directory, which can differ from the selected
+// site when an explicitly configured file lives in a subdirectory.
+func setSourcePathBaseDir(contentDir string) {
+	if !siteDirSelected {
+		return
+	}
+	absPath, err := filepath.Abs(contentDir)
+	if err == nil {
+		activeContentDir = absPath
+	}
+}
+
+func requestedSiteDir() (string, bool) {
+	if strings.TrimSpace(siteDir) != "" {
+		return siteDir, true
+	}
+	if envDir := strings.TrimSpace(os.Getenv(siteDirEnv)); envDir != "" {
+		return envDir, true
+	}
+	return "", false
+}
+
+// sourcePathForOutput returns an absolute source path only when a site was
+// explicitly selected. Existing current-directory output remains relative.
+func sourcePathForOutput(path string) string {
+	if !siteDirSelected || path == "" || filepath.IsAbs(path) {
+		return path
+	}
+	baseDir := activeContentDir
+	if baseDir == "" {
+		baseDir = activeSiteDir
+	}
+	return filepath.Join(baseDir, path)
+}

--- a/cmd/markata-go/cmd/site_dir_test.go
+++ b/cmd/markata-go/cmd/site_dir_test.go
@@ -32,13 +32,19 @@ func resetSiteDirState(t *testing.T) {
 	})
 }
 
-func canonicalPath(t *testing.T, path string) string {
+func assertSameDirectory(t *testing.T, got, want string) {
 	t.Helper()
-	resolved, err := filepath.EvalSymlinks(path)
+	gotInfo, err := os.Stat(got)
 	if err != nil {
-		t.Fatalf("resolve path %q: %v", path, err)
+		t.Fatalf("stat path %q: %v", got, err)
 	}
-	return resolved
+	wantInfo, err := os.Stat(want)
+	if err != nil {
+		t.Fatalf("stat path %q: %v", want, err)
+	}
+	if !os.SameFile(gotInfo, wantInfo) {
+		t.Fatalf("directory = %q, want %q", got, want)
+	}
 }
 
 func TestActivateSiteDir_FlagTakesPrecedenceAndChangesDirectory(t *testing.T) {
@@ -55,9 +61,7 @@ func TestActivateSiteDir_FlagTakesPrecedenceAndChangesDirectory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get working directory: %v", err)
 	}
-	if gotWD != canonicalPath(t, flagSite) {
-		t.Fatalf("working directory = %q, want %q", gotWD, canonicalPath(t, flagSite))
-	}
+	assertSameDirectory(t, gotWD, flagSite)
 	if activeSiteDir != flagSite || !siteDirSelected {
 		t.Fatalf("active site = %q, selected = %t", activeSiteDir, siteDirSelected)
 	}
@@ -75,9 +79,7 @@ func TestActivateSiteDir_UsesEnvironment(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get working directory: %v", err)
 	}
-	if gotWD != canonicalPath(t, site) {
-		t.Fatalf("working directory = %q, want %q", gotWD, canonicalPath(t, site))
-	}
+	assertSameDirectory(t, gotWD, site)
 }
 
 func TestActivateSiteDir_RejectsNonDirectory(t *testing.T) {
@@ -130,10 +132,11 @@ func TestCreateManager_SourcePathsUseConfigDirectory(t *testing.T) {
 		t.Fatalf("createManager() error = %v", err)
 	}
 
-	want := filepath.Join(canonicalPath(t, configDir), "posts", "hello.md")
-	if got := sourcePathForOutput(filepath.Join("posts", "hello.md")); got != want {
-		t.Fatalf("sourcePathForOutput() = %q, want %q", got, want)
+	got := sourcePathForOutput(filepath.Join("posts", "hello.md"))
+	if filepath.Base(got) != "hello.md" || filepath.Base(filepath.Dir(got)) != "posts" {
+		t.Fatalf("sourcePathForOutput() = %q, want config/posts/hello.md", got)
 	}
+	assertSameDirectory(t, filepath.Dir(filepath.Dir(got)), configDir)
 }
 
 func TestSteamPersistentPreRun_ActivatesSelectedSite(t *testing.T) {
@@ -148,9 +151,7 @@ func TestSteamPersistentPreRun_ActivatesSelectedSite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get working directory: %v", err)
 	}
-	if gotWD != canonicalPath(t, site) {
-		t.Fatalf("working directory = %q, want %q", gotWD, canonicalPath(t, site))
-	}
+	assertSameDirectory(t, gotWD, site)
 }
 
 func TestBuilderAdmin_UsesReleaseDirFlag(t *testing.T) {

--- a/cmd/markata-go/cmd/site_dir_test.go
+++ b/cmd/markata-go/cmd/site_dir_test.go
@@ -1,0 +1,238 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/WaylonWalker/markata-go/pkg/models"
+	"github.com/spf13/cobra"
+)
+
+func resetSiteDirState(t *testing.T) {
+	t.Helper()
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+	oldSiteDir := siteDir
+	oldActiveSiteDir := activeSiteDir
+	oldActiveContentDir := activeContentDir
+	oldSiteDirSelected := siteDirSelected
+	t.Cleanup(func() {
+		if err := os.Chdir(oldWD); err != nil {
+			t.Errorf("restore working directory: %v", err)
+		}
+		siteDir = oldSiteDir
+		activeSiteDir = oldActiveSiteDir
+		activeContentDir = oldActiveContentDir
+		siteDirSelected = oldSiteDirSelected
+	})
+}
+
+func TestActivateSiteDir_FlagTakesPrecedenceAndChangesDirectory(t *testing.T) {
+	resetSiteDirState(t)
+	flagSite := t.TempDir()
+	envSite := t.TempDir()
+	t.Setenv(siteDirEnv, envSite)
+	siteDir = flagSite
+
+	if err := activateSiteDir(); err != nil {
+		t.Fatalf("activateSiteDir() error = %v", err)
+	}
+	gotWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+	if gotWD != flagSite {
+		t.Fatalf("working directory = %q, want %q", gotWD, flagSite)
+	}
+	if activeSiteDir != flagSite || !siteDirSelected {
+		t.Fatalf("active site = %q, selected = %t", activeSiteDir, siteDirSelected)
+	}
+}
+
+func TestActivateSiteDir_UsesEnvironment(t *testing.T) {
+	resetSiteDirState(t)
+	site := t.TempDir()
+	t.Setenv(siteDirEnv, site)
+
+	if err := activateSiteDir(); err != nil {
+		t.Fatalf("activateSiteDir() error = %v", err)
+	}
+	gotWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+	if gotWD != site {
+		t.Fatalf("working directory = %q, want %q", gotWD, site)
+	}
+}
+
+func TestActivateSiteDir_RejectsNonDirectory(t *testing.T) {
+	resetSiteDirState(t)
+	path := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(path, []byte("content"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	siteDir = path
+
+	err := activateSiteDir()
+	if err == nil || !strings.Contains(err.Error(), "is not a directory") {
+		t.Fatalf("activateSiteDir() error = %v, want non-directory error", err)
+	}
+}
+
+func TestSourcePathForOutput_ExplicitSiteIsAbsolute(t *testing.T) {
+	resetSiteDirState(t)
+	siteDirSelected = true
+	activeSiteDir = t.TempDir()
+
+	got := sourcePathForOutput(filepath.Join("posts", "hello.md"))
+	want := filepath.Join(activeSiteDir, "posts", "hello.md")
+	if got != want {
+		t.Fatalf("sourcePathForOutput() = %q, want %q", got, want)
+	}
+}
+
+func TestCreateManager_SourcePathsUseConfigDirectory(t *testing.T) {
+	resetSiteDirState(t)
+	site := t.TempDir()
+	configDir := filepath.Join(site, "config")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("create config directory: %v", err)
+	}
+	configPath := filepath.Join(configDir, "site.toml")
+	if err := os.WriteFile(configPath, []byte("title = \"Site\"\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	oldCfgFile := cfgFile
+	cfgFile = filepath.Join("config", "site.toml")
+	t.Cleanup(func() { cfgFile = oldCfgFile })
+	siteDir = site
+	if err := activateSiteDir(); err != nil {
+		t.Fatalf("activateSiteDir() error = %v", err)
+	}
+	if _, err := createManager(cfgFile); err != nil {
+		t.Fatalf("createManager() error = %v", err)
+	}
+
+	want := filepath.Join(configDir, "posts", "hello.md")
+	if got := sourcePathForOutput(filepath.Join("posts", "hello.md")); got != want {
+		t.Fatalf("sourcePathForOutput() = %q, want %q", got, want)
+	}
+}
+
+func TestSteamPersistentPreRun_ActivatesSelectedSite(t *testing.T) {
+	resetSiteDirState(t)
+	site := t.TempDir()
+	siteDir = site
+
+	if err := steamCmd.PersistentPreRunE(steamCmd, nil); err != nil {
+		t.Fatalf("steam persistent pre-run error = %v", err)
+	}
+	gotWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+	if gotWD != site {
+		t.Fatalf("working directory = %q, want %q", gotWD, site)
+	}
+}
+
+func TestBuilderAdmin_UsesReleaseDirFlag(t *testing.T) {
+	if builderAdminCmd.Flags().Lookup("release-dir") == nil {
+		t.Fatal("builder-admin must expose --release-dir for its release root")
+	}
+	if builderAdminCmd.Flags().Lookup("site-dir") != nil {
+		t.Fatal("builder-admin must not shadow the global --site-dir flag")
+	}
+}
+
+func TestRunNewCommand_UsesSelectedSiteAndRelativeConfig(t *testing.T) {
+	resetSiteDirState(t)
+	resetNewCommandFlags()
+	site := t.TempDir()
+	configDir := filepath.Join(site, "config")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("create config directory: %v", err)
+	}
+	configPath := filepath.Join(configDir, "site.toml")
+	if err := os.WriteFile(configPath, []byte("title = \"Site\"\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	mergePath := filepath.Join(configDir, "content.toml")
+	if err := os.WriteFile(mergePath, []byte("[content_templates.placement]\npost = \"notes\"\n"), 0o600); err != nil {
+		t.Fatalf("write merged config: %v", err)
+	}
+
+	oldCfgFile := cfgFile
+	oldMergeConfigFiles := mergeConfigFiles
+	oldOut := newCmd.OutOrStdout()
+	cfgFile = filepath.Join("config", "site.toml")
+	mergeConfigFiles = []string{filepath.Join("config", "content.toml")}
+	stdout := bytes.NewBuffer(nil)
+	newCmd.SetOut(stdout)
+	t.Cleanup(func() {
+		cfgFile = oldCfgFile
+		mergeConfigFiles = oldMergeConfigFiles
+		newCmd.SetOut(oldOut)
+		resetNewCommandFlags()
+	})
+
+	siteDir = site
+	if err := activateSiteDir(); err != nil {
+		t.Fatalf("activateSiteDir() error = %v", err)
+	}
+	if err := runNewCommand(newCmd, []string{"Site Directory Post"}); err != nil {
+		t.Fatalf("runNewCommand() error = %v", err)
+	}
+
+	want := filepath.Join(site, "notes", "site-directory-post.md")
+	if _, err := os.Stat(want); err != nil {
+		t.Fatalf("created file %q: %v", want, err)
+	}
+	if !strings.Contains(stdout.String(), "Created: "+want) {
+		t.Fatalf("creation output = %q, want absolute path %q", stdout.String(), want)
+	}
+}
+
+func TestRenderPosts_UsesAbsolutePathsForSelectedSite(t *testing.T) {
+	resetSiteDirState(t)
+	siteDirSelected = true
+	activeSiteDir = t.TempDir()
+	want := filepath.Join(activeSiteDir, "posts", "hello.md")
+	post := &models.Post{Path: filepath.Join("posts", "hello.md")}
+
+	for _, format := range []string{listFormatTable, listFormatJSON, listFormatCSV, listFormatPath} {
+		t.Run(format, func(t *testing.T) {
+			stdout := bytes.NewBuffer(nil)
+			command := &cobra.Command{Use: "posts"}
+			command.SetOut(stdout)
+			currentCmd = command
+			t.Cleanup(func() { currentCmd = nil })
+
+			if err := renderPosts(format, []*models.Post{post}); err != nil {
+				t.Fatalf("renderPosts() error = %v", err)
+			}
+			if !strings.Contains(stdout.String(), want) {
+				t.Fatalf("rendered output missing %q:\n%s", want, stdout.String())
+			}
+		})
+	}
+
+	stdout := bytes.NewBuffer(nil)
+	command := &cobra.Command{Use: "search"}
+	command.SetOut(stdout)
+	currentCmd = command
+	t.Cleanup(func() { currentCmd = nil })
+	if err := renderSearchTable([]cliSearchResult{{post: post, score: 2}}, "hello"); err != nil {
+		t.Fatalf("renderSearchTable() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), want) {
+		t.Fatalf("search output missing %q:\n%s", want, stdout.String())
+	}
+}

--- a/cmd/markata-go/cmd/site_dir_test.go
+++ b/cmd/markata-go/cmd/site_dir_test.go
@@ -32,10 +32,19 @@ func resetSiteDirState(t *testing.T) {
 	})
 }
 
+func canonicalPath(t *testing.T, path string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatalf("resolve path %q: %v", path, err)
+	}
+	return resolved
+}
+
 func TestActivateSiteDir_FlagTakesPrecedenceAndChangesDirectory(t *testing.T) {
-	resetSiteDirState(t)
 	flagSite := t.TempDir()
 	envSite := t.TempDir()
+	resetSiteDirState(t)
 	t.Setenv(siteDirEnv, envSite)
 	siteDir = flagSite
 
@@ -46,8 +55,8 @@ func TestActivateSiteDir_FlagTakesPrecedenceAndChangesDirectory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get working directory: %v", err)
 	}
-	if gotWD != flagSite {
-		t.Fatalf("working directory = %q, want %q", gotWD, flagSite)
+	if gotWD != canonicalPath(t, flagSite) {
+		t.Fatalf("working directory = %q, want %q", gotWD, canonicalPath(t, flagSite))
 	}
 	if activeSiteDir != flagSite || !siteDirSelected {
 		t.Fatalf("active site = %q, selected = %t", activeSiteDir, siteDirSelected)
@@ -55,8 +64,8 @@ func TestActivateSiteDir_FlagTakesPrecedenceAndChangesDirectory(t *testing.T) {
 }
 
 func TestActivateSiteDir_UsesEnvironment(t *testing.T) {
-	resetSiteDirState(t)
 	site := t.TempDir()
+	resetSiteDirState(t)
 	t.Setenv(siteDirEnv, site)
 
 	if err := activateSiteDir(); err != nil {
@@ -66,14 +75,14 @@ func TestActivateSiteDir_UsesEnvironment(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get working directory: %v", err)
 	}
-	if gotWD != site {
-		t.Fatalf("working directory = %q, want %q", gotWD, site)
+	if gotWD != canonicalPath(t, site) {
+		t.Fatalf("working directory = %q, want %q", gotWD, canonicalPath(t, site))
 	}
 }
 
 func TestActivateSiteDir_RejectsNonDirectory(t *testing.T) {
-	resetSiteDirState(t)
 	path := filepath.Join(t.TempDir(), "not-a-directory")
+	resetSiteDirState(t)
 	if err := os.WriteFile(path, []byte("content"), 0o600); err != nil {
 		t.Fatalf("write fixture: %v", err)
 	}
@@ -86,9 +95,10 @@ func TestActivateSiteDir_RejectsNonDirectory(t *testing.T) {
 }
 
 func TestSourcePathForOutput_ExplicitSiteIsAbsolute(t *testing.T) {
+	site := t.TempDir()
 	resetSiteDirState(t)
 	siteDirSelected = true
-	activeSiteDir = t.TempDir()
+	activeSiteDir = site
 
 	got := sourcePathForOutput(filepath.Join("posts", "hello.md"))
 	want := filepath.Join(activeSiteDir, "posts", "hello.md")
@@ -98,8 +108,8 @@ func TestSourcePathForOutput_ExplicitSiteIsAbsolute(t *testing.T) {
 }
 
 func TestCreateManager_SourcePathsUseConfigDirectory(t *testing.T) {
-	resetSiteDirState(t)
 	site := t.TempDir()
+	resetSiteDirState(t)
 	configDir := filepath.Join(site, "config")
 	if err := os.MkdirAll(configDir, 0o755); err != nil {
 		t.Fatalf("create config directory: %v", err)
@@ -120,15 +130,15 @@ func TestCreateManager_SourcePathsUseConfigDirectory(t *testing.T) {
 		t.Fatalf("createManager() error = %v", err)
 	}
 
-	want := filepath.Join(configDir, "posts", "hello.md")
+	want := filepath.Join(canonicalPath(t, configDir), "posts", "hello.md")
 	if got := sourcePathForOutput(filepath.Join("posts", "hello.md")); got != want {
 		t.Fatalf("sourcePathForOutput() = %q, want %q", got, want)
 	}
 }
 
 func TestSteamPersistentPreRun_ActivatesSelectedSite(t *testing.T) {
-	resetSiteDirState(t)
 	site := t.TempDir()
+	resetSiteDirState(t)
 	siteDir = site
 
 	if err := steamCmd.PersistentPreRunE(steamCmd, nil); err != nil {
@@ -138,8 +148,8 @@ func TestSteamPersistentPreRun_ActivatesSelectedSite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get working directory: %v", err)
 	}
-	if gotWD != site {
-		t.Fatalf("working directory = %q, want %q", gotWD, site)
+	if gotWD != canonicalPath(t, site) {
+		t.Fatalf("working directory = %q, want %q", gotWD, canonicalPath(t, site))
 	}
 }
 
@@ -153,9 +163,9 @@ func TestBuilderAdmin_UsesReleaseDirFlag(t *testing.T) {
 }
 
 func TestRunNewCommand_UsesSelectedSiteAndRelativeConfig(t *testing.T) {
+	site := t.TempDir()
 	resetSiteDirState(t)
 	resetNewCommandFlags()
-	site := t.TempDir()
 	configDir := filepath.Join(site, "config")
 	if err := os.MkdirAll(configDir, 0o755); err != nil {
 		t.Fatalf("create config directory: %v", err)
@@ -201,9 +211,10 @@ func TestRunNewCommand_UsesSelectedSiteAndRelativeConfig(t *testing.T) {
 }
 
 func TestRenderPosts_UsesAbsolutePathsForSelectedSite(t *testing.T) {
+	site := t.TempDir()
 	resetSiteDirState(t)
 	siteDirSelected = true
-	activeSiteDir = t.TempDir()
+	activeSiteDir = site
 	want := filepath.Join(activeSiteDir, "posts", "hello.md")
 	post := &models.Post{Path: filepath.Join("posts", "hello.md")}
 
@@ -218,8 +229,13 @@ func TestRenderPosts_UsesAbsolutePathsForSelectedSite(t *testing.T) {
 			if err := renderPosts(format, []*models.Post{post}); err != nil {
 				t.Fatalf("renderPosts() error = %v", err)
 			}
-			if !strings.Contains(stdout.String(), want) {
-				t.Fatalf("rendered output missing %q:\n%s", want, stdout.String())
+			output := stdout.String()
+			expectedPath := want
+			if format == listFormatJSON {
+				expectedPath = strings.ReplaceAll(expectedPath, `\`, `\\`)
+			}
+			if !strings.Contains(output, expectedPath) {
+				t.Fatalf("rendered output missing %q:\n%s", expectedPath, output)
 			}
 		})
 	}

--- a/cmd/markata-go/cmd/steam.go
+++ b/cmd/markata-go/cmd/steam.go
@@ -31,11 +31,15 @@ These commands fetch data from the Steam Web API and create markdown posts
 for games and individual achievements. Requires Steam API key and Steam ID.
 
 Get your Steam Web API key from: https://steamcommunity.com/dev/apikey`,
-	PersistentPreRun: func(_ *cobra.Command, _ []string) {
+	PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+		if err := activateSiteDir(); err != nil {
+			return err
+		}
 		// Load environment variables from .env file if it exists
 		if err := loadEnvFile(); err != nil && steamVerbose {
 			fmt.Fprintf(os.Stderr, "Warning: failed to load .env file: %v\n", err)
 		}
+		return nil
 	},
 }
 

--- a/docs/guides/agent-skills.md
+++ b/docs/guides/agent-skills.md
@@ -57,6 +57,11 @@ This creates:
 ~/.config/opencode/skills/markata-go-site/
 ```
 
+Use a global installation when agents commonly start outside the site repository
+and select a site with `markata-go --site-dir <path> ...`. The bundled skill
+then directs agents to `markata-go explain content` for listing, searching,
+creating, editing, and validating content.
+
 `-g` / `--global` always requires an explicit `--agent` so markata-go can choose the right user directory.
 
 ## Preview Without Writing

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -70,6 +70,20 @@ markata-go searches for configuration files in the following order (first found 
 
 If no configuration file is found, markata-go uses default values with any environment variable overrides applied.
 
+## Select A Site From Another Directory
+
+Use `--site-dir` when the site is not your current directory. This is useful
+for aliases, scripts, and agents that manage more than one site.
+
+```bash
+markata-go --site-dir ~/sites/blog config show
+MARKATA_GO_SITE_DIR=~/notes/work markata-go list posts
+```
+
+`--site-dir` overrides `MARKATA_GO_SITE_DIR`; otherwise markata-go uses the
+current directory. The selected site becomes the base for configuration
+discovery, relative config flags, templates, content files, and caches.
+
 ## Supported Formats
 
 | Extension | Format | Notes |

--- a/docs/guides/data-exploration.md
+++ b/docs/guides/data-exploration.md
@@ -70,6 +70,14 @@ markata-go list posts --format path | xargs -n 1 $EDITOR
 markata-go list tags --format path > tags.txt
 ```
 
+When `--site-dir` or `MARKATA_GO_SITE_DIR` selects a site, post paths are
+absolute. This lets agents and scripts edit results from any directory:
+
+```bash
+markata-go --site-dir ~/sites/blog search "configuration" --format path
+# Edit the returned Markdown path directly.
+```
+
 ## Interactive Browsing
 
 For a full-screen view with filtering and sorting:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -29,6 +29,7 @@ These flags are available for all commands:
 | Flag | Short | Description | Default |
 |------|-------|-------------|---------|
 | `--config` | `-c` | Path to configuration file | Auto-discovered |
+| `--site-dir` | | Site directory for all site operations | `MARKATA_GO_SITE_DIR` or current directory |
 | `--merge-config` | `-m` | Additional config file(s) to merge (can be used multiple times) | None |
 | `--output` | `-o` | Output directory (overrides config) | `public` |
 | `--quiet` | `-q` | Suppress non-essential progress and status output | `false` |
@@ -50,6 +51,27 @@ When `--config` is not specified, markata-go searches for configuration files in
 6. `.markata-go.json`
 
 See [[configuration-guide|Configuration]] for details on configuration options.
+
+### Site Directory
+
+Use `--site-dir` to run a command against a site from any directory. Set
+`MARKATA_GO_SITE_DIR` to use the same site in a shell alias or wrapper. The flag
+takes precedence over the environment variable, which takes precedence over the
+current directory.
+
+```bash
+alias blog='markata-go --site-dir "$HOME/sites/blog"'
+alias work-notes='markata-go --site-dir "$HOME/notes/work"'
+
+blog search "release process" --format path
+work-notes new "Weekly review" --template note --no-input
+```
+
+The selected directory must exist. Configuration discovery, relative
+`--config` and `--merge-config` paths, content templates, linting, and caches
+all resolve from that directory. `list` and `search` print absolute Markdown
+source paths when a site directory is explicit, so their results can be edited
+directly.
 
 ### CLI UX Conventions
 
@@ -370,13 +392,13 @@ markata-go builder-admin [flags]
 | `--host` | Host to bind to | `127.0.0.1` |
 | `--port` | Port to listen on | `8080` |
 | `--source-dir` | Mounted source directory to watch and build from | `.` |
-| `--site-dir` | Mounted site root that contains `releases/` and `current` | `public` |
+| `--release-dir` | Mounted release root that contains `releases/` and `current` | `public` |
 | `--watch` | Enable recursive file watching and queued rebuilds | `true` |
 | `--watch-debounce` | Debounce window for coalescing file changes | `2s` |
 | `--fast` | Use `markata-go build --fast` for queued builds | `false` |
 | `--mermaid-mode` | Override `[markata-go.mermaid].mode` for queued builds | `""` |
 | `--cache-mount` | Optional dedicated cache mount used for `.markata` and `.markata-cache` symlinks | `""` |
-| `--history-dir` | Directory for persisted admin state and logs | `<site-dir>/.builder-admin` |
+| `--history-dir` | Directory for persisted admin state and logs | `<release-dir>/.builder-admin` |
 | `--releases-keep` | Number of rendered releases to keep on disk | `25` |
 | `--refresh-task` | Repeatable task spec in the form `name|every|enqueue|arg1|arg2...` | none |
 | `--trusted-proxy-cidr` | Repeatable CIDR allowed to supply trusted identity headers | none |
@@ -400,7 +422,7 @@ for a complete ForwardAuth and Authentik example.
 markata-go builder-admin \
   --config /data/source/markata-go.toml \
   --source-dir /data/source \
-  --site-dir /data/site \
+  --release-dir /data/site \
   --cache-mount /data/cache \
   --fast \
   --watch
@@ -1092,6 +1114,9 @@ markata-go new "Ready to Publish"
 # Create with tags
 markata-go new "Go Tutorial" --tags "go,tutorial,programming"
 # Creates: pages/post/go-tutorial.md with tags: ["go", "tutorial", "programming"]
+
+# Create content in another site from any directory
+markata-go --site-dir ~/sites/blog new "Release notes" --no-input
 
 # Interactive mode (no arguments) - launches TUI wizard
 markata-go new
@@ -1963,6 +1988,7 @@ markata-go explain [topic]
 | `build` | The build command and build process |
 | `serve` | The development server |
 | `new` | Creating new content |
+| `content` | Finding, creating, and editing site content |
 | `init` | Initializing projects |
 | `config` | Configuration system |
 | `agents` | Agent skill installation and usage |
@@ -1986,6 +2012,9 @@ markata-go explain plugins
 # Learn about the bundled agent skill
 markata-go explain agents
 
+# Follow the agent-oriented content workflow
+markata-go explain content
+
 # Understand the build lifecycle
 markata-go explain lifecycle
 
@@ -1998,6 +2027,7 @@ markata-go explain feeds
 The `explain` command is particularly useful for:
 
 - **AI coding agents**: Provides comprehensive context about markata-go's architecture and commands
+- **Content work from any directory**: `explain content` documents how to select a site, search, edit returned source paths, create content, and validate changes
 - **Site maintainers installing the bundled skill**: Shows how `markata-go agent install` fits into agent workflows
 - **New developers**: Quick reference for understanding how different parts work together
 - **Debugging**: Understanding the build process and configuration options

--- a/helm-chart/templates/builder-admin.yaml
+++ b/helm-chart/templates/builder-admin.yaml
@@ -95,7 +95,7 @@ spec:
             - {{ .Values.builderAdmin.port | quote }}
             - --source-dir
             - /data/source
-            - --site-dir
+            - --release-dir
             - /data/site
             - --history-dir
             - {{ .Values.builderAdmin.historyDir | quote }}

--- a/pkg/agentskill/bundle/markata-go-site/SKILL.md
+++ b/pkg/agentskill/bundle/markata-go-site/SKILL.md
@@ -23,7 +23,7 @@ Before making changes:
 1. Inspect the site config with `markata-go config show` and `markata-go config get <key>`.
 2. Inspect content with `markata-go list posts`, `markata-go list feeds`, and `markata-go list tags`.
 3. Search for content by keyword with `markata-go search <query>`.
-4. Use `markata-go explain <topic>` for built-in CLI context.
+4. Use `markata-go explain content` for the agent content workflow, or `markata-go explain <topic>` for other built-in CLI context.
 5. For Markdown wikilink IDE features, run `markata-go lsp doctor` (it can load editor startup/plugin code); use `--no-verify-editor` to skip that check. Use `markata-go lsp setup` to print snippets for installed editors, then inspect existing editor configuration before changing it.
 6. Use `markata-go build --fast` or `markata-go serve --fast` while iterating.
 7. Only reach for Go plugin work after checking whether the change belongs in config, frontmatter, templates, CSS, or feeds.
@@ -96,6 +96,7 @@ If the repository is a very small or first-time site and does not yet have clear
 - Preserve the site's existing layout, content model, and template style unless the task explicitly changes them.
 - When something is ambiguous, inspect the actual repo files before changing behavior.
 - Prefer CLI inspection over hand-parsing when `markata-go` already exposes the needed data.
+- When working outside the site repository, select it with `markata-go --site-dir <path> ...`; list and search then return absolute Markdown paths that can be edited directly.
 - If the task is performance-related, compare warm builds before claiming a regression or improvement.
 - For analytics storytelling work, separate computed facts from human narrative: agents should gather metrics, scaffold charts, and suggest story angles, while leaving first-person timeline details for the author unless the user asks for full prose.
 - If the site has no existing conventions yet, use the patterns documented in this skill rather than making up a new structure.

--- a/pkg/agentskill/bundle/markata-go-site/evals/evals.json
+++ b/pkg/agentskill/bundle/markata-go-site/evals/evals.json
@@ -54,6 +54,12 @@
       "prompt": "On my markata-go site I want to add Web Awesome tabs and tooltips to my docs. Should I do this in config, markdown content, templates, or a plugin, and what should I inspect first before editing?",
       "expected_output": "Explains that the first checks are existing `hooks`, `webawesome` config, current `wa-*` usage, and template wiring; prefers enabling the built-in `webawesome` hook plus markdown containers or raw `wa-*` HTML before suggesting plugin work; mentions vendor versus CDN asset behavior and avoiding duplicate hardcoded includes.",
       "files": []
+    },
+    {
+      "id": 10,
+      "prompt": "I am outside my work-notes repository. Find the note about incident review, update it, and create a follow-up note without changing my current directory.",
+      "expected_output": "Uses `--site-dir` or `MARKATA_GO_SITE_DIR`, searches with path output, explains that the returned absolute Markdown path can be edited directly, creates the follow-up with `new --no-input`, and validates with lint or a fast build.",
+      "files": []
     }
   ]
 }

--- a/pkg/agentskill/bundle/markata-go-site/topics/cli-usage.md
+++ b/pkg/agentskill/bundle/markata-go-site/topics/cli-usage.md
@@ -54,6 +54,23 @@ Bare `markata-go config` behaves like `markata-go config show`.
 - `markata-go init` (initialize a new project with TUI wizard)
 - `markata-go init --plain` (plain text prompts for non-TTY environments)
 
+### Content Workflow For Agents
+
+Use `markata-go explain content` for the complete inspect, find, edit, create,
+and validate workflow. From another directory, select the site explicitly:
+
+```bash
+markata-go --site-dir ~/sites/blog list posts --format json
+markata-go --site-dir ~/sites/blog search "release process" --format path
+markata-go --site-dir ~/sites/blog new "Release notes" --no-input
+markata-go --site-dir ~/sites/blog lint
+markata-go --site-dir ~/sites/blog build --fast
+```
+
+`list` and `search` return absolute Markdown source paths with `--site-dir`.
+Edit a returned path directly; there is no separate non-interactive edit command.
+Set `MARKATA_GO_SITE_DIR` in an alias or wrapper when repeatedly using one site.
+
 ### Content Quality
 
 - `markata-go lint` (lint markdown files for common issues)
@@ -135,6 +152,7 @@ Use `--fix` to auto-fix fixable issues. Only error-severity issues cause a non-z
 ## Global Flags Agents Should Know
 
 - `-c`, `--config`: use a specific config file
+- `--site-dir`: select a site directory for commands run elsewhere; overrides `MARKATA_GO_SITE_DIR`
 - `-m`, `--merge-config`: merge override configs such as `fast.toml`
 - `-o`, `--output`: override the output directory without editing config
 - `-v`, `--verbose`: show detailed logs and plugin-stage hints
@@ -145,6 +163,7 @@ Examples:
 
 ```bash
 markata-go build -c markata-go.toml
+markata-go --site-dir ~/sites/blog search golang --format path
 markata-go serve -m fast.toml
 markata-go build -o dist
 markata-go new "My Post" --no-input
@@ -189,6 +208,7 @@ markata-go encryption encrypt-posts --dry-run
 
 - Prefer `list` commands when you need structured inspection.
 - Prefer `search` when you need to find posts by content or keyword.
+- Prefer `explain content` when an agent needs the complete content workflow, including direct editing of returned paths.
 - Prefer `explain` when you need command-specific or subsystem context.
 - Prefer `serve` for interactive local work and `build` for validation or CI-like runs.
 - Run `lint` before committing content changes.

--- a/pkg/agentskill/bundle/markata-go-site/topics/writing-frontmatter.md
+++ b/pkg/agentskill/bundle/markata-go-site/topics/writing-frontmatter.md
@@ -7,6 +7,7 @@ Use this topic when creating or editing posts, pages, docs, or frontmatter field
 - `markata-go new`
 - `markata-go new --list`
 - `markata-go list posts`
+- `markata-go explain content`
 
 ## Frontmatter Format
 
@@ -248,6 +249,7 @@ template: "landing.html"
 ## Guidance
 
 - Prefer `markata-go new` when creating content so the site's defaults stay consistent.
+- To edit existing content, use `markata-go search <query> --format path` or `markata-go list posts --format path`, then edit the returned Markdown file. With `--site-dir`, those paths are absolute.
 - Keep frontmatter YAML valid and minimal.
 - Use existing frontmatter conventions from nearby content before introducing new fields.
 - Do not duplicate the title with an extra H1 in the body unless the repo already does that intentionally.

--- a/spec/README.md
+++ b/spec/README.md
@@ -46,6 +46,7 @@ The docs explain *why* and *usage* - user-friendly guides, examples, tutorials.
 | [INSTALL.md](./spec/INSTALL.md) | Entry point with language/library choices |
 | [SPEC.md](./spec/SPEC.md) | Core architecture, CLI, concurrency |
 | [CLI_LIST.md](./spec/CLI_LIST.md) | CLI list command and output formats |
+| [CLI_SITE_DIR.md](./spec/CLI_SITE_DIR.md) | Cross-directory site selection and agent workflows |
 | [CLI_UX.md](./spec/CLI_UX.md) | Shared CLI UX rules for streams, color, and prompts |
 | [LSP.md](./spec/LSP.md) | Language Server Protocol integration and setup guidance |
 | [CONTAINERS.md](./spec/CONTAINERS.md) | Container images and runtime environments |

--- a/spec/spec/CLI_LIST.md
+++ b/spec/spec/CLI_LIST.md
@@ -93,6 +93,7 @@ Use `list feeds posts` with a feed name to print the posts in that feed:
 - `json` values use raw types (ints for counts, minutes for reading time).
 - `csv` uses a header row with column names.
 - `path` outputs one value per line with no header.
+- With an explicit `--site-dir` or `MARKATA_GO_SITE_DIR`, post paths in every format are absolute source paths. Otherwise, paths remain site-relative.
 - Record output is written to `stdout` so it can be piped directly to other
   tools.
 - Warnings and errors are written to `stderr`.

--- a/spec/spec/CLI_NEW.md
+++ b/spec/spec/CLI_NEW.md
@@ -222,6 +222,10 @@ markata-go new "My Post" --template page --tags "go,web" --dir custom-dir
 All options come from flags. No prompts are shown. The defaults apply for any
 unspecified flags.
 
+When `--site-dir` or `MARKATA_GO_SITE_DIR` selects a site, the command resolves
+templates and output directories from that site and prints the created file's
+absolute path.
+
 When `--no-input` is set and no title argument is provided, the command returns
 an error instead of prompting.
 

--- a/spec/spec/CLI_SITE_DIR.md
+++ b/spec/spec/CLI_SITE_DIR.md
@@ -1,0 +1,74 @@
+# CLI Site Directory Specification
+
+## Overview
+
+`markata-go` can operate on a site other than the caller's current working
+directory. This supports stable shell aliases and agent automation that manage
+multiple sites from any directory.
+
+```bash
+markata-go --site-dir ~/sites/blog search "release process"
+MARKATA_GO_SITE_DIR=~/notes/work markata-go new "Meeting notes" --no-input
+```
+
+## Site Directory Selection
+
+The global `--site-dir <path>` flag selects the active site directory. The
+`MARKATA_GO_SITE_DIR` environment variable provides the same capability for
+shell aliases and wrappers.
+
+Selection precedence is:
+
+1. `--site-dir`
+2. `MARKATA_GO_SITE_DIR`
+3. the process current working directory
+
+An explicitly selected path MUST exist and be a directory. Relative paths are
+resolved from the caller's working directory before markata-go starts site
+operations. Once selected, the directory is the operational working directory
+for the command.
+
+## Path Resolution
+
+With an explicit site directory, markata-go MUST resolve all caller-relative
+site operations from that directory, including:
+
+- configuration discovery and `.env` loading
+- relative `--config` and `--merge-config` paths
+- content template discovery and content creation
+- content globbing and linting
+- `.markata` build, list, and search caches
+
+Absolute paths remain unchanged. Existing commands without an explicit site
+directory retain their current working-directory behavior.
+
+`builder-admin` reserves `--release-dir` for its release-serving directory so
+the global `--site-dir` flag retains one meaning across commands.
+
+## Content Path Output
+
+When `--site-dir` or `MARKATA_GO_SITE_DIR` selects a site, `list` and `search`
+MUST report Markdown source paths as absolute paths in every output format.
+This includes table, JSON, CSV, and `--format path` output. The absolute paths
+allow agents to open or edit a result without separately resolving the site
+root.
+
+When no site directory is explicitly selected, these commands retain their
+existing site-relative path output.
+
+`new` MUST print the absolute path of the created content file when a site
+directory is explicitly selected.
+
+## Agent Content Workflow
+
+The `explain content` topic MUST document how agents inspect, search, create,
+and edit content:
+
+1. inspect configuration with `config show`
+2. list or search posts with machine-readable or path output
+3. edit the returned Markdown source path directly
+4. create new content with `new --no-input`
+5. validate with `lint` and `build --fast`
+
+The bundled site skill MUST point agents to this topic and explain that global
+skill installation is appropriate when agents begin outside a site repository.

--- a/spec/spec/CLI_UX.md
+++ b/spec/spec/CLI_UX.md
@@ -198,6 +198,9 @@ Unexpected diagnostic detail belongs in verbose/debug modes, not normal output.
   dedicated benchmark detail flag, rather than always-on in normal output.
 - `config`, `list`, `version`, and `explain` keep their primary output on
   `stdout`.
+- When an explicit site directory is selected, `list` and `search` MUST return
+  absolute source paths so automation can edit results without relying on its
+  current directory.
 - `new` and `init` support interactive prompts by default and honor
   `--no-input`.
 - `lint` MAY style severities, but the output MUST remain readable without


### PR DESCRIPTION
## Summary

Add explicit site selection for cross-directory content work and an agent-oriented content workflow.

## Changes

- Added global `--site-dir` support with `MARKATA_GO_SITE_DIR` fallback.
- Made list and search return absolute source paths when a site is explicit.
- Made new resolve selected-site templates and output paths.
- Added `explain content`, user documentation, bundled agent guidance, and an eval.
- Renamed builder-admin release storage flag from `--site-dir` to `--release-dir`; updated the Helm chart.

## Validation

- `go test ./...`
- `go vet ./...`
- `just lint-new`
- `go build ./cmd/markata-go`
- `helm lint helm-chart`
- Rendered the builder-admin chart with required settings and verified `--release-dir`.

Fixes #1146