### PR TITLE
feat(markdown): add Plaindown-compatible expressive headings

### DIFF
--- a/docs/guides/markdown.md
+++ b/docs/guides/markdown.md
@@ -90,6 +90,31 @@ Use `#` characters to create headings (levels 1-6):
 
     The linter will warn you if H1 headings are detected in content.
 
+#### Expressive headings
+
+Headings and frontmatter titles use ordinary semantic Markdown inline elements.
+The active theme and font pack choose how strongly they are presented in H1 and
+H2 headings:
+
+```yaml
+---
+title: "Good themes make **good places** to ==think.=="
+---
+```
+
+```markdown
+## A **good theme** makes _quiet words_, `technical words`, and ==loud words== work together.
+
+## Make a ~~perfect~~ memorable site.
+```
+
+This supports strong, emphasis, mark, code, links, and GFM strikethrough,
+including nested forms such as `==**strange little ideas.**==`. These are
+semantic elements rather than a separate heading syntax. Visible headings keep
+their rich semantics, while browser titles, feeds, search, and social metadata
+use the readable plain-text title. This behavior is intended to match
+[Plaindown](https://git.waylonwalker.com/waylon/md.waylonwalker.com).
+
 ### Paragraphs
 
 Paragraphs are separated by blank lines:

--- a/docs/guides/markdown.md
+++ b/docs/guides/markdown.md
@@ -108,7 +108,7 @@ title: "Good themes make **good places** to ==think.=="
 ## Make a ~~perfect~~ memorable site.
 ```
 
-This supports strong, emphasis, mark, code, links, and GFM strikethrough,
+This supports strong, emphasis, mark, code, links, superscript, subscript, and GFM strikethrough,
 including nested forms such as `==**strange little ideas.**==`. These are
 semantic elements rather than a separate heading syntax. Visible headings keep
 their rich semantics, while browser titles, feeds, search, and social metadata

--- a/pkg/agentskill/bundle/markata-go-site/reference/template-context.md
+++ b/pkg/agentskill/bundle/markata-go-site/reference/template-context.md
@@ -45,12 +45,19 @@ Usually available in HTML templates:
 - `post.html`
 - `post.article_html`
 - `post.title`
+- `post.title_html` (safe rendered inline Markdown for visible headings)
+- `post.title_text` (semantic plain text for metadata, feeds, search, and slugs)
+- `post.title_source` (authored/source title)
 - `post.date`
 - `post.description`
 - `post.author`
 - `post.authors`
 - `post.author_objects`
 - `post.Extra`
+
+`post.title` uses the semantic plain title. Use `post.title_html` only in a
+trusted visual heading context. A successfully derived empty `title_text` is
+intentional and must not fall back to `title_source`.
 
 ## Stats And Analytics Fields
 

--- a/pkg/filter/evaluator.go
+++ b/pkg/filter/evaluator.go
@@ -372,7 +372,7 @@ func getKnownField(post *models.Post, name string) (interface{}, bool) {
 		if post.Title == nil {
 			return nil, true
 		}
-		return *post.Title, true
+		return post.PlainTitle(), true
 	case "date", "Date":
 		if post.Date == nil {
 			return nil, true

--- a/pkg/lifecycle/manager.go
+++ b/pkg/lifecycle/manager.go
@@ -709,6 +709,12 @@ func (m *Manager) Map(field, filterExpr, sortField string, reverse bool) ([]inte
 
 // getPostField retrieves a field value from a post using reflection.
 func getPostField(post *models.Post, field string) interface{} {
+	if strings.EqualFold(field, "title") {
+		if post == nil || post.Title == nil {
+			return nil
+		}
+		return post.PlainTitle()
+	}
 	// Check Extra fields first
 	if post.Extra != nil {
 		if v, ok := post.Extra[field]; ok {

--- a/pkg/lifecycle/manager_test.go
+++ b/pkg/lifecycle/manager_test.go
@@ -486,6 +486,20 @@ func TestManagerMap(t *testing.T) {
 	}
 }
 
+func TestManagerMap_TitleUsesSemanticRepresentation(t *testing.T) {
+	source := "Good **places** to ==think=="
+	post := &models.Post{Title: &source, TitleText: "Good places to think", TitleTextDerived: true}
+	m := NewManager()
+	m.SetPosts([]*models.Post{post})
+	values, err := m.Map("title", "", "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(values) != 1 || values[0] != "Good places to think" {
+		t.Fatalf("Map(title) = %#v", values)
+	}
+}
+
 func TestManagerCache(t *testing.T) {
 	m := NewManager()
 

--- a/pkg/models/post.go
+++ b/pkg/models/post.go
@@ -25,6 +25,13 @@ type Post struct {
 	// Title is the optional post title
 	Title *string `json:"title,omitempty" yaml:"title,omitempty" toml:"title,omitempty"`
 
+	// TitleHTML is the safe inline-Markdown rendering for visual title contexts.
+	TitleHTML string `json:"-" yaml:"-" toml:"-"`
+
+	// TitleText is the semantic plain-text title for metadata and other
+	// non-visual consumers. Title remains the authored/source value.
+	TitleText string `json:"-" yaml:"-" toml:"-"`
+
 	// Date is the optional publication date
 	Date *time.Time `json:"date,omitempty" yaml:"date,omitempty" toml:"date,omitempty"`
 
@@ -258,12 +265,33 @@ func (p *Post) GenerateSlug() {
 }
 
 func (p *Post) GenerateSlugWithMode(mode string) {
+	title := p.Title
+	if p.TitleText != "" {
+		titleText := p.TitleText
+		title = &titleText
+	}
 	switch NormalizeSlugMode(mode) {
 	case SlugModePath:
-		p.Slug = generatePathSlug(p.Path, p.Title)
+		p.Slug = generatePathSlug(p.Path, title)
 	default:
-		p.Slug = generateFlatSlug(p.Path, p.Title)
+		p.Slug = generateFlatSlug(p.Path, title)
 	}
+}
+
+// PlainTitle returns the semantic title for metadata and other plain-text
+// consumers, falling back to the source title for callers outside the build
+// lifecycle.
+func (p *Post) PlainTitle() string {
+	if p == nil {
+		return ""
+	}
+	if p.TitleText != "" {
+		return p.TitleText
+	}
+	if p.Title != nil {
+		return *p.Title
+	}
+	return ""
 }
 
 // Slugify converts a string to a URL-safe slug.

--- a/pkg/models/post.go
+++ b/pkg/models/post.go
@@ -32,6 +32,11 @@ type Post struct {
 	// non-visual consumers. Title remains the authored/source value.
 	TitleText string `json:"-" yaml:"-" toml:"-"`
 
+	// TitleTextDerived records that title processing has completed. It is
+	// separate from TitleText because an authored title can derive to an empty
+	// semantic value.
+	TitleTextDerived bool `json:"-" yaml:"-" toml:"-"`
+
 	// Date is the optional publication date
 	Date *time.Time `json:"date,omitempty" yaml:"date,omitempty" toml:"date,omitempty"`
 
@@ -266,7 +271,7 @@ func (p *Post) GenerateSlug() {
 
 func (p *Post) GenerateSlugWithMode(mode string) {
 	title := p.Title
-	if p.TitleText != "" {
+	if p.TitleTextDerived || p.TitleText != "" {
 		titleText := p.TitleText
 		title = &titleText
 	}
@@ -285,7 +290,7 @@ func (p *Post) PlainTitle() string {
 	if p == nil {
 		return ""
 	}
-	if p.TitleText != "" {
+	if p.TitleTextDerived || p.TitleText != "" {
 		return p.TitleText
 	}
 	if p.Title != nil {

--- a/pkg/models/share.go
+++ b/pkg/models/share.go
@@ -214,8 +214,8 @@ func buildPostURL(base, href string) string {
 
 func newSharePlaceholders(post *Post, fallbackTitle, postURL string) map[string]string {
 	title := fallbackTitle
-	if post.Title != nil && *post.Title != "" {
-		title = *post.Title
+	if post.PlainTitle() != "" {
+		title = post.PlainTitle()
 	}
 	if title == "" {
 		title = post.Slug

--- a/pkg/plugins/atom.go
+++ b/pkg/plugins/atom.go
@@ -150,10 +150,8 @@ func postToAtomEntry(post *models.Post, meta siteMetadata, fallback time.Time) A
 	permalink := meta.URL + post.Href
 
 	// Get title
-	title := ""
-	if post.Title != nil {
-		title = *post.Title
-	} else {
+	title := post.PlainTitle()
+	if title == "" {
 		title = post.Slug
 	}
 

--- a/pkg/plugins/breadcrumbs.go
+++ b/pkg/plugins/breadcrumbs.go
@@ -420,8 +420,8 @@ func (p *BreadcrumbsPlugin) humanizeSegment(segment string) string {
 
 // getPostTitle returns the post's title for display.
 func (p *BreadcrumbsPlugin) getPostTitle(post *models.Post) string {
-	if post.Title != nil && *post.Title != "" {
-		return *post.Title
+	if post.PlainTitle() != "" {
+		return post.PlainTitle()
 	}
 	return ""
 }

--- a/pkg/plugins/embeds.go
+++ b/pkg/plugins/embeds.go
@@ -568,8 +568,8 @@ func (p *EmbedsPlugin) buildInternalEmbedCard(post *models.Post, displayText str
 
 	title := displayText
 	if title == "" {
-		if post.Title != nil && *post.Title != "" {
-			title = *post.Title
+		if post.PlainTitle() != "" {
+			title = post.PlainTitle()
 		} else {
 			title = post.Slug
 		}

--- a/pkg/plugins/error_pages.go
+++ b/pkg/plugins/error_pages.go
@@ -88,9 +88,8 @@ func (p *ErrorPagesPlugin) generatePostsIndex(m *lifecycle.Manager, cfg *models.
 			URL:  "/" + post.Slug + "/",
 		}
 
-		if post.Title != nil {
-			entry.Title = *post.Title
-		} else {
+		entry.Title = post.PlainTitle()
+		if entry.Title == "" {
 			entry.Title = post.Slug
 		}
 

--- a/pkg/plugins/garden_view.go
+++ b/pkg/plugins/garden_view.go
@@ -405,9 +405,8 @@ func (p *GardenViewPlugin) postToNode(post *models.Post) GardenNode {
 		Tags: post.Tags,
 	}
 
-	if post.Title != nil {
-		node.Label = *post.Title
-	} else {
+	node.Label = post.PlainTitle()
+	if node.Label == "" {
 		node.Label = post.Slug
 	}
 

--- a/pkg/plugins/glossary.go
+++ b/pkg/plugins/glossary.go
@@ -403,8 +403,8 @@ func (p *GlossaryPlugin) isGlossaryPost(post *models.Post) bool {
 func (p *GlossaryPlugin) extractGlossaryTerm(post *models.Post) *GlossaryTerm {
 	// Get the term name (title)
 	termName := ""
-	if post.Title != nil && *post.Title != "" {
-		termName = *post.Title
+	if post.PlainTitle() != "" {
+		termName = post.PlainTitle()
 	} else {
 		// Use slug as fallback
 		termName = post.Slug

--- a/pkg/plugins/inline_titles.go
+++ b/pkg/plugins/inline_titles.go
@@ -1,0 +1,68 @@
+package plugins
+
+import (
+	"html"
+
+	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
+	"github.com/WaylonWalker/markata-go/pkg/models"
+)
+
+// InlineTitlesPlugin derives safe rich and plain-text representations from
+// authored title source after auto-title inference and before metadata
+// plugins run.
+type InlineTitlesPlugin struct{}
+
+// NewInlineTitlesPlugin creates a title representation plugin.
+func NewInlineTitlesPlugin() *InlineTitlesPlugin { return &InlineTitlesPlugin{} }
+
+// Name returns the unique plugin name.
+func (p *InlineTitlesPlugin) Name() string { return "inline_titles" }
+
+// Priority places title rendering immediately after auto-title inference.
+func (p *InlineTitlesPlugin) Priority(stage lifecycle.Stage) int {
+	if stage == lifecycle.StageTransform {
+		return lifecycle.PriorityFirst + 1
+	}
+	return lifecycle.PriorityDefault
+}
+
+// Transform populates TitleHTML and TitleText without changing Title, which
+// remains the authored/source title for compatibility.
+func (p *InlineTitlesPlugin) Transform(m *lifecycle.Manager) error {
+	value, ok := m.Cache().Get(CacheKeyInlineRenderer)
+	if !ok {
+		return nil
+	}
+	renderInline, ok := value.(InlineRenderFunc)
+	if !ok {
+		return nil
+	}
+	posts := m.FilterPosts(func(post *models.Post) bool {
+		return !post.Skip && post.Title != nil && *post.Title != ""
+	})
+	return m.ProcessPostsSliceConcurrently(posts, func(post *models.Post) error {
+		result, err := renderInline(*post.Title)
+		if err != nil {
+			return err
+		}
+		post.TitleHTML = result.HTML
+		post.TitleText = result.Text
+		return nil
+	})
+}
+
+// PopulateTitleFallback provides a safe representation for manually-created
+// posts when the normal lifecycle renderer is not installed.
+func PopulateTitleFallback(post *models.Post) {
+	if post == nil || post.Title == nil || *post.Title == "" || post.TitleText != "" {
+		return
+	}
+	post.TitleText = html.UnescapeString(*post.Title)
+	post.TitleHTML = html.EscapeString(post.TitleText)
+}
+
+var (
+	_ lifecycle.Plugin          = (*InlineTitlesPlugin)(nil)
+	_ lifecycle.TransformPlugin = (*InlineTitlesPlugin)(nil)
+	_ lifecycle.PriorityPlugin  = (*InlineTitlesPlugin)(nil)
+)

--- a/pkg/plugins/inline_titles.go
+++ b/pkg/plugins/inline_titles.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"fmt"
 	"html"
 
 	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
@@ -31,14 +32,18 @@ func (p *InlineTitlesPlugin) Priority(stage lifecycle.Stage) int {
 func (p *InlineTitlesPlugin) Transform(m *lifecycle.Manager) error {
 	value, ok := m.Cache().Get(CacheKeyInlineRenderer)
 	if !ok {
-		return nil
+		renderer := NewRenderMarkdownPlugin()
+		if err := renderer.Configure(m); err != nil {
+			return fmt.Errorf("configure inline title renderer: %w", err)
+		}
+		value, _ = m.Cache().Get(CacheKeyInlineRenderer)
 	}
 	renderInline, ok := value.(InlineRenderFunc)
 	if !ok {
-		return nil
+		return fmt.Errorf("inline title renderer is unavailable")
 	}
 	posts := m.FilterPosts(func(post *models.Post) bool {
-		return !post.Skip && post.Title != nil && *post.Title != ""
+		return !post.Skip && post.Title != nil
 	})
 	return m.ProcessPostsSliceConcurrently(posts, func(post *models.Post) error {
 		result, err := renderInline(*post.Title)
@@ -47,6 +52,29 @@ func (p *InlineTitlesPlugin) Transform(m *lifecycle.Manager) error {
 		}
 		post.TitleHTML = result.HTML
 		post.TitleText = result.Text
+		post.TitleTextDerived = true
+		if post.Slug == "" && !post.Has("_slug_explicit") {
+			post.GenerateSlugWithMode(configuredSlugMode(m.Config(), post.Path))
+			post.GenerateHref()
+		}
+		if cache := GetBuildCache(m); cache != nil {
+			cache.SetPostSlug(post.Path, post.Slug)
+			feedChanged, tagChanged, gardenChanged := cache.UpdatePostSemanticHashes(
+				post.Path,
+				computePostFeedItemHash(post),
+				computePostTagIndexHash(post),
+				computePostGardenHash(post),
+			)
+			if feedChanged {
+				cache.MarkFeedSlugChanged(post.Slug)
+			}
+			if tagChanged {
+				cache.MarkSlugChanged(post.Slug)
+			}
+			if gardenChanged {
+				cache.MarkSlugChanged(post.Slug)
+			}
+		}
 		return nil
 	})
 }
@@ -54,11 +82,12 @@ func (p *InlineTitlesPlugin) Transform(m *lifecycle.Manager) error {
 // PopulateTitleFallback provides a safe representation for manually-created
 // posts when the normal lifecycle renderer is not installed.
 func PopulateTitleFallback(post *models.Post) {
-	if post == nil || post.Title == nil || *post.Title == "" || post.TitleText != "" {
+	if post == nil || post.Title == nil || post.TitleTextDerived {
 		return
 	}
 	post.TitleText = html.UnescapeString(*post.Title)
 	post.TitleHTML = html.EscapeString(post.TitleText)
+	post.TitleTextDerived = true
 }
 
 var (

--- a/pkg/plugins/inline_titles_test.go
+++ b/pkg/plugins/inline_titles_test.go
@@ -26,6 +26,20 @@ func TestRenderInline_ProducesRichAndPlainRepresentations(t *testing.T) {
 	}
 }
 
+func TestRenderInline_ParsesSuperscriptAndSubscript(t *testing.T) {
+	p := NewRenderMarkdownPlugin()
+	result, err := p.renderInline("H~2~O and x^2^")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.HTML != "H<sub>2</sub>O and x<sup>2</sup>" {
+		t.Fatalf("HTML = %q", result.HTML)
+	}
+	if result.Text != "H2O and x2" {
+		t.Fatalf("Text = %q", result.Text)
+	}
+}
+
 func TestRenderInline_SemanticsAndSafety(t *testing.T) {
 	p := NewRenderMarkdownPlugin()
 	result, err := p.renderInline("<script>alert(1)</script> _quiet_ ==**loud**== [bad](javascript:alert(1)) ~~old~~ `literal ==mark==`")

--- a/pkg/plugins/inline_titles_test.go
+++ b/pkg/plugins/inline_titles_test.go
@@ -1,0 +1,118 @@
+package plugins
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
+	"github.com/WaylonWalker/markata-go/pkg/models"
+	"github.com/yuin/goldmark/ast"
+	extast "github.com/yuin/goldmark/extension/ast"
+	"github.com/yuin/goldmark/text"
+)
+
+func TestRenderInline_ProducesRichAndPlainRepresentations(t *testing.T) {
+	p := NewRenderMarkdownPlugin()
+	result, err := p.renderInline("Good themes make **good places** to ==think.==")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.HTML != `Good themes make <strong>good places</strong> to <mark>think.</mark>` {
+		t.Fatalf("HTML = %q", result.HTML)
+	}
+	if result.Text != "Good themes make good places to think." {
+		t.Fatalf("Text = %q", result.Text)
+	}
+}
+
+func TestRenderInline_SemanticsAndSafety(t *testing.T) {
+	p := NewRenderMarkdownPlugin()
+	result, err := p.renderInline("<script>alert(1)</script> _quiet_ ==**loud**== [bad](javascript:alert(1)) ~~old~~ `literal ==mark==`")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"<em>quiet</em>", "<mark><strong>loud</strong></mark>", "<del>old</del>"} {
+		if !strings.Contains(result.HTML, want) {
+			t.Errorf("HTML %q does not contain %q", result.HTML, want)
+		}
+	}
+	if strings.Contains(result.HTML, "<script>") || strings.Contains(result.HTML, "javascript:") {
+		t.Fatalf("unsafe HTML or link leaked: %q", result.HTML)
+	}
+	if strings.Contains(result.Text, "**") || strings.Contains(result.Text, "<script>") {
+		t.Fatalf("syntax leaked into text: %q", result.Text)
+	}
+}
+
+func TestMarkParser_BuildsNestedInlineAST(t *testing.T) {
+	p := NewRenderMarkdownPlugin()
+	source := []byte("==**strong**== ==_emphasis_== ==`code`== ==[link](/test)== ==~~deleted~~==")
+	document := p.md.Parser().Parse(text.NewReader(source))
+	paragraph := document.FirstChild()
+	if paragraph == nil {
+		t.Fatal("expected paragraph")
+	}
+	wantKinds := []ast.NodeKind{KindMark, ast.KindEmphasis, KindMark, ast.KindEmphasis, KindMark, ast.KindCodeSpan, KindMark, ast.KindLink, KindMark, extast.KindStrikethrough}
+	var kinds []ast.NodeKind
+	if err := ast.Walk(paragraph, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if entering && node.Kind() != ast.KindParagraph && node.Kind() != ast.KindText {
+			kinds = append(kinds, node.Kind())
+		}
+		return ast.WalkContinue, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(kinds) != len(wantKinds) {
+		t.Fatalf("node kinds = %v, want %v", kinds, wantKinds)
+	}
+	for i := range wantKinds {
+		if kinds[i] != wantKinds[i] {
+			t.Fatalf("node kinds = %v, want %v", kinds, wantKinds)
+		}
+	}
+	var emphasisLevels []int
+	if err := ast.Walk(paragraph, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if entering {
+			if emphasis, ok := node.(*ast.Emphasis); ok {
+				emphasisLevels = append(emphasisLevels, emphasis.Level)
+			}
+		}
+		return ast.WalkContinue, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(emphasisLevels, []int{2, 1}) {
+		t.Fatalf("emphasis levels = %v", emphasisLevels)
+	}
+}
+
+func TestModelsPost_PlainTitleAndSlugUseSemanticTitle(t *testing.T) {
+	title := "Good themes make **good places** to ==think.=="
+	post := &models.Post{Path: "posts/.md", Title: &title, TitleText: "Good themes make good places to think."}
+	post.GenerateSlug()
+	if post.Slug != "good-themes-make-good-places-to-think" {
+		t.Fatalf("slug = %q", post.Slug)
+	}
+}
+
+func TestInlineTitlesPlugin_PopulatesExplicitRepresentations(t *testing.T) {
+	p := NewRenderMarkdownPlugin()
+	m := lifecycle.NewManager()
+	if err := p.Configure(m); err != nil {
+		t.Fatal(err)
+	}
+	title := "Good themes make **good places** to ==think.=="
+	post := models.NewPost("post.md")
+	post.Title = &title
+	m.AddPost(post)
+	if err := NewInlineTitlesPlugin().Transform(m); err != nil {
+		t.Fatal(err)
+	}
+	if post.TitleHTML != `Good themes make <strong>good places</strong> to <mark>think.</mark>` {
+		t.Fatalf("TitleHTML = %q", post.TitleHTML)
+	}
+	if post.TitleText != "Good themes make good places to think." {
+		t.Fatalf("TitleText = %q", post.TitleText)
+	}
+}

--- a/pkg/plugins/inline_titles_test.go
+++ b/pkg/plugins/inline_titles_test.go
@@ -1,12 +1,15 @@
 package plugins
 
 import (
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
 
 	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
 	"github.com/WaylonWalker/markata-go/pkg/models"
+	"github.com/WaylonWalker/markata-go/pkg/templates"
 	"github.com/yuin/goldmark/ast"
 	extast "github.com/yuin/goldmark/extension/ast"
 	"github.com/yuin/goldmark/text"
@@ -128,5 +131,101 @@ func TestInlineTitlesPlugin_PopulatesExplicitRepresentations(t *testing.T) {
 	}
 	if post.TitleText != "Good themes make good places to think." {
 		t.Fatalf("TitleText = %q", post.TitleText)
+	}
+}
+
+func TestMinimalPlugins_DerivesTitleAndTitleFallbackSlugThroughLifecycle(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".md")
+	source := "---\ntitle: Good **places** to ==think==\n---\nBody\n"
+	if err := os.WriteFile(path, []byte(source), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	m := lifecycle.NewManager()
+	m.Config().ContentDir = dir
+	m.SetFiles([]string{".md"})
+	m.RegisterPlugins(MinimalPlugins()...)
+	if err := m.RunTo(lifecycle.StageTransform); err != nil {
+		t.Fatal(err)
+	}
+	posts := m.Posts()
+	if len(posts) != 1 {
+		t.Fatalf("posts = %d, want 1", len(posts))
+	}
+	post := posts[0]
+	if *post.Title != "Good **places** to ==think==" {
+		t.Fatalf("source title changed: %q", *post.Title)
+	}
+	if post.TitleText != "Good places to think" || post.TitleTextDerived != true {
+		t.Fatalf("semantic title = %q, derived = %v", post.TitleText, post.TitleTextDerived)
+	}
+	if post.TitleHTML != `Good <strong>places</strong> to <mark>think</mark>` {
+		t.Fatalf("title HTML = %q", post.TitleHTML)
+	}
+	if post.Slug != "good-places-to-think" {
+		t.Fatalf("slug = %q", post.Slug)
+	}
+	if got := templates.GetPostMap(post)["title"]; got != "Good places to think" {
+		t.Fatalf("template title = %#v", got)
+	}
+}
+
+func TestInlineTitles_EmptySemanticTitleDoesNotFallBackToSource(t *testing.T) {
+	p := NewRenderMarkdownPlugin()
+	m := lifecycle.NewManager()
+	if err := p.Configure(m); err != nil {
+		t.Fatal(err)
+	}
+	title := "<!-- hidden -->"
+	post := models.NewPost("hidden.md")
+	post.Title = &title
+	m.AddPost(post)
+	if err := NewInlineTitlesPlugin().Transform(m); err != nil {
+		t.Fatal(err)
+	}
+	if !post.TitleTextDerived || post.PlainTitle() != "" {
+		t.Fatalf("plain title = %q, derived = %v", post.PlainTitle(), post.TitleTextDerived)
+	}
+	if got := templates.GetPostMap(post)["title"]; got != "" {
+		t.Fatalf("template title leaked source markup: %#v", got)
+	}
+}
+
+func TestPluginRegistry_ResolvesInlineTitles(t *testing.T) {
+	plugin, ok := PluginByName("inline_titles")
+	if !ok || plugin.Name() != "inline_titles" {
+		t.Fatalf("inline_titles registry result = %#v, %v", plugin, ok)
+	}
+	plugins, warnings := ByNames([]string{"inline_titles"})
+	if len(warnings) != 0 || len(plugins) != 1 {
+		t.Fatalf("ByNames() = %d plugins, warnings %v", len(plugins), warnings)
+	}
+}
+
+func TestParsePostFromContent_DerivesTitleFallbackSlug(t *testing.T) {
+	post, err := ParsePostFromContent(".md", "---\ntitle: Good **places** to ==think==\n---\nBody\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if post.Slug != "good-places-to-think" || post.Href != "/good-places-to-think/" {
+		t.Fatalf("slug/href = %q/%q", post.Slug, post.Href)
+	}
+	if post.PlainTitle() != "Good places to think" {
+		t.Fatalf("plain title = %q", post.PlainTitle())
+	}
+}
+
+func TestInlineTitles_InitializesSharedRendererWhenNotRegistered(t *testing.T) {
+	m := lifecycle.NewManager()
+	title := "Good **places**"
+	post := models.NewPost("post.md")
+	post.Title = &title
+	m.AddPost(post)
+	if err := NewInlineTitlesPlugin().Transform(m); err != nil {
+		t.Fatal(err)
+	}
+	if post.TitleText != "Good places" || post.TitleHTML != "Good <strong>places</strong>" {
+		t.Fatalf("derived title = %q / %q", post.TitleText, post.TitleHTML)
 	}
 }

--- a/pkg/plugins/jsonfeed.go
+++ b/pkg/plugins/jsonfeed.go
@@ -126,9 +126,8 @@ func postToJSONFeedItem(post *models.Post, meta siteMetadata) JSONFeedItem {
 	}
 
 	// Add title
-	if post.Title != nil {
-		item.Title = *post.Title
-	} else {
+	item.Title = post.PlainTitle()
+	if item.Title == "" {
 		item.Title = post.Slug
 	}
 

--- a/pkg/plugins/load.go
+++ b/pkg/plugins/load.go
@@ -670,7 +670,25 @@ func ParsePostFromContentWithConfig(path, content string, cfg *models.Config) (*
 			}
 		}
 	}
-	return loader.parseFile(path, content)
+	post, err := loader.parseFile(path, content)
+	if err != nil || post.Slug != "" || post.Title == nil || post.Has("_slug_explicit") {
+		return post, err
+	}
+
+	// Standalone callers do not run the transform stage. Complete the same
+	// title derivation here before resolving a title-only fallback slug.
+	m := lifecycle.NewManager()
+	renderer := NewRenderMarkdownPlugin()
+	if err := renderer.Configure(m); err != nil {
+		return nil, err
+	}
+	m.AddPost(post)
+	if err := NewInlineTitlesPlugin().Transform(m); err != nil {
+		return nil, err
+	}
+	post.GenerateSlugWithMode(models.SlugModeForPath(path, loader.slugMode, loader.slugRules))
+	post.GenerateHref()
+	return post, nil
 }
 
 // parseFile parses a markdown file's content into a Post object.
@@ -703,7 +721,11 @@ func (p *LoadPlugin) parseFile(path, content string) (*models.Post, error) {
 	// Generate slug if not explicitly set in frontmatter
 	// If slug was explicitly set (even to empty string), respect it
 	if !post.Has("_slug_explicit") && post.Slug == "" {
-		post.GenerateSlugWithMode(models.SlugModeForPath(path, p.slugMode, p.slugRules))
+		candidate := models.NewPost(path)
+		candidate.GenerateSlugWithMode(models.SlugModeForPath(path, p.slugMode, p.slugRules))
+		if candidate.Slug != "" {
+			post.Slug = candidate.Slug
+		}
 	}
 
 	// Generate href from slug

--- a/pkg/plugins/mark.go
+++ b/pkg/plugins/mark.go
@@ -34,9 +34,23 @@ func NewMark() *Mark {
 	return &Mark{}
 }
 
-// markParser parses ==text== syntax for highlighted text.
-// This uses a simple greedy approach: find == opening, then find == closing.
+// markParser parses ==text== syntax for highlighted text as a delimiter pair.
+// Using Goldmark's delimiter processing lets the normal inline parsers build
+// nested children (for example, ==**bold**==) instead of treating the marked
+// source as one literal text node.
 type markParser struct{}
+
+type markDelimiterProcessor struct{}
+
+func (p *markDelimiterProcessor) IsDelimiter(b byte) bool { return b == '=' }
+
+func (p *markDelimiterProcessor) CanOpenCloser(opener, closer *parser.Delimiter) bool {
+	return opener.Char == closer.Char
+}
+
+func (p *markDelimiterProcessor) OnMatch(_ int) ast.Node { return NewMark() }
+
+var defaultMarkDelimiterProcessor = &markDelimiterProcessor{}
 
 // newMarkParser creates a new mark parser.
 func newMarkParser() parser.InlineParser {
@@ -49,60 +63,20 @@ func (p *markParser) Trigger() []byte {
 }
 
 // Parse parses the ==text== syntax.
-func (p *markParser) Parse(_ ast.Node, block text.Reader, _ parser.Context) ast.Node {
+func (p *markParser) Parse(_ ast.Node, block text.Reader, pc parser.Context) ast.Node {
+	before := block.PrecendingCharacter()
 	line, segment := block.PeekLine()
-
-	// Must start with ==
-	if len(line) < 4 || line[0] != '=' || line[1] != '=' {
+	node := parser.ScanDelimiter(line, before, 2, defaultMarkDelimiterProcessor)
+	if node == nil || node.OriginalLength != 2 || before == '=' {
 		return nil
 	}
-
-	// Don't match === (could be other syntax or just decoration)
-	if len(line) > 2 && line[2] == '=' {
-		return nil
-	}
-
-	// Find the closing ==
-	// Start searching after the opening ==
-	content := line[2:]
-	closeIdx := -1
-
-	for i := 0; i < len(content)-1; i++ {
-		if content[i] == '=' && content[i+1] == '=' {
-			// Found closing ==, but make sure we have content
-			if i > 0 {
-				closeIdx = i
-				break
-			}
-		}
-	}
-
-	if closeIdx == -1 {
-		return nil
-	}
-
-	// Extract the content between == and ==
-	markedContent := content[:closeIdx]
-	if len(markedContent) == 0 {
-		return nil
-	}
-
-	// Create the mark node
-	mark := NewMark()
-
-	// Add the content as a text child
-	// The content segment starts at: segment.Start + 2 (after opening ==)
-	// and ends at: segment.Start + 2 + closeIdx
-	contentSegment := text.NewSegment(segment.Start+2, segment.Start+2+closeIdx)
-	textNode := ast.NewTextSegment(contentSegment)
-	mark.AppendChild(mark, textNode)
-
-	// Advance past the entire ==content== (opening + content + closing)
-	totalLen := 2 + closeIdx + 2
-	block.Advance(totalLen)
-
-	return mark
+	node.Segment = segment.WithStop(segment.Start + node.OriginalLength)
+	block.Advance(node.OriginalLength)
+	pc.PushDelimiter(node)
+	return node
 }
+
+func (p *markParser) CloseBlock(_ ast.Node, _ parser.Context) {}
 
 // markHTMLRenderer renders Mark nodes to HTML.
 type markHTMLRenderer struct {

--- a/pkg/plugins/mentions.go
+++ b/pkg/plugins/mentions.go
@@ -1178,10 +1178,7 @@ func (p *MentionsPlugin) registerPostAsHandle(post *models.Post, source models.M
 	handle = strings.ToLower(handle)
 
 	// Get the title for the entry
-	title := ""
-	if post.Title != nil {
-		title = *post.Title
-	}
+	title := post.PlainTitle()
 
 	// Build metadata from the post's frontmatter fields
 	metadata := p.buildPostMetadata(post, source)
@@ -1275,9 +1272,8 @@ func (p *MentionsPlugin) buildPostMetadata(post *models.Post, source models.Ment
 	}
 
 	// Name from post title
-	if post.Title != nil {
-		metadata.Name = *post.Title
-	} else {
+	metadata.Name = post.PlainTitle()
+	if metadata.Name == "" {
 		metadata.Name = post.Slug
 	}
 

--- a/pkg/plugins/pagefind.go
+++ b/pkg/plugins/pagefind.go
@@ -306,10 +306,10 @@ func isSearchExcluded(post *models.Post) bool {
 }
 
 func postTitle(post *models.Post) string {
-	if post == nil || post.Title == nil {
+	if post == nil || post.PlainTitle() == "" {
 		return ""
 	}
-	return *post.Title
+	return post.PlainTitle()
 }
 
 func postDescription(post *models.Post) string {

--- a/pkg/plugins/post_copy.go
+++ b/pkg/plugins/post_copy.go
@@ -146,8 +146,8 @@ func buildPostCopyText(post *models.Post, config *lifecycle.Config, postURL stri
 }
 
 func resolvePostTitle(post *models.Post, fallback string) string {
-	if post != nil && post.Title != nil && *post.Title != "" {
-		return *post.Title
+	if post != nil && post.PlainTitle() != "" {
+		return post.PlainTitle()
 	}
 	if fallback != "" {
 		return fallback
@@ -165,10 +165,10 @@ func buildTerminalPage(post *models.Post, config *lifecycle.Config, ansi bool) s
 
 	var buf strings.Builder
 
-	if post.Title != nil && *post.Title != "" {
-		buf.WriteString(*post.Title)
+	if post.PlainTitle() != "" {
+		buf.WriteString(post.PlainTitle())
 		buf.WriteString("\n")
-		buf.WriteString(strings.Repeat(terminalpage.DoubleRule, len([]rune(*post.Title))))
+		buf.WriteString(strings.Repeat(terminalpage.DoubleRule, len([]rune(post.PlainTitle()))))
 		buf.WriteString("\n\n")
 	}
 	if post.Description != nil && *post.Description != "" {

--- a/pkg/plugins/publish_feeds.go
+++ b/pkg/plugins/publish_feeds.go
@@ -1264,9 +1264,9 @@ func (p *PublishFeedsPlugin) publishMarkdown(fc *models.FeedConfig, slug, output
 
 	// Posts list
 	for _, post := range fc.Posts {
-		postTitle := post.Slug
-		if post.Title != nil {
-			postTitle = html.UnescapeString(*post.Title)
+		postTitle := post.PlainTitle()
+		if postTitle == "" {
+			postTitle = post.Slug
 		}
 
 		sb.WriteString("- [" + postTitle + "](" + post.Href + ")")
@@ -1311,9 +1311,9 @@ func (p *PublishFeedsPlugin) publishText(fc *models.FeedConfig, slug, outputDir 
 
 	// Posts list
 	for _, post := range fc.Posts {
-		postTitle := post.Slug
-		if post.Title != nil {
-			postTitle = html.UnescapeString(*post.Title)
+		postTitle := post.PlainTitle()
+		if postTitle == "" {
+			postTitle = post.Slug
 		}
 
 		if post.Date != nil {

--- a/pkg/plugins/publish_html.go
+++ b/pkg/plugins/publish_html.go
@@ -728,9 +728,9 @@ func (p *PublishHTMLPlugin) renderOGWithBuiltinTemplate(post *models.Post, confi
 	siteTitle := getSiteTitle(config)
 	siteURL := getSiteURL(config)
 
-	title := post.Slug
-	if post.Title != nil {
-		title = *post.Title
+	title := post.PlainTitle()
+	if title == "" {
+		title = post.Slug
 	}
 
 	description := ""
@@ -985,9 +985,9 @@ func (p *PublishHTMLPlugin) wrapInTemplate(post *models.Post, config *lifecycle.
 	siteURL := getSiteURL(config)
 	siteTitle := getSiteTitle(config)
 
-	title := post.Slug
-	if post.Title != nil {
-		title = *post.Title
+	title := post.PlainTitle()
+	if title == "" {
+		title = post.Slug
 	}
 
 	description := ""

--- a/pkg/plugins/registry.go
+++ b/pkg/plugins/registry.go
@@ -166,6 +166,7 @@ func DefaultPlugins() []lifecycle.Plugin {
 
 		// Transform stage plugins (in order)
 		NewAutoTitlePlugin(),              // Auto-generate titles first
+		NewInlineTitlesPlugin(),           // Derive rich/plain title representations
 		NewAuthorsPlugin(),                // Resolve author IDs to Author objects
 		NewDescriptionPlugin(),            // Auto-generate descriptions early
 		NewStructuredDataPlugin(),         // Generate structured data (needs title, description)

--- a/pkg/plugins/registry.go
+++ b/pkg/plugins/registry.go
@@ -49,6 +49,7 @@ func registerBuiltinPluginsLocked() {
 	pluginRegistry.constructors["toc"] = func() lifecycle.Plugin { return NewTocPlugin() }
 	pluginRegistry.constructors["description"] = func() lifecycle.Plugin { return NewDescriptionPlugin() }
 	pluginRegistry.constructors["auto_title"] = func() lifecycle.Plugin { return NewAutoTitlePlugin() }
+	pluginRegistry.constructors["inline_titles"] = func() lifecycle.Plugin { return NewInlineTitlesPlugin() }
 	pluginRegistry.constructors["reading_time"] = func() lifecycle.Plugin { return NewReadingTimePlugin() }
 	pluginRegistry.constructors["static_assets"] = func() lifecycle.Plugin { return NewStaticAssetsPlugin() }
 	pluginRegistry.constructors["palette_css"] = func() lifecycle.Plugin { return NewPaletteCSSPlugin() }
@@ -245,6 +246,8 @@ func MinimalPlugins() []lifecycle.Plugin {
 	return []lifecycle.Plugin{
 		NewGlobPlugin(),
 		NewLoadPlugin(),
+		NewAutoTitlePlugin(),
+		NewInlineTitlesPlugin(),
 		NewRenderMarkdownPlugin(),
 		NewTemplatesPlugin(),
 		NewPublishHTMLPlugin(),
@@ -256,6 +259,7 @@ func MinimalPlugins() []lifecycle.Plugin {
 func TransformPlugins() []lifecycle.Plugin {
 	return []lifecycle.Plugin{
 		NewAutoTitlePlugin(),
+		NewInlineTitlesPlugin(),
 		NewDescriptionPlugin(),
 		NewReadingTimePlugin(),
 		NewStatsPlugin(),

--- a/pkg/plugins/render_markdown.go
+++ b/pkg/plugins/render_markdown.go
@@ -154,6 +154,7 @@ func createMarkdownRenderer(chromaTheme string, lineNumbers bool, extConfig Mark
 		&AdmonitionExtension{},
 		// Mark extension for ==highlighted text==
 		&MarkExtension{},
+		&ScriptExtension{},
 		// Keys extension for ++Ctrl+Alt+Del++
 		&KeysExtension{},
 		// Container extension for ::: class

--- a/pkg/plugins/render_markdown.go
+++ b/pkg/plugins/render_markdown.go
@@ -17,9 +17,11 @@ import (
 	"github.com/yuin/goldmark"
 	emoji "github.com/yuin/goldmark-emoji"
 	highlighting "github.com/yuin/goldmark-highlighting/v2"
+	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/extension"
 	"github.com/yuin/goldmark/parser"
 	"github.com/yuin/goldmark/renderer/html"
+	"github.com/yuin/goldmark/text"
 	"github.com/yuin/goldmark/util"
 
 	figure "github.com/mangoumbrella/goldmark-figure"
@@ -45,8 +47,9 @@ const attributionMarker = "<!--markata-attribution-->"
 
 // RenderMarkdownPlugin converts markdown content to HTML using goldmark.
 type RenderMarkdownPlugin struct {
-	md    goldmark.Markdown
-	cache *buildcache.Cache // build cache for HTML caching
+	md       goldmark.Markdown
+	inlineMD goldmark.Markdown
+	cache    *buildcache.Cache // build cache for HTML caching
 }
 
 // CacheKeyMarkdownRenderer is the manager cache key for the markdown render
@@ -57,6 +60,22 @@ const CacheKeyMarkdownRenderer = "markdown.renderer"
 // MarkdownRenderFunc is the signature of the on-demand markdown renderer
 // stored under CacheKeyMarkdownRenderer.
 type MarkdownRenderFunc func(content string) (string, error)
+
+// InlineResult contains the two representations needed when inline Markdown
+// is used outside an article body. HTML is for trusted display contexts; Text
+// is for metadata, feeds, search, and other plain-text consumers.
+type InlineResult struct {
+	HTML string
+	Text string
+}
+
+// InlineRenderFunc renders an inline Markdown fragment with the site's
+// configured Markdown extensions and safe HTML policy.
+type InlineRenderFunc func(source string) (InlineResult, error)
+
+// CacheKeyInlineRenderer is the manager cache key for the shared inline
+// renderer used by title processing and other plugins.
+const CacheKeyInlineRenderer = "markdown.inline_renderer"
 
 // NewRenderMarkdownPlugin creates a new RenderMarkdownPlugin with goldmark configured.
 // The goldmark instance is configured with:
@@ -71,7 +90,8 @@ type MarkdownRenderFunc func(content string) (string, error)
 // site's palette configuration.
 func NewRenderMarkdownPlugin() *RenderMarkdownPlugin {
 	return &RenderMarkdownPlugin{
-		md: createMarkdownRenderer(palettes.DefaultChromaThemeDark, false, DefaultMarkdownExtensionConfig()),
+		md:       createMarkdownRenderer(palettes.DefaultChromaThemeDark, false, DefaultMarkdownExtensionConfig(), true),
+		inlineMD: createMarkdownRenderer(palettes.DefaultChromaThemeDark, false, DefaultMarkdownExtensionConfig(), false),
 	}
 }
 
@@ -100,7 +120,11 @@ func DefaultMarkdownExtensionConfig() MarkdownExtensionConfig {
 }
 
 // createMarkdownRenderer creates a goldmark instance with the specified highlighting options.
-func createMarkdownRenderer(chromaTheme string, lineNumbers bool, extConfig MarkdownExtensionConfig) goldmark.Markdown {
+func createMarkdownRenderer(chromaTheme string, lineNumbers bool, extConfig MarkdownExtensionConfig, unsafeOptions ...bool) goldmark.Markdown {
+	unsafeHTML := true
+	if len(unsafeOptions) > 0 {
+		unsafeHTML = unsafeOptions[0]
+	}
 	// Use CSS classes instead of inline styles for syntax highlighting.
 	// This enables theme customization via external CSS files.
 	formatOptions := []chromahtml.Option{
@@ -174,7 +198,7 @@ func createMarkdownRenderer(chromaTheme string, lineNumbers bool, extConfig Mark
 		extensions = append(extensions, extension.Footnote)
 	}
 
-	return goldmark.New(
+	options := []goldmark.Option{
 		goldmark.WithExtensions(extensions...),
 		goldmark.WithParserOptions(
 			parser.WithAutoHeadingID(),
@@ -185,11 +209,11 @@ func createMarkdownRenderer(chromaTheme string, lineNumbers bool, extConfig Mark
 				util.Prioritized(&AttributeTransformer{}, -100),
 			),
 		),
-		goldmark.WithRendererOptions(
-			// Allow raw HTML in markdown
-			html.WithUnsafe(),
-		),
-	)
+	}
+	if unsafeHTML {
+		options = append(options, goldmark.WithRendererOptions(html.WithUnsafe()))
+	}
+	return goldmark.New(options...)
 }
 
 // Name returns the unique name of the plugin.
@@ -218,14 +242,60 @@ func (p *RenderMarkdownPlugin) Configure(m *lifecycle.Manager) error {
 	extConfig := p.resolveExtensionConfig(m.Config().Extra)
 
 	// Reconfigure the markdown renderer with the resolved theme and extensions
-	p.md = createMarkdownRenderer(chromaTheme, lineNumbers, extConfig)
+	p.md = createMarkdownRenderer(chromaTheme, lineNumbers, extConfig, true)
+	p.inlineMD = createMarkdownRenderer(chromaTheme, false, extConfig, false)
 
 	// Register the render function so other plugins (e.g. feed helpers during
 	// jinja_md transform) can render markdown on-demand when ArticleHTML has
 	// not yet been populated by the Render stage.
 	m.Cache().Set(CacheKeyMarkdownRenderer, MarkdownRenderFunc(p.doRender))
+	m.Cache().Set(CacheKeyInlineRenderer, InlineRenderFunc(p.renderInline))
 
 	return nil
+}
+
+// renderInline renders a Markdown fragment without a paragraph wrapper. It
+// parses through the same configured Goldmark instance as body content while
+// deliberately keeping raw HTML disabled for this metadata-adjacent path.
+func (p *RenderMarkdownPlugin) renderInline(source string) (InlineResult, error) {
+	// A leading text token keeps tag-looking input in an inline paragraph
+	// rather than letting Goldmark classify a leading HTML block. Raw HTML is
+	// still disabled on this renderer, so the source cannot become executable.
+	bytesSource := []byte("x " + source)
+	document := p.inlineMD.Parser().Parse(text.NewReader(bytesSource))
+	paragraph := document.FirstChild()
+	if paragraph == nil {
+		return InlineResult{}, nil
+	}
+
+	var htmlBuffer bytes.Buffer
+	var plain strings.Builder
+	for child := paragraph.FirstChild(); child != nil; child = child.NextSibling() {
+		if err := p.inlineMD.Renderer().Render(&htmlBuffer, bytesSource, child); err != nil {
+			return InlineResult{}, err
+		}
+		appendInlineText(&plain, child, bytesSource)
+	}
+	richHTML := strings.TrimPrefix(htmlBuffer.String(), "x ")
+	plainText := strings.TrimPrefix(plain.String(), "x ")
+	return InlineResult{HTML: richHTML, Text: strings.Join(strings.Fields(plainText), " ")}, nil
+}
+
+func appendInlineText(out *strings.Builder, node ast.Node, source []byte) {
+	if err := ast.Walk(node, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		switch n := n.(type) {
+		case *ast.Text:
+			out.Write(n.Segment.Value(source))
+		case *ast.String:
+			out.Write(n.Value)
+		}
+		return ast.WalkContinue, nil
+	}); err != nil {
+		return
+	}
 }
 
 // resolveHighlightConfig extracts highlight configuration from the config.Extra map.

--- a/pkg/plugins/render_markdown_test.go
+++ b/pkg/plugins/render_markdown_test.go
@@ -68,6 +68,22 @@ func TestRenderMarkdownPlugin_Headings(t *testing.T) {
 	}
 }
 
+func TestRenderMarkdownPlugin_ExpressiveH1AndH2(t *testing.T) {
+	p := NewRenderMarkdownPlugin()
+	post := &models.Post{Content: "# **Strong** _emphasis_ ==mark== `code` [link](/test) ~~delete~~\n\n## ==**nested**=="}
+	if err := p.renderPost(post); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"<strong>Strong</strong> <em>emphasis</em> <mark>mark</mark> <code>code</code> <a href=\"/test\">link</a> <del>delete</del>",
+		"<mark><strong>nested</strong></mark>",
+	} {
+		if !strings.Contains(post.ArticleHTML, want) {
+			t.Errorf("rendered headings %q do not contain %q", post.ArticleHTML, want)
+		}
+	}
+}
+
 func TestRenderMarkdownPlugin_Emphasis(t *testing.T) {
 	p := NewRenderMarkdownPlugin()
 	post := &models.Post{Content: "*italic* and **bold**"}

--- a/pkg/plugins/rss.go
+++ b/pkg/plugins/rss.go
@@ -155,10 +155,8 @@ func postToRSSItem(post *models.Post, meta siteMetadata) RSSItem {
 	permalink := meta.URL + post.Href
 
 	// Get title
-	title := ""
-	if post.Title != nil {
-		title = *post.Title
-	} else {
+	title := post.PlainTitle()
+	if title == "" {
 		title = post.Slug
 	}
 

--- a/pkg/plugins/script.go
+++ b/pkg/plugins/script.go
@@ -1,0 +1,107 @@
+package plugins
+
+import (
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/renderer/html"
+	"github.com/yuin/goldmark/text"
+	"github.com/yuin/goldmark/util"
+)
+
+var (
+	KindSuperscript = ast.NewNodeKind("Superscript")
+	KindSubscript   = ast.NewNodeKind("Subscript")
+)
+
+type scriptNode struct {
+	ast.BaseInline
+	kind ast.NodeKind
+}
+
+func (n *scriptNode) Kind() ast.NodeKind { return n.kind }
+
+func (n *scriptNode) Dump(source []byte, level int) {
+	ast.DumpHelper(n, source, level, nil, nil)
+}
+
+type scriptParser struct {
+	trigger byte
+	kind    ast.NodeKind
+}
+
+func (p *scriptParser) Trigger() []byte { return []byte{p.trigger} }
+
+func (p *scriptParser) Parse(_ ast.Node, block text.Reader, pc parser.Context) ast.Node {
+	before := block.PrecendingCharacter()
+	line, segment := block.PeekLine()
+	processor := &scriptDelimiterProcessor{trigger: p.trigger, kind: p.kind}
+	node := parser.ScanDelimiter(line, before, 1, processor)
+	if node == nil || node.OriginalLength != 1 || before == rune(p.trigger) {
+		return nil
+	}
+	node.Segment = segment.WithStop(segment.Start + node.OriginalLength)
+	block.Advance(node.OriginalLength)
+	pc.PushDelimiter(node)
+	return node
+}
+
+func (p *scriptParser) CloseBlock(_ ast.Node, _ parser.Context) {}
+
+type scriptDelimiterProcessor struct {
+	trigger byte
+	kind    ast.NodeKind
+}
+
+func (p *scriptDelimiterProcessor) IsDelimiter(b byte) bool { return b == p.trigger }
+
+func (p *scriptDelimiterProcessor) CanOpenCloser(opener, closer *parser.Delimiter) bool {
+	return opener.Char == closer.Char
+}
+
+func (p *scriptDelimiterProcessor) OnMatch(_ int) ast.Node {
+	return &scriptNode{kind: p.kind}
+}
+
+type scriptHTMLRenderer struct{ html.Config }
+
+func newScriptHTMLRenderer() renderer.NodeRenderer {
+	return &scriptHTMLRenderer{Config: html.NewConfig()}
+}
+
+func (r *scriptHTMLRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
+	reg.Register(KindSuperscript, r.renderSuperscript)
+	reg.Register(KindSubscript, r.renderSubscript)
+}
+
+func (r *scriptHTMLRenderer) renderSuperscript(w util.BufWriter, _ []byte, _ ast.Node, entering bool) (ast.WalkStatus, error) {
+	return renderScriptTag(w, "sup", entering), nil
+}
+
+func (r *scriptHTMLRenderer) renderSubscript(w util.BufWriter, _ []byte, _ ast.Node, entering bool) (ast.WalkStatus, error) {
+	return renderScriptTag(w, "sub", entering), nil
+}
+
+func renderScriptTag(w util.BufWriter, tag string, entering bool) ast.WalkStatus {
+	if entering {
+		_, _ = w.WriteString("<" + tag + ">") //nolint:errcheck // Goldmark owns the writer lifecycle
+	} else {
+		_, _ = w.WriteString("</" + tag + ">") //nolint:errcheck // Goldmark owns the writer lifecycle
+	}
+	return ast.WalkContinue
+}
+
+// ScriptExtension adds Markdown-native ^superscript^ and ~subscript~ while
+// leaving GFM's ~~strikethrough~~ delimiter intact.
+type ScriptExtension struct{}
+
+func (e *ScriptExtension) Extend(m goldmark.Markdown) {
+	m.Parser().AddOptions(parser.WithInlineParsers(
+		util.Prioritized(&scriptParser{trigger: '^', kind: KindSuperscript}, 490),
+		util.Prioritized(&scriptParser{trigger: '~', kind: KindSubscript}, 490),
+	))
+	m.Renderer().AddOptions(renderer.WithNodeRenderers(
+		util.Prioritized(newScriptHTMLRenderer(), 490),
+	))
+}

--- a/pkg/plugins/structured_data.go
+++ b/pkg/plugins/structured_data.go
@@ -47,7 +47,7 @@ func (p *StructuredDataPlugin) Transform(m *lifecycle.Manager) error {
 		if post.Skip || post.Draft {
 			return false
 		}
-		return post.Title != nil && *post.Title != ""
+		return post.PlainTitle() != ""
 	})
 
 	return m.ProcessPostsSliceConcurrently(posts, func(post *models.Post) error {
@@ -83,7 +83,7 @@ func (p *StructuredDataPlugin) generateJSONLD(post *models.Post, config *lifecyc
 	postURL := siteURL + post.Href
 
 	// Create BlogPosting schema
-	bp := models.NewBlogPosting(*post.Title, postURL)
+	bp := models.NewBlogPosting(post.PlainTitle(), postURL)
 
 	// Add description
 	if post.Description != nil {
@@ -136,7 +136,7 @@ func (p *StructuredDataPlugin) generateOpenGraph(sd *models.StructuredData, post
 	postURL := siteURL + post.Href
 
 	// Required tags
-	sd.AddOpenGraph("og:title", *post.Title)
+	sd.AddOpenGraph("og:title", post.PlainTitle())
 	sd.AddOpenGraph("og:url", postURL)
 	sd.AddOpenGraph("og:site_name", siteTitle)
 
@@ -211,7 +211,7 @@ func (p *StructuredDataPlugin) generateTwitterCard(sd *models.StructuredData, po
 	}
 
 	// Title
-	sd.AddTwitter("twitter:title", *post.Title)
+	sd.AddTwitter("twitter:title", post.PlainTitle())
 
 	// Description (truncated to 200 chars for Twitter)
 	if post.Description != nil {

--- a/pkg/plugins/templates.go
+++ b/pkg/plugins/templates.go
@@ -1183,8 +1183,8 @@ func appendFeedParamToHref(href, feedSlug string) string {
 // postToSidebarJSON converts a Post to a sidebarPostJSON.
 func postToSidebarJSON(fp *models.Post, active bool, feedSlug string) sidebarPostJSON {
 	title := fp.Slug
-	if fp.Title != nil {
-		title = *fp.Title
+	if fp.PlainTitle() != "" {
+		title = fp.PlainTitle()
 	}
 	return sidebarPostJSON{
 		Slug:   fp.Slug,

--- a/pkg/plugins/webmentions_leaderboard.go
+++ b/pkg/plugins/webmentions_leaderboard.go
@@ -202,8 +202,8 @@ func (p *WebmentionsLeaderboardPlugin) sortAndLimit(
 
 // getPostTitle extracts the title from a post.
 func getPostTitle(post *models.Post) string {
-	if post.Title != nil && *post.Title != "" {
-		return *post.Title
+	if post.PlainTitle() != "" {
+		return post.PlainTitle()
 	}
 	return post.Slug
 }

--- a/pkg/search/index.go
+++ b/pkg/search/index.go
@@ -288,7 +288,7 @@ func toPostDoc(p *models.Post) Document {
 		doc.Tags = p.Tags
 	}
 	if p.Title != nil && (!p.Private || explicitFrontmatterTitle(p)) {
-		doc.Title = *p.Title
+		doc.Title = p.PlainTitle()
 	} else if p.Private {
 		doc.Title = ""
 	}

--- a/pkg/services/post_service.go
+++ b/pkg/services/post_service.go
@@ -307,7 +307,7 @@ func matchesSearch(p *models.Post, query string, opts SearchOptions) bool {
 		query = strings.ToLower(query)
 	}
 
-	if (searchAll || hasField(fields, "title")) && p.Title != nil && contains(*p.Title, query) {
+	if (searchAll || hasField(fields, "title")) && contains(p.PlainTitle(), query) {
 		return true
 	}
 	if (searchAll || hasField(fields, "description")) && p.Description != nil && contains(*p.Description, query) {

--- a/pkg/sidebar/builder.go
+++ b/pkg/sidebar/builder.go
@@ -368,8 +368,8 @@ func (b *Builder) BuildFromFeeds() []models.SidebarNavItem {
 // postToNavItem converts a Post to a SidebarNavItem.
 func postToNavItem(post *models.Post) models.SidebarNavItem {
 	title := post.Slug
-	if post.Title != nil && *post.Title != "" {
-		title = *post.Title
+	if post.PlainTitle() != "" {
+		title = post.PlainTitle()
 	}
 	return models.SidebarNavItem{
 		Title: title,

--- a/pkg/templates/context.go
+++ b/pkg/templates/context.go
@@ -131,10 +131,13 @@ func postToMapUncached(p *models.Post) map[string]interface{} {
 
 	// Handle pointer fields - dereference if not nil
 	if p.Title != nil {
-		m["title"] = *p.Title
+		m["title"] = p.PlainTitle()
 	} else {
 		m["title"] = nil
 	}
+	m["title_source"] = p.Title
+	m["title_html"] = p.TitleHTML
+	m["title_text"] = p.PlainTitle()
 
 	if p.Date != nil {
 		m["date"] = *p.Date
@@ -241,10 +244,13 @@ func postSummaryToMap(post *models.Post) map[string]interface{} {
 		"slug": post.Slug,
 	}
 	if post.Title != nil {
-		result["title"] = *post.Title
+		result["title"] = post.PlainTitle()
 	} else {
 		result["title"] = nil
 	}
+	result["title_source"] = post.Title
+	result["title_html"] = post.TitleHTML
+	result["title_text"] = post.PlainTitle()
 
 	return result
 }

--- a/pkg/themes/default/static/css/main.css
+++ b/pkg/themes/default/static/css/main.css
@@ -246,6 +246,58 @@ h4 { font-size: var(--text-xl); }
 h5 { font-size: var(--text-lg); }
 h6 { font-size: var(--text-base); font-weight: 600; }
 
+/* Expressive inline Markdown in display headings. The semantic elements stay
+   ordinary in prose; only page/article H1 and content H1/H2 receive this
+   stronger treatment. Font packs may override the line-height variable when
+   their display metrics need more vertical room. */
+:is(.post-header h1, .post-content h1, .post-content h2) {
+  line-height: var(--leading-heading-expressive, 1.35);
+}
+
+:is(.post-header h1, .post-content h1, .post-content h2) strong {
+  color: var(--color-primary);
+}
+
+:is(.post-header h1, .post-content h1, .post-content h2) em {
+  font-style: italic;
+  font-weight: 500;
+}
+
+:is(.post-header h1, .post-content h1, .post-content h2) mark {
+  color: var(--color-background);
+  background: color-mix(in srgb, var(--color-primary) 78%, var(--color-text) 22%);
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+  padding: 0 .12em;
+}
+
+:is(.post-header h1, .post-content h1, .post-content h2) mark :is(strong, em, code, del, a) {
+  color: inherit;
+}
+
+:is(.post-header h1, .post-content h1, .post-content h2) code {
+  font-family: var(--font-mono);
+  font-size: .72em;
+  font-weight: 600;
+  letter-spacing: .01em;
+  padding: .08em .24em;
+  border: 1px solid color-mix(in srgb, currentColor 28%, transparent);
+  border-radius: .25em;
+}
+
+:is(.post-header h1, .post-content h1, .post-content h2) a {
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-color: var(--color-primary);
+  text-decoration-thickness: .08em;
+  text-underline-offset: .12em;
+}
+
+:is(.post-header h1, .post-content h1, .post-content h2) del {
+  color: var(--color-text-muted);
+  text-decoration-color: var(--color-primary);
+}
+
 /* Heading Anchors */
 .heading-anchor {
   opacity: 0;

--- a/pkg/themes/default/static/css/main.css
+++ b/pkg/themes/default/static/css/main.css
@@ -252,6 +252,9 @@ h6 { font-size: var(--text-base); font-weight: 600; }
    their display metrics need more vertical room. */
 :is(.post-header h1, .post-content h1, .post-content h2) {
   line-height: var(--leading-heading-expressive, 1.35);
+  border-top: 2px solid var(--heading-rule);
+  border-bottom: 2px solid var(--heading-rule);
+  padding: .42em .16em .48em;
 }
 
 :is(.post-header h1, .post-content h1, .post-content h2) strong {
@@ -271,7 +274,8 @@ h6 { font-size: var(--text-base); font-weight: 600; }
   background: var(--heading-mark-bg);
   box-decoration-break: clone;
   -webkit-box-decoration-break: clone;
-  padding: 0 .12em;
+  padding: 0 .16em;
+  border-radius: .18em;
 }
 
 :is(.post-header h1, .post-content h1, .post-content h2) mark :is(strong, em, code, del, a) {

--- a/pkg/themes/default/static/css/main.css
+++ b/pkg/themes/default/static/css/main.css
@@ -255,17 +255,20 @@ h6 { font-size: var(--text-base); font-weight: 600; }
 }
 
 :is(.post-header h1, .post-content h1, .post-content h2) strong {
-  color: var(--color-primary);
+  color: var(--heading-accent);
+  font-weight: inherit;
 }
 
 :is(.post-header h1, .post-content h1, .post-content h2) em {
+  color: var(--heading-accent);
+  font-family: var(--font-heading);
   font-style: italic;
   font-weight: 500;
 }
 
 :is(.post-header h1, .post-content h1, .post-content h2) mark {
-  color: var(--color-background);
-  background: color-mix(in srgb, var(--color-primary) 78%, var(--color-text) 22%);
+  color: var(--heading-mark-fg);
+  background: var(--heading-mark-bg);
   box-decoration-break: clone;
   -webkit-box-decoration-break: clone;
   padding: 0 .12em;
@@ -276,26 +279,28 @@ h6 { font-size: var(--text-base); font-weight: 600; }
 }
 
 :is(.post-header h1, .post-content h1, .post-content h2) code {
-  font-family: var(--font-mono);
+  font-family: var(--font-code, var(--font-mono));
   font-size: .72em;
   font-weight: 600;
   letter-spacing: .01em;
   padding: .08em .24em;
   border: 1px solid color-mix(in srgb, currentColor 28%, transparent);
   border-radius: .25em;
+  background: var(--heading-code-bg);
+  color: var(--heading-code-fg);
 }
 
 :is(.post-header h1, .post-content h1, .post-content h2) a {
   color: inherit;
   text-decoration: underline;
-  text-decoration-color: var(--color-primary);
+  text-decoration-color: var(--heading-link-decoration);
   text-decoration-thickness: .08em;
   text-underline-offset: .12em;
 }
 
 :is(.post-header h1, .post-content h1, .post-content h2) del {
   color: var(--color-text-muted);
-  text-decoration-color: var(--color-primary);
+  text-decoration-color: var(--heading-link-decoration);
 }
 
 /* Heading Anchors */

--- a/pkg/themes/default/static/css/main.css
+++ b/pkg/themes/default/static/css/main.css
@@ -250,39 +250,41 @@ h6 { font-size: var(--text-base); font-weight: 600; }
    ordinary in prose; only page/article H1 and content H1/H2 receive this
    stronger treatment. Font packs may override the line-height variable when
    their display metrics need more vertical room. */
-:is(.post-header h1, .post-content h1, .post-content h2) {
+@layer overrides {
+html[data-fontpack] :is(.post-header h1, .post-content h1, .post-content h2) {
+  font-family: var(--font-display, var(--font-heading)) !important;
   line-height: var(--leading-heading-expressive, 1.35);
   border-top: 2px solid var(--heading-rule);
   border-bottom: 2px solid var(--heading-rule);
   padding: .42em .16em .48em;
 }
 
-:is(.post-header h1, .post-content h1, .post-content h2) strong {
-  color: var(--heading-accent);
+html[data-fontpack] :is(.post-header h1, .post-content h1, .post-content h2) strong {
+  color: var(--heading-accent) !important;
   font-weight: inherit;
 }
 
-:is(.post-header h1, .post-content h1, .post-content h2) em {
-  color: var(--heading-accent);
-  font-family: var(--font-heading);
+html[data-fontpack] :is(.post-header h1, .post-content h1, .post-content h2) em {
+  color: var(--heading-accent) !important;
+  font-family: var(--font-display, var(--font-heading)) !important;
   font-style: italic;
   font-weight: 500;
 }
 
-:is(.post-header h1, .post-content h1, .post-content h2) mark {
-  color: var(--heading-mark-fg);
-  background: var(--heading-mark-bg);
+html[data-fontpack] :is(.post-header h1, .post-content h1, .post-content h2) mark {
+  color: var(--heading-mark-fg) !important;
+  background: var(--heading-mark-bg) !important;
   box-decoration-break: clone;
   -webkit-box-decoration-break: clone;
   padding: 0 .16em;
   border-radius: .18em;
 }
 
-:is(.post-header h1, .post-content h1, .post-content h2) mark :is(strong, em, code, del, a) {
-  color: inherit;
+html[data-fontpack] :is(.post-header h1, .post-content h1, .post-content h2) mark :is(strong, em, code, del, a) {
+  color: inherit !important;
 }
 
-:is(.post-header h1, .post-content h1, .post-content h2) code {
+html[data-fontpack] :is(.post-header h1, .post-content h1, .post-content h2) code {
   font-family: var(--font-code, var(--font-mono));
   font-size: .72em;
   font-weight: 600;
@@ -294,7 +296,7 @@ h6 { font-size: var(--text-base); font-weight: 600; }
   color: var(--heading-code-fg);
 }
 
-:is(.post-header h1, .post-content h1, .post-content h2) a {
+html[data-fontpack] :is(.post-header h1, .post-content h1, .post-content h2) a {
   color: inherit;
   text-decoration: underline;
   text-decoration-color: var(--heading-link-decoration);
@@ -302,9 +304,10 @@ h6 { font-size: var(--text-base); font-weight: 600; }
   text-underline-offset: .12em;
 }
 
-:is(.post-header h1, .post-content h1, .post-content h2) del {
-  color: var(--color-text-muted);
-  text-decoration-color: var(--heading-link-decoration);
+html[data-fontpack] :is(.post-header h1, .post-content h1, .post-content h2) del {
+  color: color-mix(in srgb, var(--color-text) 54%, var(--color-background) 46%) !important;
+  text-decoration-color: color-mix(in srgb, var(--heading-accent) 64%, var(--color-text) 36%) !important;
+}
 }
 
 /* Heading Anchors */

--- a/pkg/themes/default/static/css/variables.css
+++ b/pkg/themes/default/static/css/variables.css
@@ -11,9 +11,9 @@
   --color-link-hover: #1e40af;
 
   /* Semantic roles for expressive H1/H2 inline Markdown. */
-  --heading-accent: var(--color-code-operator, var(--color-warning, var(--color-primary)));
-  --heading-mark-bg: color-mix(in srgb, var(--color-code-operator, var(--color-warning, var(--color-primary))) 70%, var(--color-background) 30%);
-  --heading-mark-fg: var(--color-background);
+  --heading-accent: var(--color-primary);
+  --heading-mark-bg: var(--color-mark-bg, color-mix(in srgb, var(--color-warning, var(--color-primary)) 70%, var(--color-background) 30%));
+  --heading-mark-fg: var(--color-mark-text, var(--color-background));
   --heading-code-bg: color-mix(in srgb, var(--color-surface) 72%, var(--color-primary) 28%);
   --heading-code-fg: var(--color-text);
   --heading-link-decoration: var(--color-primary);

--- a/pkg/themes/default/static/css/variables.css
+++ b/pkg/themes/default/static/css/variables.css
@@ -10,6 +10,14 @@
   --color-link: #1d4ed8;
   --color-link-hover: #1e40af;
 
+  /* Semantic roles for expressive H1/H2 inline Markdown. */
+  --heading-accent: var(--color-primary);
+  --heading-mark-bg: color-mix(in srgb, var(--color-primary) 82%, var(--color-text) 18%);
+  --heading-mark-fg: var(--color-background);
+  --heading-code-bg: color-mix(in srgb, var(--color-surface) 72%, var(--color-primary) 28%);
+  --heading-code-fg: var(--color-text);
+  --heading-link-decoration: var(--color-primary);
+
   /* Semantic colors */
   --color-text: #1f2937;
   --color-text-muted: #6b7280;
@@ -33,6 +41,7 @@
   --font-body: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   --font-heading: var(--font-body);
   --font-mono: ui-monospace, 'Cascadia Code', 'Fira Code', 'JetBrains Mono', Consolas, monospace;
+  --leading-heading-expressive: 1.35;
 
   /* Font sizes (modular scale) */
   --text-xs: 0.75rem;

--- a/pkg/themes/default/static/css/variables.css
+++ b/pkg/themes/default/static/css/variables.css
@@ -11,8 +11,8 @@
   --color-link-hover: #1e40af;
 
   /* Semantic roles for expressive H1/H2 inline Markdown. */
-  --heading-accent: var(--color-primary);
-  --heading-mark-bg: color-mix(in srgb, var(--color-primary) 82%, var(--color-text) 18%);
+  --heading-accent: var(--color-code-operator, var(--color-warning, var(--color-primary)));
+  --heading-mark-bg: color-mix(in srgb, var(--color-code-operator, var(--color-warning, var(--color-primary))) 70%, var(--color-background) 30%);
   --heading-mark-fg: var(--color-background);
   --heading-code-bg: color-mix(in srgb, var(--color-surface) 72%, var(--color-primary) 28%);
   --heading-code-fg: var(--color-text);

--- a/pkg/themes/default/static/css/variables.css
+++ b/pkg/themes/default/static/css/variables.css
@@ -12,10 +12,10 @@
 
   /* Semantic roles for expressive H1/H2 inline Markdown. */
   --heading-accent: var(--color-primary);
-  --heading-mark-bg: var(--color-mark-bg, color-mix(in srgb, var(--color-warning, var(--color-primary)) 70%, var(--color-background) 30%));
-  --heading-mark-fg: var(--color-mark-text, var(--color-background));
-  --heading-code-bg: color-mix(in srgb, var(--color-surface) 72%, var(--color-primary) 28%);
-  --heading-code-fg: var(--color-text);
+  --heading-mark-bg: var(--color-primary);
+  --heading-mark-fg: var(--color-background);
+  --heading-code-bg: var(--color-code-bg, var(--color-surface));
+  --heading-code-fg: var(--color-code-text, var(--color-text));
   --heading-link-decoration: var(--color-primary);
   --heading-rule: color-mix(in srgb, var(--color-text) 72%, var(--heading-accent) 28%);
 

--- a/pkg/themes/default/static/css/variables.css
+++ b/pkg/themes/default/static/css/variables.css
@@ -17,6 +17,7 @@
   --heading-code-bg: color-mix(in srgb, var(--color-surface) 72%, var(--color-primary) 28%);
   --heading-code-fg: var(--color-text);
   --heading-link-decoration: var(--color-primary);
+  --heading-rule: color-mix(in srgb, var(--color-text) 72%, var(--heading-accent) 28%);
 
   /* Semantic colors */
   --color-text: #1f2937;

--- a/pkg/themes/readability_test.go
+++ b/pkg/themes/readability_test.go
@@ -17,6 +17,21 @@ func TestCSSTypographyReadability(t *testing.T) {
 	}
 	css := string(mainCSS)
 
+	t.Run("expressive heading roles preserve semantic contrast", func(t *testing.T) {
+		for _, required := range []string{
+			":is(.post-header h1, .post-content h1, .post-content h2)",
+			"font-weight: inherit",
+			"box-decoration-break: clone",
+			"-webkit-box-decoration-break: clone",
+			"mark :is(strong, em, code, del, a)",
+			"var(--font-code, var(--font-mono))",
+		} {
+			if !strings.Contains(css, required) {
+				t.Errorf("main.css missing expressive heading rule %q", required)
+			}
+		}
+	})
+
 	varsCSS, err := ReadStatic("css/variables.css")
 	if err != nil {
 		t.Fatalf("Failed to read variables.css: %v", err)

--- a/pkg/themes/readability_test.go
+++ b/pkg/themes/readability_test.go
@@ -19,7 +19,7 @@ func TestCSSTypographyReadability(t *testing.T) {
 
 	t.Run("expressive heading roles preserve semantic contrast", func(t *testing.T) {
 		for _, required := range []string{
-			":is(.post-header h1, .post-content h1, .post-content h2)",
+			"html[data-fontpack] :is(.post-header h1, .post-content h1, .post-content h2)",
 			"font-weight: inherit",
 			"border-top: 2px solid var(--heading-rule)",
 			"border-bottom: 2px solid var(--heading-rule)",

--- a/pkg/themes/readability_test.go
+++ b/pkg/themes/readability_test.go
@@ -21,6 +21,8 @@ func TestCSSTypographyReadability(t *testing.T) {
 		for _, required := range []string{
 			":is(.post-header h1, .post-content h1, .post-content h2)",
 			"font-weight: inherit",
+			"border-top: 2px solid var(--heading-rule)",
+			"border-bottom: 2px solid var(--heading-rule)",
 			"box-decoration-break: clone",
 			"-webkit-box-decoration-break: clone",
 			"mark :is(strong, em, code, del, a)",

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -653,8 +653,8 @@ func (m Model) styleFeedTitle(feed *lifecycle.Feed, title string) string {
 func postToRow(p *models.Post) table.Row {
 	// Title (truncate to 33 chars to leave room for selection indicator)
 	title := "(untitled)"
-	if p.Title != nil && *p.Title != "" {
-		title = *p.Title
+	if p.PlainTitle() != "" {
+		title = p.PlainTitle()
 	}
 	if len(title) > 33 {
 		title = title[:30] + "..."
@@ -1304,8 +1304,8 @@ func (m Model) buildPostViewportContent(p *models.Post, width int) string {
 // appendPostMetadata appends post metadata to the provided string builder.
 func (m Model) appendPostMetadata(metadata *strings.Builder, p *models.Post, theme *Theme, width int) {
 	title := "(untitled)"
-	if p.Title != nil && *p.Title != "" {
-		title = *p.Title
+	if p.PlainTitle() != "" {
+		title = p.PlainTitle()
 	}
 	fmt.Fprintf(metadata, "  %s  %s\n", theme.DetailLabelStyle.Render("Title:"), title)
 	fmt.Fprintf(metadata, "  %s  %s\n", theme.DetailLabelStyle.Render("Path:"), p.Path)

--- a/pkg/tui/search.go
+++ b/pkg/tui/search.go
@@ -303,7 +303,7 @@ func searchPostsSubstring(posts []*models.Post, queryStr string, limit int) []se
 }
 
 func matchesPostSubstring(p *models.Post, q string) bool {
-	if p.Title != nil && strings.Contains(strings.ToLower(*p.Title), q) {
+	if strings.Contains(strings.ToLower(p.PlainTitle()), q) {
 		return true
 	}
 	if p.Description != nil && strings.Contains(strings.ToLower(*p.Description), q) {

--- a/spec/spec/CONTENT.md
+++ b/spec/spec/CONTENT.md
@@ -17,6 +17,23 @@ This document specifies how markdown content is processed.
 └─────────────┘    └─────────────┘    └─────────────┘    └─────────────┘
 ```
 
+## Expressive Inline Titles and Headings
+
+Markdown inline semantics are supported in body headings and frontmatter
+titles. The authored `Post.Title` remains the source string. The build derives
+two explicit representations:
+
+- `TitleHTML` is safe inline HTML for the visible page title.
+- `TitleText` is semantic plain text for browser titles, feeds, search,
+  structured data, social metadata, slugs, and other non-visual consumers.
+
+The shared inline renderer uses the configured Goldmark extensions, including
+GFM strikethrough and Markata's `==mark==` extension. Mark is a delimiter
+container, so nested constructs such as `==**strong**==`, ``==`code`==``, and
+`==[link](/path)==` retain their child semantics. Raw HTML is not enabled in
+title rendering, and title links use the same safe destination policy as body
+Markdown.
+
 ---
 
 ## Frontmatter Extraction

--- a/spec/spec/CONTENT.md
+++ b/spec/spec/CONTENT.md
@@ -28,7 +28,7 @@ two explicit representations:
   structured data, social metadata, slugs, and other non-visual consumers.
 
 The shared inline renderer uses the configured Goldmark extensions, including
-GFM strikethrough and Markata's `==mark==` extension. Mark is a delimiter
+GFM strikethrough, superscript/subscript, and Markata's `==mark==` extension. Mark is a delimiter
 container, so nested constructs such as `==**strong**==`, ``==`code`==``, and
 `==[link](/path)==` retain their child semantics. Raw HTML is not enabled in
 title rendering, and title links use the same safe destination policy as body

--- a/spec/spec/DATA_MODEL.md
+++ b/spec/spec/DATA_MODEL.md
@@ -47,6 +47,22 @@ These fields SHOULD be supported:
 | `author` | string? | null | Legacy single-author field |
 | `author_objects` | Author[] | [] | Computed: resolved Author structs (not serialized, see [AUTHORS.md](AUTHORS.md)) |
 
+### Title representations
+
+An authored `title` remains available as the source value. After the
+`auto_title` and `inline_titles` transform plugins run, posts also expose:
+
+| Field | Description |
+|-------|-------------|
+| `title_html` | Safe inline-Markdown HTML for visible headings |
+| `title_text` | Semantic plain text for metadata, feeds, search, browser titles, and slugs |
+| `title_source` | The authored/source title value |
+
+`title_text` has an explicit derived state. An empty value can mean either
+that derivation has not run or that the source contained no semantic text.
+Once derivation completes, consumers MUST use the empty derived value and MUST
+NOT fall back to authored Markdown syntax.
+
 ### Field Behaviors
 
 #### `published` - Shadow Pages

--- a/spec/spec/LIFECYCLE.md
+++ b/spec/spec/LIFECYCLE.md
@@ -157,6 +157,16 @@ This specification offers **three lifecycle variants** to suit different impleme
 8. `write` - Write all output files
 9. `cleanup` - Release resources
 
+Title lifecycle ordering is part of the standard transform contract:
+
+```text
+auto_title → inline_titles → semantic-title consumers
+```
+
+`inline_titles` derives `title_html` and `title_text` before plugins that
+consume titles for metadata, feeds, search, or title-derived slugs. Load may
+leave an automatic fallback slug pending until this transform completes.
+
 **Key differences from Full:**
 - `configure` combines model creation + config loading + plugin init
 - `transform` replaces `pre_render` (clearer name)

--- a/templates/layouts/bare.html
+++ b/templates/layouts/bare.html
@@ -1,7 +1,7 @@
 {# Bare Layout - Minimal layout with content only #}
 {% extends "base.html" %}
 
-{% block title %}{{ post.title | default:config.title | default:'My Site' }}{% endblock %}
+{% block title %}{{ post.title_text | default:config.title | default:'My Site' }}{% endblock %}
 {% block description %}{{ post.description | default:config.description | default:'' }}{% endblock %}
 
 {% block body_class %}layout layout--bare{% endblock %}

--- a/templates/layouts/blog.html
+++ b/templates/layouts/blog.html
@@ -1,7 +1,7 @@
 {# Blog Layout - Single-column layout optimized for reading #}
 {% extends "base.html" %}
 
-{% block title %}{{ post.title | default:config.title | default:'My Site' }}{% endblock %}
+{% block title %}{{ post.title_text | default:config.title | default:'My Site' }}{% endblock %}
 {% block description %}{{ post.description | default:config.description | default:'' }}{% endblock %}
 
 {% block body_class %}layout layout--blog{% endblock %}
@@ -39,7 +39,7 @@
     <main class="layout-content layout-content--blog" id="main-content" tabindex="-1" style="--content-max-width: {{ config.layout.blog.content_max_width | default:'720px' }}">
         <article class="post post--blog h-entry" data-pagefind-body>
             <header class="post-header">
-                <h1 class="p-name">{{ post.title }}</h1>
+                <h1 class="p-name">{{ post.title_html | safe }}</h1>
                 {% include "components/post_byline.html" %}
                 {% if config.layout.blog.show_tags and post.tags %}
                 <div class="tags">
@@ -52,7 +52,7 @@
 
             {% if post.cover_image %}
             <figure class="post-cover">
-                <img src="{{ post.cover_image | with_size:"1200,675" }}" alt="{{ post.title }}" width="1200" height="675" loading="lazy">
+                <img src="{{ post.cover_image | with_size:"1200,675" }}" alt="{{ post.title_text }}" width="1200" height="675" loading="lazy">
             </figure>
             {% endif %}
 

--- a/templates/layouts/docs.html
+++ b/templates/layouts/docs.html
@@ -1,7 +1,7 @@
 {# Documentation Layout - 3-panel layout with sidebar, content, and TOC #}
 {% extends "base.html" %}
 
-{% block title %}{{ post.title | default:config.title | default:'My Site' }}{% endblock %}
+{% block title %}{{ post.title_text | default:config.title | default:'My Site' }}{% endblock %}
 {% block description %}{{ post.description | default:config.description | default:'' }}{% endblock %}
 
 {% block body_class %}layout layout--docs{% endblock %}
@@ -59,7 +59,7 @@
     <main class="layout-content" id="main-content" tabindex="-1" style="--content-max-width: {{ config.layout.docs.content_max_width | default:'800px' }}">
         <article class="post h-entry" data-pagefind-body>
             <header class="post-header">
-                <h1 class="p-name">{{ post.title }}</h1>
+                <h1 class="p-name">{{ post.title_html | safe }}</h1>
                 {% if post.description %}
                 <p class="post-description p-summary">{{ post.description }}</p>
                 {% endif %}

--- a/templates/layouts/landing.html
+++ b/templates/layouts/landing.html
@@ -1,7 +1,7 @@
 {# Landing Layout - Full-width layout for marketing pages #}
 {% extends "base.html" %}
 
-{% block title %}{{ post.title | default:config.title | default:'My Site' }}{% endblock %}
+{% block title %}{{ post.title_text | default:config.title | default:'My Site' }}{% endblock %}
 {% block description %}{{ post.description | default:config.description | default:'' }}{% endblock %}
 
 {% block body_class %}layout layout--landing{% endblock %}

--- a/templates/post.html
+++ b/templates/post.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}{{ post.title }} | {{ config.title | default:'My Site' }}{% endblock %}
+{% block title %}{{ post.title_text }} | {{ config.title | default:'My Site' }}{% endblock %}
 {% block description %}{{ post.description | default:'' }}{% endblock %}
 
 {% block meta %}
@@ -33,7 +33,7 @@
 {% endfor %}
 {% else %}
 {# Fallback to basic OG tags if no structured data #}
-<meta property="og:title" content="{{ post.title }}">
+<meta property="og:title" content="{{ post.title_text }}">
 <meta property="og:type" content="article">
 <meta property="og:url" content="{{ config.url }}{{ post.href }}">
 {% if post.description %}
@@ -69,7 +69,7 @@
 
         <header class="post-header">
             <div class="post-header__title-row">
-                <h1 class="p-name" data-pagefind-meta="title">{{ post.title }}</h1>
+                <h1 class="p-name" data-pagefind-meta="title">{{ post.title_html | safe }}</h1>
 
                 {# Author byline and post metadata #}
             {% include "components/post_byline.html" %}

--- a/templates/slides.html
+++ b/templates/slides.html
@@ -2,7 +2,7 @@
 
 {% block body_class %}slides-page{% endblock %}
 
-{% block title %}{{ post.title }} | {{ config.title | default:'My Site' }}{% endblock %}
+{% block title %}{{ post.title_text }} | {{ config.title | default:'My Site' }}{% endblock %}
 {% block description %}{{ post.description | default:'' }}{% endblock %}
 
 {% block header %}{% endblock %}


### PR DESCRIPTION
## Summary

Implements the shared Plaindown/Markata expressive Markdown heading contract.

- Adds nested Goldmark delimiter parsing for `==mark==`.
- Derives safe `TitleHTML` and semantic `TitleText` while preserving source `Title`.
- Uses rich title HTML only for visible H1 contexts and plain text for metadata, feeds, search, structured data, slugs, TUI, and cards.
- Aligns H1/H2 styling with Plaindown intent and Markata font-pack variables, including wrapped mark contrast and code/link/deletion treatments.
- Documents the contract and adds parser, inline-renderer, title, slug, heading, and CSS assertions.

Subtitles and `hgroup` are intentionally out of scope.

Fixes #1157

## Validation

- `just test`
- `just check`
- `just ci`
- `just lint-new`
- `git diff --check`