### PR TITLE
fix(helm): allow Content Index CORS from nginx

### DIFF
--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -23,6 +23,7 @@ This chart deploys a reusable markata-go notes workload that:
 - If your new namespace does not already have `aws-default`, enable `aws.sealedSecret` and provide sealed credentials in values.
 - By default the chart reuses a shared `markata-go-encryption` Secret name for `MARKATA_GO_ENCRYPTION_KEY_DEFAULT`; override `markataEncryption.secretName` only if your established secret uses a different name.
 - If your notes contain private content, provide that Secret externally in the namespace or enable `markataEncryption.sealedSecret`.
+- The nginx site serves `site.contentIndexPath` with `Access-Control-Allow-Origin: *` by default. Set it to an empty string to disable this rule.
 
 ## Setting up the encryption secret
 

--- a/helm-chart/templates/nginx-config.yaml
+++ b/helm-chart/templates/nginx-config.yaml
@@ -70,6 +70,15 @@ data:
           {{- end }}
         }
 
+        {{- if .Values.site.contentIndexPath }}
+        # The Content Index is public metadata and has no article bodies.
+        # Allow browser consumers such as Plaindown to read it cross-origin.
+        location = {{ .Values.site.contentIndexPath }} {
+          add_header Access-Control-Allow-Origin "*" always;
+          try_files $uri =404;
+        }
+        {{- end }}
+
         location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot|avif|webp)$ {
           expires 365d;
           add_header Cache-Control "public, immutable";

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -168,6 +168,9 @@ site:
     tag: "1.27.5-alpine"
     pullPolicy: IfNotPresent
   use404Page: false
+  # Public metadata artifact consumed by browser clients from other origins.
+  # Set this to an empty string to disable the exact-location CORS rule.
+  contentIndexPath: /content-index.json
   resources:
     requests:
       cpu: 20m


### PR DESCRIPTION
Fixes #1170

## Summary
- configure the markata-go Helm chart nginx to serve the public Content Index with `Access-Control-Allow-Origin: *`
- scope the rule to the exact configured artifact path
- make the path configurable with `site.contentIndexPath` and allow disabling it with an empty value
- document the chart behavior

## Deployment context
The production site runs as `waylonwalker-com-prod-notes-site` in Kubernetes with nginx from the markata-go Helm chart. The public hostname is routed through the cluster ingress and Cloudflare tunnel/proxy. The live nginx ConfigMap currently has no Content Index CORS rule.

## Validation
- Helm template rendered `location = /content-index.json` with the CORS header
- `TMPDIR="$PWD/.tmp" go test ./...`
- `TMPDIR="$PWD/.tmp" just lint-new`
- `git diff --check`

All local and CI checks should run against the clean chart-only change.