### PR TITLE
fix(helm): restart nginx when config changes

### DIFF
--- a/helm-chart/templates/site.yaml
+++ b/helm-chart/templates/site.yaml
@@ -16,6 +16,8 @@ spec:
       labels:
         service: "{{ .Values.project_identifier }}-notes-site"
         {{- include "markata-notes.labels" . | nindent 8 }}
+      annotations:
+        checksum/nginx-config: {{ include (print $.Template.BasePath "/nginx-config.yaml") . | sha256sum }}
     spec:
       serviceAccountName: "{{ include "markata-notes.serviceAccountName" . }}"
       automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}


### PR DESCRIPTION
Follow-up to #1173.

The nginx config is mounted with `subPath`, so a ConfigMap update does not reload the existing nginx process. Add a pod-template checksum annotation for the nginx ConfigMap so Argo chart updates roll the site deployment and load the Content Index CORS rule.

Validation:
- `helm lint helm-chart`
- `helm template` confirms the checksum annotation and Content Index location
- `git diff --check`