### PR TITLE
fix(encryption): stabilize source encryption cache

### DIFF
--- a/cmd/markata-go/cmd/encryption.go
+++ b/cmd/markata-go/cmd/encryption.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/WaylonWalker/markata-go/pkg/buildcache"
 	"github.com/WaylonWalker/markata-go/pkg/config"
 	"github.com/WaylonWalker/markata-go/pkg/encryption"
 	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
@@ -194,16 +195,20 @@ func runEncryptPostsCommand(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	sourceCache, cacheErr := buildcache.LoadSourceEncryptionCache(buildcache.DefaultCacheDir)
+	if cacheErr != nil {
+		fmt.Fprintf(cmd.OutOrStdout(), "Warning: %v; unchanged files may receive new ciphertext.\n", cacheErr)
+	}
 	prepared, err := prepareSourceFiles(files, encryptionWorkers, func(file string) (preparedEncryptPost, error) {
-		return prepareEncryptPostSourceFile(file, cfg)
+		return prepareEncryptPostSourceFileWithCache(file, cfg, sourceCache)
 	})
 	if err != nil {
 		return err
 	}
 
 	stats := encryptPostsStats{}
-	for _, candidate := range prepared {
-		result := candidate.result
+	for index := range prepared {
+		result := prepared[index].result
 		stats.add(result)
 		if result.Action == encryptPostActionEncrypted {
 			if encryptionDryRun {
@@ -214,17 +219,21 @@ func runEncryptPostsCommand(cmd *cobra.Command, _ []string) error {
 
 	if !encryptionDryRun {
 		documents := make([]sourceDocument, 0, stats.Encrypted)
-		for _, candidate := range prepared {
-			if candidate.result.Action == encryptPostActionEncrypted {
-				documents = append(documents, candidate.document)
+		for index := range prepared {
+			if prepared[index].result.Action == encryptPostActionEncrypted {
+				documents = append(documents, prepared[index].document)
 			}
+		}
+		cacheSourceEncryptionDocuments(sourceCache, documents)
+		if err := sourceCache.Save(); err != nil {
+			fmt.Fprintf(cmd.OutOrStdout(), "Warning: save source encryption cache: %v; future round trips may generate new ciphertext.\n", err)
 		}
 		if err := writeSourceDocuments(documents); err != nil {
 			return err
 		}
-		for _, candidate := range prepared {
-			if candidate.result.Action == encryptPostActionEncrypted {
-				fmt.Fprintln(cmd.OutOrStdout(), formatEncryptionProgress("ENCRYPTED", currentLogTheme.Success, candidate.result.Path, candidate.result.KeyName))
+		for index := range prepared {
+			if prepared[index].result.Action == encryptPostActionEncrypted {
+				fmt.Fprintln(cmd.OutOrStdout(), formatEncryptionProgress("ENCRYPTED", currentLogTheme.Success, prepared[index].result.Path, prepared[index].result.KeyName))
 			}
 		}
 	}
@@ -250,6 +259,10 @@ func runDecryptPostsCommand(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	sourceCache, cacheErr := buildcache.LoadSourceEncryptionCache(buildcache.DefaultCacheDir)
+	if cacheErr != nil {
+		fmt.Fprintf(cmd.OutOrStdout(), "Warning: %v; unchanged files may receive new ciphertext.\n", cacheErr)
+	}
 	prepared, err := prepareSourceFiles(files, encryptionWorkers, func(file string) (preparedDecryptPost, error) {
 		return prepareDecryptPostSourceFile(file, cfg)
 	})
@@ -258,8 +271,8 @@ func runDecryptPostsCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	stats := decryptPostsStats{}
-	for _, candidate := range prepared {
-		result := candidate.result
+	for index := range prepared {
+		result := prepared[index].result
 		stats.add(result)
 		if result.Action == decryptPostActionDecrypted {
 			if decryptionDryRun {
@@ -270,17 +283,21 @@ func runDecryptPostsCommand(cmd *cobra.Command, args []string) error {
 
 	if !decryptionDryRun {
 		documents := make([]sourceDocument, 0, stats.Decrypted)
-		for _, candidate := range prepared {
-			if candidate.result.Action == decryptPostActionDecrypted {
-				documents = append(documents, candidate.document)
+		for index := range prepared {
+			if prepared[index].result.Action == decryptPostActionDecrypted {
+				documents = append(documents, prepared[index].document)
 			}
+		}
+		cacheSourceEncryptionDocuments(sourceCache, documents)
+		if err := sourceCache.Save(); err != nil {
+			fmt.Fprintf(cmd.OutOrStdout(), "Warning: save source encryption cache: %v; future round trips may generate new ciphertext.\n", err)
 		}
 		if err := writeSourceDocuments(documents); err != nil {
 			return err
 		}
-		for _, candidate := range prepared {
-			if candidate.result.Action == decryptPostActionDecrypted {
-				fmt.Fprintln(cmd.OutOrStdout(), formatEncryptionProgress("DECRYPTED", currentLogTheme.Success, candidate.result.Path, candidate.result.KeyName))
+		for index := range prepared {
+			if prepared[index].result.Action == decryptPostActionDecrypted {
+				fmt.Fprintln(cmd.OutOrStdout(), formatEncryptionProgress("DECRYPTED", currentLogTheme.Success, prepared[index].result.Path, prepared[index].result.KeyName))
 			}
 		}
 	}
@@ -419,10 +436,12 @@ func prepareDecryptPostSourceFile(path string, cfg *models.Config) (preparedDecr
 	return preparedDecryptPost{
 		result: decryptPostResult{Path: path, KeyName: keyName, Action: decryptPostActionDecrypted},
 		document: sourceDocument{
-			path:     path,
-			original: content,
-			content:  decryptedSourceDocument(rawFrontmatter, plaintext),
-			mode:     sourceFileMode(path),
+			path:                    path,
+			original:                content,
+			content:                 decryptedSourceDocument(rawFrontmatter, plaintext),
+			mode:                    sourceFileMode(path),
+			sourceEncryptionKeyName: keyName,
+			sourceEncryptedBody:     body,
 		},
 	}, nil
 }
@@ -533,6 +552,10 @@ func encryptPostSourceFile(path string, cfg *models.Config, dryRun bool) (encryp
 }
 
 func prepareEncryptPostSourceFile(path string, cfg *models.Config) (preparedEncryptPost, error) {
+	return prepareEncryptPostSourceFileWithCache(path, cfg, nil)
+}
+
+func prepareEncryptPostSourceFileWithCache(path string, cfg *models.Config, cache *buildcache.SourceEncryptionCache) (preparedEncryptPost, error) {
 	contentBytes, err := os.ReadFile(path)
 	if err != nil {
 		return preparedEncryptPost{}, fmt.Errorf("read %s: %w", path, err)
@@ -574,17 +597,25 @@ func prepareEncryptPostSourceFile(path string, cfg *models.Config) (preparedEncr
 		return preparedEncryptPost{}, fmt.Errorf("private post %s key %q failed policy: %w", path, keyName, err)
 	}
 
-	encryptedBody, err := encryption.EncryptSourceMarkdown(body, keyName, password)
-	if err != nil {
-		return preparedEncryptPost{}, fmt.Errorf("encrypt source body for %s: %w", path, err)
+	encryptedBody := ""
+	if cache != nil {
+		encryptedBody, _ = cache.Get(path, body, keyName, password)
+	}
+	if encryptedBody == "" {
+		encryptedBody, err = encryption.EncryptSourceMarkdown(body, keyName, password)
+		if err != nil {
+			return preparedEncryptPost{}, fmt.Errorf("encrypt source body for %s: %w", path, err)
+		}
 	}
 	return preparedEncryptPost{
 		result: encryptPostResult{Path: path, KeyName: keyName, Action: encryptPostActionEncrypted},
 		document: sourceDocument{
-			path:     path,
-			original: content,
-			content:  encryptedSourceDocument(rawFrontmatter, encryptedBody),
-			mode:     sourceFileMode(path),
+			path:                    path,
+			original:                content,
+			content:                 encryptedSourceDocument(rawFrontmatter, encryptedBody),
+			mode:                    sourceFileMode(path),
+			sourceEncryptionKeyName: keyName,
+			sourceEncryptedBody:     encryptedBody,
 		},
 	}, nil
 }
@@ -597,10 +628,21 @@ func sourceFileMode(path string) os.FileMode {
 }
 
 type sourceDocument struct {
-	path     string
-	original string
-	content  string
-	mode     os.FileMode
+	path                    string
+	original                string
+	content                 string
+	mode                    os.FileMode
+	sourceEncryptionKeyName string
+	sourceEncryptedBody     string
+}
+
+func cacheSourceEncryptionDocuments(cache *buildcache.SourceEncryptionCache, documents []sourceDocument) {
+	if cache == nil {
+		return
+	}
+	for _, document := range documents {
+		cache.Put(document.path, document.sourceEncryptionKeyName, document.sourceEncryptedBody)
+	}
 }
 
 // writeSourceDocuments writes a prepared batch only when every source still
@@ -761,6 +803,9 @@ func validateEncryptPostsPassword(password string, cfg *models.Config) error {
 
 func applyEncryptPostsPrivateTags(post *models.Post, cfg *models.Config) {
 	if post == nil || cfg == nil || post.Skip || post.Draft {
+		return
+	}
+	if post.IsExplicitlyPublic() {
 		return
 	}
 	for _, tag := range post.Tags {

--- a/cmd/markata-go/cmd/encryption_test.go
+++ b/cmd/markata-go/cmd/encryption_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/WaylonWalker/markata-go/pkg/buildcache"
 	"github.com/WaylonWalker/markata-go/pkg/encryption"
 	"github.com/WaylonWalker/markata-go/pkg/models"
 	"github.com/WaylonWalker/markata-go/pkg/plugins"
@@ -244,6 +245,30 @@ tagged secret
 	}
 }
 
+func TestEncryptPostSourceFile_ExplicitPrivateFalseOverridesTag(t *testing.T) {
+	cfg := testEncryptPostsConfig()
+	cfg.Encryption.PrivateTags = map[string]string{"diary": "personal"}
+	path := writeMarkdownFile(t, `---
+title: Public diary
+private: false
+tags:
+  - diary
+---
+public body
+`)
+
+	result, err := encryptPostSourceFile(path, cfg, false)
+	if err != nil {
+		t.Fatalf("encryptPostSourceFile() error = %v", err)
+	}
+	if result.Action != encryptPostActionPublic {
+		t.Fatalf("action = %q, want %q", result.Action, encryptPostActionPublic)
+	}
+	if encryption.IsSourceEncrypted(strings.TrimSpace(strings.SplitN(readFileString(t, path), "---", 3)[2])) {
+		t.Fatal("explicit private: false post was encrypted")
+	}
+}
+
 func TestEncryptPostSourceFile_AlreadyEncryptedSkipsWithoutKey(t *testing.T) {
 	cfg := testEncryptPostsConfig()
 	encryptedBody, err := encryption.EncryptSourceMarkdown("secret body\n", "default", "h7Qm!2Vx9#Lp4@Td")
@@ -386,6 +411,51 @@ body
 	}
 	if got := readFileString(t, path); got != original {
 		t.Fatalf("round trip mismatch:\ngot  %q\nwant %q", got, original)
+	}
+}
+
+func TestSourceEncryptionCache_ReusesCiphertextAfterDecrypt(t *testing.T) {
+	cfg := testEncryptPostsConfig()
+	t.Setenv("MARKATA_GO_ENCRYPTION_KEY_DEFAULT", "h7Qm!2Vx9#Lp4@Td")
+	path := writeMarkdownFile(t, `---
+title: Secret
+private: true
+---
+secret body
+`)
+	cache, err := buildcache.LoadSourceEncryptionCache(t.TempDir())
+	if err != nil {
+		t.Fatalf("load source encryption cache: %v", err)
+	}
+
+	first, err := prepareEncryptPostSourceFileWithCache(path, cfg, cache)
+	if err != nil {
+		t.Fatalf("initial preparation: %v", err)
+	}
+	if err := writeSourceDocuments([]sourceDocument{first.document}); err != nil {
+		t.Fatalf("write encrypted source: %v", err)
+	}
+	cacheSourceEncryptionDocuments(cache, []sourceDocument{first.document})
+	originalEncrypted := readFileString(t, path)
+
+	decrypted, err := prepareDecryptPostSourceFile(path, cfg)
+	if err != nil {
+		t.Fatalf("decrypt preparation: %v", err)
+	}
+	if err := writeSourceDocuments([]sourceDocument{decrypted.document}); err != nil {
+		t.Fatalf("write decrypted source: %v", err)
+	}
+	cacheSourceEncryptionDocuments(cache, []sourceDocument{decrypted.document})
+
+	reencrypted, err := prepareEncryptPostSourceFileWithCache(path, cfg, cache)
+	if err != nil {
+		t.Fatalf("re-encrypt preparation: %v", err)
+	}
+	if err := writeSourceDocuments([]sourceDocument{reencrypted.document}); err != nil {
+		t.Fatalf("write re-encrypted source: %v", err)
+	}
+	if got := readFileString(t, path); got != originalEncrypted {
+		t.Fatalf("re-encryption changed unchanged ciphertext")
 	}
 }
 

--- a/docs/guides/encryption.md
+++ b/docs/guides/encryption.md
@@ -206,6 +206,23 @@ written.
 
 A typical edit cycle is `decrypt-posts <file>`, edit the Markdown, then `encrypt-posts` before committing.
 
+The commands keep authenticated ciphertext in
+`.markata/source-encryption-cache.json`. When a body is unchanged,
+`encrypt-posts` verifies and restores the existing ciphertext instead of
+generating a new random nonce. This keeps decrypt/re-encrypt cycles from
+changing every encrypted file. The cache stores ciphertext only, never
+plaintext or password-derived hashes, and is written with owner-only
+permissions.
+
+To opt one post out of a private tag or template default, set an explicit
+boolean override:
+
+```yaml
+private: false
+```
+
+An explicit `private: false` takes precedence over `encryption.private_tags`.
+
 Both bulk commands prepare documents in parallel by default, then begin writing only after every candidate is successfully prepared. A missing key, invalid password, malformed source file, cryptographic error, or detected edit during preparation leaves the repository unchanged. Replacements use atomic file writes, and a write failure restores earlier files. Use `--workers 1` if you need serial processing; `--workers 0` is the default and uses `GOMAXPROCS` workers.
 
 When run in a terminal, encryption progress uses your active CLI color theme. Use `--color` to force colors or `--no-color` for plain output.

--- a/pkg/buildcache/cache.go
+++ b/pkg/buildcache/cache.go
@@ -44,7 +44,7 @@ import (
 )
 
 // CacheVersion is incremented when the cache format changes.
-const CacheVersion = 1
+const CacheVersion = 2
 
 // DefaultCacheDir is the directory for cache files.
 const DefaultCacheDir = ".markata"
@@ -1719,27 +1719,28 @@ const PostCacheDir = "post-cache"
 // CachedPostData holds the serializable parts of a Post for caching.
 // This excludes rendered HTML which is cached separately.
 type CachedPostData struct {
-	Path           string            `json:"path"`
-	Content        string            `json:"content"`
-	Slug           string            `json:"slug"`
-	Href           string            `json:"href"`
-	Title          *string           `json:"title,omitempty"`
-	Date           *time.Time        `json:"date,omitempty"`
-	Modified       *time.Time        `json:"modified,omitempty"`
-	Published      bool              `json:"published"`
-	Draft          bool              `json:"draft"`
-	Private        bool              `json:"private"`
-	Skip           bool              `json:"skip"`
-	SecretKey      string            `json:"secret_key,omitempty"`
-	Tags           []string          `json:"tags,omitempty"`
-	Description    *string           `json:"description,omitempty"`
-	Template       string            `json:"template"`
-	Templates      map[string]string `json:"templates,omitempty"`
-	RawFrontmatter string            `json:"raw_frontmatter"`
-	InputHash      string            `json:"input_hash"`
-	Authors        []string          `json:"authors,omitempty"`
-	Author         *string           `json:"author,omitempty"`
-	Extra          map[string]any    `json:"extra,omitempty"`
+	Path            string            `json:"path"`
+	Content         string            `json:"content"`
+	Slug            string            `json:"slug"`
+	Href            string            `json:"href"`
+	Title           *string           `json:"title,omitempty"`
+	Date            *time.Time        `json:"date,omitempty"`
+	Modified        *time.Time        `json:"modified,omitempty"`
+	Published       bool              `json:"published"`
+	Draft           bool              `json:"draft"`
+	Private         bool              `json:"private"`
+	PrivateOverride *bool             `json:"private_override,omitempty"`
+	Skip            bool              `json:"skip"`
+	SecretKey       string            `json:"secret_key,omitempty"`
+	Tags            []string          `json:"tags,omitempty"`
+	Description     *string           `json:"description,omitempty"`
+	Template        string            `json:"template"`
+	Templates       map[string]string `json:"templates,omitempty"`
+	RawFrontmatter  string            `json:"raw_frontmatter"`
+	InputHash       string            `json:"input_hash"`
+	Authors         []string          `json:"authors,omitempty"`
+	Author          *string           `json:"author,omitempty"`
+	Extra           map[string]any    `json:"extra,omitempty"`
 }
 
 // GetCachedPostData returns cached post data if ModTime matches.

--- a/pkg/buildcache/source_encryption_cache.go
+++ b/pkg/buildcache/source_encryption_cache.go
@@ -1,0 +1,138 @@
+package buildcache
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/WaylonWalker/markata-go/pkg/encryption"
+)
+
+const (
+	SourceEncryptionCacheFileName = "source-encryption-cache.json"
+	sourceEncryptionCacheVersion  = 1
+)
+
+// SourceEncryptionCache preserves authenticated ciphertext across a
+// decrypt/edit/encrypt cycle. It deliberately stores no plaintext or
+// password-derived verifier.
+type SourceEncryptionCache struct {
+	mu      sync.RWMutex
+	path    string
+	Version int                              `json:"version"`
+	Entries map[string]SourceEncryptionEntry `json:"entries"`
+}
+
+// SourceEncryptionEntry is ciphertext associated with one source path.
+type SourceEncryptionEntry struct {
+	KeyName       string `json:"key_name"`
+	EncryptedBody string `json:"encrypted_body"`
+}
+
+// LoadSourceEncryptionCache loads the dedicated source-encryption cache.
+// Missing or malformed caches are treated as empty caches and returned as a
+// warning error so callers can continue without sacrificing correctness.
+func LoadSourceEncryptionCache(cacheDir string) (*SourceEncryptionCache, error) {
+	if cacheDir == "" {
+		cacheDir = DefaultCacheDir
+	}
+	cache := &SourceEncryptionCache{
+		path:    filepath.Join(cacheDir, SourceEncryptionCacheFileName),
+		Version: sourceEncryptionCacheVersion,
+		Entries: make(map[string]SourceEncryptionEntry),
+	}
+	data, err := os.ReadFile(cache.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return cache, nil
+		}
+		return cache, fmt.Errorf("read source encryption cache: %w", err)
+	}
+	var disk SourceEncryptionCache
+	if err := json.Unmarshal(data, &disk); err != nil || disk.Version != sourceEncryptionCacheVersion {
+		if err == nil {
+			err = fmt.Errorf("unsupported version %d", disk.Version)
+		}
+		return cache, fmt.Errorf("parse source encryption cache: %w", err)
+	}
+	cache.Entries = disk.Entries
+	if cache.Entries == nil {
+		cache.Entries = make(map[string]SourceEncryptionEntry)
+	}
+	return cache, nil
+}
+
+// Get returns a cache hit only after AES-GCM authentication and an exact
+// plaintext comparison with the current source body succeed.
+func (c *SourceEncryptionCache) Get(path, plaintext, keyName, password string) (string, bool) {
+	c.mu.RLock()
+	entry, ok := c.Entries[path]
+	c.mu.RUnlock()
+	if !ok || !strings.EqualFold(strings.TrimSpace(entry.KeyName), strings.TrimSpace(keyName)) {
+		return "", false
+	}
+	decrypted, resolvedKey, err := encryption.DecryptSourceMarkdown(entry.EncryptedBody, password)
+	if err != nil || !strings.EqualFold(strings.TrimSpace(resolvedKey), strings.TrimSpace(keyName)) || decrypted != plaintext {
+		return "", false
+	}
+	return entry.EncryptedBody, true
+}
+
+// Put records an authenticated ciphertext for a source path.
+func (c *SourceEncryptionCache) Put(path, keyName, encryptedBody string) {
+	if path == "" || keyName == "" || encryptedBody == "" {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.Entries[path] = SourceEncryptionEntry{KeyName: keyName, EncryptedBody: encryptedBody}
+}
+
+// Save atomically persists the cache with owner-only permissions.
+func (c *SourceEncryptionCache) Save() error {
+	c.mu.RLock()
+	disk := struct {
+		Version int                              `json:"version"`
+		Entries map[string]SourceEncryptionEntry `json:"entries"`
+	}{Version: sourceEncryptionCacheVersion, Entries: make(map[string]SourceEncryptionEntry, len(c.Entries))}
+	for path, entry := range c.Entries {
+		disk.Entries[path] = entry
+	}
+	c.mu.RUnlock()
+
+	data, err := json.Marshal(disk)
+	if err != nil {
+		return fmt.Errorf("marshal source encryption cache: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(c.path), 0o700); err != nil {
+		return fmt.Errorf("create source encryption cache directory: %w", err)
+	}
+	temporary, err := os.CreateTemp(filepath.Dir(c.path), ".source-encryption-cache-*")
+	if err != nil {
+		return fmt.Errorf("create source encryption cache temporary file: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+	if err := temporary.Chmod(0o600); err != nil {
+		temporary.Close()
+		return err
+	}
+	if _, err := temporary.Write(data); err != nil {
+		temporary.Close()
+		return fmt.Errorf("write source encryption cache: %w", err)
+	}
+	if err := temporary.Sync(); err != nil {
+		temporary.Close()
+		return fmt.Errorf("sync source encryption cache: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close source encryption cache: %w", err)
+	}
+	if err := os.Rename(temporaryPath, c.path); err != nil {
+		return fmt.Errorf("replace source encryption cache: %w", err)
+	}
+	return nil
+}

--- a/pkg/buildcache/source_encryption_cache_test.go
+++ b/pkg/buildcache/source_encryption_cache_test.go
@@ -1,0 +1,44 @@
+package buildcache
+
+import (
+	"testing"
+
+	"github.com/WaylonWalker/markata-go/pkg/encryption"
+)
+
+func TestSourceEncryptionCache_SaveLoadAndValidate(t *testing.T) {
+	cacheDir := t.TempDir()
+	cache, err := LoadSourceEncryptionCache(cacheDir)
+	if err != nil {
+		t.Fatalf("load cache: %v", err)
+	}
+	password := "h7Qm!2Vx9#Lp4@Td" //nolint:gosec // test password
+	body := "secret body\n"
+	encrypted, err := encryption.EncryptSourceMarkdown(body, "default", password)
+	if err != nil {
+		t.Fatalf("encrypt body: %v", err)
+	}
+	cache.Put("post.md", "default", encrypted)
+	if err := cache.Save(); err != nil {
+		t.Fatalf("save cache: %v", err)
+	}
+
+	reloaded, err := LoadSourceEncryptionCache(cacheDir)
+	if err != nil {
+		t.Fatalf("reload persisted cache: %v", err)
+	}
+	if got, ok := reloaded.Get("post.md", body, "default", password); !ok || got != encrypted {
+		t.Fatal("persisted cache did not validate unchanged ciphertext")
+	}
+	if _, ok := reloaded.Get("post.md", "changed body\n", "default", password); ok {
+		t.Fatal("cache accepted changed plaintext")
+	}
+	if _, ok := reloaded.Get("post.md", body, "default", "wrong-password"); ok {
+		t.Fatal("cache accepted the wrong password")
+	}
+
+	reloaded.Entries["post.md"] = SourceEncryptionEntry{KeyName: "default", EncryptedBody: "tampered"}
+	if _, ok := reloaded.Get("post.md", body, "default", password); ok {
+		t.Fatal("cache accepted tampered ciphertext")
+	}
+}

--- a/pkg/listcache/listcache.go
+++ b/pkg/listcache/listcache.go
@@ -279,7 +279,7 @@ func saveCache(path string, cache Cache) error {
 	return nil
 }
 
-func discoverFiles(m *lifecycle.Manager) (files []string, modTimes map[string]plugins.GlobFileInfo, err error) {
+func discoverFiles(m *lifecycle.Manager) ([]string, map[string]plugins.GlobFileInfo, error) {
 	glob := plugins.NewGlobPlugin()
 	if err := glob.Configure(m); err != nil {
 		return nil, nil, err

--- a/pkg/listcache/listcache.go
+++ b/pkg/listcache/listcache.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	CacheVersion    = 5
+	CacheVersion    = 6
 	DefaultCacheDir = ".markata/cache"
 	CacheFileName   = "list.json"
 )
@@ -44,27 +44,28 @@ type FileInfo struct {
 }
 
 type CachedPost struct {
-	Path        string            `json:"path"`
-	Content     string            `json:"content"`
-	Slug        string            `json:"slug"`
-	Href        string            `json:"href"`
-	Title       *string           `json:"title,omitempty"`
-	Date        *time.Time        `json:"date,omitempty"`
-	Published   bool              `json:"published"`
-	Draft       bool              `json:"draft"`
-	Private     bool              `json:"private"`
-	Skip        bool              `json:"skip"`
-	Tags        []string          `json:"tags,omitempty"`
-	Description *string           `json:"description,omitempty"`
-	Template    string            `json:"template"`
-	Templates   map[string]string `json:"templates,omitempty"`
-	Authors     []string          `json:"authors,omitempty"`
-	Author      *string           `json:"author,omitempty"`
-	SecretKey   string            `json:"secret_key,omitempty"`
-	Extra       map[string]any    `json:"extra,omitempty"`
-	WordCount   int               `json:"word_count"`
-	ReadingTime int               `json:"reading_time"`
-	CharCount   int               `json:"char_count"`
+	Path            string            `json:"path"`
+	Content         string            `json:"content"`
+	Slug            string            `json:"slug"`
+	Href            string            `json:"href"`
+	Title           *string           `json:"title,omitempty"`
+	Date            *time.Time        `json:"date,omitempty"`
+	Published       bool              `json:"published"`
+	Draft           bool              `json:"draft"`
+	Private         bool              `json:"private"`
+	PrivateOverride *bool             `json:"private_override,omitempty"`
+	Skip            bool              `json:"skip"`
+	Tags            []string          `json:"tags,omitempty"`
+	Description     *string           `json:"description,omitempty"`
+	Template        string            `json:"template"`
+	Templates       map[string]string `json:"templates,omitempty"`
+	Authors         []string          `json:"authors,omitempty"`
+	Author          *string           `json:"author,omitempty"`
+	SecretKey       string            `json:"secret_key,omitempty"`
+	Extra           map[string]any    `json:"extra,omitempty"`
+	WordCount       int               `json:"word_count"`
+	ReadingTime     int               `json:"reading_time"`
+	CharCount       int               `json:"char_count"`
 }
 
 type CachedFeed struct {
@@ -279,7 +280,7 @@ func saveCache(path string, cache Cache) error {
 	return nil
 }
 
-func discoverFiles(m *lifecycle.Manager) ([]string, map[string]plugins.GlobFileInfo, error) {
+func discoverFiles(m *lifecycle.Manager) (files []string, modTimes map[string]plugins.GlobFileInfo, err error) {
 	glob := plugins.NewGlobPlugin()
 	if err := glob.Configure(m); err != nil {
 		return nil, nil, err
@@ -383,12 +384,15 @@ func markPrivateTags(cfg *lifecycle.Config, posts []*models.Post) {
 	}
 	privateTags := modelsConfig.Encryption.PrivateTags
 	for _, post := range posts {
-		if post == nil || post.Skip || post.Draft || post.Private {
+		if post == nil || post.Skip || post.Draft || post.Private || post.IsExplicitlyPublic() {
 			continue
 		}
 		for _, tag := range post.Tags {
-			if _, ok := privateTags[strings.ToLower(tag)]; ok {
+			if keyName, ok := privateTags[strings.ToLower(tag)]; ok {
 				post.Private = true
+				if post.SecretKey == "" {
+					post.SecretKey = keyName
+				}
 				break
 			}
 		}
@@ -396,8 +400,11 @@ func markPrivateTags(cfg *lifecycle.Config, posts []*models.Post) {
 			continue
 		}
 		if post.Template != "" {
-			if _, ok := privateTags[strings.ToLower(post.Template)]; ok {
+			if keyName, ok := privateTags[strings.ToLower(post.Template)]; ok {
 				post.Private = true
+				if post.SecretKey == "" {
+					post.SecretKey = keyName
+				}
 			}
 		}
 	}
@@ -445,27 +452,28 @@ func cloneFeedConfigs(feeds []models.FeedConfig) []models.FeedConfig {
 
 func modelToCachedPost(post *models.Post) CachedPost {
 	return CachedPost{
-		Path:        post.Path,
-		Content:     post.Content,
-		Slug:        post.Slug,
-		Href:        post.Href,
-		Title:       post.Title,
-		Date:        post.Date,
-		Published:   post.Published,
-		Draft:       post.Draft,
-		Private:     post.Private,
-		Skip:        post.Skip,
-		Tags:        append([]string{}, post.Tags...),
-		Description: post.Description,
-		Template:    post.Template,
-		Templates:   cloneStringMap(post.Templates),
-		Authors:     append([]string{}, post.Authors...),
-		Author:      post.Author,
-		SecretKey:   post.SecretKey, // pragma: allowlist secret
-		Extra:       cloneAnyMap(post.Extra),
-		WordCount:   getExtraInt(post.Extra, "word_count"),
-		ReadingTime: getExtraInt(post.Extra, "reading_time"),
-		CharCount:   getExtraInt(post.Extra, "char_count"),
+		Path:            post.Path,
+		Content:         post.Content,
+		Slug:            post.Slug,
+		Href:            post.Href,
+		Title:           post.Title,
+		Date:            post.Date,
+		Published:       post.Published,
+		Draft:           post.Draft,
+		Private:         post.Private,
+		PrivateOverride: post.PrivateOverride,
+		Skip:            post.Skip,
+		Tags:            append([]string{}, post.Tags...),
+		Description:     post.Description,
+		Template:        post.Template,
+		Templates:       cloneStringMap(post.Templates),
+		Authors:         append([]string{}, post.Authors...),
+		Author:          post.Author,
+		SecretKey:       post.SecretKey, // pragma: allowlist secret
+		Extra:           cloneAnyMap(post.Extra),
+		WordCount:       getExtraInt(post.Extra, "word_count"),
+		ReadingTime:     getExtraInt(post.Extra, "reading_time"),
+		CharCount:       getExtraInt(post.Extra, "char_count"),
 	}
 }
 
@@ -479,6 +487,7 @@ func cachedPostToModel(cached CachedPost) *models.Post {
 	post.Published = cached.Published
 	post.Draft = cached.Draft
 	post.Private = cached.Private
+	post.PrivateOverride = cached.PrivateOverride
 	post.Skip = cached.Skip
 	post.Tags = append([]string{}, cached.Tags...)
 	post.Description = cached.Description

--- a/pkg/models/post.go
+++ b/pkg/models/post.go
@@ -41,6 +41,10 @@ type Post struct {
 	// Private posts are rendered but excluded from feeds, sitemaps, and add noindex meta tag
 	Private bool `json:"private" yaml:"private" toml:"private"`
 
+	// PrivateOverride records whether private was explicitly set in frontmatter.
+	// A non-nil false value opts out of inferred privacy from private tags.
+	PrivateOverride *bool `json:"-" yaml:"-" toml:"-"`
+
 	// SecretKey is the name of the encryption key to use for this post.
 	// When set along with Private=true, the post content will be encrypted.
 	// The actual key is read from environment variable MARKATA_GO_ENCRYPTION_KEY_{SecretKey}
@@ -134,6 +138,12 @@ type Post struct {
 
 	// Computed fields (not in frontmatter)
 	AuthorObjects []Author `json:"-" yaml:"-" toml:"-"`
+}
+
+// IsExplicitlyPublic reports whether frontmatter explicitly opted out of
+// inferred privacy.
+func (p *Post) IsExplicitlyPublic() bool {
+	return p != nil && p.PrivateOverride != nil && !*p.PrivateOverride
 }
 
 // NewPost creates a new Post with the given source file path and default values.

--- a/pkg/plugins/encryption.go
+++ b/pkg/plugins/encryption.go
@@ -217,6 +217,10 @@ func (p *EncryptionPlugin) applyPrivateTags(posts []*models.Post) {
 		if post.Skip || post.Draft {
 			continue
 		}
+		// An explicit private: false is an opt-out from tag/template defaults.
+		if post.IsExplicitlyPublic() {
+			continue
+		}
 
 		// Check tags
 		matched := false

--- a/pkg/plugins/encryption_test.go
+++ b/pkg/plugins/encryption_test.go
@@ -405,6 +405,16 @@ func TestEncryptionPlugin_ApplyPrivateTags(t *testing.T) {
 			wantSecretKey: "personal",
 		},
 		{
+			name: "explicit private false overrides matching tag",
+			post: func() *models.Post {
+				private := false
+				post := &models.Post{Tags: []string{"diary"}, PrivateOverride: &private}
+				return post
+			}(),
+			wantPrivate:   false,
+			wantSecretKey: "",
+		},
+		{
 			name: "no matching tag leaves post unchanged",
 			post: &models.Post{
 				Tags: []string{"golang", "tutorial"},

--- a/pkg/plugins/load.go
+++ b/pkg/plugins/load.go
@@ -449,6 +449,7 @@ func (p *LoadPlugin) restorePostFromCache(data *buildcache.CachedPostData, cache
 	post.Published = data.Published
 	post.Draft = data.Draft
 	post.Private = data.Private
+	post.PrivateOverride = data.PrivateOverride
 	post.Skip = data.Skip
 	post.Tags = data.Tags
 	post.Description = data.Description
@@ -601,27 +602,28 @@ func computePostGardenHash(post *models.Post) string {
 // postToCachedData converts a Post to cacheable data.
 func (p *LoadPlugin) postToCachedData(post *models.Post) *buildcache.CachedPostData {
 	return &buildcache.CachedPostData{
-		Path:           post.Path,
-		Content:        post.Content,
-		Slug:           post.Slug,
-		Href:           post.Href,
-		Title:          post.Title,
-		Date:           post.Date,
-		Modified:       post.Modified,
-		Published:      post.Published,
-		Draft:          post.Draft,
-		Private:        post.Private,
-		Skip:           post.Skip,
-		Tags:           post.Tags,
-		Description:    post.Description,
-		Template:       post.Template,
-		Templates:      post.Templates,
-		RawFrontmatter: post.RawFrontmatter,
-		InputHash:      post.InputHash,
-		Authors:        post.Authors,
-		Author:         post.Author,
-		SecretKey:      post.SecretKey, // pragma: allowlist secret
-		Extra:          post.Extra,
+		Path:            post.Path,
+		Content:         post.Content,
+		Slug:            post.Slug,
+		Href:            post.Href,
+		Title:           post.Title,
+		Date:            post.Date,
+		Modified:        post.Modified,
+		Published:       post.Published,
+		Draft:           post.Draft,
+		Private:         post.Private,
+		PrivateOverride: post.PrivateOverride,
+		Skip:            post.Skip,
+		Tags:            post.Tags,
+		Description:     post.Description,
+		Template:        post.Template,
+		Templates:       post.Templates,
+		RawFrontmatter:  post.RawFrontmatter,
+		InputHash:       post.InputHash,
+		Authors:         post.Authors,
+		Author:          post.Author,
+		SecretKey:       post.SecretKey, // pragma: allowlist secret
+		Extra:           post.Extra,
 	}
 }
 
@@ -782,6 +784,9 @@ func (p *LoadPlugin) applySourcePrivateTags(post *models.Post) {
 	if len(p.encryptionTags) == 0 || post == nil || post.Skip || post.Draft {
 		return
 	}
+	if post.IsExplicitlyPublic() {
+		return
+	}
 	for _, tag := range post.Tags {
 		if keyName, ok := p.encryptionTags[strings.ToLower(tag)]; ok {
 			post.Private = true
@@ -876,7 +881,9 @@ func (p *LoadPlugin) applyMetadata(post *models.Post, metadata map[string]interf
 	post.Draft = GetBool(metadata, "draft", false)
 
 	// Private
-	post.Private = GetBool(metadata, "private", false)
+	if err := applyPrivateMetadata(post, metadata); err != nil {
+		return err
+	}
 
 	// Skip
 	post.Skip = GetBool(metadata, "skip", false)
@@ -949,6 +956,22 @@ func (p *LoadPlugin) applyMetadata(post *models.Post, metadata map[string]interf
 		}
 	}
 
+	return nil
+}
+
+func applyPrivateMetadata(post *models.Post, metadata map[string]interface{}) error {
+	post.Private = false
+	post.PrivateOverride = nil
+	rawPrivate, ok := metadata["private"]
+	if !ok {
+		return nil
+	}
+	private, ok := rawPrivate.(bool)
+	if !ok {
+		return fmt.Errorf("frontmatter field private must be a boolean")
+	}
+	post.Private = private
+	post.PrivateOverride = &private
 	return nil
 }
 

--- a/pkg/plugins/load_test.go
+++ b/pkg/plugins/load_test.go
@@ -10,6 +10,33 @@ import (
 	"github.com/WaylonWalker/markata-go/pkg/models"
 )
 
+func TestParsePostFromContent_PrivateOverride(t *testing.T) {
+	public, err := ParsePostFromContent("public.md", "---\nprivate: false\n---\nbody\n")
+	if err != nil {
+		t.Fatalf("parse explicit false: %v", err)
+	}
+	if !public.IsExplicitlyPublic() || public.Private {
+		t.Fatal("explicit private: false was not preserved")
+	}
+
+	private, err := ParsePostFromContent("private.md", "---\nprivate: true\n---\nbody\n")
+	if err != nil {
+		t.Fatalf("parse explicit true: %v", err)
+	}
+	if private.IsExplicitlyPublic() || !private.Private {
+		t.Fatal("explicit private: true was not preserved")
+	}
+}
+
+func TestParsePostFromContent_InvalidPrivateValue(t *testing.T) {
+	for _, value := range []string{"\"false\"", "0", "null"} {
+		_, err := ParsePostFromContent("invalid.md", "---\nprivate: "+value+"\n---\nbody\n")
+		if err == nil {
+			t.Errorf("private: %s should fail parsing", value)
+		}
+	}
+}
+
 func TestResolveFileModTime_UsesGlobCachedModTime(t *testing.T) {
 	m := lifecycle.NewManager()
 	m.Cache().Set(cacheKeyGlobFileModTimes, map[string]int64{"post.md": 12345})

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -230,7 +230,7 @@ func NewModelWithTheme(app *services.App, theme *Theme) Model {
 	helpSearchInput.CharLimit = 100
 
 	// Initialize posts table with columns and theme
-	postsTable := createPostsTableWithTheme(80, theme) // Default width, updated on resize
+	postsTable := createPostsTableWithTheme(80, theme, "date") // Default width, updated on resize
 
 	// Initialize tags table with columns and theme
 	tagsTable := createTagsTableWithTheme(80, theme) // Default width, will be updated on resize
@@ -326,11 +326,11 @@ func createFeedsTableWithTheme(width int, theme *Theme) table.Model {
 }
 
 // createPostsTableWithTheme creates and configures the posts table with theme colors.
-func createPostsTableWithTheme(width int, theme *Theme) table.Model {
-	return createTableWithTheme(postsTableColumns(width), theme)
+func createPostsTableWithTheme(width int, theme *Theme, sortBy string) table.Model {
+	return createTableWithTheme(postsTableColumns(width, theme, sortBy), theme)
 }
 
-func postsTableColumns(width int) []table.Column {
+func postsTableColumns(width int, theme *Theme, sortBy string) []table.Column {
 	// Column widths: TITLE(35) + DATE(12) + WORDS(8) + READ(8) + TAGS(18) + PATH(remaining)
 	// Account for padding/borders (approximately 10 chars)
 	pathWidth := width - 35 - 12 - 8 - 8 - 18 - 10
@@ -359,7 +359,7 @@ func (m Model) handleWindowResize(msg tea.WindowSizeMsg) (tea.Model, tea.Cmd) {
 	m.height = msg.Height
 
 	// Update table dimensions with theme
-	m.postsTable = createPostsTableWithTheme(msg.Width, m.theme)
+	m.postsTable = createPostsTableWithTheme(msg.Width, m.theme, m.sortBy)
 	m.postsTable.SetHeight(msg.Height - 10) // Leave room for header/footer
 	m.tagsTable = createTagsTableWithTheme(msg.Width, m.theme)
 	m.tagsTable.SetHeight(msg.Height - 10)
@@ -1000,7 +1000,7 @@ func (m Model) handleSortHotkey(field string) (tea.Model, tea.Cmd) {
 		m.sortBy = field
 		m.sortOrder = services.SortDesc
 	}
-	m.postsTable.SetColumns(postsTableColumns(m.width))
+	m.postsTable.SetColumns(postsTableColumns(m.width, m.theme, m.sortBy))
 
 	// Reset cursor and reload posts
 	m.cursor = 0
@@ -1733,7 +1733,7 @@ func (m Model) handleSortMenuKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "enter":
 		m.sortBy = sortOptions[m.sortMenuIdx].value
 		m.showSortMenu = false
-		m.postsTable.SetColumns(postsTableColumns(m.width))
+		m.postsTable.SetColumns(postsTableColumns(m.width, m.theme, m.sortBy))
 		m.cursor = 0
 		m.postsTable.SetCursor(0)
 		return m, m.loadPosts()

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -330,7 +330,7 @@ func createPostsTableWithTheme(width int, theme *Theme, sortBy string) table.Mod
 	return createTableWithTheme(postsTableColumns(width, theme, sortBy), theme)
 }
 
-func postsTableColumns(width int, theme *Theme, sortBy string) []table.Column {
+func postsTableColumns(width int, _ *Theme, _ string) []table.Column {
 	// Column widths: TITLE(35) + DATE(12) + WORDS(8) + READ(8) + TAGS(18) + PATH(remaining)
 	// Account for padding/borders (approximately 10 chars)
 	pathWidth := width - 35 - 12 - 8 - 8 - 18 - 10

--- a/pkg/tui/model_test.go
+++ b/pkg/tui/model_test.go
@@ -602,7 +602,7 @@ func TestRenderPostsTable_PreservesHeaders(t *testing.T) {
 	m := Model{
 		theme:      theme,
 		sortBy:     "date",
-		postsTable: createPostsTableWithTheme(120, theme),
+		postsTable: createPostsTableWithTheme(120, theme, "date"),
 		posts:      []*models.Post{{Title: &title}},
 	}
 	m.postsTable.SetRows(m.postsToRows())

--- a/spec/spec/ENCRYPTION.md
+++ b/spec/spec/ENCRYPTION.md
@@ -183,6 +183,10 @@ The full list of post paths should not be printed in the error message.
 
 Posts with `Draft = true` or `Skip = true` are excluded from all encryption processing. They are not subject to key validation and are never encrypted.
 
+An explicit `private: false` is also an opt-out from `encryption.private_tags` and
+template-key privacy defaults. This allows an individual post to remain public
+even when its tag or template normally marks posts private.
+
 ### Disabled State
 
 When `enabled = false`, the plugin's `Render()` method returns `nil` immediately. No posts are modified.
@@ -289,6 +293,17 @@ markata-go encryption decrypt-posts --workers 4
 - The password is read from `MARKATA_GO_ENCRYPTION_KEY_<KEY>`. A missing env var or an incorrect password MUST fail before any file is written.
 - Key strength policy is NOT enforced for decryption; only the correct password matters.
 - `--workers` bounds concurrent source-body preparation. The default (`0`) uses `GOMAXPROCS`; set `--workers 1` to process serially.
+
+### Source encryption round trips
+
+The source-encryption commands store authenticated ciphertext in the dedicated
+`.markata/source-encryption-cache.json` file. After `decrypt-posts`, an
+unchanged body passed to `encrypt-posts` is decrypted and compared with the
+current body before its original ciphertext and nonce are reused. Only changed
+source bodies are re-encrypted, so a decrypt/edit/encrypt cycle does not create
+repository-wide ciphertext churn. The cache contains no plaintext, password,
+or password-derived verifier. Cache failures are non-fatal; encryption falls
+back to fresh ciphertext and reports a warning.
 
 ### Source Command Write Safety
 


### PR DESCRIPTION
## Summary
- Preserve authenticated ciphertext across unchanged decrypt/re-encrypt cycles.
- Honor explicit `private: false` over private tag and template defaults.
- Persist privacy overrides through build and list caches.
- Add documentation, specification updates, and regression tests.
- Fix lint issues surfaced by `just ci`.

Refs #1135

## Validation
- `just ci`

No deployment performed.