### PR TITLE
feat(content-index): include resolved media metadata

### DIFF
--- a/docs/guides/content-index.md
+++ b/docs/guides/content-index.md
@@ -33,6 +33,13 @@ Use each document's repository-relative `path` to find its source file. The
 `feeds` array already contains resolved Markata feed membership. Consumers
 should not implement Markata's feed filter language again.
 
+Documents may also include optional resolved frontmatter and author metadata:
+`image`, `video`, `avatar`, `bio`, `thumbnail`, `cover`, `og_image`, `author`,
+`authors`, `category`, and `categories`. Media values are source references;
+Markata does not copy or download those assets into the index. Author order is
+preserved. `cover` uses `cover` first and `cover_image` as a compatibility
+fallback. `og_image` uses `og_image` first and `social_image` as a fallback.
+
 `source.commit` identifies the Git `HEAD` observed for the build.
 `source.dirty` is false when the working tree was observed clean at the Content
 Index source-state boundaries. It is true when Git reports tracked, staged,

--- a/pkg/contentindex/contentindex_test.go
+++ b/pkg/contentindex/contentindex_test.go
@@ -15,7 +15,8 @@ func TestMarshalParseRoundTrip(t *testing.T) {
 	title := "Hello"
 	when := time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)
 	dirty := false
-	want := Index{Schema: Schema, SchemaVersion: 1, Scope: "public", Generator: Generator{Name: GeneratorName, Version: "test"}, Source: Source{Commit: "abc", Dirty: &dirty}, Documents: []Document{{Path: "posts/hello.md", Slug: "hello", Href: "/hello/", Title: &title, TitleText: &title, Date: &when, Published: true, Tags: []string{"go"}, Feeds: []string{"blog"}}}, DocumentCount: 1}
+	image, video, author, category := "https://example.test/image.webp", "https://example.test/video.mp4", "waylon", "notes"
+	want := Index{Schema: Schema, SchemaVersion: 1, Scope: "public", Generator: Generator{Name: GeneratorName, Version: "test"}, Source: Source{Commit: "abc", Dirty: &dirty}, Documents: []Document{{Path: "posts/hello.md", Slug: "hello", Href: "/hello/", Title: &title, TitleText: &title, Date: &when, Published: true, Tags: []string{"go"}, Feeds: []string{"blog"}, Image: &image, Video: &video, Author: &author, Authors: []string{"waylon", "guest"}, Category: &category, Categories: []string{"notes", "writing"}}}, DocumentCount: 1}
 	data, err := Marshal(want)
 	if err != nil {
 		t.Fatal(err)
@@ -26,6 +27,9 @@ func TestMarshalParseRoundTrip(t *testing.T) {
 	}
 	if got.DocumentCount != 1 || got.Scope != "public" || got.Documents[0].Path != want.Documents[0].Path || got.Source.Commit != "abc" || got.Source.Dirty == nil || *got.Source.Dirty || got.Documents[0].Date == nil || !got.Documents[0].Date.Equal(when) {
 		t.Fatalf("round trip lost data: %#v", got)
+	}
+	if got.Documents[0].Image == nil || *got.Documents[0].Image != image || got.Documents[0].Video == nil || *got.Documents[0].Video != video || got.Documents[0].Author == nil || *got.Documents[0].Author != author || len(got.Documents[0].Authors) != 2 || got.Documents[0].Category == nil || *got.Documents[0].Category != category {
+		t.Fatalf("optional media and author metadata was lost: %#v", got.Documents[0])
 	}
 	if !strings.Contains(string(data), `"$schema":"`+SchemaURL+`"`) {
 		t.Fatalf("missing canonical schema identity: %s", data)

--- a/pkg/contentindex/model.go
+++ b/pkg/contentindex/model.go
@@ -50,4 +50,15 @@ type Document struct {
 	Description *string
 	Feeds       []string
 	Aliases     []string
+	Image       *string
+	Video       *string
+	Avatar      *string
+	Bio         *string
+	Thumbnail   *string
+	Cover       *string
+	OGImage     *string
+	Author      *string
+	Authors     []string
+	Category    *string
+	Categories  []string
 }

--- a/pkg/contentindex/v1.go
+++ b/pkg/contentindex/v1.go
@@ -50,6 +50,17 @@ type v1Document struct {
 	Description *string    `json:"description,omitempty"`
 	Feeds       []string   `json:"feeds,omitempty"`
 	Aliases     []string   `json:"aliases,omitempty"`
+	Image       *string    `json:"image,omitempty"`
+	Video       *string    `json:"video,omitempty"`
+	Avatar      *string    `json:"avatar,omitempty"`
+	Bio         *string    `json:"bio,omitempty"`
+	Thumbnail   *string    `json:"thumbnail,omitempty"`
+	Cover       *string    `json:"cover,omitempty"`
+	OGImage     *string    `json:"og_image,omitempty"`
+	Author      *string    `json:"author,omitempty"`
+	Authors     []string   `json:"authors,omitempty"`
+	Category    *string    `json:"category,omitempty"`
+	Categories  []string   `json:"categories,omitempty"`
 }
 
 func encodeV1(index Index) ([]byte, error) {
@@ -90,7 +101,7 @@ func encodeV1(index Index) ([]byte, error) {
 		d.Tags = sortedStrings(d.Tags)
 		d.Feeds = sortedStrings(d.Feeds)
 		d.Aliases = sortedStrings(d.Aliases)
-		docs[i] = v1Document{Path: d.Path, Slug: d.Slug, Href: d.Href, Title: d.Title, TitleText: d.TitleText, Date: d.Date, Modified: d.Modified, Published: d.Published, Draft: d.Draft, Private: d.Private, Template: d.Template, Tags: d.Tags, Description: d.Description, Feeds: d.Feeds, Aliases: d.Aliases}
+		docs[i] = v1Document{Path: d.Path, Slug: d.Slug, Href: d.Href, Title: d.Title, TitleText: d.TitleText, Date: d.Date, Modified: d.Modified, Published: d.Published, Draft: d.Draft, Private: d.Private, Template: d.Template, Tags: d.Tags, Description: d.Description, Feeds: d.Feeds, Aliases: d.Aliases, Image: d.Image, Video: d.Video, Avatar: d.Avatar, Bio: d.Bio, Thumbnail: d.Thumbnail, Cover: d.Cover, OGImage: d.OGImage, Author: d.Author, Authors: append([]string(nil), d.Authors...), Category: d.Category, Categories: sortedStrings(d.Categories)}
 	}
 	var commit *string
 	if index.Source.Commit != "" {
@@ -192,7 +203,7 @@ func decodeV1(data []byte) (Index, error) {
 				return Index{}, fmt.Errorf("documents[%d].%s must be a boolean", i, field)
 			}
 		}
-		for _, field := range []string{"tags", "feeds", "aliases"} {
+		for _, field := range []string{"tags", "feeds", "aliases", "authors", "categories"} {
 			if value, ok := document[field]; ok {
 				if isJSONNull(value) {
 					return Index{}, fmt.Errorf("documents[%d].%s must be an array of strings", i, field)
@@ -203,15 +214,15 @@ func decodeV1(data []byte) (Index, error) {
 				}
 			}
 		}
-		for _, field := range []string{"date", "modified", "template"} {
+		for _, field := range []string{"date", "modified", "template", "image", "video", "avatar", "bio", "thumbnail", "cover", "og_image", "author", "category"} {
 			if value, ok := document[field]; ok {
 				if isJSONNull(value) {
 					return Index{}, fmt.Errorf("documents[%d].%s must be a string", i, field)
 				}
-				if field == "template" {
+				if field != "date" && field != "modified" {
 					var text string
 					if err := json.Unmarshal(value, &text); err != nil {
-						return Index{}, fmt.Errorf("documents[%d].template must be a string", i)
+						return Index{}, fmt.Errorf("documents[%d].%s must be a string", i, field)
 					}
 				} else {
 					var date time.Time
@@ -266,7 +277,7 @@ func decodeV1(data []byte) (Index, error) {
 			return Index{}, fmt.Errorf("documents[%d].path is duplicated: %q", i, d.Path)
 		}
 		seenPaths[d.Path] = struct{}{}
-		result.Documents[i] = Document{d.Path, d.Slug, d.Href, d.Title, d.TitleText, d.Date, d.Modified, d.Published, d.Draft, d.Private, d.Template, append([]string(nil), d.Tags...), d.Description, append([]string(nil), d.Feeds...), append([]string(nil), d.Aliases...)}
+		result.Documents[i] = Document{Path: d.Path, Slug: d.Slug, Href: d.Href, Title: d.Title, TitleText: d.TitleText, Date: d.Date, Modified: d.Modified, Published: d.Published, Draft: d.Draft, Private: d.Private, Template: d.Template, Tags: append([]string(nil), d.Tags...), Description: d.Description, Feeds: append([]string(nil), d.Feeds...), Aliases: append([]string(nil), d.Aliases...), Image: d.Image, Video: d.Video, Avatar: d.Avatar, Bio: d.Bio, Thumbnail: d.Thumbnail, Cover: d.Cover, OGImage: d.OGImage, Author: d.Author, Authors: append([]string(nil), d.Authors...), Category: d.Category, Categories: append([]string(nil), d.Categories...)}
 	}
 	return result, nil
 }

--- a/pkg/contentindex/v1_schema.json
+++ b/pkg/contentindex/v1_schema.json
@@ -27,7 +27,11 @@
         "published": {"type": "boolean"}, "draft": {"type": "boolean"}, "private": {"type": "boolean"},
         "template": {"type": "string"}, "tags": {"type": "array", "items": {"type": "string"}},
         "description": {"type": ["string", "null"]}, "feeds": {"type": "array", "items": {"type": "string"}},
-        "aliases": {"type": "array", "items": {"type": "string"}}
+        "aliases": {"type": "array", "items": {"type": "string"}},
+        "image": {"type": "string"}, "video": {"type": "string"}, "avatar": {"type": "string"},
+        "thumbnail": {"type": "string"}, "cover": {"type": "string"}, "og_image": {"type": "string"}, "bio": {"type": "string"},
+        "author": {"type": "string"}, "authors": {"type": "array", "items": {"type": "string"}},
+        "category": {"type": "string"}, "categories": {"type": "array", "items": {"type": "string"}}
       }
     }
   }

--- a/pkg/plugins/content_index.go
+++ b/pkg/plugins/content_index.go
@@ -192,7 +192,68 @@ func (e *contentIndexWriteError) Unwrap() error    { return e.err }
 func (e *contentIndexWriteError) IsCritical() bool { return true }
 
 func documentFromPost(post *models.Post, feedNames []string) contentindex.Document {
-	return contentindex.Document{Path: post.Path, Slug: post.Slug, Href: post.Href, Title: post.Title, TitleText: titleText(post), Date: post.Date, Modified: post.Modified, Published: post.Published, Draft: post.Draft, Private: post.Private, Template: post.Template, Tags: sortedStrings(post.Tags), Description: post.Description, Feeds: append([]string(nil), feedNames...), Aliases: aliases(post)}
+	return contentindex.Document{Path: post.Path, Slug: post.Slug, Href: post.Href, Title: post.Title, TitleText: titleText(post), Date: post.Date, Modified: post.Modified, Published: post.Published, Draft: post.Draft, Private: post.Private, Template: post.Template, Tags: sortedStrings(post.Tags), Description: post.Description, Feeds: append([]string(nil), feedNames...), Aliases: aliases(post), Image: extraString(post, "image"), Video: extraString(post, "video"), Avatar: resolvedAvatar(post), Bio: resolvedBio(post), Thumbnail: extraString(post, "thumbnail"), Cover: firstExtraString(post, "cover", "cover_image"), OGImage: firstExtraString(post, "og_image", "social_image"), Author: post.Author, Authors: append([]string(nil), post.GetAuthors()...), Category: extraString(post, "category"), Categories: extraStrings(post, "categories")}
+}
+
+func firstExtraString(post *models.Post, keys ...string) *string {
+	for _, key := range keys {
+		if value := extraString(post, key); value != nil {
+			return value
+		}
+	}
+	return nil
+}
+
+func resolvedAvatar(post *models.Post) *string {
+	if value := extraString(post, "avatar"); value != nil {
+		return value
+	}
+	for index := range post.AuthorObjects {
+		author := &post.AuthorObjects[index]
+		if author.Avatar != nil && *author.Avatar != "" {
+			return author.Avatar
+		}
+	}
+	return nil
+}
+
+func resolvedBio(post *models.Post) *string {
+	if value := extraString(post, "bio"); value != nil {
+		return value
+	}
+	for index := range post.AuthorObjects {
+		author := &post.AuthorObjects[index]
+		if author.Bio != nil && *author.Bio != "" {
+			return author.Bio
+		}
+	}
+	return nil
+}
+
+func extraString(post *models.Post, key string) *string {
+	value, ok := post.Extra[key].(string)
+	if !ok || value == "" {
+		return nil
+	}
+	return &value
+}
+
+func extraStrings(post *models.Post, key string) []string {
+	value := post.Extra[key]
+	var result []string
+	switch values := value.(type) {
+	case []string:
+		result = append(result, values...)
+	case []interface{}:
+		for _, item := range values {
+			if value, ok := item.(string); ok {
+				result = append(result, value)
+			}
+		}
+	case string:
+		result = append(result, values)
+	}
+	return sortedStrings(result)
 }
 
 func titleText(post *models.Post) *string {

--- a/pkg/plugins/content_index_test.go
+++ b/pkg/plugins/content_index_test.go
@@ -17,6 +17,18 @@ func TestContentIndexPlugin_WritesPublicMetadataAndFeeds(t *testing.T) {
 	m.SetConfig(&lifecycle.Config{ContentDir: dir, OutputDir: dir, Extra: map[string]interface{}{"content_index": map[string]interface{}{"enabled": true, "output": output}, "markata_version": "test"}})
 	public := models.NewPost("posts/public.md")
 	public.Slug, public.Href, public.Published, public.Tags = "public", "/public/", true, []string{"z", "a"}
+	public.Extra["image"] = "https://images.example.test/public.webp"
+	public.Extra["video"] = "https://videos.example.test/public.mp4"
+	public.Extra["bio"] = "Author biography"
+	public.Extra["thumbnail"] = "https://images.example.test/thumb.webp"
+	public.Extra["cover_image"] = "https://images.example.test/cover.webp"
+	public.Extra["og_image"] = "https://images.example.test/og.webp"
+	public.Extra["category"] = "notes"
+	public.Extra["categories"] = []interface{}{"writing", "personal"}
+	public.Author = contentIndexStringPtr("waylon")
+	public.Authors = []string{"waylon", "guest"}
+	authorAvatar, authorBio := "https://images.example.test/author.webp", "Author biography"
+	public.AuthorObjects = []models.Author{{ID: "waylon", Avatar: &authorAvatar, Bio: &authorBio}}
 	unpublished := models.NewPost("pages/unpublished.md")
 	unpublished.Slug, unpublished.Href = "unpublished", "/unpublished/"
 	private := models.NewPost("posts/private.md")
@@ -45,7 +57,16 @@ func TestContentIndexPlugin_WritesPublicMetadataAndFeeds(t *testing.T) {
 	if index.Documents[0].Published || len(index.Documents[0].Feeds) != 1 || index.Documents[0].Feeds[0] != "draft" {
 		t.Fatalf("unpublished direct page or draft feed was conflated: %#v", index.Documents[0])
 	}
+	document := index.Documents[1]
+	if document.Image == nil || *document.Image != "https://images.example.test/public.webp" || document.Video == nil || document.Avatar == nil || *document.Avatar != authorAvatar || document.Bio == nil || *document.Bio != authorBio || document.Thumbnail == nil || document.Cover == nil || *document.Cover != "https://images.example.test/cover.webp" || document.OGImage == nil {
+		t.Fatalf("media metadata = %#v", document)
+	}
+	if document.Author == nil || *document.Author != "waylon" || len(document.Authors) != 2 || document.Category == nil || *document.Category != "notes" || len(document.Categories) != 2 {
+		t.Fatalf("author/category metadata = %#v", document)
+	}
 }
+
+func contentIndexStringPtr(value string) *string { return &value }
 
 func TestContentIndexPlugin_DisabledByDefault(t *testing.T) {
 	dir := t.TempDir()

--- a/spec/spec/CONTENT_INDEX.md
+++ b/spec/spec/CONTENT_INDEX.md
@@ -49,6 +49,15 @@ the resolved Markata URL identifiers. `title` is the authored/display value;
 are RFC 3339 date-time strings and absent dates are omitted. `description` is
 optional. Tags, aliases, and feeds are arrays of strings.
 
+The following optional document fields MAY be emitted when present in resolved
+frontmatter or author metadata: `image`, `video`, `avatar`, `thumbnail`,
+`cover`, `og_image`, `author`, `authors`, `bio`, `category`, and `categories`.
+Media fields are source references, not downloaded assets. `authors` and
+`categories` are arrays of strings; the other fields are strings. Author order
+is preserved because the first author can be semantically significant.
+Consumers
+MUST continue to ignore these fields when they do not need them.
+
 Documents are sorted by normalized source path. Tags, aliases, and feed names
 are sorted lexicographically. JSON object keys are emitted in a fixed Go
 struct order. These rules make equivalent builds byte-deterministic.


### PR DESCRIPTION
## Summary
- add optional Content Index v1 fields for image, video, avatar, bio, thumbnail, cover, og_image, author, authors, category, and categories
- preserve author order and resolve cover/OG-image compatibility aliases
- include resolved author avatar and bio fallbacks
- document the fields and add producer/wire/schema tests

These fields are optional and additive within Content Index v1. Media values are references only; article bodies and assets are not embedded.

## Validation
- `TMPDIR="$PWD/.tmp" go test ./pkg/contentindex`
- `TMPDIR="$PWD/.tmp" go test ./pkg/plugins -run 'ContentIndex|ContentIndexPlugin|MarshalParseRoundTrip' -count=1`\n- `git diff --check`