### PR TITLE
perf: skip unchanged asset minification

### DIFF
--- a/pkg/fontpacks/output.go
+++ b/pkg/fontpacks/output.go
@@ -447,7 +447,7 @@ func (r *Resolved) CopyFS(assetFS fs.FS, assetRoot, outputDir string) error {
 			return err
 		}
 		// Generated web asset must remain world-readable for static hosting.
-		if err := os.WriteFile(filepath.Join(outputDir, "assets", "fonts", name), data, 0o644); err != nil { //nolint:gosec // public static asset
+		if err := writePublicFile(filepath.Join(outputDir, "assets", "fonts", name), data); err != nil {
 			return err
 		}
 	}
@@ -455,7 +455,29 @@ func (r *Resolved) CopyFS(assetFS fs.FS, assetRoot, outputDir string) error {
 		return err
 	}
 	// Generated web asset must remain world-readable for static hosting.
-	return os.WriteFile(filepath.Join(outputDir, "css", "fonts.css"), []byte(r.CSS), 0o644) //nolint:gosec // public static asset
+	return writePublicFile(filepath.Join(outputDir, "css", "fonts.css"), []byte(r.CSS))
+}
+
+func writePublicFile(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".markata-write-")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Chmod(0o644); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
 }
 
 type managedFonts struct {
@@ -497,7 +519,7 @@ func updateManagedFonts(outputDir string, assets []Asset) error {
 	}
 	data = append(data, '\n')
 	// Generated web asset must remain world-readable for static hosting.
-	return os.WriteFile(manifestPath, data, 0o644) //nolint:gosec // public static asset
+	return writePublicFile(manifestPath, data)
 }
 
 // CleanManagedFonts removes only files named by the previous Markata manifest.

--- a/pkg/plugins/css_minify.go
+++ b/pkg/plugins/css_minify.go
@@ -213,9 +213,8 @@ func (p *CSSMinifyPlugin) minifyFile(filePath string) (original, minified int64,
 
 	minified = int64(result.Len())
 
-	// Write the minified content back
-	//nolint:gosec // G306: CSS files need 0644 for web serving
-	if err := os.WriteFile(filePath, result.Bytes(), 0o644); err != nil {
+	// Replace the file atomically so hard-linked live releases are not mutated.
+	if err := writeGeneratedFile(filePath, result.Bytes()); err != nil {
 		return original, 0, fmt.Errorf("writing minified file: %w", err)
 	}
 

--- a/pkg/plugins/fontpack.go
+++ b/pkg/plugins/fontpack.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -90,7 +91,7 @@ func (p *FontpackPlugin) Write(m *lifecycle.Manager) error {
 	if err != nil {
 		return err
 	}
-	cacheKey := fontpackCacheKey(rendered.String(), names)
+	cacheKey := fontpackCacheKey(rendered.String(), names, p.source.Catalog)
 	if !p.source.Builtin || !fontpackOutputCached(output, cacheKey) {
 		resolved, err := p.source.Catalog.ResolveManyFSWithOptions(names, p.source.FS, p.source.Root, rendered.String(), fontpackResolveOptions(p.source))
 		if err != nil {
@@ -103,6 +104,8 @@ func (p *FontpackPlugin) Write(m *lifecycle.Manager) error {
 			if err := os.WriteFile(filepath.Join(output, fontpackCacheFile), []byte(cacheKey), 0o600); err != nil {
 				return err
 			}
+		} else if err := os.Remove(filepath.Join(output, fontpackCacheFile)); err != nil && !os.IsNotExist(err) {
+			return err
 		}
 	}
 	for _, post := range m.Posts() {
@@ -113,8 +116,12 @@ func (p *FontpackPlugin) Write(m *lifecycle.Manager) error {
 	return nil
 }
 
-func fontpackCacheKey(rendered string, names []string) string {
-	return buildcache.ContentHash(fontpackCacheVersion + "\x00" + rendered + "\x00" + strings.Join(names, "\x00"))
+func fontpackCacheKey(rendered string, names []string, catalog *fontpacks.Catalog) string {
+	catalogData, err := json.Marshal(catalog)
+	if err != nil {
+		return ""
+	}
+	return buildcache.ContentHash(fontpackCacheVersion + "\x00" + string(catalogData) + "\x00" + rendered + "\x00" + strings.Join(names, "\x00"))
 }
 
 func fontpackOutputCached(output, key string) bool {
@@ -122,8 +129,20 @@ func fontpackOutputCached(output, key string) bool {
 	if err != nil || strings.TrimSpace(string(data)) != key {
 		return false
 	}
-	_, err = os.Stat(filepath.Join(output, "css", "fonts.css"))
-	return err == nil
+	if info, err := os.Stat(filepath.Join(output, "css", "fonts.css")); err != nil || !info.Mode().IsRegular() {
+		return false
+	}
+	files, err := fontpacks.ManagedFontFiles(output)
+	if err != nil {
+		return false
+	}
+	for _, file := range files {
+		info, err := os.Stat(filepath.Join(output, "assets", "fonts", file))
+		if err != nil || !info.Mode().IsRegular() {
+			return false
+		}
+	}
+	return true
 }
 
 func fontpackResolveOptions(source *fontpacks.CatalogSource) fontpacks.ResolveOptions {

--- a/pkg/plugins/fontpack.go
+++ b/pkg/plugins/fontpack.go
@@ -2,11 +2,19 @@ package plugins
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 
+	"github.com/WaylonWalker/markata-go/pkg/buildcache"
 	"github.com/WaylonWalker/markata-go/pkg/fontpacks"
 	"github.com/WaylonWalker/markata-go/pkg/lifecycle"
+)
+
+const (
+	fontpackCacheFile    = ".markata-fontpack-cache"
+	fontpackCacheVersion = "1"
 )
 
 // FontpackPlugin installs one site-wide typography stylesheet. It never calls
@@ -82,12 +90,20 @@ func (p *FontpackPlugin) Write(m *lifecycle.Manager) error {
 	if err != nil {
 		return err
 	}
-	resolved, err := p.source.Catalog.ResolveManyFSWithOptions(names, p.source.FS, p.source.Root, rendered.String(), fontpackResolveOptions(p.source))
-	if err != nil {
-		return err
-	}
-	if err := resolved.CopyFS(p.source.FS, p.source.Root, output); err != nil {
-		return err
+	cacheKey := fontpackCacheKey(rendered.String(), names)
+	if !p.source.Builtin || !fontpackOutputCached(output, cacheKey) {
+		resolved, err := p.source.Catalog.ResolveManyFSWithOptions(names, p.source.FS, p.source.Root, rendered.String(), fontpackResolveOptions(p.source))
+		if err != nil {
+			return err
+		}
+		if err := resolved.CopyFS(p.source.FS, p.source.Root, output); err != nil {
+			return err
+		}
+		if p.source.Builtin {
+			if err := os.WriteFile(filepath.Join(output, fontpackCacheFile), []byte(cacheKey), 0o600); err != nil {
+				return err
+			}
+		}
 	}
 	for _, post := range m.Posts() {
 		if name := pageNames[post.Path]; name != "" {
@@ -95,6 +111,19 @@ func (p *FontpackPlugin) Write(m *lifecycle.Manager) error {
 		}
 	}
 	return nil
+}
+
+func fontpackCacheKey(rendered string, names []string) string {
+	return buildcache.ContentHash(fontpackCacheVersion + "\x00" + rendered + "\x00" + strings.Join(names, "\x00"))
+}
+
+func fontpackOutputCached(output, key string) bool {
+	data, err := os.ReadFile(filepath.Join(output, fontpackCacheFile))
+	if err != nil || strings.TrimSpace(string(data)) != key {
+		return false
+	}
+	_, err = os.Stat(filepath.Join(output, "css", "fonts.css"))
+	return err == nil
 }
 
 func fontpackResolveOptions(source *fontpacks.CatalogSource) fontpacks.ResolveOptions {

--- a/pkg/plugins/fontpack_test.go
+++ b/pkg/plugins/fontpack_test.go
@@ -1,6 +1,8 @@
 package plugins
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -26,5 +28,39 @@ func TestMarkHTMLFontpackReplacesExactlyOneAttribute(t *testing.T) {
 				t.Fatalf("duplicate data-fontpack attribute: %q", got)
 			}
 		})
+	}
+}
+
+func TestFontpackCacheKeyChangesWithRenderedContent(t *testing.T) {
+	names := []string{"system", "serif"}
+	first := fontpackCacheKey("<p>one</p>", names)
+	second := fontpackCacheKey("<p>two</p>", names)
+	if first == second {
+		t.Fatal("fontpack cache key did not change with rendered content")
+	}
+}
+
+func TestFontpackOutputCachedRequiresMatchingKeyAndStylesheet(t *testing.T) {
+	output := t.TempDir()
+	if fontpackOutputCached(output, "key") {
+		t.Fatal("missing marker was treated as a cache hit")
+	}
+	if err := os.WriteFile(filepath.Join(output, fontpackCacheFile), []byte("key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if fontpackOutputCached(output, "key") {
+		t.Fatal("missing stylesheet was treated as a cache hit")
+	}
+	if err := os.Mkdir(filepath.Join(output, "css"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(output, "css", "fonts.css"), []byte(""), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !fontpackOutputCached(output, "key") {
+		t.Fatal("matching marker and stylesheet were not treated as a cache hit")
+	}
+	if fontpackOutputCached(output, "different") {
+		t.Fatal("mismatched marker was treated as a cache hit")
 	}
 }

--- a/pkg/plugins/fontpack_test.go
+++ b/pkg/plugins/fontpack_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/WaylonWalker/markata-go/pkg/fontpacks"
 )
 
 func TestMarkHTMLFontpackReplacesExactlyOneAttribute(t *testing.T) {
@@ -33,8 +35,12 @@ func TestMarkHTMLFontpackReplacesExactlyOneAttribute(t *testing.T) {
 
 func TestFontpackCacheKeyChangesWithRenderedContent(t *testing.T) {
 	names := []string{"system", "serif"}
-	first := fontpackCacheKey("<p>one</p>", names)
-	second := fontpackCacheKey("<p>two</p>", names)
+	catalog, err := fontpacks.BuiltinSource()
+	if err != nil {
+		t.Fatal(err)
+	}
+	first := fontpackCacheKey("<p>one</p>", names, catalog.Catalog)
+	second := fontpackCacheKey("<p>two</p>", names, catalog.Catalog)
 	if first == second {
 		t.Fatal("fontpack cache key did not change with rendered content")
 	}
@@ -55,6 +61,12 @@ func TestFontpackOutputCachedRequiresMatchingKeyAndStylesheet(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(output, "css", "fonts.css"), []byte(""), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(output, "assets", "fonts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(output, "assets", "fonts", ".markata-fonts.json"), []byte(`{"files":[]}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	if !fontpackOutputCached(output, "key") {

--- a/pkg/plugins/js_minify.go
+++ b/pkg/plugins/js_minify.go
@@ -204,9 +204,8 @@ func (p *JSMinifyPlugin) minifyFile(filePath string) (original, minified int64, 
 
 	minified = int64(buf.Len())
 
-	// Write the minified content back
-	//nolint:gosec // G306: JS files need 0644 for web serving
-	if err := os.WriteFile(filePath, buf.Bytes(), 0o644); err != nil {
+	// Replace the file atomically so hard-linked live releases are not mutated.
+	if err := writeGeneratedFile(filePath, buf.Bytes()); err != nil {
 		return original, 0, fmt.Errorf("writing minified file: %w", err)
 	}
 

--- a/pkg/plugins/minify_helpers.go
+++ b/pkg/plugins/minify_helpers.go
@@ -30,10 +30,34 @@ type minifyCache struct {
 	mu    sync.Mutex
 }
 
+func writeGeneratedFile(path string, data []byte) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".markata-minify-")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Chmod(0o644); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
 func loadMinifyCache(path, root string) *minifyCache {
 	cache := &minifyCache{root: root, files: make(map[string]string)}
 	if data, err := os.ReadFile(path); err == nil {
 		if err := json.Unmarshal(data, &cache.files); err != nil {
+			cache.files = make(map[string]string)
+		}
+		if cache.files == nil {
 			cache.files = make(map[string]string)
 		}
 	}
@@ -73,7 +97,7 @@ func (c *minifyCache) save(path string) {
 	data, err := json.Marshal(c.files)
 	c.mu.Unlock()
 	if err == nil {
-		if err := os.WriteFile(path, data, 0o600); err != nil {
+		if err := writeGeneratedFile(path, data); err != nil {
 			return
 		}
 	}

--- a/pkg/plugins/minify_helpers.go
+++ b/pkg/plugins/minify_helpers.go
@@ -2,7 +2,11 @@
 package plugins
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"log"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -20,6 +24,61 @@ type minifyResult struct {
 	minified int64
 }
 
+type minifyCache struct {
+	root  string
+	files map[string]string
+	mu    sync.Mutex
+}
+
+func loadMinifyCache(path, root string) *minifyCache {
+	cache := &minifyCache{root: root, files: make(map[string]string)}
+	if data, err := os.ReadFile(path); err == nil {
+		if err := json.Unmarshal(data, &cache.files); err != nil {
+			cache.files = make(map[string]string)
+		}
+	}
+	return cache
+}
+
+func (c *minifyCache) hashMatches(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(c.root, path)
+	if err != nil {
+		return false
+	}
+	hash := sha256.Sum256(data)
+	return c.files[filepath.ToSlash(rel)] == hex.EncodeToString(hash[:])
+}
+
+func (c *minifyCache) record(path string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	rel, err := filepath.Rel(c.root, path)
+	if err != nil {
+		return
+	}
+	hash := sha256.Sum256(data)
+	c.mu.Lock()
+	c.files[filepath.ToSlash(rel)] = hex.EncodeToString(hash[:])
+	c.mu.Unlock()
+}
+
+func (c *minifyCache) save(path string) {
+	c.mu.Lock()
+	data, err := json.Marshal(c.files)
+	c.mu.Unlock()
+	if err == nil {
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			return
+		}
+	}
+}
+
 // runMinification processes a list of files through a minifier, logging statistics.
 // It is shared between css_minify and js_minify plugins.
 // Files are processed concurrently using a worker pool sized to the given concurrency.
@@ -34,9 +93,16 @@ func runMinification(pluginName string, files []string, isExcluded excludeFunc, 
 	// Filter excluded files first (cheap, serial)
 	toProcess := make([]string, 0, len(files))
 	var filesSkipped int
+	root := filepath.Dir(filepath.Dir(files[0]))
+	cachePath := filepath.Join(root, ".markata-"+pluginName+"-cache")
+	cache := loadMinifyCache(cachePath, root)
 	for _, file := range files {
 		if isExcluded(file) {
 			log.Printf("[%s] Skipping excluded file: %s", pluginName, filepath.Base(file))
+			filesSkipped++
+			continue
+		}
+		if cache.hashMatches(file) {
 			filesSkipped++
 			continue
 		}
@@ -73,6 +139,7 @@ func runMinification(pluginName string, files []string, isExcluded excludeFunc, 
 				log.Printf("[%s] Warning: failed to minify %s: %v", pluginName, filepath.Base(f), err)
 				return
 			}
+			cache.record(f)
 			resultsCh <- minifyResult{original: original, minified: minifiedSize}
 		}(file)
 	}
@@ -91,6 +158,7 @@ func runMinification(pluginName string, files []string, isExcluded excludeFunc, 
 		totalMinified += r.minified
 		filesProcessed++
 	}
+	cache.save(cachePath)
 
 	if totalOriginal > 0 {
 		reduction := float64(totalOriginal-totalMinified) / float64(totalOriginal) * 100

--- a/pkg/plugins/minify_helpers_test.go
+++ b/pkg/plugins/minify_helpers_test.go
@@ -31,3 +31,13 @@ func TestRunMinificationCachesUnchangedFiles(t *testing.T) {
 		t.Fatalf("minifier called %d times, want 1", calls)
 	}
 }
+
+func TestLoadMinifyCacheTreatsNullAsEmpty(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "cache")
+	if err := os.WriteFile(path, []byte("null"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cache := loadMinifyCache(path, root)
+	cache.files["css/site.css"] = "hash"
+}

--- a/pkg/plugins/minify_helpers_test.go
+++ b/pkg/plugins/minify_helpers_test.go
@@ -1,0 +1,33 @@
+package plugins
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunMinificationCachesUnchangedFiles(t *testing.T) {
+	output := t.TempDir()
+	cssDir := filepath.Join(output, "css")
+	if err := os.MkdirAll(cssDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	file := filepath.Join(cssDir, "site.css")
+	if err := os.WriteFile(file, []byte("body { color: red; }"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	calls := 0
+	minify := func(path string) (int64, int64, error) {
+		calls++
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return 0, 0, err
+		}
+		return int64(len(data)), int64(len(data)), nil
+	}
+	runMinification("css_minify", []string{file}, func(string) bool { return false }, minify, 1)
+	runMinification("css_minify", []string{file}, func(string) bool { return false }, minify, 1)
+	if calls != 1 {
+		t.Fatalf("minifier called %d times, want 1", calls)
+	}
+}


### PR DESCRIPTION
## Summary
- persist content hashes for generated CSS and JS assets
- skip minification when seeded output is unchanged
- add regression coverage for the cache

## Validation
- `just lint-new`
- `just test`
- `go test ./pkg/plugins/...`
- `git diff --check`