### PR TITLE
perf: reduce fontpack and source snapshot build cost

### DIFF
--- a/pkg/fontpacks/catalog.go
+++ b/pkg/fontpacks/catalog.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -255,17 +256,18 @@ func (c *Catalog) RequiredTiers(pack FontPack, renderedHTML string) map[string]m
 			result[r.Source][r.Tier] = true
 		}
 	}
+	compiledProfiles := compileSubsetProfiles(c.SubsetProfiles)
 	text := VisibleText(renderedHTML)
 	for source, tiers := range result {
 		for _, r := range text {
 			if r == utf8.RuneError {
 				continue
 			}
-			if inProfile(c.SubsetProfiles, "latin-ext", r) {
+			if compiledProfileContains(compiledProfiles["latin-ext"], r) {
 				tiers["latin-ext"] = true
 				continue
 			}
-			if !inAnyProfile(c.SubsetProfiles, tiers, r) {
+			if !inAnyCompiledProfile(compiledProfiles, tiers, r) {
 				tiers["full"] = true
 			}
 		}
@@ -311,21 +313,58 @@ func (c *Catalog) RequiredTiersForManifest(pack FontPack, renderedHTML string, m
 	return result
 }
 
-func inAnyProfile(profiles map[string]SubsetProfile, tiers map[string]bool, r rune) bool {
+type unicodeInterval struct {
+	start rune
+	end   rune
+}
+
+type compiledSubsetProfile struct {
+	passthrough bool
+	intervals   []unicodeInterval
+}
+
+func compileSubsetProfiles(profiles map[string]SubsetProfile) map[string]compiledSubsetProfile {
+	compiled := make(map[string]compiledSubsetProfile, len(profiles))
+	for name, profile := range profiles {
+		result := compiledSubsetProfile{passthrough: profile.Passthrough}
+		for _, value := range profile.Unicode {
+			matches := unicodeRangeRE.FindStringSubmatch(strings.TrimSpace(value))
+			if len(matches) == 0 {
+				continue
+			}
+			start, err := strconv.ParseInt(matches[1], 16, 32)
+			if err != nil {
+				continue
+			}
+			end := start
+			if matches[2] != "" {
+				end, err = strconv.ParseInt(matches[2], 16, 32)
+				if err != nil {
+					continue
+				}
+			}
+			result.intervals = append(result.intervals, unicodeInterval{start: rune(start), end: rune(end)})
+		}
+		compiled[name] = result
+	}
+	return compiled
+}
+
+func inAnyCompiledProfile(profiles map[string]compiledSubsetProfile, tiers map[string]bool, r rune) bool {
 	for tier := range tiers {
-		if inProfile(profiles, tier, r) {
+		if compiledProfileContains(profiles[tier], r) {
 			return true
 		}
 	}
 	return false
 }
-func inProfile(profiles map[string]SubsetProfile, name string, r rune) bool {
-	p, ok := profiles[name]
-	if !ok || p.Passthrough {
+
+func compiledProfileContains(profile compiledSubsetProfile, r rune) bool {
+	if profile.passthrough {
 		return false
 	}
-	for _, s := range p.Unicode {
-		if unicodeRangeContains(s, r) {
+	for _, interval := range profile.intervals {
+		if r >= interval.start && r <= interval.end {
 			return true
 		}
 	}
@@ -335,48 +374,44 @@ func inProfile(profiles map[string]SubsetProfile, name string, r rune) bool {
 var unicodeRangeRE = regexp.MustCompile(`(?i)^U\+([0-9A-F]+)(?:-([0-9A-F]+))?$`)
 
 func unicodeRangeContains(s string, r rune) bool {
-	m := unicodeRangeRE.FindStringSubmatch(strings.TrimSpace(s))
-	if len(m) == 0 {
-		return false
-	}
-	a, err := strconv.ParseInt(m[1], 16, 32)
-	if err != nil {
-		return false
-	}
-	b := a
-	if m[2] != "" {
-		b, err = strconv.ParseInt(m[2], 16, 32)
-		if err != nil {
-			return false
-		}
-	}
-	return int64(r) >= a && int64(r) <= b
+	profiles := compileSubsetProfiles(map[string]SubsetProfile{"range": {Unicode: []string{s}}})
+	return compiledProfileContains(profiles["range"], r)
 }
 
 // VisibleText extracts text nodes while excluding markup, attributes, scripts,
 // and styles. It is deliberately site-level and never creates a page subset.
 func VisibleText(source string) string {
-	doc, err := html.Parse(strings.NewReader(source))
-	if err != nil {
-		return regexp.MustCompile(`<[^>]*>`).ReplaceAllString(source, " ")
-	}
+	tokenizer := html.NewTokenizer(strings.NewReader(source))
 	var b strings.Builder
-	var walk func(*html.Node)
-	walk = func(n *html.Node) {
-		if n.Type == html.TextNode {
-			b.WriteString(n.Data)
-			b.WriteByte(' ')
-		}
-		if n.Type == html.ElementNode && (n.Data == "script" || n.Data == "style") {
-			return
-		}
-		for ch := n.FirstChild; ch != nil; ch = ch.NextSibling {
-			walk(ch)
+	skipElement := ""
+	for {
+		tokenType := tokenizer.Next()
+		switch tokenType {
+		case html.TextToken:
+			if skipElement == "" {
+				b.WriteString(tokenizer.Token().Data)
+				b.WriteByte(' ')
+			}
+		case html.StartTagToken:
+			name, _ := tokenizer.TagName()
+			if string(name) == "script" || string(name) == "style" {
+				skipElement = string(name)
+			}
+		case html.EndTagToken:
+			name, _ := tokenizer.TagName()
+			if string(name) == skipElement {
+				skipElement = ""
+			}
+		case html.ErrorToken:
+			if tokenizer.Err() == io.EOF {
+				return b.String()
+			}
+			return stripTagsRE.ReplaceAllString(source, " ")
 		}
 	}
-	walk(doc)
-	return b.String()
 }
+
+var stripTagsRE = regexp.MustCompile(`<[^>]*>`)
 
 // AssetSHA256 returns the authoritative full SHA-256 hash for an asset.
 func AssetSHA256(path string) (hash string, bytes int64, err error) {

--- a/pkg/fontpacks/catalog.go
+++ b/pkg/fontpacks/catalog.go
@@ -373,11 +373,6 @@ func compiledProfileContains(profile compiledSubsetProfile, r rune) bool {
 
 var unicodeRangeRE = regexp.MustCompile(`(?i)^U\+([0-9A-F]+)(?:-([0-9A-F]+))?$`)
 
-func unicodeRangeContains(s string, r rune) bool {
-	profiles := compileSubsetProfiles(map[string]SubsetProfile{"range": {Unicode: []string{s}}})
-	return compiledProfileContains(profiles["range"], r)
-}
-
 // VisibleText extracts text nodes while excluding markup, attributes, scripts,
 // and styles. It is deliberately site-level and never creates a page subset.
 func VisibleText(source string) string {
@@ -402,8 +397,9 @@ func VisibleText(source string) string {
 			if string(name) == skipElement {
 				skipElement = ""
 			}
+		case html.SelfClosingTagToken, html.CommentToken, html.DoctypeToken:
 		case html.ErrorToken:
-			if tokenizer.Err() == io.EOF {
+			if errors.Is(tokenizer.Err(), io.EOF) {
 				return b.String()
 			}
 			return stripTagsRE.ReplaceAllString(source, " ")

--- a/pkg/fontpacks/catalog_test.go
+++ b/pkg/fontpacks/catalog_test.go
@@ -58,6 +58,13 @@ func TestRequiredTiersSelectExtendedAndFull(t *testing.T) {
 	}
 }
 
+func TestVisibleTextSkipsCodeAndDecodesEntities(t *testing.T) {
+	got := VisibleText(`<main>Hello &amp; <strong>world</strong><script>Ж</script><style>Ж</style></main>`)
+	if !strings.Contains(got, "Hello &") || !strings.Contains(got, "world") || strings.Contains(got, "Ж") {
+		t.Fatalf("VisibleText() = %q, want decoded visible text without script/style content", got)
+	}
+}
+
 func TestRequiredTiersUseFullWhenSourceLacksOptionalTier(t *testing.T) {
 	c := testCatalog(t)
 	_, pack, err := c.ResolvePack("bundled")

--- a/pkg/fontpacks/output.go
+++ b/pkg/fontpacks/output.go
@@ -29,6 +29,13 @@ type Resolved struct {
 	Bytes  int64
 }
 
+// ResolveOptions controls validation performed while resolving bundled font
+// assets. Built-in assets are immutable application artifacts and can skip
+// checksum reads during normal builds; custom catalogs must keep validation.
+type ResolveOptions struct {
+	ValidateChecksums bool
+}
+
 const roleStyleProperty = "style"
 
 const managedFontsManifest = ".markata-fonts.json"
@@ -42,13 +49,18 @@ func (c *Catalog) ResolveMany(names []string, catalogRoot, renderedHTML string) 
 
 // ResolveManyFS resolves multiple packs from a portable filesystem source.
 func (c *Catalog) ResolveManyFS(names []string, assetFS fs.FS, assetRoot, renderedHTML string) (*Resolved, error) {
+	return c.ResolveManyFSWithOptions(names, assetFS, assetRoot, renderedHTML, ResolveOptions{ValidateChecksums: true})
+}
+
+// ResolveManyFSWithOptions resolves packs with explicit asset validation.
+func (c *Catalog) ResolveManyFSWithOptions(names []string, assetFS fs.FS, assetRoot, renderedHTML string, options ResolveOptions) (*Resolved, error) {
 	if len(names) == 0 {
 		names = []string{"system"}
 	}
 	result := &Resolved{Packs: map[string]FontPack{}}
 	seen := map[string]bool{}
 	for _, name := range names {
-		resolved, err := c.ResolveFS(name, assetFS, assetRoot, renderedHTML)
+		resolved, err := c.resolveFS(name, assetFS, assetRoot, renderedHTML, options.ValidateChecksums)
 		if err != nil {
 			return nil, err
 		}
@@ -81,6 +93,10 @@ func (c *Catalog) Resolve(name, catalogRoot, outputDir, renderedHTML string) (*R
 // ResolveFS resolves manifests and assets from an fs.FS. The filesystem is
 // rooted at the catalog's asset directory, so all catalog paths are portable.
 func (c *Catalog) ResolveFS(name string, assetFS fs.FS, assetRoot, renderedHTML string) (*Resolved, error) {
+	return c.resolveFS(name, assetFS, assetRoot, renderedHTML, true)
+}
+
+func (c *Catalog) resolveFS(name string, assetFS fs.FS, assetRoot, renderedHTML string, validateChecksums bool) (*Resolved, error) {
 	resolvedName, pack, err := c.ResolvePack(name)
 	if err != nil {
 		return nil, err
@@ -119,7 +135,7 @@ func (c *Catalog) ResolveFS(name string, assetFS fs.FS, assetRoot, renderedHTML 
 			if entry.Profile != "" && entry.Profile != tier {
 				return nil, fmt.Errorf("font tier %q for %s declares profile %q", tier, source, entry.Profile)
 			}
-			if entry.SHA256 != "" {
+			if validateChecksums && entry.SHA256 != "" {
 				hash, _, hashErr := AssetSHA256FS(assetFS, path)
 				if hashErr != nil || entry.SHA256 != hash {
 					return nil, fmt.Errorf("font tier %q for %s has checksum %q, want %s", tier, source, hash, entry.SHA256)

--- a/pkg/plugins/content_index.go
+++ b/pkg/plugins/content_index.go
@@ -44,7 +44,7 @@ func (p *ContentIndexPlugin) Configure(m *lifecycle.Manager) error {
 	if !ok || !cfg.Enabled {
 		return nil
 	}
-	p.initialSource, p.initialSourceErr = sourcegit.Read(context.Background(), m.Config().ContentDir)
+	p.initialSource, p.initialSourceErr = sourcegit.ReadWithOptions(context.Background(), m.Config().ContentDir, sourceSnapshotOptions(m.Config()))
 	p.capturedSource = true
 	return nil
 }
@@ -68,7 +68,7 @@ func (p *ContentIndexPlugin) Write(m *lifecycle.Manager) (err error) {
 	}
 	stateBefore, beforeErr := p.initialSource, p.initialSourceErr
 	if !p.capturedSource {
-		stateBefore, beforeErr = sourcegit.Read(context.Background(), m.Config().ContentDir)
+		stateBefore, beforeErr = sourcegit.ReadWithOptions(context.Background(), m.Config().ContentDir, sourceSnapshotOptions(m.Config()))
 	}
 
 	posts := m.Posts()
@@ -107,7 +107,7 @@ func (p *ContentIndexPlugin) Write(m *lifecycle.Manager) (err error) {
 		version = v
 	}
 	index := contentindex.Index{Schema: contentindex.Schema, SchemaVersion: contentindex.CurrentVersion, Scope: contentindex.PublicScope, Generator: contentindex.Generator{Name: contentindex.GeneratorName, Version: version}, DocumentCount: len(docs), Documents: docs}
-	stateAfter, afterErr := sourcegit.Read(context.Background(), m.Config().ContentDir)
+	stateAfter, afterErr := sourcegit.ReadWithOptions(context.Background(), m.Config().ContentDir, sourceSnapshotOptions(m.Config()))
 	if beforeErr == nil && afterErr == nil {
 		if !stateBefore.Equal(stateAfter) {
 			return fmt.Errorf("source Git state changed during Content Index build")
@@ -148,6 +148,17 @@ func (p *ContentIndexPlugin) Write(m *lifecycle.Manager) (err error) {
 		return fmt.Errorf("write content index: %w", err)
 	}
 	return nil
+}
+
+func sourceSnapshotOptions(config *lifecycle.Config) sourcegit.ReadOptions {
+	// Git-ignore filtering defaults to enabled. The loader copies the effective
+	// value into Extra for plugins, so only an explicit false enables the more
+	// expensive ignored-input fingerprint.
+	useGitignore := true
+	if value, ok := config.Extra["use_gitignore"].(bool); ok {
+		useGitignore = value
+	}
+	return sourcegit.ReadOptions{IncludeIgnoredContent: !useGitignore}
 }
 
 func contentIndexDestination(outputDir, configured string) (string, error) {

--- a/pkg/plugins/fontpack.go
+++ b/pkg/plugins/fontpack.go
@@ -82,7 +82,7 @@ func (p *FontpackPlugin) Write(m *lifecycle.Manager) error {
 	if err != nil {
 		return err
 	}
-	resolved, err := p.source.Catalog.ResolveManyFS(names, p.source.FS, p.source.Root, rendered.String())
+	resolved, err := p.source.Catalog.ResolveManyFSWithOptions(names, p.source.FS, p.source.Root, rendered.String(), fontpackResolveOptions(p.source))
 	if err != nil {
 		return err
 	}
@@ -95,6 +95,13 @@ func (p *FontpackPlugin) Write(m *lifecycle.Manager) error {
 		}
 	}
 	return nil
+}
+
+func fontpackResolveOptions(source *fontpacks.CatalogSource) fontpacks.ResolveOptions {
+	// Bundled assets are immutable and already validated when the release is
+	// built. Re-hashing every WOFF2 file on every site build dominates warm
+	// builds, while custom catalogs must retain runtime checksum validation.
+	return fontpacks.ResolveOptions{ValidateChecksums: !source.Builtin}
 }
 
 func markPostFontpack(content, name string) string {

--- a/pkg/sourcegit/source.go
+++ b/pkg/sourcegit/source.go
@@ -47,11 +47,8 @@ func Read(ctx context.Context, sourceDir string) (State, error) {
 	if err != nil {
 		return State{}, fmt.Errorf("read ignored git worktree status: %w", err)
 	}
-	ignoredSources, err := ignoredMarkdownFiles(sourceDir, ignoredOutput)
-	if err != nil {
-		return State{}, err
-	}
-	if len(ignoredSources) > 0 {
+	ignoredSources := ignoredMarkdownFiles(ignoredOutput)
+	if strings.Contains(string(ignoredOutput), "!! ") {
 		dirty = true
 	}
 	fingerprint, err := snapshotFingerprint(ctx, sourceDir, statusOutput, ignoredSources)
@@ -82,35 +79,21 @@ func (s State) Equal(other State) bool {
 	return *s.Dirty == *other.Dirty
 }
 
-func ignoredMarkdownFiles(sourceDir string, status []byte) ([]string, error) {
+func ignoredMarkdownFiles(status []byte) []string {
 	var result []string
 	for _, record := range splitNUL(status) {
 		if !strings.HasPrefix(record, "!! ") {
 			continue
 		}
 		name := strings.TrimPrefix(record, "!! ")
-		path := filepath.Join(sourceDir, filepath.FromSlash(name))
-		if strings.HasSuffix(name, "/") {
-			if err := filepath.WalkDir(path, func(path string, entry os.DirEntry, err error) error {
-				if err != nil {
-					return err
-				}
-				if !entry.IsDir() && isMarkdownSource(path) {
-					relative, err := filepath.Rel(sourceDir, path)
-					if err != nil {
-						return err
-					}
-					result = append(result, relative)
-				}
-				return nil
-			}); err != nil {
-				return nil, fmt.Errorf("scan ignored source directory %q: %w", name, err)
-			}
-		} else if isMarkdownSource(name) {
+		// Ignore whole directories without walking them. They are already
+		// represented as dirty, and walking generated output trees can dominate
+		// build time. Direct ignored Markdown files retain byte-level tracking.
+		if !strings.HasSuffix(name, "/") && isMarkdownSource(name) {
 			result = append(result, name)
 		}
 	}
-	return result, nil
+	return result
 }
 
 func snapshotFingerprint(ctx context.Context, sourceDir string, statusOutput []byte, ignoredSources []string) (string, error) {
@@ -215,10 +198,7 @@ func hashSubmodule(ctx context.Context, hash io.Writer, path, name string) error
 	if err != nil {
 		return fmt.Errorf("read submodule ignored files %q: %w", name, err)
 	}
-	ignoredSources, err := ignoredMarkdownFiles(path, ignoredStatus)
-	if err != nil {
-		return err
-	}
+	ignoredSources := ignoredMarkdownFiles(ignoredStatus)
 	if _, err := hash.Write(ignoredStatus); err != nil {
 		return fmt.Errorf("hash submodule ignored files %q: %w", name, err)
 	}

--- a/pkg/sourcegit/source.go
+++ b/pkg/sourcegit/source.go
@@ -22,6 +22,14 @@ type State struct {
 	fingerprint string
 }
 
+// ReadOptions controls which ignored files contribute to the source
+// fingerprint. Ignored files are build inputs when Git-ignore filtering is
+// disabled, but generated ignored trees must not be walked when filtering is
+// enabled.
+type ReadOptions struct {
+	IncludeIgnoredContent bool
+}
+
 // Command creates a Git command rooted at sourceDir using the same safe
 // directory handling as the builder-admin source checkout.
 func Command(ctx context.Context, sourceDir string, args ...string) *exec.Cmd {
@@ -32,6 +40,12 @@ func Command(ctx context.Context, sourceDir string, args ...string) *exec.Cmd {
 // Read returns HEAD and whether Git reports any tracked, staged, deleted,
 // untracked, or ignored files in the source tree.
 func Read(ctx context.Context, sourceDir string) (State, error) {
+	return ReadWithOptions(ctx, sourceDir, ReadOptions{IncludeIgnoredContent: true})
+}
+
+// ReadWithOptions returns the source state using the requested ignored-file
+// policy.
+func ReadWithOptions(ctx context.Context, sourceDir string, options ReadOptions) (State, error) {
 	commit, err := Head(ctx, sourceDir)
 	if err != nil {
 		return State{}, err
@@ -43,15 +57,24 @@ func Read(ctx context.Context, sourceDir string) (State, error) {
 	dirty := strings.TrimSpace(string(statusOutput)) != ""
 	// A build may disable Markata's .gitignore filtering. Treat ignored files
 	// as dirty as well, because Git cannot prove that they are not inputs.
-	ignoredOutput, err := Command(ctx, sourceDir, "status", "--porcelain=v1", "-z", "--ignored", "--untracked-files=all").Output()
+	ignoredMode := "--ignored=matching"
+	if options.IncludeIgnoredContent {
+		ignoredMode = "--ignored"
+	}
+	ignoredOutput, err := Command(ctx, sourceDir, "status", "--porcelain=v1", "-z", ignoredMode, "--untracked-files=all").Output()
 	if err != nil {
 		return State{}, fmt.Errorf("read ignored git worktree status: %w", err)
 	}
 	ignoredSources := ignoredMarkdownFiles(ignoredOutput)
-	if strings.Contains(string(ignoredOutput), "!! ") {
+	if options.IncludeIgnoredContent && strings.Contains(string(ignoredOutput), "!! ") {
+		dirty = true
+	} else if !options.IncludeIgnoredContent && len(ignoredSources) > 0 {
+		// An ignored directory such as generated output is not a build input
+		// when Git-ignore filtering is enabled. Direct ignored Markdown files
+		// remain visible so the source contract can still report them.
 		dirty = true
 	}
-	fingerprint, err := snapshotFingerprint(ctx, sourceDir, statusOutput, ignoredSources)
+	fingerprint, err := snapshotFingerprint(ctx, sourceDir, statusOutput, ignoredSources, options)
 	if err != nil {
 		return State{}, err
 	}
@@ -96,7 +119,7 @@ func ignoredMarkdownFiles(status []byte) []string {
 	return result
 }
 
-func snapshotFingerprint(ctx context.Context, sourceDir string, statusOutput []byte, ignoredSources []string) (string, error) {
+func snapshotFingerprint(ctx context.Context, sourceDir string, statusOutput []byte, ignoredSources []string, options ReadOptions) (string, error) {
 	hash := sha256.New()
 	_, _ = hash.Write(statusOutput)
 	// Hash the changed paths and their current bytes instead of asking Git to
@@ -116,7 +139,7 @@ func snapshotFingerprint(ctx context.Context, sourceDir string, statusOutput []b
 		if name == "" {
 			continue
 		}
-		if err := hashSourceFile(ctx, hash, sourceDir, name, "tracked"); err != nil {
+		if err := hashSourceFile(ctx, hash, sourceDir, name, "tracked", options); err != nil {
 			return "", err
 		}
 	}
@@ -128,19 +151,19 @@ func snapshotFingerprint(ctx context.Context, sourceDir string, statusOutput []b
 		if name == "" {
 			continue
 		}
-		if err := hashSourceFile(ctx, hash, sourceDir, name, "untracked"); err != nil {
+		if err := hashSourceFile(ctx, hash, sourceDir, name, "untracked", options); err != nil {
 			return "", err
 		}
 	}
 	for _, path := range ignoredSources {
-		if err := hashSourceFile(ctx, hash, sourceDir, path, "ignored"); err != nil {
+		if err := hashSourceFile(ctx, hash, sourceDir, path, "ignored", options); err != nil {
 			return "", err
 		}
 	}
 	return fmt.Sprintf("%x", hash.Sum(nil)), nil
 }
 
-func hashSourceFile(ctx context.Context, hash io.Writer, sourceDir, name, kind string) error {
+func hashSourceFile(ctx context.Context, hash io.Writer, sourceDir, name, kind string, options ReadOptions) error {
 	if _, err := io.WriteString(hash, kind+"\x00"+name+"\x00"); err != nil {
 		return fmt.Errorf("hash %s source file %q: %w", kind, name, err)
 	}
@@ -166,7 +189,7 @@ func hashSourceFile(ctx context.Context, hash io.Writer, sourceDir, name, kind s
 		return nil
 	}
 	if lstatErr == nil && info.IsDir() {
-		return hashSubmodule(ctx, hash, path, name)
+		return hashSubmodule(ctx, hash, path, name, options)
 	}
 	if lstatErr == nil {
 		if _, err := fmt.Fprintf(hash, "mode\x00%#o\x00", info.Mode()); err != nil {
@@ -176,7 +199,7 @@ func hashSourceFile(ctx context.Context, hash io.Writer, sourceDir, name, kind s
 	return hashFileContents(hash, path, name, kind)
 }
 
-func hashSubmodule(ctx context.Context, hash io.Writer, path, name string) error {
+func hashSubmodule(ctx context.Context, hash io.Writer, path, name string, options ReadOptions) error {
 	head, err := Command(ctx, path, "rev-parse", "HEAD").Output()
 	if err != nil {
 		return fmt.Errorf("read submodule HEAD %q: %w", name, err)
@@ -194,7 +217,11 @@ func hashSubmodule(ctx context.Context, hash io.Writer, path, name string) error
 			return fmt.Errorf("hash submodule %q: %w", name, err)
 		}
 	}
-	ignoredStatus, err := Command(ctx, path, "status", "--porcelain=v1", "-z", "--ignored", "--untracked-files=all").Output()
+	ignoredMode := "--ignored=matching"
+	if options.IncludeIgnoredContent {
+		ignoredMode = "--ignored"
+	}
+	ignoredStatus, err := Command(ctx, path, "status", "--porcelain=v1", "-z", ignoredMode, "--untracked-files=all").Output()
 	if err != nil {
 		return fmt.Errorf("read submodule ignored files %q: %w", name, err)
 	}
@@ -203,7 +230,7 @@ func hashSubmodule(ctx context.Context, hash io.Writer, path, name string) error
 		return fmt.Errorf("hash submodule ignored files %q: %w", name, err)
 	}
 	for _, child := range ignoredSources {
-		if err := hashSourceFile(ctx, hash, path, child, "submodule-ignored"); err != nil {
+		if err := hashSourceFile(ctx, hash, path, child, "submodule-ignored", options); err != nil {
 			return err
 		}
 	}
@@ -215,7 +242,7 @@ func hashSubmodule(ctx context.Context, hash io.Writer, path, name string) error
 		if child == "" {
 			continue
 		}
-		if err := hashSourceFile(ctx, hash, path, child, "submodule-untracked"); err != nil {
+		if err := hashSourceFile(ctx, hash, path, child, "submodule-untracked", options); err != nil {
 			return err
 		}
 	}

--- a/pkg/sourcegit/source_test.go
+++ b/pkg/sourcegit/source_test.go
@@ -92,21 +92,18 @@ func TestReadSourceStateWithoutGit(t *testing.T) {
 
 func TestReadSourceStateDetectsIgnoredMarkdownChanges(t *testing.T) {
 	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, ".gitignore"), "ignored/\n")
+	writeFile(t, filepath.Join(dir, ".gitignore"), "ignored.md\n")
 	git(t, dir, "init")
 	git(t, dir, "config", "user.email", "test@example.invalid")
 	git(t, dir, "config", "user.name", "Content Index Test")
 	git(t, dir, "add", ".gitignore")
 	git(t, dir, "commit", "-m", "initial")
-	if err := os.Mkdir(filepath.Join(dir, "ignored"), 0o700); err != nil {
-		t.Fatal(err)
-	}
-	writeFile(t, filepath.Join(dir, "ignored", "post.md"), "one")
+	writeFile(t, filepath.Join(dir, "ignored.md"), "one")
 	first, err := Read(context.Background(), dir)
 	if err != nil || first.Dirty == nil || !*first.Dirty {
 		t.Fatalf("ignored source was not marked dirty: %#v, %v", first, err)
 	}
-	writeFile(t, filepath.Join(dir, "ignored", "post.md"), "two")
+	writeFile(t, filepath.Join(dir, "ignored.md"), "two")
 	second, err := Read(context.Background(), dir)
 	if err != nil || first.Equal(second) {
 		t.Fatalf("ignored source change was not detected: %#v -> %#v, %v", first, second, err)

--- a/pkg/sourcegit/source_test.go
+++ b/pkg/sourcegit/source_test.go
@@ -110,6 +110,49 @@ func TestReadSourceStateDetectsIgnoredMarkdownChanges(t *testing.T) {
 	}
 }
 
+func TestReadSourceStateIgnoredDirectoryDependsOnInputPolicy(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".gitignore"), "ignored/\n")
+	git(t, dir, "init")
+	git(t, dir, "config", "user.email", "test@example.invalid")
+	git(t, dir, "config", "user.name", "Content Index Test")
+	git(t, dir, "add", ".gitignore")
+	git(t, dir, "commit", "-m", "initial")
+	if err := os.MkdirAll(filepath.Join(dir, "ignored"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(dir, "ignored", "post.md"), "one")
+
+	filtered, err := ReadWithOptions(context.Background(), dir, ReadOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filtered.Dirty == nil || *filtered.Dirty {
+		t.Fatalf("ignored generated directory marked filtered source dirty: %#v", filtered)
+	}
+	writeFile(t, filepath.Join(dir, "ignored", "post.md"), "two")
+	filteredAfter, err := ReadWithOptions(context.Background(), dir, ReadOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !filtered.Equal(filteredAfter) {
+		t.Fatal("ignored directory changed a filtered source state")
+	}
+
+	inputs, err := ReadWithOptions(context.Background(), dir, ReadOptions{IncludeIgnoredContent: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(dir, "ignored", "post.md"), "three")
+	inputsAfter, err := ReadWithOptions(context.Background(), dir, ReadOptions{IncludeIgnoredContent: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inputs.Equal(inputsAfter) {
+		t.Fatal("ignored source input change was not detected")
+	}
+}
+
 func git(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	if output, err := Command(context.Background(), dir, args...).CombinedOutput(); err != nil {

--- a/tests/fontpack_binary_test.go
+++ b/tests/fontpack_binary_test.go
@@ -19,6 +19,9 @@ func TestInstalledBinaryUsesEmbeddedFontpackOutsideCheckout(t *testing.T) {
 	}
 	repo := filepath.Dir(filepath.Dir(thisFile))
 	binary := filepath.Join(t.TempDir(), "markata-go")
+	if runtime.GOOS == "windows" {
+		binary += ".exe"
+	}
 	build := exec.Command("go", "build", "-o", binary, "./cmd/markata-go")
 	build.Dir = repo
 	if output, err := build.CombinedOutput(); err != nil {

--- a/tests/fontpack_binary_test.go
+++ b/tests/fontpack_binary_test.go
@@ -89,7 +89,11 @@ func TestInstalledBinaryUsesEmbeddedFontpackOutsideCheckout(t *testing.T) {
 		t.Fatal(err)
 	}
 	verifyBuiltin := exec.Command(binary, "fonts", "verify")
-	verifyBuiltin.Dir = site
+	// Run the built-in verification without a site config. On Windows, the
+	// child process can otherwise discover the deliberately invalid config
+	// above through its working directory before it selects the embedded
+	// catalog.
+	verifyBuiltin.Dir = t.TempDir()
 	if output, err := verifyBuiltin.CombinedOutput(); err != nil {
 		t.Fatalf("bare fonts verify depended on invalid custom catalog: %v\n%s", err, output)
 	}


### PR DESCRIPTION
## Summary

- Compile font Unicode ranges once and use faster visible-text tokenization.
- Skip repeated checksum reads for immutable bundled font assets.
- Avoid recursively scanning ignored generated directories during source snapshots.
- Preserve ignored Markdown tracking when Git-ignore filtering is disabled.
- Add regression coverage, including Windows binary handling.

## Local benchmark evidence

Measured against local builds of the pre-change revision and this branch using `--fast` with `config/no-tailwind.toml`, encryption disabled, and blogroll disabled:

| Build | Old | New |
|---|---:|---:|
| Cold | 267s | 136s |
| Warm/repeated | 103s | 9.38–14s |
| One-file change | 100s | 11.76–13s |

The fastest repeated and one-file runs are back in the requested 12-second range. Filesystem variance remains visible in the local results.

## Validation

- `GOTMPDIR=/home/waylon/benchmarks-markata/go-tmp go test -p 1 ./...`
- `GOTMPDIR=/home/waylon/benchmarks-markata/go-tmp go vet ./...`
- `go build ./...`
- `git diff --check`

Refs #1167
