### PR TITLE
perf: reduce build cleanup and source snapshot cost

### DIFF
--- a/docs/guides/deployment/builder-admin.md
+++ b/docs/guides/deployment/builder-admin.md
@@ -241,7 +241,9 @@ work, and completed builds, refreshes, and rollbacks in one list. Use **Enqueue 
 manual build, then inspect its row for status, queue wait, build duration, trigger, and release.
 
 Select **Details** on a build to see phase timings, changed paths, parsed performance lines, and
-the raw log. Raw IDs and filesystem paths are detail data rather than dashboard metrics. On narrow screens,
+the raw log. Release pruning runs asynchronously after publication, so a completed build can be live
+before old release files finish deleting; the recorded prune timing updates when cleanup completes.
+Raw IDs and filesystem paths are detail data rather than dashboard metrics. On narrow screens,
 each build and release reflows into a labeled record so operators do not need to read a clipped
 desktop table.
 

--- a/pkg/builderadmin/service.go
+++ b/pkg/builderadmin/service.go
@@ -197,6 +197,12 @@ type Service struct {
 	watchTimer           *time.Timer
 	stateMu              sync.Mutex
 	state                State
+	releaseMu            sync.Mutex
+	pruneScheduleMu      sync.Mutex
+	pruneRunning         bool
+	prunePending         []pruneRequest
+	pruneCancel          context.CancelFunc
+	pruneDone            chan struct{}
 	leaderMu             sync.RWMutex
 	leader               bool
 	leaderCancel         context.CancelFunc
@@ -217,6 +223,11 @@ type leaderRecord struct {
 type queueRequest struct {
 	QueuedOperation
 	commandArgs []string
+}
+
+type pruneRequest struct {
+	ctx     context.Context
+	buildID string
 }
 
 //nolint:gocyclo // Configuration normalization is intentionally kept together at construction.
@@ -414,6 +425,16 @@ func (s *Service) releaseLeadership() {
 	s.leaderMu.Unlock()
 	if cancel != nil {
 		cancel()
+	}
+	s.pruneScheduleMu.Lock()
+	pruneCancel := s.pruneCancel
+	pruneDone := s.pruneDone
+	s.pruneScheduleMu.Unlock()
+	if pruneCancel != nil {
+		pruneCancel()
+	}
+	if pruneDone != nil {
+		<-pruneDone
 	}
 	if s.leaderLock != nil {
 		_ = unlockFile(s.leaderLock)
@@ -1050,6 +1071,7 @@ func (s *Service) runBuild(ctx context.Context, req queueRequest) {
 	}
 	defer logFile.Close()
 	record.LogPath = logPath
+	leaderCtx := ctx
 	ctx, cancel := context.WithTimeout(ctx, s.cfg.BuildTimeout)
 	defer cancel()
 
@@ -1112,16 +1134,12 @@ func (s *Service) runBuild(ctx context.Context, req queueRequest) {
 	record.ReleasePath = releasePath
 	record.BecameLive = true
 
-	phaseStart = time.Now()
-	s.updateRunningPhase("prune")
-	_ = s.pruneReleases()
-	record.PruneMS = time.Since(phaseStart).Milliseconds()
-
 	record.Status = "success"
 	record.FinishedAt = time.Now().UTC()
 	record.TotalMS = record.FinishedAt.Sub(started).Milliseconds()
 	record.PerfSummary = extractPerfSummaryFromFile(filepath.Join(s.logDir, logPath))
 	s.finishBuild(record)
+	s.schedulePrune(leaderCtx, record.ID)
 }
 
 func (s *Service) runRefresh(ctx context.Context, req queueRequest) {
@@ -1212,6 +1230,8 @@ func (s *Service) runRollback(req queueRequest) {
 	defer logFile.Close()
 	record.LogPath = logPath
 	s.updateRunningPhase("promote")
+	s.releaseMu.Lock()
+	defer s.releaseMu.Unlock()
 	releasePath := filepath.Join(s.cfg.SiteDir, "releases", req.ReleaseID)
 	if _, err := os.Stat(releasePath); err != nil {
 		record.Status = "failed"
@@ -1291,6 +1311,8 @@ func (s *Service) buildCommandArgs(id, buildWork string) ([]string, func(), erro
 }
 
 func (s *Service) promoteBuild(buildWork string) (string, string, error) {
+	s.releaseMu.Lock()
+	defer s.releaseMu.Unlock()
 	releaseID := time.Now().UTC().Format("20060102T150405Z") + "-" + hostSuffix()
 	releasePath := filepath.Join(s.cfg.SiteDir, "releases", releaseID)
 	if err := os.RemoveAll(releasePath); err != nil {
@@ -1320,12 +1342,79 @@ func (s *Service) pruneReleases() error {
 		return nil
 	}
 	for _, release := range releases[s.cfg.ReleasesKeep:] {
-		if release.Current {
+		s.releaseMu.Lock()
+		currentID := s.currentReleaseID()
+		if release.Current || release.ID == currentID {
+			s.releaseMu.Unlock()
 			continue
 		}
 		_ = os.RemoveAll(release.Path)
+		s.releaseMu.Unlock()
 	}
 	return nil
+}
+
+func (s *Service) schedulePrune(ctx context.Context, buildID string) {
+	s.pruneScheduleMu.Lock()
+	if s.pruneRunning {
+		s.prunePending = append(s.prunePending, pruneRequest{ctx: ctx, buildID: buildID})
+		s.pruneScheduleMu.Unlock()
+		return
+	}
+	pruneCtx, cancel := context.WithCancel(ctx)
+	s.pruneRunning = true
+	s.pruneCancel = cancel
+	s.pruneDone = make(chan struct{})
+	done := s.pruneDone
+	s.pruneScheduleMu.Unlock()
+	go s.runScheduledPrunes(pruneCtx, buildID, done)
+}
+
+func (s *Service) runScheduledPrunes(ctx context.Context, buildID string, done chan struct{}) {
+	defer func() {
+		close(done)
+		s.pruneScheduleMu.Lock()
+		if s.pruneDone == done {
+			s.pruneRunning = false
+			s.pruneCancel = nil
+			s.pruneDone = nil
+		}
+		s.pruneScheduleMu.Unlock()
+	}()
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		started := time.Now()
+		_ = s.pruneReleases()
+		pruneMS := time.Since(started).Milliseconds()
+		s.stateMu.Lock()
+		for i := range s.state.Builds {
+			if s.state.Builds[i].ID == buildID {
+				s.state.Builds[i].PruneMS = pruneMS
+				s.saveStateLocked()
+				break
+			}
+		}
+		s.stateMu.Unlock()
+
+		s.pruneScheduleMu.Lock()
+		if len(s.prunePending) == 0 {
+			s.pruneRunning = false
+			s.pruneCancel = nil
+			s.pruneDone = nil
+			s.pruneScheduleMu.Unlock()
+			return
+		}
+		next := s.prunePending[0]
+		s.prunePending = s.prunePending[1:]
+		s.pruneScheduleMu.Unlock()
+		if next.ctx == nil || next.ctx.Err() != nil {
+			continue
+		}
+		buildID = next.buildID
+		ctx = next.ctx
+	}
 }
 
 func (s *Service) runLoggedCommand(ctx context.Context, log io.Writer, cwd string, env []string, args ...string) error {

--- a/pkg/sourcegit/source.go
+++ b/pkg/sourcegit/source.go
@@ -116,11 +116,27 @@ func ignoredMarkdownFiles(sourceDir string, status []byte) ([]string, error) {
 func snapshotFingerprint(ctx context.Context, sourceDir string, statusOutput []byte, ignoredSources []string) (string, error) {
 	hash := sha256.New()
 	_, _ = hash.Write(statusOutput)
-	diff, err := Command(ctx, sourceDir, "diff", "HEAD", "--binary").Output()
+	// Hash the changed paths and their current bytes instead of asking Git to
+	// render a complete binary patch. The latter is needlessly expensive for a
+	// large dirty checkout, while path + bytes preserves the same snapshot
+	// distinction for tracked content changes.
+	rawDiff, err := Command(ctx, sourceDir, "diff", "HEAD", "--raw", "-z", "--").Output()
 	if err != nil {
-		return "", fmt.Errorf("read git worktree diff: %w", err)
+		return "", fmt.Errorf("read changed source metadata: %w", err)
 	}
-	_, _ = hash.Write(diff)
+	_, _ = hash.Write(rawDiff)
+	changed, err := Command(ctx, sourceDir, "diff", "HEAD", "--name-only", "-z", "--").Output()
+	if err != nil {
+		return "", fmt.Errorf("read changed source paths: %w", err)
+	}
+	for _, name := range splitNUL(changed) {
+		if name == "" {
+			continue
+		}
+		if err := hashSourceFile(ctx, hash, sourceDir, name, "tracked"); err != nil {
+			return "", err
+		}
+	}
 	untracked, err := Command(ctx, sourceDir, "ls-files", "--others", "--exclude-standard", "-z").Output()
 	if err != nil {
 		return "", fmt.Errorf("read untracked source files: %w", err)
@@ -129,39 +145,119 @@ func snapshotFingerprint(ctx context.Context, sourceDir string, statusOutput []b
 		if name == "" {
 			continue
 		}
-		if _, err := io.WriteString(hash, name); err != nil {
-			return "", fmt.Errorf("hash untracked source file %q: %w", name, err)
-		}
-		file, err := os.Open(filepath.Join(sourceDir, filepath.FromSlash(name)))
-		if err != nil {
-			return "", fmt.Errorf("read untracked source file %q: %w", name, err)
-		}
-		if _, err := io.Copy(hash, file); err != nil {
-			_ = file.Close()
-			return "", fmt.Errorf("hash untracked source file %q: %w", name, err)
-		}
-		if err := file.Close(); err != nil {
-			return "", fmt.Errorf("close untracked source file %q: %w", name, err)
+		if err := hashSourceFile(ctx, hash, sourceDir, name, "untracked"); err != nil {
+			return "", err
 		}
 	}
 	for _, path := range ignoredSources {
-		name := path
-		if _, err := io.WriteString(hash, name); err != nil {
-			return "", fmt.Errorf("hash ignored source file %q: %w", name, err)
-		}
-		file, err := os.Open(filepath.Join(sourceDir, filepath.FromSlash(name)))
-		if err != nil {
-			return "", fmt.Errorf("read ignored source file %q: %w", name, err)
-		}
-		if _, err := io.Copy(hash, file); err != nil {
-			_ = file.Close()
-			return "", fmt.Errorf("hash ignored source file %q: %w", name, err)
-		}
-		if err := file.Close(); err != nil {
-			return "", fmt.Errorf("close ignored source file %q: %w", name, err)
+		if err := hashSourceFile(ctx, hash, sourceDir, path, "ignored"); err != nil {
+			return "", err
 		}
 	}
 	return fmt.Sprintf("%x", hash.Sum(nil)), nil
+}
+
+func hashSourceFile(ctx context.Context, hash io.Writer, sourceDir, name, kind string) error {
+	if _, err := io.WriteString(hash, kind+"\x00"+name+"\x00"); err != nil {
+		return fmt.Errorf("hash %s source file %q: %w", kind, name, err)
+	}
+	path := filepath.Join(sourceDir, filepath.FromSlash(name))
+	info, lstatErr := os.Lstat(path)
+	if lstatErr != nil && !os.IsNotExist(lstatErr) {
+		return fmt.Errorf("stat %s source file %q: %w", kind, name, lstatErr)
+	}
+	if lstatErr == nil && info.Mode()&os.ModeSymlink != 0 {
+		if _, err := fmt.Fprintf(hash, "mode\x00%#o\x00", info.Mode()); err != nil {
+			return fmt.Errorf("hash mode for source file %q: %w", name, err)
+		}
+		target, err := os.Readlink(path)
+		if err != nil {
+			return fmt.Errorf("readlink %s source file %q: %w", kind, name, err)
+		}
+		if _, err := io.WriteString(hash, "symlink\x00"+target+"\x00"); err != nil {
+			return fmt.Errorf("hash symlink source file %q: %w", name, err)
+		}
+		if targetInfo, err := os.Stat(path); err == nil && targetInfo.Mode().IsRegular() {
+			return hashFileContents(hash, path, name, kind)
+		}
+		return nil
+	}
+	if lstatErr == nil && info.IsDir() {
+		return hashSubmodule(ctx, hash, path, name)
+	}
+	if lstatErr == nil {
+		if _, err := fmt.Fprintf(hash, "mode\x00%#o\x00", info.Mode()); err != nil {
+			return fmt.Errorf("hash mode for source file %q: %w", name, err)
+		}
+	}
+	return hashFileContents(hash, path, name, kind)
+}
+
+func hashSubmodule(ctx context.Context, hash io.Writer, path, name string) error {
+	head, err := Command(ctx, path, "rev-parse", "HEAD").Output()
+	if err != nil {
+		return fmt.Errorf("read submodule HEAD %q: %w", name, err)
+	}
+	status, err := Command(ctx, path, "status", "--porcelain", "--untracked-files=all").Output()
+	if err != nil {
+		return fmt.Errorf("read submodule status %q: %w", name, err)
+	}
+	diff, err := Command(ctx, path, "diff", "HEAD", "--binary").Output()
+	if err != nil {
+		return fmt.Errorf("read submodule diff %q: %w", name, err)
+	}
+	for _, part := range [][]byte{head, status, diff} {
+		if _, err := hash.Write(part); err != nil {
+			return fmt.Errorf("hash submodule %q: %w", name, err)
+		}
+	}
+	ignoredStatus, err := Command(ctx, path, "status", "--porcelain=v1", "-z", "--ignored", "--untracked-files=all").Output()
+	if err != nil {
+		return fmt.Errorf("read submodule ignored files %q: %w", name, err)
+	}
+	ignoredSources, err := ignoredMarkdownFiles(path, ignoredStatus)
+	if err != nil {
+		return err
+	}
+	if _, err := hash.Write(ignoredStatus); err != nil {
+		return fmt.Errorf("hash submodule ignored files %q: %w", name, err)
+	}
+	for _, child := range ignoredSources {
+		if err := hashSourceFile(ctx, hash, path, child, "submodule-ignored"); err != nil {
+			return err
+		}
+	}
+	untracked, err := Command(ctx, path, "ls-files", "--others", "--exclude-standard", "-z").Output()
+	if err != nil {
+		return fmt.Errorf("read submodule untracked files %q: %w", name, err)
+	}
+	for _, child := range splitNUL(untracked) {
+		if child == "" {
+			continue
+		}
+		if err := hashSourceFile(ctx, hash, path, child, "submodule-untracked"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func hashFileContents(hash io.Writer, path, name, kind string) error {
+	file, err := os.Open(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read %s source file %q: %w", kind, name, err)
+	}
+	if _, err := io.Copy(hash, file); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("hash %s source file %q: %w", kind, name, err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close %s source file %q: %w", kind, name, err)
+	}
+	return nil
 }
 
 func isMarkdownSource(name string) bool {

--- a/pkg/sourcegit/source_test.go
+++ b/pkg/sourcegit/source_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -52,6 +53,34 @@ func TestReadSourceState(t *testing.T) {
 	state, err = Read(context.Background(), dir)
 	if err != nil || state.Dirty == nil || !*state.Dirty {
 		t.Fatalf("untracked dirty state = %#v, err = %v", state, err)
+	}
+}
+
+func TestReadSourceStateDetectsTrackedModeChanges(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Git executable mode bits are not portable on Windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "post.md")
+	writeFile(t, path, "one")
+	git(t, dir, "init")
+	git(t, dir, "config", "user.email", "test@example.invalid")
+	git(t, dir, "config", "user.name", "Content Index Test")
+	git(t, dir, "add", "post.md")
+	git(t, dir, "commit", "-m", "initial")
+	clean, err := Read(context.Background(), dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	modeChanged, err := Read(context.Background(), dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if clean.Equal(modeChanged) {
+		t.Fatal("tracked mode change was not detected")
 	}
 }
 

--- a/spec/spec/BUILDER_ADMIN.md
+++ b/spec/spec/BUILDER_ADMIN.md
@@ -82,7 +82,11 @@ Successful builds MUST preserve the existing atomic release publication model:
 3. run `markata-go build` into the work directory
 4. move the finished output into `releases/<release-id>/`
 5. atomically repoint `current` to the new release
-6. prune old releases according to retention policy
+6. publish build success and queue release pruning according to retention policy
+
+Release pruning MUST NOT block successful publication or the next queued build.
+Pruning MUST remain serialized with promotion and rollback, and MUST re-check
+the current release before deleting each expired release.
 
 Every retained successful release MUST be available through the protected preview path
 `/__preview/<release-id>/`. Preview routing MUST use the same ForwardAuth policy as builder-admin
@@ -95,7 +99,7 @@ The service MUST record phase timings for at least:
 - prepare
 - build
 - promote
-- prune
+- prune (recorded when asynchronous cleanup completes)
 - total
 
 The service MUST store the full raw build log and a parsed performance summary that includes any `Duration:` and `Hotspots:` lines emitted by markata-go.


### PR DESCRIPTION
Refs #1167

Reduce production build latency without weakening source provenance or release safety.

Changes:
- fingerprint changed source paths and bytes instead of rendering full binary Git patches; retain mode, symlink, and submodule handling
- run serialized release pruning asynchronously after publication, with leadership cancellation and promotion/rollback safety
- document asynchronous pruning behavior