### PR TITLE
perf(encryption): parallel source encrypt/decrypt with atomic writes and hidden shortcuts

### DIFF
--- a/cmd/markata-go/cmd/encryption.go
+++ b/cmd/markata-go/cmd/encryption.go
@@ -1,10 +1,13 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/WaylonWalker/markata-go/pkg/config"
@@ -20,6 +23,7 @@ var (
 	encryptionCheckKey       string
 	encryptionDryRun         bool
 	decryptionDryRun         bool
+	encryptionWorkers        int
 )
 
 var encryptionCmd = &cobra.Command{
@@ -59,7 +63,7 @@ var encryptPostsCmd = &cobra.Command{
 
 Posts are encrypted in place by default. Draft, skipped, public, and already
 source-encrypted posts are reported but not rewritten. Use --dry-run to preview
-changes without modifying files.
+changes without modifying files. Use --workers to bound concurrent preparation.
 `,
 	Args: cobra.NoArgs,
 	RunE: runEncryptPostsCommand,
@@ -78,9 +82,28 @@ reported but not rewritten. Use --dry-run to preview changes without modifying f
 
 The key name is read from the encrypted source marker, falling back to
 encryption.default_key. The password is read from MARKATA_GO_ENCRYPTION_KEY_<KEY>.
+Use --workers to bound concurrent preparation.
 `,
 	Args: cobra.ArbitraryArgs,
 	RunE: runDecryptPostsCommand,
+}
+
+// encryptCmd is a deliberately hidden shortcut for encrypt-posts.
+var encryptCmd = &cobra.Command{
+	Use:    "encrypt",
+	Short:  "Encrypt all private Markdown source bodies",
+	Hidden: true,
+	Args:   cobra.NoArgs,
+	RunE:   runEncryptPostsCommand,
+}
+
+// decryptCmd is a deliberately hidden shortcut for decrypt-posts.
+var decryptCmd = &cobra.Command{
+	Use:    "decrypt [path...]",
+	Short:  "Decrypt source-encrypted Markdown bodies back to plaintext",
+	Hidden: true,
+	Args:   cobra.ArbitraryArgs,
+	RunE:   runDecryptPostsCommand,
 }
 
 func init() {
@@ -88,8 +111,14 @@ func init() {
 	generatePasswordCmd.Flags().IntVar(&encryptionPasswordLength, "length", encryption.DefaultMinPasswordLength, "password length (must be at least the configured minimum)")
 	checkPasswordCmd.Flags().StringVar(&encryptionCheckKey, "key", "", "specific key name to check (default: all required keys)")
 	encryptPostsCmd.Flags().BoolVar(&encryptionDryRun, "dry-run", false, "report files that would be encrypted without modifying them")
+	encryptPostsCmd.Flags().IntVar(&encryptionWorkers, "workers", 0, "number of concurrent workers (0 uses GOMAXPROCS)")
 	decryptPostsCmd.Flags().BoolVar(&decryptionDryRun, "dry-run", false, "report files that would be decrypted without modifying them")
-	rootCmd.AddCommand(encryptionCmd)
+	decryptPostsCmd.Flags().IntVar(&encryptionWorkers, "workers", 0, "number of concurrent workers (0 uses GOMAXPROCS)")
+	encryptCmd.Flags().BoolVar(&encryptionDryRun, "dry-run", false, "report files that would be encrypted without modifying them")
+	encryptCmd.Flags().IntVar(&encryptionWorkers, "workers", 0, "number of concurrent workers (0 uses GOMAXPROCS)")
+	decryptCmd.Flags().BoolVar(&decryptionDryRun, "dry-run", false, "report files that would be decrypted without modifying them")
+	decryptCmd.Flags().IntVar(&encryptionWorkers, "workers", 0, "number of concurrent workers (0 uses GOMAXPROCS)")
+	rootCmd.AddCommand(encryptionCmd, encryptCmd, decryptCmd)
 }
 
 func runGeneratePasswordCommand(cmd *cobra.Command, _ []string) error {
@@ -165,29 +194,38 @@ func runEncryptPostsCommand(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	prepared, err := prepareSourceFiles(files, encryptionWorkers, func(file string) (preparedEncryptPost, error) {
+		return prepareEncryptPostSourceFile(file, cfg)
+	})
+	if err != nil {
+		return err
+	}
+
 	stats := encryptPostsStats{}
-	candidates := make([]encryptPostResult, 0)
-	for _, file := range files {
-		result, err := encryptPostSourceFile(file, cfg, true)
-		if err != nil {
-			return err
-		}
+	for _, candidate := range prepared {
+		result := candidate.result
 		stats.add(result)
 		if result.Action == encryptPostActionEncrypted {
-			candidates = append(candidates, result)
 			if encryptionDryRun {
-				fmt.Fprintf(cmd.OutOrStdout(), "WOULD ENCRYPT %s key=%s\n", result.Path, result.KeyName)
+				fmt.Fprintln(cmd.OutOrStdout(), formatEncryptionProgress("WOULD ENCRYPT", currentLogTheme.Warning, result.Path, result.KeyName))
 			}
 		}
 	}
 
 	if !encryptionDryRun {
-		for _, candidate := range candidates {
-			result, err := encryptPostSourceFile(candidate.Path, cfg, false)
-			if err != nil {
-				return err
+		documents := make([]sourceDocument, 0, stats.Encrypted)
+		for _, candidate := range prepared {
+			if candidate.result.Action == encryptPostActionEncrypted {
+				documents = append(documents, candidate.document)
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "ENCRYPTED %s key=%s\n", result.Path, result.KeyName)
+		}
+		if err := writeSourceDocuments(documents); err != nil {
+			return err
+		}
+		for _, candidate := range prepared {
+			if candidate.result.Action == encryptPostActionEncrypted {
+				fmt.Fprintln(cmd.OutOrStdout(), formatEncryptionProgress("ENCRYPTED", currentLogTheme.Success, candidate.result.Path, candidate.result.KeyName))
+			}
 		}
 	}
 
@@ -195,8 +233,8 @@ func runEncryptPostsCommand(cmd *cobra.Command, _ []string) error {
 	if encryptionDryRun {
 		action = "Would encrypt"
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "%s %d private post(s); skipped %d already encrypted, %d public, %d draft/skip.\n",
-		action, stats.Encrypted, stats.AlreadyEncrypted, stats.Public, stats.DraftOrSkip)
+	fmt.Fprintln(cmd.OutOrStdout(), formatEncryptionSummary(action, currentLogTheme.Success, fmt.Sprintf("%d private post(s); skipped %d already encrypted, %d public, %d draft/skip.",
+		stats.Encrypted, stats.AlreadyEncrypted, stats.Public, stats.DraftOrSkip)))
 
 	return nil
 }
@@ -212,29 +250,38 @@ func runDecryptPostsCommand(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	prepared, err := prepareSourceFiles(files, encryptionWorkers, func(file string) (preparedDecryptPost, error) {
+		return prepareDecryptPostSourceFile(file, cfg)
+	})
+	if err != nil {
+		return err
+	}
+
 	stats := decryptPostsStats{}
-	candidates := make([]decryptPostResult, 0)
-	for _, file := range files {
-		result, err := decryptPostSourceFile(file, cfg, true)
-		if err != nil {
-			return err
-		}
+	for _, candidate := range prepared {
+		result := candidate.result
 		stats.add(result)
 		if result.Action == decryptPostActionDecrypted {
-			candidates = append(candidates, result)
 			if decryptionDryRun {
-				fmt.Fprintf(cmd.OutOrStdout(), "WOULD DECRYPT %s key=%s\n", result.Path, result.KeyName)
+				fmt.Fprintln(cmd.OutOrStdout(), formatEncryptionProgress("WOULD DECRYPT", currentLogTheme.Warning, result.Path, result.KeyName))
 			}
 		}
 	}
 
 	if !decryptionDryRun {
-		for _, candidate := range candidates {
-			result, err := decryptPostSourceFile(candidate.Path, cfg, false)
-			if err != nil {
-				return err
+		documents := make([]sourceDocument, 0, stats.Decrypted)
+		for _, candidate := range prepared {
+			if candidate.result.Action == decryptPostActionDecrypted {
+				documents = append(documents, candidate.document)
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "DECRYPTED %s key=%s\n", result.Path, result.KeyName)
+		}
+		if err := writeSourceDocuments(documents); err != nil {
+			return err
+		}
+		for _, candidate := range prepared {
+			if candidate.result.Action == decryptPostActionDecrypted {
+				fmt.Fprintln(cmd.OutOrStdout(), formatEncryptionProgress("DECRYPTED", currentLogTheme.Success, candidate.result.Path, candidate.result.KeyName))
+			}
 		}
 	}
 
@@ -242,8 +289,8 @@ func runDecryptPostsCommand(cmd *cobra.Command, args []string) error {
 	if decryptionDryRun {
 		action = "Would decrypt"
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "%s %d post(s); skipped %d not encrypted.\n",
-		action, stats.Decrypted, stats.NotEncrypted)
+	fmt.Fprintln(cmd.OutOrStdout(), formatEncryptionSummary(action, currentLogTheme.Success,
+		fmt.Sprintf("%d post(s); skipped %d not encrypted.", stats.Decrypted, stats.NotEncrypted)))
 
 	return nil
 }
@@ -313,24 +360,43 @@ func (s *decryptPostsStats) add(result decryptPostResult) {
 	}
 }
 
+type preparedDecryptPost struct {
+	result   decryptPostResult
+	document sourceDocument
+}
+
 func decryptPostSourceFile(path string, cfg *models.Config, dryRun bool) (decryptPostResult, error) {
+	prepared, err := prepareDecryptPostSourceFile(path, cfg)
+	if err != nil {
+		return decryptPostResult{}, err
+	}
+	if dryRun || prepared.result.Action != decryptPostActionDecrypted {
+		return prepared.result, nil
+	}
+	if err := writeSourceDocuments([]sourceDocument{prepared.document}); err != nil {
+		return decryptPostResult{}, err
+	}
+	return prepared.result, nil
+}
+
+func prepareDecryptPostSourceFile(path string, cfg *models.Config) (preparedDecryptPost, error) {
 	contentBytes, err := os.ReadFile(path)
 	if err != nil {
-		return decryptPostResult{}, fmt.Errorf("read %s: %w", path, err)
+		return preparedDecryptPost{}, fmt.Errorf("read %s: %w", path, err)
 	}
 	content := string(contentBytes)
 
 	_, body, rawFrontmatter, err := plugins.ParseFrontmatterWithRaw(content)
 	if err != nil {
-		return decryptPostResult{}, fmt.Errorf("parse frontmatter %s: %w", path, err)
+		return preparedDecryptPost{}, fmt.Errorf("parse frontmatter %s: %w", path, err)
 	}
 	if !encryption.IsSourceEncrypted(body) {
-		return decryptPostResult{Path: path, Action: decryptPostActionNotEncrypted}, nil
+		return preparedDecryptPost{result: decryptPostResult{Path: path, Action: decryptPostActionNotEncrypted}}, nil
 	}
 
 	envelope, _, err := encryption.ParseSourceEnvelope(body)
 	if err != nil {
-		return decryptPostResult{}, fmt.Errorf("parse encrypted source %s: %w", path, err)
+		return preparedDecryptPost{}, fmt.Errorf("parse encrypted source %s: %w", path, err)
 	}
 
 	keyName := strings.TrimSpace(envelope.KeyName)
@@ -338,31 +404,27 @@ func decryptPostSourceFile(path string, cfg *models.Config, dryRun bool) (decryp
 		keyName = strings.TrimSpace(cfg.Encryption.DefaultKey)
 	}
 	if keyName == "" {
-		return decryptPostResult{}, fmt.Errorf("encrypted post %s has no key name; set encryption.default_key", path)
+		return preparedDecryptPost{}, fmt.Errorf("encrypted post %s has no key name; set encryption.default_key", path)
 	}
 	envName := plugins.EncryptionEnvPrefix + strings.ToUpper(keyName)
 	password := os.Getenv(envName)
 	if password == "" {
-		return decryptPostResult{}, fmt.Errorf("encrypted post %s requires %s", path, envName)
+		return preparedDecryptPost{}, fmt.Errorf("encrypted post %s requires %s", path, envName)
 	}
 
 	plaintext, _, err := encryption.DecryptSourceMarkdown(body, password)
 	if err != nil {
-		return decryptPostResult{}, fmt.Errorf("decrypt source body for %s: %w", path, err)
+		return preparedDecryptPost{}, fmt.Errorf("decrypt source body for %s: %w", path, err)
 	}
-	if dryRun {
-		return decryptPostResult{Path: path, KeyName: keyName, Action: decryptPostActionDecrypted}, nil
-	}
-
-	nextContent := decryptedSourceDocument(rawFrontmatter, plaintext)
-	mode := os.FileMode(0o600)
-	if stat, err := os.Stat(path); err == nil {
-		mode = stat.Mode().Perm()
-	}
-	if err := os.WriteFile(path, []byte(nextContent), mode); err != nil {
-		return decryptPostResult{}, fmt.Errorf("write decrypted source %s: %w", path, err)
-	}
-	return decryptPostResult{Path: path, KeyName: keyName, Action: decryptPostActionDecrypted}, nil
+	return preparedDecryptPost{
+		result: decryptPostResult{Path: path, KeyName: keyName, Action: decryptPostActionDecrypted},
+		document: sourceDocument{
+			path:     path,
+			original: content,
+			content:  decryptedSourceDocument(rawFrontmatter, plaintext),
+			mode:     sourceFileMode(path),
+		},
+	}, nil
 }
 
 func decryptedSourceDocument(rawFrontmatter, body string) string {
@@ -438,6 +500,11 @@ type encryptPostsStats struct {
 	DraftOrSkip      int
 }
 
+type preparedEncryptPost struct {
+	result   encryptPostResult
+	document sourceDocument
+}
+
 func (s *encryptPostsStats) add(result encryptPostResult) {
 	switch result.Action {
 	case encryptPostActionEncrypted:
@@ -452,30 +519,44 @@ func (s *encryptPostsStats) add(result encryptPostResult) {
 }
 
 func encryptPostSourceFile(path string, cfg *models.Config, dryRun bool) (encryptPostResult, error) {
+	prepared, err := prepareEncryptPostSourceFile(path, cfg)
+	if err != nil {
+		return encryptPostResult{}, err
+	}
+	if dryRun || prepared.result.Action != encryptPostActionEncrypted {
+		return prepared.result, nil
+	}
+	if err := writeSourceDocuments([]sourceDocument{prepared.document}); err != nil {
+		return encryptPostResult{}, err
+	}
+	return prepared.result, nil
+}
+
+func prepareEncryptPostSourceFile(path string, cfg *models.Config) (preparedEncryptPost, error) {
 	contentBytes, err := os.ReadFile(path)
 	if err != nil {
-		return encryptPostResult{}, fmt.Errorf("read %s: %w", path, err)
+		return preparedEncryptPost{}, fmt.Errorf("read %s: %w", path, err)
 	}
 	content := string(contentBytes)
 
 	_, body, rawFrontmatter, err := plugins.ParseFrontmatterWithRaw(content)
 	if err != nil {
-		return encryptPostResult{}, fmt.Errorf("parse frontmatter %s: %w", path, err)
+		return preparedEncryptPost{}, fmt.Errorf("parse frontmatter %s: %w", path, err)
 	}
 	if encryption.IsSourceEncrypted(body) {
-		return encryptPostResult{Path: path, Action: encryptPostActionAlreadyEncrypted}, nil
+		return preparedEncryptPost{result: encryptPostResult{Path: path, Action: encryptPostActionAlreadyEncrypted}}, nil
 	}
 
 	post, err := plugins.ParsePostFromContentWithConfig(path, content, cfg)
 	if err != nil {
-		return encryptPostResult{}, fmt.Errorf("parse %s: %w", path, err)
+		return preparedEncryptPost{}, fmt.Errorf("parse %s: %w", path, err)
 	}
 	applyEncryptPostsPrivateTags(post, cfg)
 	if post.Draft || post.Skip {
-		return encryptPostResult{Path: path, Action: encryptPostActionDraftOrSkip}, nil
+		return preparedEncryptPost{result: encryptPostResult{Path: path, Action: encryptPostActionDraftOrSkip}}, nil
 	}
 	if !post.Private {
-		return encryptPostResult{Path: path, Action: encryptPostActionPublic}, nil
+		return preparedEncryptPost{result: encryptPostResult{Path: path, Action: encryptPostActionPublic}}, nil
 	}
 
 	keyName := strings.TrimSpace(post.SecretKey)
@@ -483,33 +564,183 @@ func encryptPostSourceFile(path string, cfg *models.Config, dryRun bool) (encryp
 		keyName = strings.TrimSpace(cfg.Encryption.DefaultKey)
 	}
 	if keyName == "" {
-		return encryptPostResult{}, fmt.Errorf("private post %s has no encryption key; set secret_key or encryption.default_key", path)
+		return preparedEncryptPost{}, fmt.Errorf("private post %s has no encryption key; set secret_key or encryption.default_key", path)
 	}
 	password := os.Getenv(plugins.EncryptionEnvPrefix + strings.ToUpper(keyName))
 	if password == "" {
-		return encryptPostResult{}, fmt.Errorf("private post %s requires %s%s", path, plugins.EncryptionEnvPrefix, strings.ToUpper(keyName))
+		return preparedEncryptPost{}, fmt.Errorf("private post %s requires %s%s", path, plugins.EncryptionEnvPrefix, strings.ToUpper(keyName))
 	}
 	if err := validateEncryptPostsPassword(password, cfg); err != nil {
-		return encryptPostResult{}, fmt.Errorf("private post %s key %q failed policy: %w", path, keyName, err)
+		return preparedEncryptPost{}, fmt.Errorf("private post %s key %q failed policy: %w", path, keyName, err)
 	}
 
 	encryptedBody, err := encryption.EncryptSourceMarkdown(body, keyName, password)
 	if err != nil {
-		return encryptPostResult{}, fmt.Errorf("encrypt source body for %s: %w", path, err)
+		return preparedEncryptPost{}, fmt.Errorf("encrypt source body for %s: %w", path, err)
 	}
-	if dryRun {
-		return encryptPostResult{Path: path, KeyName: keyName, Action: encryptPostActionEncrypted}, nil
+	return preparedEncryptPost{
+		result: encryptPostResult{Path: path, KeyName: keyName, Action: encryptPostActionEncrypted},
+		document: sourceDocument{
+			path:     path,
+			original: content,
+			content:  encryptedSourceDocument(rawFrontmatter, encryptedBody),
+			mode:     sourceFileMode(path),
+		},
+	}, nil
+}
+
+func sourceFileMode(path string) os.FileMode {
+	if stat, err := os.Stat(path); err == nil {
+		return stat.Mode().Perm()
+	}
+	return 0o600
+}
+
+type sourceDocument struct {
+	path     string
+	original string
+	content  string
+	mode     os.FileMode
+}
+
+// writeSourceDocuments writes a prepared batch only when every source still
+// matches the content used during preparation. Each replacement is atomic; if
+// a later write fails, previously written documents are restored.
+func writeSourceDocuments(documents []sourceDocument) error {
+	for _, document := range documents {
+		if err := ensureSourceUnchanged(document); err != nil {
+			return err
+		}
 	}
 
-	nextContent := encryptedSourceDocument(rawFrontmatter, encryptedBody)
-	mode := os.FileMode(0o600)
-	if stat, err := os.Stat(path); err == nil {
-		mode = stat.Mode().Perm()
+	written := make([]sourceDocument, 0, len(documents))
+	for _, document := range documents {
+		if err := ensureSourceUnchanged(document); err != nil {
+			rollbackErr := restoreSourceDocuments(written)
+			if rollbackErr != nil {
+				return fmt.Errorf("source changed; rollback failed: %w", errors.Join(err, rollbackErr))
+			}
+			return err
+		}
+		if err := writeSourceDocumentAtomically(document.path, document.content, document.mode); err != nil {
+			rollbackErr := restoreSourceDocuments(written)
+			if rollbackErr != nil {
+				return fmt.Errorf("write source %s; rollback failed: %w", document.path, errors.Join(err, rollbackErr))
+			}
+			return fmt.Errorf("write source %s: %w", document.path, err)
+		}
+		written = append(written, document)
 	}
-	if err := os.WriteFile(path, []byte(nextContent), mode); err != nil {
-		return encryptPostResult{}, fmt.Errorf("write encrypted source %s: %w", path, err)
+	return nil
+}
+
+func restoreSourceDocuments(documents []sourceDocument) error {
+	for i := len(documents) - 1; i >= 0; i-- {
+		document := documents[i]
+		current, err := os.ReadFile(document.path)
+		if err != nil {
+			return fmt.Errorf("read source before restore %s: %w", document.path, err)
+		}
+		if string(current) != document.content {
+			return fmt.Errorf("source changed before restore: %s", document.path)
+		}
+		if err := writeSourceDocumentAtomically(document.path, document.original, document.mode); err != nil {
+			return fmt.Errorf("restore source %s: %w", document.path, err)
+		}
 	}
-	return encryptPostResult{Path: path, KeyName: keyName, Action: encryptPostActionEncrypted}, nil
+	return nil
+}
+
+func ensureSourceUnchanged(document sourceDocument) error {
+	current, err := os.ReadFile(document.path)
+	if err != nil {
+		return fmt.Errorf("read source before write %s: %w", document.path, err)
+	}
+	if string(current) != document.original {
+		return fmt.Errorf("source changed during encryption preparation: %s", document.path)
+	}
+	return nil
+}
+
+func writeSourceDocumentAtomically(path, content string, mode os.FileMode) error {
+	temporary, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".markata-*")
+	if err != nil {
+		return err
+	}
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+
+	if err := temporary.Chmod(mode); err != nil {
+		temporary.Close()
+		return err
+	}
+	if _, err := temporary.WriteString(content); err != nil {
+		temporary.Close()
+		return err
+	}
+	if err := temporary.Sync(); err != nil {
+		temporary.Close()
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	return os.Rename(temporaryPath, path)
+}
+
+func formatEncryptionProgress(action, actionColor, path, keyName string) string {
+	return fmt.Sprintf("%s %s key=%s",
+		colorizeOutput(action, actionColor),
+		colorizeOutput(path, currentLogTheme.Component),
+		colorizeOutput(keyName, currentLogTheme.Warning))
+}
+
+func formatEncryptionSummary(action, actionColor, summary string) string {
+	return fmt.Sprintf("%s %s", colorizeOutput(action, actionColor), summary)
+}
+
+// prepareSourceFiles runs CPU-bound source transformations concurrently while
+// retaining input order. Callers must complete this phase before writing files
+// so a preparation error never leaves a partially transformed repository.
+func prepareSourceFiles[T any](paths []string, workers int, prepare func(string) (T, error)) ([]T, error) {
+	results := make([]T, len(paths))
+	errs := make([]error, len(paths))
+	if len(paths) == 0 {
+		return results, nil
+	}
+	if workers < 0 {
+		return nil, fmt.Errorf("workers must be zero or greater")
+	}
+	if workers == 0 {
+		workers = runtime.GOMAXPROCS(0)
+	}
+	if workers > len(paths) {
+		workers = len(paths)
+	}
+
+	jobs := make(chan int)
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for index := range jobs {
+				results[index], errs[index] = prepare(paths[index])
+			}
+		}()
+	}
+	for index := range paths {
+		jobs <- index
+	}
+	close(jobs)
+	wg.Wait()
+
+	for _, err := range errs {
+		if err != nil {
+			return nil, err
+		}
+	}
+	return results, nil
 }
 
 func validateEncryptPostsPassword(password string, cfg *models.Config) error {

--- a/cmd/markata-go/cmd/encryption_test.go
+++ b/cmd/markata-go/cmd/encryption_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/WaylonWalker/markata-go/pkg/encryption"
 	"github.com/WaylonWalker/markata-go/pkg/models"
 	"github.com/WaylonWalker/markata-go/pkg/plugins"
+	"github.com/spf13/cobra"
 )
 
 func TestGeneratePasswordCommand_DefaultLength(t *testing.T) {
@@ -31,6 +32,51 @@ func TestGeneratePasswordCommand_DefaultLength(t *testing.T) {
 	}
 	if err := encryption.ValidatePassword(password, encryption.DefaultMinPasswordLength, encryption.DefaultMinEstimatedCrackDuration); err != nil {
 		t.Fatalf("generated password failed validation: %v", err)
+	}
+}
+
+func TestEncryptionShortcuts_HiddenAndConfigured(t *testing.T) {
+	for _, shortcut := range []*cobra.Command{encryptCmd, decryptCmd} {
+		if !shortcut.Hidden {
+			t.Errorf("%s shortcut must be hidden", shortcut.Name())
+		}
+		if shortcut.RunE == nil {
+			t.Errorf("%s shortcut must have a command handler", shortcut.Name())
+		}
+		if shortcut.Flags().Lookup("dry-run") == nil {
+			t.Errorf("%s shortcut is missing --dry-run", shortcut.Name())
+		}
+		if shortcut.Flags().Lookup("workers") == nil {
+			t.Errorf("%s shortcut is missing --workers", shortcut.Name())
+		}
+	}
+	if encryptCmd.RunE == nil || decryptCmd.RunE == nil {
+		t.Fatal("encryption shortcuts must delegate to the bulk command handlers")
+	}
+}
+
+func TestFormatEncryptionProgress_UsesColorWhenEnabled(t *testing.T) {
+	originalForceColor := forceColor
+	originalNoColor := noColor
+	defer func() {
+		forceColor = originalForceColor
+		noColor = originalNoColor
+	}()
+	forceColor = true
+	noColor = false
+
+	colored := formatEncryptionProgress("ENCRYPTED", currentLogTheme.Success, "post.md", "default")
+	if !strings.Contains(colored, "\033[") {
+		t.Fatalf("expected ANSI color output, got %q", colored)
+	}
+
+	noColor = true
+	plain := formatEncryptionProgress("ENCRYPTED", currentLogTheme.Success, "post.md", "default")
+	if strings.Contains(plain, "\033[") {
+		t.Fatalf("expected plain output with --no-color, got %q", plain)
+	}
+	if plain != "ENCRYPTED post.md key=default" {
+		t.Fatalf("plain output = %q", plain)
 	}
 }
 
@@ -425,6 +471,88 @@ secret body
 	t.Setenv("MARKATA_GO_ENCRYPTION_KEY_DEFAULT", "wrong-password-value-1")
 	if _, err := decryptPostSourceFile(path, cfg, true); err == nil {
 		t.Fatal("expected error when password is wrong")
+	}
+}
+
+func TestPrepareEncryptPostSourceFiles_FailureDoesNotModifyAnyFile(t *testing.T) {
+	cfg := testEncryptPostsConfig()
+	t.Setenv("MARKATA_GO_ENCRYPTION_KEY_DEFAULT", "h7Qm!2Vx9#Lp4@Td")
+	dir := t.TempDir()
+	validPath := filepath.Join(dir, "valid.md")
+	invalidPath := filepath.Join(dir, "invalid.md")
+	valid := "---\ntitle: Valid\nprivate: true\n---\nprivate body\n"
+	invalid := "---\ntitle: Invalid\nprivate: true\nsecret_key: missing\n---\nprivate body\n"
+	for path, content := range map[string]string{validPath: valid, invalidPath: invalid} {
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+
+	_, err := prepareSourceFiles([]string{validPath, invalidPath}, 2, func(path string) (preparedEncryptPost, error) {
+		return prepareEncryptPostSourceFile(path, cfg)
+	})
+	if err == nil {
+		t.Fatal("expected preparation to fail for missing key")
+	}
+	if got := readFileString(t, validPath); got != valid {
+		t.Fatalf("valid file changed after another preparation failed: got %q, want %q", got, valid)
+	}
+	if got := readFileString(t, invalidPath); got != invalid {
+		t.Fatalf("invalid file changed after preparation failed: got %q, want %q", got, invalid)
+	}
+}
+
+func TestPrepareSourceFiles_PreservesInputOrder(t *testing.T) {
+	paths := []string{"first", "second", "third"}
+	results, err := prepareSourceFiles(paths, 2, func(path string) (string, error) {
+		return path + "-done", nil
+	})
+	if err != nil {
+		t.Fatalf("prepareSourceFiles() error = %v", err)
+	}
+	want := []string{"first-done", "second-done", "third-done"}
+	for i := range want {
+		if results[i] != want[i] {
+			t.Errorf("results[%d] = %q, want %q", i, results[i], want[i])
+		}
+	}
+}
+
+func TestPrepareSourceFiles_NegativeWorkersFails(t *testing.T) {
+	_, err := prepareSourceFiles([]string{"post.md"}, -1, func(path string) (string, error) {
+		return path, nil
+	})
+	if err == nil {
+		t.Fatal("expected negative workers to fail")
+	}
+}
+
+func TestWriteSourceDocuments_ChangedSourceLeavesBatchUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	firstPath := filepath.Join(dir, "first.md")
+	secondPath := filepath.Join(dir, "second.md")
+	for path, content := range map[string]string{firstPath: "first original", secondPath: "second original"} {
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+
+	// Simulate an edit after preparation, before the batch write begins.
+	if err := os.WriteFile(secondPath, []byte("second edited"), 0o600); err != nil {
+		t.Fatalf("edit %s: %v", secondPath, err)
+	}
+	err := writeSourceDocuments([]sourceDocument{
+		{path: firstPath, original: "first original", content: "first transformed", mode: 0o600},
+		{path: secondPath, original: "second original", content: "second transformed", mode: 0o600},
+	})
+	if err == nil {
+		t.Fatal("expected changed source to fail")
+	}
+	if got := readFileString(t, firstPath); got != "first original" {
+		t.Fatalf("first file changed after stale source detection: got %q", got)
+	}
+	if got := readFileString(t, secondPath); got != "second edited" {
+		t.Fatalf("edited file was overwritten: got %q", got)
 	}
 }
 

--- a/docs/guides/encryption.md
+++ b/docs/guides/encryption.md
@@ -146,6 +146,7 @@ markata-go encryption check
 markata-go encryption check --key default
 markata-go encryption encrypt-posts --dry-run
 markata-go encryption encrypt-posts
+markata-go encryption encrypt-posts --workers 4
 ```
 
 The command prints only the password to stdout, making it easy to pipe into your `.env` file or a password manager. The optional `--length` flag requests a longer password (it must be at least the configured `min_password_length`). The generated password already meets the default crack-time and length thresholds.
@@ -193,6 +194,9 @@ markata-go encryption decrypt-posts pages/private/
 
 # decrypt everything matched by glob.patterns
 markata-go encryption decrypt-posts
+
+# use four concurrent workers (0, the default, uses available Go CPU parallelism)
+markata-go encryption decrypt-posts --workers 4
 ```
 
 The key name comes from the `key=` value in the encrypted marker, falling back to `encryption.default_key`. The
@@ -201,6 +205,10 @@ skipped, frontmatter is preserved exactly, and a missing env var or wrong passwo
 written.
 
 A typical edit cycle is `decrypt-posts <file>`, edit the Markdown, then `encrypt-posts` before committing.
+
+Both bulk commands prepare documents in parallel by default, then begin writing only after every candidate is successfully prepared. A missing key, invalid password, malformed source file, cryptographic error, or detected edit during preparation leaves the repository unchanged. Replacements use atomic file writes, and a write failure restores earlier files. Use `--workers 1` if you need serial processing; `--workers 0` is the default and uses `GOMAXPROCS` workers.
+
+When run in a terminal, encryption progress uses your active CLI color theme. Use `--color` to force colors or `--no-color` for plain output.
 
 ## Lint Rule
 

--- a/pkg/agentskill/bundle/markata-go-site/topics/cli-usage.md
+++ b/pkg/agentskill/bundle/markata-go-site/topics/cli-usage.md
@@ -86,8 +86,10 @@ Set `MARKATA_GO_SITE_DIR` in an alias or wrapper when repeatedly using one site.
 - `markata-go encryption check` (verify configured encryption keys)
 - `markata-go encryption encrypt-posts --dry-run` (preview source encryption for private posts)
 - `markata-go encryption encrypt-posts` (encrypt private Markdown bodies in place)
+- `markata-go encryption encrypt-posts --workers 4` (bound concurrent preparation; default `0` uses `GOMAXPROCS`)
 - `markata-go encryption decrypt-posts --dry-run` (preview decrypting source-encrypted posts)
 - `markata-go encryption decrypt-posts [path...]` (decrypt source-encrypted Markdown bodies in place)
+- Bulk encryption and decryption prepare every file before writing, so a missing key or invalid ciphertext does not leave the repository partially transformed.
 
 ### Theme And Palette
 

--- a/spec/spec/ENCRYPTION.md
+++ b/spec/spec/ENCRYPTION.md
@@ -198,6 +198,19 @@ Client-side decryption uses the Web Crypto API with matching parameters.
 
 ## CLI Utilities
 
+### Hidden Root Shortcuts
+
+The CLI provides hidden root-level shortcuts for the common source-encryption workflow:
+
+```
+markata-go encrypt [flags]
+markata-go decrypt [path...] [flags]
+```
+
+`encrypt` has the same behavior and flags as `encryption encrypt-posts`; `decrypt` has the same behavior and flags as `encryption decrypt-posts`. These shortcuts are intentionally omitted from standard help and user documentation, while remaining available for interactive use and automation.
+
+Bulk-command status labels, paths, and key names use the active CLI theme when output is a terminal. `--color` forces color, while `--no-color`, `--log-format plain`, `NO_COLOR`, and non-terminal output use plain text.
+
 ### `encryption generate-password`
 
 Generate a policy-compliant encryption password without invoking the full build. The command prints the generated password to stdout so it can be captured in scripts or piped into other tools.
@@ -245,11 +258,13 @@ Encrypt all private Markdown source bodies matched by the active content glob co
 
 ```
 markata-go encryption encrypt-posts
+markata-go encryption encrypt-posts --workers 4
 markata-go encryption encrypt-posts --dry-run
 ```
 
 - The command rewrites matching files in place by default.
 - `--dry-run` reports which files would be encrypted without modifying the filesystem.
+- `--workers` bounds concurrent source-body preparation. The default (`0`) uses `GOMAXPROCS`; set `--workers 1` to process serially.
 - Posts that are draft, skipped, public, or already source-encrypted are not rewritten.
 - Missing or weak keys cause the command to fail before writing changed files.
 
@@ -262,6 +277,7 @@ markata-go encryption decrypt-posts
 markata-go encryption decrypt-posts --dry-run
 markata-go encryption decrypt-posts path/to/post.md
 markata-go encryption decrypt-posts content/private/
+markata-go encryption decrypt-posts --workers 4
 ```
 
 - With no path arguments the command scans the active content glob configuration.
@@ -272,6 +288,11 @@ markata-go encryption decrypt-posts content/private/
 - The key name is read from the encrypted source marker (`key=...`), falling back to `encryption.default_key`.
 - The password is read from `MARKATA_GO_ENCRYPTION_KEY_<KEY>`. A missing env var or an incorrect password MUST fail before any file is written.
 - Key strength policy is NOT enforced for decryption; only the correct password matters.
+- `--workers` bounds concurrent source-body preparation. The default (`0`) uses `GOMAXPROCS`; set `--workers 1` to process serially.
+
+### Source Command Write Safety
+
+`encrypt-posts` and `decrypt-posts` prepare every candidate document concurrently, then perform writes only after all preparation succeeds. Before writing, the commands verify that each source still matches the content read during preparation. Each replacement uses an atomic rename; a write failure restores documents already written and reports any restoration failure. Consequently, a malformed post, missing key, invalid password, encryption/decryption failure, or detected concurrent edit leaves source files unchanged. Command output remains in the input-file order regardless of worker completion order.
 
 ## Lint Integration
 


### PR DESCRIPTION
## Summary

Parallelize `encryption encrypt-posts` and `decryption decrypt-posts` by preparing all source transformations concurrently before writing any file.

## Changes

- **Parallel preparation:** `prepareSourceFiles` uses a bounded worker pool (default `GOMAXPROCS`) to read, parse, and cryptographically transform every candidate document concurrently.
- **Atomic batch writes:** Each replacement uses a temp-file rename. Before writing, the command verifies the source hasn't changed since preparation. A write failure restores earlier documents in reverse order.
- **Hidden root shortcuts:** `markata-go encrypt` and `markata-go decrypt` for faster interactive use. Both delegate to the existing `encrypt-posts`/ `decrypt-posts` handlers.
- **`--workers` flag:** Controls concurrent worker count (default `0` = `GOMAXPROCS`), available on both `encrypt-posts`/ `decrypt-posts` and the hidden shortcuts.
- **Colored output:** Action labels, paths, and key names use the active CLI theme. Plain output preserved for pipes, `--no-color`, and `--log-format plain`.

## Safety guarantees

- All-or-nothing write: preparation errors, missing keys, weak/wrong passwords, and concurrent source edits leave the working tree unchanged.
- Stale-write detection: each source is re-read before writing and compared against the preparation snapshot. If it changed, the batch fails before modifying any file.
- Rollback on write failure: if the Nth file cannot be written, previously written files are restored in reverse order.

## Documentation

- Encryption spec (`spec/spec/ENCRYPTION.md`) updated with `--workers`, hidden shortcuts, color behavior, and write safety.
- User guide (`docs/guides/encryption.md`) updated with usage examples and safety description.
- Bundled agent skill (`pkg/agentskill/bundle/markata-go-site/topics/cli-usage.md`) updated with `--workers` example and write-safety note.

Closes #1148