### PR TITLE
perf: cache unchanged bundled fontpacks

### DIFF
--- a/pkg/fontpacks/output.go
+++ b/pkg/fontpacks/output.go
@@ -447,7 +447,7 @@ func (r *Resolved) CopyFS(assetFS fs.FS, assetRoot, outputDir string) error {
 			return err
 		}
 		// Generated web asset must remain world-readable for static hosting.
-		if err := os.WriteFile(filepath.Join(outputDir, "assets", "fonts", name), data, 0o644); err != nil { //nolint:gosec // public static asset
+		if err := writePublicFile(filepath.Join(outputDir, "assets", "fonts", name), data); err != nil {
 			return err
 		}
 	}
@@ -455,7 +455,29 @@ func (r *Resolved) CopyFS(assetFS fs.FS, assetRoot, outputDir string) error {
 		return err
 	}
 	// Generated web asset must remain world-readable for static hosting.
-	return os.WriteFile(filepath.Join(outputDir, "css", "fonts.css"), []byte(r.CSS), 0o644) //nolint:gosec // public static asset
+	return writePublicFile(filepath.Join(outputDir, "css", "fonts.css"), []byte(r.CSS))
+}
+
+func writePublicFile(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".markata-write-")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Chmod(0o644); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
 }
 
 type managedFonts struct {
@@ -497,7 +519,7 @@ func updateManagedFonts(outputDir string, assets []Asset) error {
 	}
 	data = append(data, '\n')
 	// Generated web asset must remain world-readable for static hosting.
-	return os.WriteFile(manifestPath, data, 0o644) //nolint:gosec // public static asset
+	return writePublicFile(manifestPath, data)
 }
 
 // CleanManagedFonts removes only files named by the previous Markata manifest.

--- a/pkg/plugins/fontpack.go
+++ b/pkg/plugins/fontpack.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -90,7 +91,7 @@ func (p *FontpackPlugin) Write(m *lifecycle.Manager) error {
 	if err != nil {
 		return err
 	}
-	cacheKey := fontpackCacheKey(rendered.String(), names)
+	cacheKey := fontpackCacheKey(rendered.String(), names, p.source.Catalog)
 	if !p.source.Builtin || !fontpackOutputCached(output, cacheKey) {
 		resolved, err := p.source.Catalog.ResolveManyFSWithOptions(names, p.source.FS, p.source.Root, rendered.String(), fontpackResolveOptions(p.source))
 		if err != nil {
@@ -103,6 +104,8 @@ func (p *FontpackPlugin) Write(m *lifecycle.Manager) error {
 			if err := os.WriteFile(filepath.Join(output, fontpackCacheFile), []byte(cacheKey), 0o600); err != nil {
 				return err
 			}
+		} else if err := os.Remove(filepath.Join(output, fontpackCacheFile)); err != nil && !os.IsNotExist(err) {
+			return err
 		}
 	}
 	for _, post := range m.Posts() {
@@ -113,8 +116,12 @@ func (p *FontpackPlugin) Write(m *lifecycle.Manager) error {
 	return nil
 }
 
-func fontpackCacheKey(rendered string, names []string) string {
-	return buildcache.ContentHash(fontpackCacheVersion + "\x00" + rendered + "\x00" + strings.Join(names, "\x00"))
+func fontpackCacheKey(rendered string, names []string, catalog *fontpacks.Catalog) string {
+	catalogData, err := json.Marshal(catalog)
+	if err != nil {
+		return ""
+	}
+	return buildcache.ContentHash(fontpackCacheVersion + "\x00" + string(catalogData) + "\x00" + rendered + "\x00" + strings.Join(names, "\x00"))
 }
 
 func fontpackOutputCached(output, key string) bool {
@@ -122,8 +129,20 @@ func fontpackOutputCached(output, key string) bool {
 	if err != nil || strings.TrimSpace(string(data)) != key {
 		return false
 	}
-	_, err = os.Stat(filepath.Join(output, "css", "fonts.css"))
-	return err == nil
+	if info, err := os.Stat(filepath.Join(output, "css", "fonts.css")); err != nil || !info.Mode().IsRegular() {
+		return false
+	}
+	files, err := fontpacks.ManagedFontFiles(output)
+	if err != nil {
+		return false
+	}
+	for _, file := range files {
+		info, err := os.Stat(filepath.Join(output, "assets", "fonts", file))
+		if err != nil || !info.Mode().IsRegular() {
+			return false
+		}
+	}
+	return true
 }
 
 func fontpackResolveOptions(source *fontpacks.CatalogSource) fontpacks.ResolveOptions {

--- a/pkg/plugins/fontpack.go
+++ b/pkg/plugins/fontpack.go
@@ -2,11 +2,19 @@ package plugins
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 
+	"github.com/WaylonWalker/markata-go/pkg/buildcache"
 	"github.com/WaylonWalker/markata-go/pkg/fontpacks"
 	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
+)
+
+const (
+	fontpackCacheFile    = ".markata-fontpack-cache"
+	fontpackCacheVersion = "1"
 )
 
 // FontpackPlugin installs one site-wide typography stylesheet. It never calls
@@ -82,12 +90,20 @@ func (p *FontpackPlugin) Write(m *lifecycle.Manager) error {
 	if err != nil {
 		return err
 	}
-	resolved, err := p.source.Catalog.ResolveManyFSWithOptions(names, p.source.FS, p.source.Root, rendered.String(), fontpackResolveOptions(p.source))
-	if err != nil {
-		return err
-	}
-	if err := resolved.CopyFS(p.source.FS, p.source.Root, output); err != nil {
-		return err
+	cacheKey := fontpackCacheKey(rendered.String(), names)
+	if !p.source.Builtin || !fontpackOutputCached(output, cacheKey) {
+		resolved, err := p.source.Catalog.ResolveManyFSWithOptions(names, p.source.FS, p.source.Root, rendered.String(), fontpackResolveOptions(p.source))
+		if err != nil {
+			return err
+		}
+		if err := resolved.CopyFS(p.source.FS, p.source.Root, output); err != nil {
+			return err
+		}
+		if p.source.Builtin {
+			if err := os.WriteFile(filepath.Join(output, fontpackCacheFile), []byte(cacheKey), 0o600); err != nil {
+				return err
+			}
+		}
 	}
 	for _, post := range m.Posts() {
 		if name := pageNames[post.Path]; name != "" {
@@ -95,6 +111,19 @@ func (p *FontpackPlugin) Write(m *lifecycle.Manager) error {
 		}
 	}
 	return nil
+}
+
+func fontpackCacheKey(rendered string, names []string) string {
+	return buildcache.ContentHash(fontpackCacheVersion + "\x00" + rendered + "\x00" + strings.Join(names, "\x00"))
+}
+
+func fontpackOutputCached(output, key string) bool {
+	data, err := os.ReadFile(filepath.Join(output, fontpackCacheFile))
+	if err != nil || strings.TrimSpace(string(data)) != key {
+		return false
+	}
+	_, err = os.Stat(filepath.Join(output, "css", "fonts.css"))
+	return err == nil
 }
 
 func fontpackResolveOptions(source *fontpacks.CatalogSource) fontpacks.ResolveOptions {

--- a/pkg/plugins/fontpack_test.go
+++ b/pkg/plugins/fontpack_test.go
@@ -1,6 +1,8 @@
 package plugins
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -26,5 +28,39 @@ func TestMarkHTMLFontpackReplacesExactlyOneAttribute(t *testing.T) {
 				t.Fatalf("duplicate data-fontpack attribute: %q", got)
 			}
 		})
+	}
+}
+
+func TestFontpackCacheKeyChangesWithRenderedContent(t *testing.T) {
+	names := []string{"system", "serif"}
+	first := fontpackCacheKey("<p>one</p>", names)
+	second := fontpackCacheKey("<p>two</p>", names)
+	if first == second {
+		t.Fatal("fontpack cache key did not change with rendered content")
+	}
+}
+
+func TestFontpackOutputCachedRequiresMatchingKeyAndStylesheet(t *testing.T) {
+	output := t.TempDir()
+	if fontpackOutputCached(output, "key") {
+		t.Fatal("missing marker was treated as a cache hit")
+	}
+	if err := os.WriteFile(filepath.Join(output, fontpackCacheFile), []byte("key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if fontpackOutputCached(output, "key") {
+		t.Fatal("missing stylesheet was treated as a cache hit")
+	}
+	if err := os.Mkdir(filepath.Join(output, "css"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(output, "css", "fonts.css"), []byte(""), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !fontpackOutputCached(output, "key") {
+		t.Fatal("matching marker and stylesheet were not treated as a cache hit")
+	}
+	if fontpackOutputCached(output, "different") {
+		t.Fatal("mismatched marker was treated as a cache hit")
 	}
 }

--- a/pkg/plugins/fontpack_test.go
+++ b/pkg/plugins/fontpack_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/WaylonWalker/markata-go/pkg/fontpacks"
 )
 
 func TestMarkHTMLFontpackReplacesExactlyOneAttribute(t *testing.T) {
@@ -33,8 +35,12 @@ func TestMarkHTMLFontpackReplacesExactlyOneAttribute(t *testing.T) {
 
 func TestFontpackCacheKeyChangesWithRenderedContent(t *testing.T) {
 	names := []string{"system", "serif"}
-	first := fontpackCacheKey("<p>one</p>", names)
-	second := fontpackCacheKey("<p>two</p>", names)
+	catalog, err := fontpacks.BuiltinSource()
+	if err != nil {
+		t.Fatal(err)
+	}
+	first := fontpackCacheKey("<p>one</p>", names, catalog.Catalog)
+	second := fontpackCacheKey("<p>two</p>", names, catalog.Catalog)
 	if first == second {
 		t.Fatal("fontpack cache key did not change with rendered content")
 	}
@@ -55,6 +61,12 @@ func TestFontpackOutputCachedRequiresMatchingKeyAndStylesheet(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(output, "css", "fonts.css"), []byte(""), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(output, "assets", "fonts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(output, "assets", "fonts", ".markata-fonts.json"), []byte(`{"files":[]}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	if !fontpackOutputCached(output, "key") {


### PR DESCRIPTION
## Summary
- cache bundled fontpack output when rendered content and selected packs are unchanged
- retain runtime checksum validation and uncached behavior for custom catalogs
- add cache invalidation tests

## Validation
- `just lint-new`
- `just test`
- `go test ./pkg/plugins/...`
- `git diff --check`