### PR TITLE
fix(chart): pass builder release directory

### DIFF
--- a/helm-chart/templates/builder-admin.yaml
+++ b/helm-chart/templates/builder-admin.yaml
@@ -95,7 +95,7 @@ spec:
             - {{ .Values.builderAdmin.port | quote }}
             - --source-dir
             - /data/source
-            - --site-dir
+            - --release-dir
             - /data/site
             - --history-dir
             - {{ .Values.builderAdmin.historyDir | quote }}


### PR DESCRIPTION
The builder-admin CLI uses `--release-dir` for the release root. The performance branch chart still passed the global `--site-dir` flag, so production builds wrote output under the source checkout while builder-admin promoted an empty site release.

Use the release-dir flag so build output, promotion, and nginx current symlink share the same site root.